### PR TITLE
Add a generic webhook notifier.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ following aspects:
 * aggregating alerts by labelset
 * handling notification repeats
 * sending alert notifications via external services (currently email,
+generic web hook,
 [PagerDuty](http://www.pagerduty.com/),
 [HipChat](http://www.hipchat.com/),
 [Slack](http://www.slack.com/),

--- a/config/config.proto
+++ b/config/config.proto
@@ -58,7 +58,7 @@ message HipChatConfig {
 
 // Configuration for notification via Slack.
 message SlackConfig {
-  // Slack webhook url, (https://api.slack.com/incoming-webhooks).
+  // Slack webhook URL, (https://api.slack.com/incoming-webhooks).
   optional string webhook_url = 1;
   // Slack channel override, (like #other-channel or @username).
   optional string channel = 2;
@@ -70,6 +70,7 @@ message SlackConfig {
   optional bool send_resolved = 5 [default = false];
 }
 
+// Configuration for notification via Flowdock.
 message FlowdockConfig {
   // Flowdock flow API token.
   optional string api_token = 1;
@@ -79,6 +80,14 @@ message FlowdockConfig {
   repeated string tag = 3;
   // Notify when resolved.
   optional bool send_resolved = 4 [default = false];
+}
+
+// Configuration for notification via generic webhook.
+message WebhookConfig {
+  // URL to send POST request to.
+  optional string url = 1;
+  // Notify when resolved.
+  optional bool send_resolved = 2 [default = false];
 }
 
 // Notification configuration definition.
@@ -97,6 +106,8 @@ message NotificationConfig {
   repeated SlackConfig slack_config = 6;
   // Zero or more Flowdock notification configurations.
   repeated FlowdockConfig flowdock_config = 7;
+  // Zero or more generic web hook notification configurations.
+  repeated WebhookConfig webhook_config = 8;
 }
 
 // A regex-based label filter used in aggregations.

--- a/config/generated/config.pb.go
+++ b/config/generated/config.pb.go
@@ -15,6 +15,7 @@ It has these top-level messages:
 	HipChatConfig
 	SlackConfig
 	FlowdockConfig
+	WebhookConfig
 	NotificationConfig
 	Filter
 	AggregationRule
@@ -186,7 +187,7 @@ func (m *HipChatConfig) GetSendResolved() bool {
 
 // Configuration for notification via Slack.
 type SlackConfig struct {
-	// Slack webhook url, (https://api.slack.com/incoming-webhooks).
+	// Slack webhook URL, (https://api.slack.com/incoming-webhooks).
 	WebhookUrl *string `protobuf:"bytes,1,opt,name=webhook_url" json:"webhook_url,omitempty"`
 	// Slack channel override, (like #other-channel or @username).
 	Channel *string `protobuf:"bytes,2,opt,name=channel" json:"channel,omitempty"`
@@ -242,6 +243,7 @@ func (m *SlackConfig) GetSendResolved() bool {
 	return Default_SlackConfig_SendResolved
 }
 
+// Configuration for notification via Flowdock.
 type FlowdockConfig struct {
 	// Flowdock flow API token.
 	ApiToken *string `protobuf:"bytes,1,opt,name=api_token" json:"api_token,omitempty"`
@@ -288,6 +290,35 @@ func (m *FlowdockConfig) GetSendResolved() bool {
 	return Default_FlowdockConfig_SendResolved
 }
 
+// Configuration for notification via generic webhook.
+type WebhookConfig struct {
+	// URL to send POST request to.
+	Url *string `protobuf:"bytes,1,opt,name=url" json:"url,omitempty"`
+	// Notify when resolved.
+	SendResolved     *bool  `protobuf:"varint,2,opt,name=send_resolved,def=0" json:"send_resolved,omitempty"`
+	XXX_unrecognized []byte `json:"-"`
+}
+
+func (m *WebhookConfig) Reset()         { *m = WebhookConfig{} }
+func (m *WebhookConfig) String() string { return proto.CompactTextString(m) }
+func (*WebhookConfig) ProtoMessage()    {}
+
+const Default_WebhookConfig_SendResolved bool = false
+
+func (m *WebhookConfig) GetUrl() string {
+	if m != nil && m.Url != nil {
+		return *m.Url
+	}
+	return ""
+}
+
+func (m *WebhookConfig) GetSendResolved() bool {
+	if m != nil && m.SendResolved != nil {
+		return *m.SendResolved
+	}
+	return Default_WebhookConfig_SendResolved
+}
+
 // Notification configuration definition.
 type NotificationConfig struct {
 	// Name of this NotificationConfig. Referenced from AggregationRule.
@@ -303,8 +334,10 @@ type NotificationConfig struct {
 	// Zero or more slack notification configurations.
 	SlackConfig []*SlackConfig `protobuf:"bytes,6,rep,name=slack_config" json:"slack_config,omitempty"`
 	// Zero or more Flowdock notification configurations.
-	FlowdockConfig   []*FlowdockConfig `protobuf:"bytes,7,rep,name=flowdock_config" json:"flowdock_config,omitempty"`
-	XXX_unrecognized []byte            `json:"-"`
+	FlowdockConfig []*FlowdockConfig `protobuf:"bytes,7,rep,name=flowdock_config" json:"flowdock_config,omitempty"`
+	// Zero or more generic web hook notification configurations.
+	WebhookConfig    []*WebhookConfig `protobuf:"bytes,8,rep,name=webhook_config" json:"webhook_config,omitempty"`
+	XXX_unrecognized []byte           `json:"-"`
 }
 
 func (m *NotificationConfig) Reset()         { *m = NotificationConfig{} }
@@ -356,6 +389,13 @@ func (m *NotificationConfig) GetSlackConfig() []*SlackConfig {
 func (m *NotificationConfig) GetFlowdockConfig() []*FlowdockConfig {
 	if m != nil {
 		return m.FlowdockConfig
+	}
+	return nil
+}
+
+func (m *NotificationConfig) GetWebhookConfig() []*WebhookConfig {
+	if m != nil {
+		return m.WebhookConfig
 	}
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -57,7 +57,7 @@ func main() {
 	}
 	saveSilencesTicker := time.NewTicker(10 * time.Second)
 	go func() {
-		for _ = range saveSilencesTicker.C {
+		for range saveSilencesTicker.C {
 			if err := silencer.SaveToFile(*silencesFile); err != nil {
 				log.Error("Error saving silences to file: ", err)
 			}

--- a/manager/alert.go
+++ b/manager/alert.go
@@ -33,14 +33,14 @@ type Alerts []*Alert
 // Alert models an action triggered by Prometheus.
 type Alert struct {
 	// Short summary of alert.
-	Summary string
+	Summary string `json:"summary"`
 	// Long description of alert.
-	Description string
+	Description string `json:"description"`
 	// Label value pairs for purpose of aggregation, matching, and disposition
 	// dispatching. This must minimally include an "alertname" label.
-	Labels AlertLabelSet
+	Labels AlertLabelSet `json:"labels"`
 	// Extra key/value information which is not used for aggregation.
-	Payload AlertPayload
+	Payload AlertPayload `json:"payload"`
 }
 
 func (a *Alert) Name() string {

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -403,7 +403,7 @@ func (s *memoryAlertManager) runIteration() {
 // Run the memoryAlertManager's main dispatcher loop.
 func (s *memoryAlertManager) Run() {
 	iterationTicker := time.NewTicker(time.Second)
-	for _ = range iterationTicker.C {
+	for range iterationTicker.C {
 		s.checkSanity()
 		s.runIteration()
 	}

--- a/web/api/api.go
+++ b/web/api/api.go
@@ -25,19 +25,19 @@ import (
 )
 
 type AlertManagerService struct {
-	Manager  manager.AlertManager
-	Silencer *manager.Silencer
+	Manager    manager.AlertManager
+	Silencer   *manager.Silencer
 	PathPrefix string
 }
 
 func (s AlertManagerService) Handler() http.Handler {
 	r := httprouter.New()
-	r.POST(s.PathPrefix + "api/alerts", s.addAlerts)
-	r.GET(s.PathPrefix + "api/silences", s.silenceSummary)
-	r.POST(s.PathPrefix + "api/silences", s.addSilence)
-	r.GET(s.PathPrefix + "api/silences/:id", s.getSilence)
-	r.POST(s.PathPrefix + "api/silences/:id", s.updateSilence)
-	r.DELETE(s.PathPrefix + "api/silences/:id", s.deleteSilence)
+	r.POST(s.PathPrefix+"api/alerts", s.addAlerts)
+	r.GET(s.PathPrefix+"api/silences", s.silenceSummary)
+	r.POST(s.PathPrefix+"api/silences", s.addSilence)
+	r.GET(s.PathPrefix+"api/silences/:id", s.getSilence)
+	r.POST(s.PathPrefix+"api/silences/:id", s.updateSilence)
+	r.DELETE(s.PathPrefix+"api/silences/:id", s.deleteSilence)
 
 	return r
 }

--- a/web/silences.go
+++ b/web/silences.go
@@ -24,7 +24,7 @@ type SilenceStatus struct {
 }
 
 type SilencesHandler struct {
-	Silencer *manager.Silencer
+	Silencer   *manager.Silencer
 	PathPrefix string
 }
 


### PR DESCRIPTION
This allows for use cases such as kicking off shell scripts,
logging notifications, or anything else the alertmanager doesn't
directly support.

@juliusv 

Is there a better way to test this? This seems kinda clunky.