### PR TITLE
add status to pushover title

### DIFF
--- a/manager/notifier.go
+++ b/manager/notifier.go
@@ -444,10 +444,19 @@ func (n *notifier) sendPushoverNotification(token string, op notificationOp, use
 		return err
 	}
 
+	status := "unknown"
+	switch op {
+	case notificationOpTrigger:
+		status = "firing"
+	case notificationOpResolve:
+		status = "resolved"
+	}
+	alertname := html.EscapeString(a.Labels["alertname"])
+
 	// Send pushover message
 	_, _, err = po.Push(&pushover.Message{
-		Title:   a.Summary,
-		Message: a.Description,
+		Title:   fmt.Sprintf("%s: %s", alertname, status),
+		Message: a.Summary,
 	})
 	return err
 }


### PR DESCRIPTION
assume that the summary is the message, and that the alertname is a very short concise name for the alert