### PR TITLE
Allow specifying pushover message priority with a label

### DIFF
--- a/manager/notifier.go
+++ b/manager/notifier.go
@@ -708,11 +708,29 @@ func (n *notifier) sendPushoverNotification(token string, op notificationOp, use
 	}
 	alertname := html.EscapeString(a.Labels["alertname"])
 
+	var pushoverPriority int = 2;
+
+	if priority, ok := a.Labels["pushover_priority"]; ok {
+		switch priority {
+			case "lowest":
+				pushoverPriority = -2;
+			case "low":
+				pushoverPriority = -1;
+			case "normal":
+				pushoverPriority = 0;
+			case "high":
+				pushoverPriority = 1;
+			default:
+			case "emergency":
+				pushoverPriority = 2;
+		}
+	}
+
 	// Send pushover message
 	_, _, err = po.Push(&pushover.Message{
 		Title:    fmt.Sprintf("%s: %s", alertname, status),
 		Message:  a.Summary,
-		Priority: pushover.Emergency,
+		Priority: pushoverPriority,
 		Retry:    *pushoverRetryTimeout,
 		Expire:   *pushoverExpireTimeout,
 	})


### PR DESCRIPTION
Basic patch to allow specifying the Pushover message priority by adding a `pushover_priority` label to alerts.

The Pushover application provides [different functionality depending on the priority of the alert](https://pushover.net/api#priority) so allowing the specification of a priority makes the alerting a lot more functional - for instance, I can receive a message with no vibrate/alert tone for a disk that is getting full, but a message which alerts me every minute until I acknowledge it for a down server even while I'm sleeping.

When creating a prometheus alerting rule, you can specify the priority as:

    ALERT DiskSpaceLow
        IF node_filesystem_free / node_filesystem_size < 0.2
        WITH {
                pushover_priority="low"
        }
        SUMMARY "Disk has less than 20% free!"
        DESCRIPTION "Disk has less than 20% free!"

The available priorities are named according to the Pushover documentation listed above:

* `lowest` / -2
* `low` / -1
* `normal` / 0
* `high` / 1
* `emergency` / 2

If no priority is specified, it will default to emergency/2, which was the value previously hardcoded, so this patch should present no issues with backward compatibility.

(This is the first bit of go I've ever written as well as my first github pull request, so apologies if I'm not doing this correctly. I needed this functionality myself and am just hoping it can be useful to someone else as well!)

Thanks!