### PR TITLE
Path prefix to support reverse proxies

### DIFF
--- a/web/alerts.go
+++ b/web/alerts.go
@@ -27,6 +27,7 @@ type AlertStatus struct {
 type AlertsHandler struct {
 	Manager                manager.AlertManager
 	IsSilencedInterrogator manager.IsSilencedInterrogator
+	PathPrefix             string
 }
 
 func (h *AlertsHandler) silenceForAlert(a *manager.Alert) *manager.Silence {
@@ -39,5 +40,5 @@ func (h *AlertsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		AlertAggregates: h.Manager.GetAll(nil),
 		SilenceForAlert: h.silenceForAlert,
 	}
-	executeTemplate(w, "alerts", alertStatus)
+	executeTemplate(w, "alerts", alertStatus, h.PathPrefix)
 }

--- a/web/api/api.go
+++ b/web/api/api.go
@@ -27,17 +27,17 @@ import (
 type AlertManagerService struct {
 	Manager  manager.AlertManager
 	Silencer *manager.Silencer
+	PathPrefix string
 }
 
 func (s AlertManagerService) Handler() http.Handler {
 	r := httprouter.New()
-
-	r.POST("/api/alerts", s.addAlerts)
-	r.GET("/api/silences", s.silenceSummary)
-	r.POST("/api/silences", s.addSilence)
-	r.GET("/api/silences/:id", s.getSilence)
-	r.POST("/api/silences/:id", s.updateSilence)
-	r.DELETE("/api/silences/:id", s.deleteSilence)
+	r.POST(s.PathPrefix + "api/alerts", s.addAlerts)
+	r.GET(s.PathPrefix + "api/silences", s.silenceSummary)
+	r.POST(s.PathPrefix + "api/silences", s.addSilence)
+	r.GET(s.PathPrefix + "api/silences/:id", s.getSilence)
+	r.POST(s.PathPrefix + "api/silences/:id", s.updateSilence)
+	r.DELETE(s.PathPrefix + "api/silences/:id", s.deleteSilence)
 
 	return r
 }

--- a/web/silences.go
+++ b/web/silences.go
@@ -25,11 +25,12 @@ type SilenceStatus struct {
 
 type SilencesHandler struct {
 	Silencer *manager.Silencer
+	PathPrefix string
 }
 
 func (h *SilencesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	silenceStatus := &SilenceStatus{
 		Silences: h.Silencer.SilenceSummary(),
 	}
-	executeTemplate(w, "silences", silenceStatus)
+	executeTemplate(w, "silences", silenceStatus, h.PathPrefix)
 }

--- a/web/status.go
+++ b/web/status.go
@@ -22,10 +22,11 @@ import (
 type StatusHandler struct {
 	mu sync.Mutex
 
-	BuildInfo map[string]string
-	Config    string
-	Flags     map[string]string
-	Birth     time.Time
+	BuildInfo  map[string]string
+	Config     string
+	Flags      map[string]string
+	Birth      time.Time
+	PathPrefix string
 }
 
 func (h *StatusHandler) UpdateConfig(c string) {
@@ -39,5 +40,5 @@ func (h *StatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	executeTemplate(w, "status", h)
+	executeTemplate(w, "status", h, h.PathPrefix)
 }

--- a/web/templates/_base.html
+++ b/web/templates/_base.html
@@ -7,13 +7,13 @@
 
     <script src="//ajax.googleapis.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
 
-    <link href="/static/vendor/bootstrap/css/bootstrap.min.css" media="all" rel="stylesheet" type="text/css" />
-    <script src="/static/vendor/bootstrap/js/bootstrap.min.js" type="text/javascript"></script>
+    <link href="{{ pathPrefix }}static/vendor/bootstrap/css/bootstrap.min.css" media="all" rel="stylesheet" type="text/css" />
+    <script src="{{ pathPrefix }}static/vendor/bootstrap/js/bootstrap.min.js" type="text/javascript"></script>
 
-    <link href="/static/vendor/tarruda_bootstrap_datetimepicker/css/bootstrap-datetimepicker.min.css" media="all" rel="stylesheet" type="text/css" />
-    <script src="/static/vendor/tarruda_bootstrap_datetimepicker/js/bootstrap-datetimepicker.min.js" type="text/javascript"></script>
+    <link href="{{ pathPrefix }}static/vendor/tarruda_bootstrap_datetimepicker/css/bootstrap-datetimepicker.min.css" media="all" rel="stylesheet" type="text/css" />
+    <script src="{{ pathPrefix }}static/vendor/tarruda_bootstrap_datetimepicker/js/bootstrap-datetimepicker.min.js" type="text/javascript"></script>
 
-    <link href="/static/css/default.css" media="all" rel="stylesheet" type="text/css" />
+    <link href="{{ pathPrefix }}static/css/default.css" media="all" rel="stylesheet" type="text/css" />
 
     {{template "head" .}}
   </head>
@@ -26,9 +26,9 @@
           {{define "alertsTabClass"}}{{end}}
           {{define "silencesTabClass"}}{{end}}
           {{define "statusTabClass"}}{{end}}
-          <li class="{{template "alertsTabClass"}}"><a href="/alerts">Alerts</a></li>
-          <li class="{{template "silencesTabClass"}}"><a href="/silences">Silences</a></li>
-          <li class="{{template "statusTabClass"}}"><a href="/status">Status</a></li>
+          <li class="{{template "alertsTabClass"}}"><a href="{{ pathPrefix }}alerts">Alerts</a></li>
+          <li class="{{template "silencesTabClass"}}"><a href="{{ pathPrefix }}silences">Silences</a></li>
+          <li class="{{template "statusTabClass"}}"><a href="{{ pathPrefix }}status">Status</a></li>
         </ul>
       </div>
     </div>

--- a/web/templates/alerts.html
+++ b/web/templates/alerts.html
@@ -1,7 +1,7 @@
 {{define "alertsTabClass"}}active{{end}}
 
 {{define "head"}}
-    <script src="/static/js/alerts.js"></script>
+    <script src="{{ pathPrefix }}static/js/alerts.js"></script>
 {{end}}
 
 {{define "content"}}

--- a/web/templates/silences.html
+++ b/web/templates/silences.html
@@ -1,7 +1,7 @@
 {{define "silencesTabClass"}}active{{end}}
 
 {{define "head"}}
-    <script src="/static/js/alerts.js"></script>
+    <script src="{{ pathPrefix }}static/js/alerts.js"></script>
 {{end}}
 
 {{define "content"}}


### PR DESCRIPTION
Same as https://github.com/prometheus/prometheus/pull/614 and https://github.com/prometheus/promdash/pull/369

Using this code my AlertManager receives alerts from my Prometheus (after changing the API URL in Prometheus) and nothing in the interface is obviously broken.

One thing to note: there was a peculiar check inside `web/web.go`:

```python
		// The "/" pattern matches everything, so we need to check
		// that we're at the root here.
		if req.URL.Path != "/" {
			http.NotFound(rw, req)
			return
		}
```

Prometheus doesn't have something like this, and after moving the root handler to the bottom of that functions thing seem to work okay without it.