### PR TITLE
Change Aggregator from channel-based to mutex-based.

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,13 +28,10 @@ func main() {
 	suppressor := manager.NewSuppressor()
 	defer suppressor.Close()
 
-	log.Println("Starting event aggregator...")
-	aggregator := manager.NewAggregator()
-	defer aggregator.Close()
-
 	summarizer := manager.NewSummaryDispatcher()
-	go aggregator.Dispatch(summarizer)
-	log.Println("Done.")
+
+	aggregator := manager.NewAggregator(summarizer)
+	defer aggregator.Close()
 
 	webService := &web.WebService{
 		AlertManagerService: &api.AlertManagerService{

--- a/manager/aggregator_test.go
+++ b/manager/aggregator_test.go
@@ -30,15 +30,8 @@ type testAggregatorScenario struct {
 }
 
 func (s *testAggregatorScenario) test(i int, t *testing.T) {
-	a := NewAggregator()
-	go a.Dispatch(&dummyReceiver{})
-
-	done := make(chan bool)
-	go func() {
-		a.SetRules(s.rules)
-		done <- true
-	}()
-	<-done
+	a := NewAggregator(&dummyReceiver{})
+	a.SetRules(s.rules)
 
 	if len(s.inMatch) > 0 {
 		err := a.Receive(s.inMatch)


### PR DESCRIPTION
This reduces code by >100 lines in the Aggregator alone by removing channel boilerplates.
