### PR TITLE
Fix email template body writer being called with parameters in wrong order

### DIFF
--- a/manager/notifier.go
+++ b/manager/notifier.go
@@ -529,7 +529,7 @@ func (n *notifier) sendEmailNotification(to string, op notificationOp, a *Alert)
 	}
 	defer wc.Close()
 
-	return writeEmailBody(wc, *smtpSender, status, to, a)
+	return writeEmailBody(wc, *smtpSender, to, status, a)
 }
 
 func (n *notifier) sendPushoverNotification(token string, op notificationOp, userKey string, a *Alert) error {


### PR DESCRIPTION
The email body writer function had it's parameters in the wrong order, leading to the insertion of the email address of the sender rather then the actual status field.

I can confirm from testing that this pull request fixes the problem.