### PR TITLE
Add a GET api to /api/alerts which pulls JSON formatted AlertAggregates.

### DIFF
--- a/web/api/alert.go
+++ b/web/api/alert.go
@@ -22,6 +22,12 @@ import (
 	"github.com/prometheus/alertmanager/manager"
 )
 
+// Return all currently firing alerts as JSON.
+func (s AlertManagerService) getAlerts(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
+	aggs := s.Manager.GetAll(nil)
+	respondJSON(w, aggs)
+}
+
 func (s AlertManagerService) addAlerts(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 	alerts := manager.Alerts{}
 	if err := parseJSON(w, r, &alerts); err != nil {

--- a/web/api/api.go
+++ b/web/api/api.go
@@ -32,6 +32,7 @@ type AlertManagerService struct {
 
 func (s AlertManagerService) Handler() http.Handler {
 	r := httprouter.New()
+	r.GET(s.PathPrefix+"api/alerts", s.getAlerts)
 	r.POST(s.PathPrefix+"api/alerts", s.addAlerts)
 	r.GET(s.PathPrefix+"api/silences", s.silenceSummary)
 	r.POST(s.PathPrefix+"api/silences", s.addSilence)


### PR DESCRIPTION
This is a tiny change which extends the /api/alerts function to write JSON formatted AlertAggregates when polled with a GET request.

This allows integrating the alertmanager with existing dashboard/notification walls which either want to poll the alerts output or get an initial scan of the current alert state.