### PR TITLE
Fix silences.json permission error with docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,12 @@ ENV PKGPATH $GOPATH/src/github.com/prometheus/alertmanager
 ENV GOROOT  /usr/src/go
 
 ADD . $PKGPATH
-RUN cd $PKGPATH && go get -d && make && rm -rf $PKGPATH/.deps
+RUN cd $PKGPATH \
+    && go get -d \
+    && make \
+    && rm -rf $PKGPATH/.deps \
+    && mkdir /alertmanager \
+    && chown nobody /alertmanager
 
 USER       nobody
 WORKDIR    /alertmanager


### PR DESCRIPTION
This fix the `Error saving silences to file: open silences.json: permission denied` error when using `prom/alertmanager` docker image.

@juliusv @discordianfish 