### PR TITLE
Add date header to please strict mail servers

### DIFF
--- a/manager/notifier.go
+++ b/manager/notifier.go
@@ -41,6 +41,7 @@ const contentTypeJson = "application/json"
 
 var bodyTmpl = template.Must(template.New("message").Parse(`From: Prometheus Alertmanager <{{.From}}>
 To: {{.To}}
+Date: {{.Date}}
 Subject: [ALERT] {{.Alert.Labels.alertname}}: {{.Alert.Summary}}
 
 {{.Alert.Description}}
@@ -205,13 +206,19 @@ func (n *notifier) sendHipChatNotification(authToken string, roomId int32, color
 }
 
 func writeEmailBody(w io.Writer, from string, to string, a *Alert) error {
+	return writeEmailBodyWithTime(w, from, to, a, time.Now())
+}
+
+func writeEmailBodyWithTime(w io.Writer, from string, to string, a *Alert, moment time.Time) error {
 	err := bodyTmpl.Execute(w, struct {
 		From  string
 		To    string
+		Date  string
 		Alert *Alert
 	}{
 		From:  from,
 		To:    to,
+		Date:  moment.Format("Mon, 2 Jan 2006 15:04:05 -0700"),
 		Alert: a,
 	})
 	if err != nil {

--- a/manager/notifier_test.go
+++ b/manager/notifier_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 )
 
 func TestWriteEmailBody(t *testing.T) {
@@ -36,10 +37,13 @@ func TestWriteEmailBody(t *testing.T) {
 		},
 	}
 	buf := &bytes.Buffer{}
-	writeEmailBody(buf, "from@prometheus.io", "to@prometheus.io", event)
+	location, _ := time.LoadLocation("Europe/Amsterdam")
+	moment := time.Date(1918, 11, 11, 11, 0, 3, 0, location)
+	writeEmailBodyWithTime(buf, "from@prometheus.io", "to@prometheus.io", event, moment)
 
 	expected := `From: Prometheus Alertmanager <from@prometheus.io>
 To: to@prometheus.io
+Date: Mon, 11 Nov 1918 11:00:03 +0019
 Subject: [ALERT] TestAlert: Testsummary
 
 Test alert description, something went wrong here.


### PR DESCRIPTION
Computer said no:

    Missing required header field: "Date"
    Delivery of the email was stopped!   

