### PR TITLE
Update fsnotify to its new source location

### DIFF
--- a/config/watcher.go
+++ b/config/watcher.go
@@ -14,8 +14,8 @@
 package config
 
 import (
-	"github.com/howeyc/fsnotify"
 	"github.com/prometheus/log"
+	"gopkg.in/fsnotify.v0"
 )
 
 type ReloadCallback func(*Config)


### PR DESCRIPTION
Probably ought to update to v1.x of fsnotify at some point as well.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/prometheus/alertmanager/69)
<!-- Reviewable:end -->
