### PR TITLE
Makefile: Use $(CURDIR) instead of $(PWD), which is more dependable

### DIFF
--- a/Makefile.INCLUDE
+++ b/Makefile.INCLUDE
@@ -31,11 +31,13 @@ else
 RELEASE_SUFFIX ?=
 endif
 
+MAKEFILE_DIR ?= $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
+
 GO_VERSION ?= 1.4.1
 GOURL      ?= https://golang.org/dl
 GOPKG      ?= go$(GO_VERSION).$(GOOS)-$(GOARCH)$(RELEASE_SUFFIX).tar.gz
-GOROOT     := $(PWD)/.deps/go
-GOPATH     := $(PWD)/.deps/gopath
+GOROOT     := $(MAKEFILE_DIR)/.deps/go
+GOPATH     := $(MAKEFILE_DIR)/.deps/gopath
 GOCC       := $(GOROOT)/bin/go
 GO         := GOROOT=$(GOROOT) GOPATH=$(GOPATH) $(GOCC)
 GOFMT      := $(GOROOT)/bin/gofmt


### PR DESCRIPTION
When building a Debian package with `debuild`, which uses fakeroot, Make doesn't have `$(PWD)` for some reason. Apparently this is a shell-dependent thing. For that reason, the `touch` command gets the wrong path in `$@`:

```
make[1]: Entering directory `/tmp/d20150222-20503-whiv4g/prometheus-alertmanager_0.0git942cd35'
mkdir -p .deps
curl -o .deps/go1.4.1.linux-amd64.tar.gz -L https://golang.org/dl/go1.4.1.linux-amd64.tar.gz
tar -C .deps -xzf .deps/go1.4.1.linux-amd64.tar.gz
touch /.deps/go/bin/go
touch: cannot touch ‘/.deps/go/bin/go’: No such file or directory
make[1]: *** [/.deps/go/bin/go] Error 1
```

(The makefile in `node_exporter` is correct, by the way.)