### PR TITLE
Suggest to use email address as silence creator

### DIFF
--- a/web/templates/_base.html
+++ b/web/templates/_base.html
@@ -60,7 +60,7 @@
           <div class="control-group">
             <label class="control-label" for="silence_created_by">Creator</label>
             <div class="controls">
-              <input type="text" id="silence_created_by" placeholder="Creator" required>
+              <input type="text" id="silence_created_by" placeholder="name@company.com" required>
             </div>
           </div>
           <div class="control-group">


### PR DESCRIPTION
Using email addresses provides a unique identifier with a defined
format. It will reduce the amount of different and ambigious identifiers
used (first, last, full, initials, different case used, etc.) while
still allowing others to use a different format.

I could also imagine making an email address mandatory.

@juliusv @matthiasr