### PR TITLE
Slack notification: add channel

### DIFF
--- a/manager/notifier.go
+++ b/manager/notifier.go
@@ -340,7 +340,7 @@ func (n *notifier) sendSlackNotification(op notificationOp, config *pb.SlackConf
 		return err
 	}
 
-	log.Infof("Sent Slack notification: %v: HTTP %d: %s", incidentKey, resp.StatusCode, respBuf)
+	log.Infof("Sent Slack notification (channel %s): %v: HTTP %d: %s", config.GetChannel(), incidentKey, resp.StatusCode, respBuf)
 	// BUG: Check response for result of operation.
 	return nil
 }


### PR DESCRIPTION
Currently a failure is logged as:
 msg="Sent Slack notification: 17555453829685976206: HTTP 500: Invalid channel specified"

 Add the actual channel in there to aid in debugging.