### PR TITLE
Flowdock notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ following aspects:
 * sending alert notifications via external services (currently email,
 [PagerDuty](http://www.pagerduty.com/),
 [HipChat](http://www.hipchat.com/),
-[Slack](http://www.slack.com/), or
-[Pushover](https://www.pushover.net/))
+[Slack](http://www.slack.com/),
+[Pushover](https://www.pushover.net/)), or
+[Flowdock](https://www.flowdock.com/))
 
 See [config/fixtures/sample.conf.input](config/fixtures/sample.conf.input) for
 an example config. The full configuration schema including a documentation for

--- a/config/config.go
+++ b/config/config.go
@@ -77,6 +77,14 @@ func (c Config) Validate() error {
 				return fmt.Errorf("Missing webhook URL in Slack config: %s", proto.MarshalTextString(sc))
 			}
 		}
+		for _, fc := range nc.FlowdockConfig {
+			if fc.ApiToken == nil {
+				return fmt.Errorf("Missing API token in Flowdock config: %s", proto.MarshalTextString(fc))
+			}
+			if fc.FromAddress == nil {
+				return fmt.Errorf("Missing from_address Flowdock config: %s", proto.MarshalTextString(fc))
+			}
+		}
 
 		if _, ok := ncNames[nc.GetName()]; ok {
 			return fmt.Errorf("Notification config name not unique: %s", nc.GetName())

--- a/config/config.proto
+++ b/config/config.proto
@@ -71,11 +71,11 @@ message SlackConfig {
 }
 
 message FlowdockConfig {
-  // Flowdock flow API token
+  // Flowdock flow API token.
   optional string api_token = 1;
-  // Flowdock from_address
+  // Flowdock from_address.
   optional string from_address = 2;
-  // Flowdock flow tags
+  // Flowdock flow tags.
   repeated string tag = 3;
   // Notify when resolved.
   optional bool send_resolved = 4 [default = false];

--- a/config/config.proto
+++ b/config/config.proto
@@ -70,6 +70,17 @@ message SlackConfig {
   optional bool send_resolved = 5 [default = false];
 }
 
+message FlowdockConfig {
+  // Flowdock flow API token
+  optional string api_token = 2;
+  // Flowdock from_address
+  optional string from_address = 3;
+  // Flowdock flow tags
+  repeated string tags = 4;
+  // Color of message when triggered.
+  optional bool send_resolved = 7 [default = false];
+}
+
 // Notification configuration definition.
 message NotificationConfig {
   // Name of this NotificationConfig. Referenced from AggregationRule.
@@ -84,6 +95,8 @@ message NotificationConfig {
   repeated HipChatConfig hipchat_config = 5;
   // Zero or more slack notification configurations.
   repeated SlackConfig slack_config = 6;
+  // Zero or more Flowdock notification configurations.
+  repeated FlowdockConfig flowdock_config = 7;
 }
 
 // A regex-based label filter used in aggregations.

--- a/config/config.proto
+++ b/config/config.proto
@@ -72,13 +72,13 @@ message SlackConfig {
 
 message FlowdockConfig {
   // Flowdock flow API token
-  optional string api_token = 2;
+  optional string api_token = 1;
   // Flowdock from_address
-  optional string from_address = 3;
+  optional string from_address = 2;
   // Flowdock flow tags
-  repeated string tags = 4;
-  // Color of message when triggered.
-  optional bool send_resolved = 7 [default = false];
+  repeated string tag = 3;
+  // Notify when resolved.
+  optional bool send_resolved = 4 [default = false];
 }
 
 // Notification configuration definition.

--- a/config/fixtures/sample.conf.input
+++ b/config/fixtures/sample.conf.input
@@ -19,6 +19,10 @@ notification_config {
     webhook_url: "webhookurl"
     send_resolved: true
   }
+  flowdock_config {
+    api_token: "4c7234902348234902384234234cdb59"
+    from_address: "aliaswithgravatar@somehwere.com"
+  }
 }
 
 aggregation_rule {

--- a/config/fixtures/sample.conf.input
+++ b/config/fixtures/sample.conf.input
@@ -22,6 +22,7 @@ notification_config {
   flowdock_config {
     api_token: "4c7234902348234902384234234cdb59"
     from_address: "aliaswithgravatar@somehwere.com"
+    tag: "monitoring"
   }
 }
 

--- a/config/generated/config.pb.go
+++ b/config/generated/config.pb.go
@@ -14,6 +14,7 @@ It has these top-level messages:
 	PushoverConfig
 	HipChatConfig
 	SlackConfig
+	FlowdockConfig
 	NotificationConfig
 	Filter
 	AggregationRule
@@ -241,6 +242,52 @@ func (m *SlackConfig) GetSendResolved() bool {
 	return Default_SlackConfig_SendResolved
 }
 
+type FlowdockConfig struct {
+	// Flowdock flow API token
+	ApiToken *string `protobuf:"bytes,2,opt,name=api_token" json:"api_token,omitempty"`
+	// Flowdock from_address
+	FromAddress *string `protobuf:"bytes,3,opt,name=from_address" json:"from_address,omitempty"`
+	// Flowdock flow tags
+	Tags []string `protobuf:"bytes,4,rep,name=tags" json:"tags,omitempty"`
+	// Color of message when triggered.
+	SendResolved     *bool  `protobuf:"varint,7,opt,name=send_resolved,def=0" json:"send_resolved,omitempty"`
+	XXX_unrecognized []byte `json:"-"`
+}
+
+func (m *FlowdockConfig) Reset()         { *m = FlowdockConfig{} }
+func (m *FlowdockConfig) String() string { return proto.CompactTextString(m) }
+func (*FlowdockConfig) ProtoMessage()    {}
+
+const Default_FlowdockConfig_SendResolved bool = false
+
+func (m *FlowdockConfig) GetApiToken() string {
+	if m != nil && m.ApiToken != nil {
+		return *m.ApiToken
+	}
+	return ""
+}
+
+func (m *FlowdockConfig) GetFromAddress() string {
+	if m != nil && m.FromAddress != nil {
+		return *m.FromAddress
+	}
+	return ""
+}
+
+func (m *FlowdockConfig) GetTags() []string {
+	if m != nil {
+		return m.Tags
+	}
+	return nil
+}
+
+func (m *FlowdockConfig) GetSendResolved() bool {
+	if m != nil && m.SendResolved != nil {
+		return *m.SendResolved
+	}
+	return Default_FlowdockConfig_SendResolved
+}
+
 // Notification configuration definition.
 type NotificationConfig struct {
 	// Name of this NotificationConfig. Referenced from AggregationRule.
@@ -254,8 +301,10 @@ type NotificationConfig struct {
 	// Zero or more hipchat notification configurations.
 	HipchatConfig []*HipChatConfig `protobuf:"bytes,5,rep,name=hipchat_config" json:"hipchat_config,omitempty"`
 	// Zero or more slack notification configurations.
-	SlackConfig      []*SlackConfig `protobuf:"bytes,6,rep,name=slack_config" json:"slack_config,omitempty"`
-	XXX_unrecognized []byte         `json:"-"`
+	SlackConfig []*SlackConfig `protobuf:"bytes,6,rep,name=slack_config" json:"slack_config,omitempty"`
+	// Zero or more Flowdock notification configurations.
+	FlowdockConfig   []*FlowdockConfig `protobuf:"bytes,7,rep,name=flowdock_config" json:"flowdock_config,omitempty"`
+	XXX_unrecognized []byte            `json:"-"`
 }
 
 func (m *NotificationConfig) Reset()         { *m = NotificationConfig{} }
@@ -300,6 +349,13 @@ func (m *NotificationConfig) GetHipchatConfig() []*HipChatConfig {
 func (m *NotificationConfig) GetSlackConfig() []*SlackConfig {
 	if m != nil {
 		return m.SlackConfig
+	}
+	return nil
+}
+
+func (m *NotificationConfig) GetFlowdockConfig() []*FlowdockConfig {
+	if m != nil {
+		return m.FlowdockConfig
 	}
 	return nil
 }

--- a/config/generated/config.pb.go
+++ b/config/generated/config.pb.go
@@ -244,13 +244,13 @@ func (m *SlackConfig) GetSendResolved() bool {
 
 type FlowdockConfig struct {
 	// Flowdock flow API token
-	ApiToken *string `protobuf:"bytes,2,opt,name=api_token" json:"api_token,omitempty"`
+	ApiToken *string `protobuf:"bytes,1,opt,name=api_token" json:"api_token,omitempty"`
 	// Flowdock from_address
-	FromAddress *string `protobuf:"bytes,3,opt,name=from_address" json:"from_address,omitempty"`
+	FromAddress *string `protobuf:"bytes,2,opt,name=from_address" json:"from_address,omitempty"`
 	// Flowdock flow tags
-	Tags []string `protobuf:"bytes,4,rep,name=tags" json:"tags,omitempty"`
-	// Color of message when triggered.
-	SendResolved     *bool  `protobuf:"varint,7,opt,name=send_resolved,def=0" json:"send_resolved,omitempty"`
+	Tag []string `protobuf:"bytes,3,rep,name=tag" json:"tag,omitempty"`
+	// Notify when resolved.
+	SendResolved     *bool  `protobuf:"varint,4,opt,name=send_resolved,def=0" json:"send_resolved,omitempty"`
 	XXX_unrecognized []byte `json:"-"`
 }
 
@@ -274,9 +274,9 @@ func (m *FlowdockConfig) GetFromAddress() string {
 	return ""
 }
 
-func (m *FlowdockConfig) GetTags() []string {
+func (m *FlowdockConfig) GetTag() []string {
 	if m != nil {
-		return m.Tags
+		return m.Tag
 	}
 	return nil
 }

--- a/config/generated/config.pb.go
+++ b/config/generated/config.pb.go
@@ -243,11 +243,11 @@ func (m *SlackConfig) GetSendResolved() bool {
 }
 
 type FlowdockConfig struct {
-	// Flowdock flow API token
+	// Flowdock flow API token.
 	ApiToken *string `protobuf:"bytes,1,opt,name=api_token" json:"api_token,omitempty"`
-	// Flowdock from_address
+	// Flowdock from_address.
 	FromAddress *string `protobuf:"bytes,2,opt,name=from_address" json:"from_address,omitempty"`
-	// Flowdock flow tags
+	// Flowdock flow tags.
 	Tag []string `protobuf:"bytes,3,rep,name=tag" json:"tag,omitempty"`
 	// Notify when resolved.
 	SendResolved     *bool  `protobuf:"varint,4,opt,name=send_resolved,def=0" json:"send_resolved,omitempty"`

--- a/manager/notifier.go
+++ b/manager/notifier.go
@@ -508,13 +508,17 @@ func (n *notifier) sendPushoverNotification(token string, op notificationOp, use
 }
 
 func processResponse(r *http.Response, targetName string, a *Alert) {
-	defer r.Body.Close()
-
-	respBuf, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		glog.Errorln("Error reading HTTP response:", err)
+	spec := fmt.Sprintf("%s notification for alert %v", targetName, a.Fingerprint())
+	if r == nil {
+		glog.Errorln("No HTTP response for", spec)
+	} else {
+		defer r.Body.Close()
+		respBuf, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			glog.Errorln("Error reading HTTP response for", spec, err)
+		}
+		glog.Infof("Sent %s. Response: HTTP %d: %s", spec, r.StatusCode, respBuf)
 	}
-	glog.Infof("Sent %s notification for alert %v. Response: HTTP %d: %s", targetName, a.Fingerprint(), r.StatusCode, respBuf)
 }
 
 func (n *notifier) handleNotification(a *Alert, op notificationOp, config *pb.NotificationConfig) {


### PR DESCRIPTION
Hi, I wrote a Flowdock notifier.

I did it a bit different way than the HipChat and Slack notifiers, I didn't want to duplicate code in e.g. serializing to JSON, and posting to HTTP URL.

There is quite a lot of duplicated code in manager/notifier.go. I was thinking I could rewite it in similar manner in another pull-request. Would you be interested in that?

I didn't write any tests, it wasn't straightforward to mock the config and the alert. Maybe it would be easier after the refactoring I suggest.