### PR TITLE
slack: add icon_emoji parameter

### DIFF
--- a/config/config.proto
+++ b/config/config.proto
@@ -76,6 +76,10 @@ message SlackConfig {
   optional string color_resolved = 4 [default = "good"];
   // Notify when resolved.
   optional bool send_resolved = 5 [default = false];
+  // IconEmoji when triggered, (like :fire:).
+  optional string icon_emoji = 6;
+  // IconEmoji when resolved, (like :+1:).
+  optional string icon_emoji_resolved = 7;
 }
 
 // Configuration for notification via Flowdock.

--- a/config/generated/config.pb.go
+++ b/config/generated/config.pb.go
@@ -250,8 +250,12 @@ type SlackConfig struct {
 	// Color of message when resolved.
 	ColorResolved *string `protobuf:"bytes,4,opt,name=color_resolved,def=good" json:"color_resolved,omitempty"`
 	// Notify when resolved.
-	SendResolved     *bool  `protobuf:"varint,5,opt,name=send_resolved,def=0" json:"send_resolved,omitempty"`
-	XXX_unrecognized []byte `json:"-"`
+	SendResolved *bool `protobuf:"varint,5,opt,name=send_resolved,def=0" json:"send_resolved,omitempty"`
+	// icon_emoji of message when triggered.
+	IconEmoji *string `protobuf:"bytes,6,opt,name=icon_emoji" json:"icon_emoji,omitempty"`
+	// icon_emoji of message when resolved.
+	IconEmojiResolved *string `protobuf:"bytes,7,opt,name=icon_emoji_resolved" json:"icon_emoji_resolved,omitempty"`
+	XXX_unrecognized  []byte  `json:"-"`
 }
 
 func (m *SlackConfig) Reset()         { *m = SlackConfig{} }
@@ -295,6 +299,20 @@ func (m *SlackConfig) GetSendResolved() bool {
 		return *m.SendResolved
 	}
 	return Default_SlackConfig_SendResolved
+}
+
+func (m *SlackConfig) GetIconEmoji() string {
+	if m != nil && m.IconEmoji != nil {
+		return *m.IconEmoji
+	}
+	return ""
+}
+
+func (m *SlackConfig) GetIconEmojiResolved() string {
+	if m != nil && m.IconEmojiResolved != nil {
+		return *m.IconEmojiResolved
+	}
+	return ""
 }
 
 // Configuration for notification via Flowdock.

--- a/manager/notifier.go
+++ b/manager/notifier.go
@@ -290,6 +290,7 @@ type slackAttachment struct {
 	TitleLink string                 `json:"title_link,omitempty"`
 	Text      string                 `json:"text"`
 	Color     string                 `json:"color,omitempty"`
+	IconEmoji string                 `json:"icon_emoji,omitempty"`
 	MrkdwnIn  []string               `json:"mrkdwn_in,omitempty"`
 	Fields    []slackAttachmentField `json:"fields,omitempty"`
 }
@@ -305,13 +306,16 @@ func (n *notifier) sendSlackNotification(op notificationOp, config *pb.SlackConf
 	// https://api.slack.com/incoming-webhooks
 	incidentKey := a.Fingerprint()
 	color := ""
+	iconEmoji := ""
 	status := ""
 	switch op {
 	case notificationOpTrigger:
 		color = config.GetColor()
+		iconEmoji = config.GetIconEmoji()
 		status = "firing"
 	case notificationOpResolve:
 		color = config.GetColorResolved()
+		iconEmoji = config.GetIconEmojiResolved()
 		status = "resolved"
 	}
 
@@ -328,6 +332,7 @@ func (n *notifier) sendSlackNotification(op notificationOp, config *pb.SlackConf
 		TitleLink: a.Payload["generatorURL"],
 		Text:      html.EscapeString(a.Description),
 		Color:     color,
+		IconEmoji: iconEmoji,
 		MrkdwnIn:  []string{"fallback", "pretext"},
 		Fields: []slackAttachmentField{
 			*statusField,


### PR DESCRIPTION
I was not able to run the tests using a docker container based on `golang:latest`.

I managed to get `make config` to run, but it rewrote large parts of `config/generated/config.pb.go`.
However, I only commited the parts relevant to this PR.

Is there a canonical docker image where all the deps are installed, or installable which I can use to do `make config` and `make test`?