### PR TITLE
Added support for @mentions in HipChat notifications

### DIFF
--- a/config/config.proto
+++ b/config/config.proto
@@ -54,6 +54,14 @@ message HipChatConfig {
   optional bool notify = 4 [default = false];
   // Notify when resolved.
   optional bool send_resolved = 6 [default = false];
+  // Prefix to be put in front of the message (useful for @mentions, etc.).
+  optional string prefix = 7 [default = ""];
+  // Format the message as "html" or "text".
+  enum MessageFormat {
+    HTML = 0;
+    TEXT = 1;
+  }
+  optional MessageFormat message_format = 8 [default = HTML];
 }
 
 // Configuration for notification via Slack.

--- a/config/generated/config.pb.go
+++ b/config/generated/config.pb.go
@@ -30,6 +30,40 @@ import math "math"
 var _ = proto.Marshal
 var _ = math.Inf
 
+// Format the message as "html" or "text".
+type HipChatConfig_MessageFormat int32
+
+const (
+	HipChatConfig_HTML HipChatConfig_MessageFormat = 0
+	HipChatConfig_TEXT HipChatConfig_MessageFormat = 1
+)
+
+var HipChatConfig_MessageFormat_name = map[int32]string{
+	0: "HTML",
+	1: "TEXT",
+}
+var HipChatConfig_MessageFormat_value = map[string]int32{
+	"HTML": 0,
+	"TEXT": 1,
+}
+
+func (x HipChatConfig_MessageFormat) Enum() *HipChatConfig_MessageFormat {
+	p := new(HipChatConfig_MessageFormat)
+	*p = x
+	return p
+}
+func (x HipChatConfig_MessageFormat) String() string {
+	return proto.EnumName(HipChatConfig_MessageFormat_name, int32(x))
+}
+func (x *HipChatConfig_MessageFormat) UnmarshalJSON(data []byte) error {
+	value, err := proto.UnmarshalJSONEnum(HipChatConfig_MessageFormat_value, data, "HipChatConfig_MessageFormat")
+	if err != nil {
+		return err
+	}
+	*x = HipChatConfig_MessageFormat(value)
+	return nil
+}
+
 // Configuration for notification via PagerDuty.
 type PagerDutyConfig struct {
 	// PagerDuty service key, see:
@@ -129,8 +163,11 @@ type HipChatConfig struct {
 	// Should this message notify or not.
 	Notify *bool `protobuf:"varint,4,opt,name=notify,def=0" json:"notify,omitempty"`
 	// Notify when resolved.
-	SendResolved     *bool  `protobuf:"varint,6,opt,name=send_resolved,def=0" json:"send_resolved,omitempty"`
-	XXX_unrecognized []byte `json:"-"`
+	SendResolved *bool `protobuf:"varint,6,opt,name=send_resolved,def=0" json:"send_resolved,omitempty"`
+	// Prefix to be put in front of the message (useful for @mentions, etc.).
+	Prefix           *string                      `protobuf:"bytes,7,opt,name=prefix,def=" json:"prefix,omitempty"`
+	MessageFormat    *HipChatConfig_MessageFormat `protobuf:"varint,8,opt,name=message_format,enum=io.prometheus.alertmanager.HipChatConfig_MessageFormat,def=0" json:"message_format,omitempty"`
+	XXX_unrecognized []byte                       `json:"-"`
 }
 
 func (m *HipChatConfig) Reset()         { *m = HipChatConfig{} }
@@ -141,6 +178,7 @@ const Default_HipChatConfig_Color string = "purple"
 const Default_HipChatConfig_ColorResolved string = "green"
 const Default_HipChatConfig_Notify bool = false
 const Default_HipChatConfig_SendResolved bool = false
+const Default_HipChatConfig_MessageFormat HipChatConfig_MessageFormat = HipChatConfig_HTML
 
 func (m *HipChatConfig) GetAuthToken() string {
 	if m != nil && m.AuthToken != nil {
@@ -182,6 +220,20 @@ func (m *HipChatConfig) GetSendResolved() bool {
 		return *m.SendResolved
 	}
 	return Default_HipChatConfig_SendResolved
+}
+
+func (m *HipChatConfig) GetPrefix() string {
+	if m != nil && m.Prefix != nil {
+		return *m.Prefix
+	}
+	return ""
+}
+
+func (m *HipChatConfig) GetMessageFormat() HipChatConfig_MessageFormat {
+	if m != nil && m.MessageFormat != nil {
+		return *m.MessageFormat
+	}
+	return Default_HipChatConfig_MessageFormat
 }
 
 // Configuration for notification via Slack.
@@ -554,4 +606,5 @@ func (m *AlertManagerConfig) GetInhibitRule() []*InhibitRule {
 }
 
 func init() {
+	proto.RegisterEnum("io.prometheus.alertmanager.HipChatConfig_MessageFormat", HipChatConfig_MessageFormat_name, HipChatConfig_MessageFormat_value)
 }


### PR DESCRIPTION
Hi! So I was planning to pester my fellow co-workers with HipChat notifications, whenever Prometheus fires alerts. In order to do so, I needed a way to add `@all` or `@somename` to the message body. (I know there is a notify flag, but that didn't seem to work as well and doesn't allow to target specific people or groups like `all` or `here`.) 

The alertmanager sends HipChat notifications in HTML format. This opens the door for nicely formatted messages, but also has the consequence, that @mentions don't work. (For some strange reason, that only Atlassian knows...)

Here is an excerpt from the `message_format` section of the HipChat documentation:

> * html - Message is rendered as HTML and receives no special treatment. Must be valid HTML and entities must be escaped (e.g.: '&amp;' instead of '&'). May contain basic tags: a, b, i, strong, em, br, img, pre, code, lists, tables.
> * text - Message is treated just like a message sent by a user. Can include @mentions, emoticons, pastes, and auto-detected URLs (Twitter, YouTube, images, etc).

In order to make it possible to use mentions, I added two new properties to the configuration: `message_format` (which can be `text` or `html`) and `prefix`, which is a free-form text that's simply prepended to the message.

In order to keep it backward-compatible `html` remains the default and both new properties are optional. However, if present, the `prefix` will also be applied to the HTML message.

I'd love to see this change make its way into master. If you have any concerns or know a better way to achieve the same result, please let me know! Also, since I'm new to Go and Protobuf please let me know, if there is anything I should change about the code.

Best regards,
Daniel