### PR TITLE
Add simple support for Slack notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.build
 .deps/
 alertmanager
 *-stamp

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ following aspects:
 * handling notification repeats
 * sending alert notifications via external services (currently email,
 [PagerDuty](http://www.pagerduty.com/),
-[HipChat](http://www.hipchat.com/), or
+[HipChat](http://www.hipchat.com/),
+[Slack](http://www.slack.com/), or
 [Pushover](https://www.pushover.net/))
 
 See [config/fixtures/sample.conf.input](config/fixtures/sample.conf.input) for

--- a/config/config.go
+++ b/config/config.go
@@ -72,6 +72,11 @@ func (c Config) Validate() error {
 				return fmt.Errorf("Missing room in HipChat config: %s", proto.MarshalTextString(hcc))
 			}
 		}
+		for _, sc := range nc.SlackConfig {
+			if sc.WebhookUrl == nil {
+				return fmt.Errorf("Missing webhook URL in Slack config: %s", proto.MarshalTextString(sc))
+			}
+		}
 
 		if _, ok := ncNames[nc.GetName()]; ok {
 			return fmt.Errorf("Notification config name not unique: %s", nc.GetName())

--- a/config/config.proto
+++ b/config/config.proto
@@ -56,6 +56,20 @@ message HipChatConfig {
   optional bool send_resolved = 6 [default = false];
 }
 
+// Configuration for notification via Slack.
+message SlackConfig {
+  // Slack webhook url, (https://api.slack.com/incoming-webhooks).
+  optional string webhook_url = 1;
+  // Slack channel override, (like #other-channel or @username).
+  optional string channel = 2;
+  // Color of message when triggered.
+  optional string color = 3 [default = "warning"];
+  // Color of message when resolved.
+  optional string color_resolved = 4 [default = "good"];
+  // Notify when resolved.
+  optional bool send_resolved = 5 [default = false];
+}
+
 // Notification configuration definition.
 message NotificationConfig {
   // Name of this NotificationConfig. Referenced from AggregationRule.
@@ -68,6 +82,8 @@ message NotificationConfig {
   repeated PushoverConfig pushover_config = 4;
   // Zero or more hipchat notification configurations.
   repeated HipChatConfig hipchat_config = 5;
+  // Zero or more slack notification configurations.
+  repeated SlackConfig slack_config = 6;
 }
 
 // A regex-based label filter used in aggregations.

--- a/config/fixtures/sample.conf.input
+++ b/config/fixtures/sample.conf.input
@@ -15,6 +15,10 @@ notification_config {
     room_id: 123456
     send_resolved: true
   }
+  slack_config {
+    webhook_url: "webhookurl"
+    send_resolved: true
+  }
 }
 
 aggregation_rule {

--- a/config/generated/config.pb.go
+++ b/config/generated/config.pb.go
@@ -13,6 +13,7 @@ It has these top-level messages:
 	EmailConfig
 	PushoverConfig
 	HipChatConfig
+	SlackConfig
 	NotificationConfig
 	Filter
 	AggregationRule
@@ -182,6 +183,64 @@ func (m *HipChatConfig) GetSendResolved() bool {
 	return Default_HipChatConfig_SendResolved
 }
 
+// Configuration for notification via Slack.
+type SlackConfig struct {
+	// Slack webhook url, (https://api.slack.com/incoming-webhooks).
+	WebhookUrl *string `protobuf:"bytes,1,opt,name=webhook_url" json:"webhook_url,omitempty"`
+	// Slack channel override, (like #other-channel or @username).
+	Channel *string `protobuf:"bytes,2,opt,name=channel" json:"channel,omitempty"`
+	// Color of message when triggered.
+	Color *string `protobuf:"bytes,3,opt,name=color,def=warning" json:"color,omitempty"`
+	// Color of message when resolved.
+	ColorResolved *string `protobuf:"bytes,4,opt,name=color_resolved,def=good" json:"color_resolved,omitempty"`
+	// Notify when resolved.
+	SendResolved     *bool  `protobuf:"varint,5,opt,name=send_resolved,def=0" json:"send_resolved,omitempty"`
+	XXX_unrecognized []byte `json:"-"`
+}
+
+func (m *SlackConfig) Reset()         { *m = SlackConfig{} }
+func (m *SlackConfig) String() string { return proto.CompactTextString(m) }
+func (*SlackConfig) ProtoMessage()    {}
+
+const Default_SlackConfig_Color string = "warning"
+const Default_SlackConfig_ColorResolved string = "good"
+const Default_SlackConfig_SendResolved bool = false
+
+func (m *SlackConfig) GetWebhookUrl() string {
+	if m != nil && m.WebhookUrl != nil {
+		return *m.WebhookUrl
+	}
+	return ""
+}
+
+func (m *SlackConfig) GetChannel() string {
+	if m != nil && m.Channel != nil {
+		return *m.Channel
+	}
+	return ""
+}
+
+func (m *SlackConfig) GetColor() string {
+	if m != nil && m.Color != nil {
+		return *m.Color
+	}
+	return Default_SlackConfig_Color
+}
+
+func (m *SlackConfig) GetColorResolved() string {
+	if m != nil && m.ColorResolved != nil {
+		return *m.ColorResolved
+	}
+	return Default_SlackConfig_ColorResolved
+}
+
+func (m *SlackConfig) GetSendResolved() bool {
+	if m != nil && m.SendResolved != nil {
+		return *m.SendResolved
+	}
+	return Default_SlackConfig_SendResolved
+}
+
 // Notification configuration definition.
 type NotificationConfig struct {
 	// Name of this NotificationConfig. Referenced from AggregationRule.
@@ -193,8 +252,10 @@ type NotificationConfig struct {
 	// Zero or more pushover notification configurations.
 	PushoverConfig []*PushoverConfig `protobuf:"bytes,4,rep,name=pushover_config" json:"pushover_config,omitempty"`
 	// Zero or more hipchat notification configurations.
-	HipchatConfig    []*HipChatConfig `protobuf:"bytes,5,rep,name=hipchat_config" json:"hipchat_config,omitempty"`
-	XXX_unrecognized []byte           `json:"-"`
+	HipchatConfig []*HipChatConfig `protobuf:"bytes,5,rep,name=hipchat_config" json:"hipchat_config,omitempty"`
+	// Zero or more slack notification configurations.
+	SlackConfig      []*SlackConfig `protobuf:"bytes,6,rep,name=slack_config" json:"slack_config,omitempty"`
+	XXX_unrecognized []byte         `json:"-"`
 }
 
 func (m *NotificationConfig) Reset()         { *m = NotificationConfig{} }
@@ -232,6 +293,13 @@ func (m *NotificationConfig) GetPushoverConfig() []*PushoverConfig {
 func (m *NotificationConfig) GetHipchatConfig() []*HipChatConfig {
 	if m != nil {
 		return m.HipchatConfig
+	}
+	return nil
+}
+
+func (m *NotificationConfig) GetSlackConfig() []*SlackConfig {
+	if m != nil {
+		return m.SlackConfig
 	}
 	return nil
 }


### PR DESCRIPTION
Like the HipChat one, here a simple implementation for Slack notifications.

![alertmanager_slack_notifcations](https://cloud.githubusercontent.com/assets/1931038/7554027/3e71e95a-f715-11e4-80b1-52e48fc8f4b2.png)

@juliusv 