### PR TITLE
Add -smtpAuth for mail servers that require authentication

### DIFF
--- a/manager/notifier.go
+++ b/manager/notifier.go
@@ -194,6 +194,8 @@ func (n *notifier) sendEmailNotification(to string, a *Alert) error {
 	if hasAuth && username != "" {
 		for _, mech := range strings.Split(mechs, " ") {
 			switch mech {
+			default:
+				continue
 			case "CRAM-MD5":
 				secret := os.Getenv("SMTP_AUTH_SECRET")
 				if secret == "" {
@@ -202,7 +204,6 @@ func (n *notifier) sendEmailNotification(to string, a *Alert) error {
 				if err := c.Auth(smtp.CRAMMD5Auth(username, secret)); err != nil {
 					return fmt.Errorf("cram-md5 auth failed: %s", err)
 				}
-				break
 			case "PLAIN":
 				password := os.Getenv("SMTP_AUTH_PASSWORD")
 				if password == "" {
@@ -219,8 +220,8 @@ func (n *notifier) sendEmailNotification(to string, a *Alert) error {
 				if err := c.Auth(smtp.PlainAuth(identity, username, password, host)); err != nil {
 					return fmt.Errorf("plain auth failed: %s", err)
 				}
-				break
 			}
+			break
 		}
 	}
 

--- a/manager/notifier.go
+++ b/manager/notifier.go
@@ -211,8 +211,13 @@ func (n *notifier) sendEmailNotification(to string, a *Alert) error {
 				}
 				identity := os.Getenv("SMTP_AUTH_IDENTITY")
 
+				// We need to know the hostname for auth (not to mention TLS).
+				host, _, err := net.SplitHostPort(*smtpSmartHost)
+				if err != nil {
+					return fmt.Errorf("invalid address: %s", err)
+				}
+
 				// PLAIN auth requires TLS to be started first.
-				host, _, _ := net.SplitHostPort(*smtpSmartHost)
 				if err := c.StartTLS(&tls.Config{ServerName: host}); err != nil {
 					return fmt.Errorf("starttls failed: %s", err)
 				}


### PR DESCRIPTION
I'm trying out alertmanager in Amazon EC2, and the easiest delivery of notifications I could think of is through Amazon's email sending service. It requires auth, though, so I threw this change together.