### PR TITLE
Treat `GeneratorURL` as optional in Alerts page.

### DIFF
--- a/web/templates/alerts.html
+++ b/web/templates/alerts.html
@@ -46,7 +46,11 @@
             </td>
             <td>{{timeSince .Created}} ago</td>
             <td>{{timeSince .LastRefreshed}} ago</td>
-            <td><a href="{{.Alert.Payload.GeneratorURL}}">{{(truncate .Alert.Payload.GeneratorURL 40)}}</a></td>
+            <td>
+              {{if .Alert.Payload.GeneratorURL}}
+                <a href="{{.Alert.Payload.GeneratorURL}}">{{(truncate .Alert.Payload.GeneratorURL 40)}}</a>
+              {{end}}
+            </td>
             <td>{{.Alert.Payload.AlertingRule}}</td>
             <td>
               {{$silence := call $silenceForAlert .Alert}}


### PR DESCRIPTION
This fixes https://github.com/prometheus/alertmanager/issues/21

Otherwise, sending an alert with a missing `GeneratorURL` payload
property would cause the template rendering to crash:

    Error executing template: template: alerts.html:51:76: executing "content" at <.Alert.Payload.Gener...>: invalid value; expected string