### PR TITLE
New Dockerfile using alpine-golang-make-onbuild base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,10 @@
-FROM       golang:latest
-MAINTAINER Prometheus Team <prometheus-developers@googlegroups.com>
+FROM        sdurrheimer/alpine-golang-make-onbuild
+MAINTAINER  Prometheus Team <prometheus-developers@googlegroups.com>
 
-RUN apt-get -qy update && apt-get -qy install vim-common
-ENV PKGPATH $GOPATH/src/github.com/prometheus/alertmanager
-ENV GOROOT  /usr/src/go
+USER root
+RUN  mkdir /alertmanager \
+     && chown golang:golang /alertmanager
 
-ADD . $PKGPATH
-RUN cd $PKGPATH \
-    && go get -d \
-    && make \
-    && rm -rf $PKGPATH/.deps \
-    && mkdir /alertmanager \
-    && chown nobody /alertmanager
-
-USER       nobody
-WORKDIR    /alertmanager
-ENTRYPOINT [ "/go/src/github.com/prometheus/alertmanager/alertmanager" ]
-EXPOSE     9093
+USER        golang
+WORKDIR     /alertmanager
+EXPOSE      9093

--- a/Makefile.COMMON
+++ b/Makefile.COMMON
@@ -49,19 +49,22 @@ ifeq ($(GOOS),darwin)
 endif
 
 GO_VERSION ?= 1.4.2
-
-ifeq ($(shell type go >/dev/null && go version | sed 's/.*go\([0-9.]*\).*/\1/'), $(GO_VERSION))
-	GOROOT := $(shell go env GOROOT)
-else
-	GOROOT := $(CURDIR)/.build/go$(GO_VERSION)
-endif
-
 GOURL      ?= https://golang.org/dl
 GOPKG      ?= go$(GO_VERSION).$(GOOS)-$(GOARCH)$(RELEASE_SUFFIX).tar.gz
 GOPATH     := $(CURDIR)/.build/gopath
-GOCC       ?= $(GOROOT)/bin/go
-GO         ?= GOROOT=$(GOROOT) GOPATH=$(GOPATH) $(GOCC)
-GOFMT      ?= $(GOROOT)/bin/gofmt
+
+# Check for the correct version of go in the path. If we find it, use it.
+# Otherwise, prepare to build go locally.
+ifeq ($(shell command -v "go" >/dev/null && go version | sed -e 's/^[^0-9.]*\([0-9.]*\).*/\1/'), $(GO_VERSION))
+	GOCC   ?= $(shell command -v "go")
+	GOFMT  ?= $(shell command -v "gofmt")
+	GO     ?= GOPATH=$(GOPATH) $(GOCC)
+else
+	GOROOT ?= $(CURDIR)/.build/go$(GO_VERSION)
+	GOCC   ?= $(GOROOT)/bin/go
+	GOFMT  ?= $(GOROOT)/bin/gofmt
+	GO     ?= GOROOT=$(GOROOT) GOPATH=$(GOPATH) $(GOCC)
+endif
 
 # Never honor GOBIN, should it be set at all.
 unexport GOBIN

--- a/README.md
+++ b/README.md
@@ -75,3 +75,16 @@ are going to be addressed in the future:
   configurable amount of time for A to start firing as well before sending
   notifications for B. This is not yet supported.
 * Alertmanager has not been tested or optimized for high alert loads yet.
+
+## Using Docker
+
+You can deploy the Alertmanager using the [prom/alertmanager](https://registry.hub.docker.com/u/prom/alertmanager/) Docker image.
+
+For example:
+
+```bash
+docker pull prom/alertmanager
+
+docker run -d -p 9093:9093 -v $PWD/alertmanager.conf:/alertmanager.conf \
+        prom/alertmanager -config.file=/alertmanager.conf
+```


### PR DESCRIPTION
The first docker related PR of a long series.

New Dockerfile using the [alpine-golang-make-onbuild](https://github.com/sdurrheimer/alpine-golang-make-onbuild) base image whose goal is to unified the way to dockerize prometheus tools and exporters based on Golang.

The binary is build using make. (Golang is installed via make too, respecting the GO_VERSION).

A testable image is available under my name on Docker hub : [Link](https://registry.hub.docker.com/u/sdurrheimer/alertmanager/)

I have also added some Docker usage instructions in the readme.

As always, the [alpine-golang-make-onbuild](https://github.com/sdurrheimer/alpine-golang-make-onbuild)  image can be also move under Prometheus organization.

@juliusv @discordianfish 