### PR TITLE
Separate out SMTP auth logic and test it.

### DIFF
--- a/manager/notifier_test.go
+++ b/manager/notifier_test.go
@@ -15,6 +15,9 @@ package manager
 
 import (
 	"bytes"
+	"crypto/tls"
+	"fmt"
+	"os"
 	"testing"
 )
 
@@ -54,5 +57,111 @@ Payload labels:
 
 	if buf.String() != expected {
 		t.Fatalf("Expected:\n%s\n\nGot:\n%s", expected, buf.String())
+	}
+}
+
+type authTestCase struct {
+	hasAuth     bool
+	mechs       string
+	expAuthType string
+}
+
+func (tc *authTestCase) test(t *testing.T) {
+	auth, cfg, err := getSMTPAuth(tc.hasAuth, tc.mechs)
+	if err != nil {
+		tc.fail(t, "unexpected error: %s", err)
+		return
+	}
+	if tc.expAuthType == "" {
+		if auth != nil {
+			tc.fail(t, "expected auth to be nil, got %T", auth)
+		}
+		if cfg != nil {
+			tc.fail(t, "expected tls config to be nil, got %v", cfg)
+		}
+	} else {
+		if fmt.Sprintf("%T", auth) != tc.expAuthType {
+			tc.fail(t, "expected auth to be %s, got %T", tc.expAuthType, auth)
+		}
+		if tc.expAuthType == "*smtp.plainAuth" {
+			if cfg == nil {
+				tc.fail(t, "expected tls config")
+			} else if cfg.ServerName != "testSMTPHost" {
+				tc.fail(t, "expected tls config to be %v, got %v",
+					&tls.Config{ServerName: "testSMTPHost"}, cfg)
+			}
+		}
+	}
+}
+
+func (tc *authTestCase) fail(t *testing.T, format string, args ...interface{}) {
+	t.Errorf("{auth test: %#v}: %s", tc, fmt.Sprintf(format, args...))
+}
+
+func runAuthTests(t *testing.T, tcs []authTestCase) {
+	for _, tc := range tcs {
+		tc.test(t)
+	}
+}
+
+func TestGetSMTPAuth(t *testing.T) {
+	// Save and clear environment.
+	vars := []string{"SMTP_AUTH_USERNAME", "SMTP_AUTH_PASSWORD", "SMTP_AUTH_SECRET", "SMTP_AUTH_IDENTITY"}
+	saved := map[string]string{}
+	for _, k := range vars {
+		saved[k] = os.Getenv(k)
+		os.Setenv(k, "")
+	}
+
+	// Set up deferred restoration of environment.
+	defer func() {
+		for k, v := range saved {
+			os.Setenv(k, v)
+		}
+	}()
+
+	// Auth never occurs without environment variables set.
+	runAuthTests(t, []authTestCase{
+		{false, "", ""},
+		{false, "PLAIN", ""},
+		{false, "CRAM-MD5", ""},
+	})
+
+	// Simple single-mechanism cases.
+	*smtpSmartHost = "testSMTPHost:port"
+	os.Setenv("SMTP_AUTH_USERNAME", "u")
+	os.Setenv("SMTP_AUTH_PASSWORD", "p") // for PLAIN
+	os.Setenv("SMTP_AUTH_SECRET", "s")   // for CRAM-MD5
+	runAuthTests(t, []authTestCase{
+		{true, "", ""},
+		{true, "CRAM-MD5", "*smtp.cramMD5Auth"},
+		{true, "PLAIN", "*smtp.plainAuth"},
+
+		// If all mechanisms are valid, return the first one that qualifies.
+		{true, "CRAM-MD5 PLAIN", "*smtp.cramMD5Auth"},
+		{true, "PLAIN CRAM-MD5", "*smtp.plainAuth"},
+	})
+
+	// Skip CRAM-MD5.
+	os.Setenv("SMTP_AUTH_SECRET", "")
+	runAuthTests(t, []authTestCase{
+		{true, "CRAM-MD5 PLAIN", "*smtp.plainAuth"},
+	})
+
+	// Skip PLAIN.
+	os.Setenv("SMTP_AUTH_PASSWORD", "")
+	os.Setenv("SMTP_AUTH_SECRET", "s")
+	runAuthTests(t, []authTestCase{
+		{true, "PLAIN CRAM-MD5", "*smtp.cramMD5Auth"},
+	})
+
+	// Error should be returned if we try to use PLAIN auth with an invalid -smtpSmartHost.
+	*smtpSmartHost = "testSMTPHost"
+	runAuthTests(t, []authTestCase{
+		{true, "PLAIN", ""},
+	})
+	os.Setenv("SMTP_AUTH_PASSWORD", "p")
+	if auth, cfg, err := getSMTPAuth(true, "PLAIN"); err == nil {
+		t.Errorf("PLAIN auth with bad host-port: expected error but got %T, %v", auth, cfg)
 	}
 }


### PR DESCRIPTION
This code feels a lot cleaner in its own function, which now has 100% test coverage.