### PR TITLE
Minor fix: Post OpsGenie alert close requests to /v1/json/alert/close endpoint

### DIFF
--- a/manager/notifier.go
+++ b/manager/notifier.go
@@ -623,9 +623,11 @@ func (n *notifier) sendOpsGenieNotification(op notificationOp, config *pb.OpsGen
 		incidentKey = a.Fingerprint()
 		buf         []byte
 		err         error
+		postUrl     string
 	)
 	switch op {
 	case notificationOpTrigger:
+		postUrl = *opsgenieAPIURL
 		msg := &opsGenieMessageCreate{
 			ApiKey:      config.GetApiKey(),
 			Message:     a.Summary,
@@ -652,6 +654,7 @@ func (n *notifier) sendOpsGenieNotification(op notificationOp, config *pb.OpsGen
 			return err
 		}
 	case notificationOpResolve:
+		postUrl = *opsgenieAPIURL + "/close"
 		msg := &opsGenieMessageClose{
 			ApiKey: config.GetApiKey(),
 			Alias:  strconv.FormatUint(uint64(incidentKey), 10),
@@ -668,7 +671,7 @@ func (n *notifier) sendOpsGenieNotification(op notificationOp, config *pb.OpsGen
 		Timeout: timeout,
 	}
 	resp, err := client.Post(
-		*opsgenieAPIURL,
+		postUrl,
 		contentTypeJSON,
 		bytes.NewBuffer(buf),
 	)

--- a/manager/notifier.go
+++ b/manager/notifier.go
@@ -33,10 +33,10 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/prometheus/log"
-	"github.com/thorduri/pushover"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sns"
+	"github.com/prometheus/log"
+	"github.com/thorduri/pushover"
 
 	pb "github.com/prometheus/alertmanager/config/generated"
 )
@@ -472,7 +472,7 @@ func (n *notifier) sendAmazonSnsNotification(op notificationOp, config *pb.Amazo
 	}
 
 	params := &sns.PublishInput{
-		Message: aws.String(fmt.Sprintf("%s -- %s", a.Description, status)),
+		Message:          aws.String(fmt.Sprintf("%s -- %s", a.Description, status)),
 		MessageStructure: aws.String("string"),
 		Subject:          aws.String(fmt.Sprintf("%s -- %s", a.Summary, status)),
 		TopicArn:         aws.String(config.GetTopicArn()),
@@ -602,7 +602,7 @@ func (n *notifier) sendEmailNotification(to string, op notificationOp, a *Alert)
 // opGenieMessageCreate is the request for sending an opsGenie notification. We are not specifying all the
 // fields. The Details field is populated with the labels from the alert.
 type opsGenieMessageCreate struct {
-	ApiKey      string                 `json:"apiKey"`
+	APIKey      string                 `json:"apiKey"`
 	Message     string                 `json:"message"`
 	Description string                 `json:"description"`
 	Alias       string                 `json:"alias"`
@@ -614,7 +614,7 @@ type opsGenieMessageCreate struct {
 
 // opsGenieMessageClose closes an open alert in OpsGenie.
 type opsGenieMessageClose struct {
-	ApiKey string `json:"apiKey"`
+	APIKey string `json:"apiKey"`
 	Alias  string `json:"alias"`
 }
 
@@ -623,13 +623,13 @@ func (n *notifier) sendOpsGenieNotification(op notificationOp, config *pb.OpsGen
 		incidentKey = a.Fingerprint()
 		buf         []byte
 		err         error
-		postUrl     string
+		postURL     string
 	)
 	switch op {
 	case notificationOpTrigger:
-		postUrl = *opsgenieAPIURL
+		postURL = *opsgenieAPIURL
 		msg := &opsGenieMessageCreate{
-			ApiKey:      config.GetApiKey(),
+			APIKey:      config.GetApiKey(),
 			Message:     a.Summary,
 			Description: a.Description,
 			Alias:       strconv.FormatUint(uint64(incidentKey), 10),
@@ -654,9 +654,9 @@ func (n *notifier) sendOpsGenieNotification(op notificationOp, config *pb.OpsGen
 			return err
 		}
 	case notificationOpResolve:
-		postUrl = *opsgenieAPIURL + "/close"
+		postURL = *opsgenieAPIURL + "/close"
 		msg := &opsGenieMessageClose{
-			ApiKey: config.GetApiKey(),
+			APIKey: config.GetApiKey(),
 			Alias:  strconv.FormatUint(uint64(incidentKey), 10),
 		}
 
@@ -671,7 +671,7 @@ func (n *notifier) sendOpsGenieNotification(op notificationOp, config *pb.OpsGen
 		Timeout: timeout,
 	}
 	resp, err := client.Post(
-		postUrl,
+		postURL,
 		contentTypeJSON,
 		bytes.NewBuffer(buf),
 	)

--- a/manager/notifier_test.go
+++ b/manager/notifier_test.go
@@ -311,9 +311,9 @@ func TestSendOpsGenieNotification(t *testing.T) {
 	}))
 	defer ts.Close()
 	opsgenieAPIURL = &ts.URL
-	apikey := "AAAB"
+	apiKey := "AAAB"
 	config := &pb.OpsGenieConfig{
-		ApiKey:       &apikey,
+		ApiKey:       &apiKey,
 		LabelsToTags: []string{"alertname"},
 		Teams:        []string{"prometheus"},
 	}
@@ -339,7 +339,7 @@ func TestSendOpsGenieNotification(t *testing.T) {
 		t.Errorf("error unmarshalling OpsGenie notification: %s", err)
 	}
 	expected := opsGenieMessageCreate{
-		ApiKey:      "AAAB",
+		APIKey:      "AAAB",
 		Message:     "Testsummary",
 		Description: "Test alert description, something went wrong here.",
 		Tags:        []string{"TestAlert"},
@@ -371,9 +371,9 @@ func TestCloseOpsGenieNotification(t *testing.T) {
 	}))
 	defer ts.Close()
 	opsgenieAPIURL = &ts.URL
-	apikey := "AAAB"
+	apiKey := "AAAB"
 	config := &pb.OpsGenieConfig{
-		ApiKey: &apikey,
+		ApiKey: &apiKey,
 	}
 	alert := &Alert{}
 	n := &notifier{}
@@ -388,7 +388,7 @@ func TestCloseOpsGenieNotification(t *testing.T) {
 		t.Errorf("error unmarshalling OpsGenie notification: %s", err)
 	}
 	expected := opsGenieMessageClose{
-		ApiKey: "AAAB",
+		APIKey: "AAAB",
 		Alias:  strconv.FormatUint(uint64(alert.Fingerprint()), 10),
 	}
 

--- a/manager/notifier_test.go
+++ b/manager/notifier_test.go
@@ -359,13 +359,14 @@ func TestSendOpsGenieNotification(t *testing.T) {
 
 func TestCloseOpsGenieNotification(t *testing.T) {
 	var body []byte
-	var url string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var err error
-		url = r.URL.String()
 		body, err = ioutil.ReadAll(r.Body)
 		if err != nil {
 			t.Errorf("error reading webhook notification: %s", err)
+		}
+		if !strings.HasSuffix(r.URL.String(), "/close") {
+			t.Errorf("OpsGenie close notifications must be POSTed to /close endpoint, was posted to %s", r.URL.String())
 		}
 	}))
 	defer ts.Close()
@@ -393,10 +394,6 @@ func TestCloseOpsGenieNotification(t *testing.T) {
 
 	if !reflect.DeepEqual(msg, expected) {
 		t.Errorf("incorrect OpsGenie notification: Expected: %s Actual: %s", expected, msg)
-	}
-
-	if !strings.HasSuffix(url, "/close") {
-		t.Errorf("OpsGenie close notifications must be POSTed to /close endpoint, was posted to %s", url)
 	}
 }
 


### PR DESCRIPTION
Closing OpsGenie alerts requires that the close request is POSTed to an endpoint ending with /close but otherwise identical to the alert creation endpoint. Update notifier.go to reflect this and add a test.

Reference: https://www.opsgenie.com/docs/web-api/alert-api#closeAlertRequest ("Sample Request")