### PR TITLE
Add runbook and alertmanager URLs to PD+email notifications.

### DIFF
--- a/manager/alert.go
+++ b/manager/alert.go
@@ -36,6 +36,8 @@ type Alert struct {
 	Summary string `json:"summary"`
 	// Long description of alert.
 	Description string `json:"description"`
+	// Runbook link or reference for the alert.
+	Runbook string `json:"runbook"`
 	// Label value pairs for purpose of aggregation, matching, and disposition
 	// dispatching. This must minimally include an "alertname" label.
 	Labels AlertLabelSet `json:"labels"`

--- a/manager/notifier_test.go
+++ b/manager/notifier_test.go
@@ -33,6 +33,7 @@ func TestWriteEmailBody(t *testing.T) {
 	event := &Alert{
 		Summary:     "Testsummary",
 		Description: "Test alert description, something went wrong here.",
+		Runbook:     "http://runbook/",
 		Labels: AlertLabelSet{
 			"alertname":       "TestAlert",
 			"grouping_label1": "grouping_value1",
@@ -46,7 +47,7 @@ func TestWriteEmailBody(t *testing.T) {
 	buf := &bytes.Buffer{}
 	location, _ := time.LoadLocation("Europe/Amsterdam")
 	moment := time.Date(1918, 11, 11, 11, 0, 3, 0, location)
-	writeEmailBodyWithTime(buf, "from@prometheus.io", "to@prometheus.io", "ALERT", event, moment)
+	writeEmailBodyWithTime(buf, "from@prometheus.io", "to@prometheus.io", "ALERT", event, moment, "http://alertmanager/")
 
 	expected := `From: Prometheus Alertmanager <from@prometheus.io>
 To: to@prometheus.io
@@ -54,6 +55,9 @@ Date: Mon, 11 Nov 1918 11:00:03 +0019
 Subject: [ALERT] TestAlert: Testsummary
 
 Test alert description, something went wrong here.
+
+Alertmanager: http://alertmanager/
+Runbook entry: http://runbook/
 
 Grouping labels:
 

--- a/web/web.go
+++ b/web/web.go
@@ -30,7 +30,6 @@ import (
 
 // Commandline flags.
 var (
-	listenAddress  = flag.String("web.listen-address", ":9093", "Address to listen on for the web interface and API.")
 	useLocalAssets = flag.Bool("web.use-local-assets", false, "Serve assets and templates from local files instead of from the binary.")
 )
 
@@ -41,8 +40,7 @@ type WebService struct {
 	StatusHandler       *StatusHandler
 }
 
-func (w WebService) ServeForever(pathPrefix string) error {
-
+func (w WebService) ServeForever(addr string, pathPrefix string) error {
 	http.Handle(pathPrefix+"favicon.ico", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "", 404)
 	}))
@@ -75,9 +73,9 @@ func (w WebService) ServeForever(pathPrefix string) error {
 	}
 	http.Handle(pathPrefix+"api/", w.AlertManagerService.Handler())
 
-	log.Info("listening on ", *listenAddress)
+	log.Info("listening on ", addr)
 
-	return http.ListenAndServe(*listenAddress, nil)
+	return http.ListenAndServe(addr, nil)
 }
 
 func getLocalTemplate(name string, pathPrefix string) (*template.Template, error) {


### PR DESCRIPTION
I don't have a way to test all the other notification mechanisms, which
is something we should fix in general. For now, only PagerDuty and email
have the new runbook and alertmanager URL information.

Not very happy with the overall cleanliness of this, and the codebase
overall, of course, but since we need this urgently tomorrow, I hope
this is fine for now.