### PR TITLE
Improve default subject template

### DIFF
--- a/notify/impl.go
+++ b/notify/impl.go
@@ -120,11 +120,19 @@ func generateTemplateData(ctx context.Context, as ...*types.Alert) *TemplateData
 		data.Alerts = append(data.Alerts, alert)
 	}
 
+	sortStart := 0
 	for k, v := range groupLabels {
 		data.GroupLabels[string(k)] = string(v)
-		data.GroupLabelnames = append(data.GroupLabelnames, string(k))
+
+		// Always have the alertname label at the first position.
+		if k == model.AlertNameLabel {
+			data.GroupLabelnames = append([]string{string(k)}, data.GroupLabelnames...)
+			sortStart = 1
+		} else {
+			data.GroupLabelnames = append(data.GroupLabelnames, string(k))
+		}
 	}
-	sort.Strings(data.GroupLabelnames)
+	sort.Strings(data.GroupLabelnames[sortStart:])
 
 	if len(alerts) >= 1 {
 		common := alerts[0].Labels.Clone()

--- a/template/default.tmpl
+++ b/template/default.tmpl
@@ -1,4 +1,4 @@
-{{ define "__subject" }}{{$dot := .}}[{{ .Status }}] {{ range $k := .GroupLabelnames }}{{ index $dot.GroupLabels $k }} {{ end }}{{if gt (len .AlertCommonLabels) (len .GroupLabels) }}({{ range $k := .AlertCommonLabelnames }}{{ if eq "" (index $dot.GroupLabels $k) }}{{ index $dot.AlertCommonLabels $k }}{{ end }}){{ end }}{{ end }}{{ end }}
+{{ define "__subject" }}{{$dot := .}}[{{ .Status }}:{{ .Alerts | len }}] {{ range $k := .GroupLabelnames }}{{ index $dot.GroupLabels $k }} {{ end }}{{if gt (len .AlertCommonLabels) (len .GroupLabels) }}({{ range $k := .AlertCommonLabelnames }}{{ if eq "" (index $dot.GroupLabels $k) }}{{ index $dot.AlertCommonLabels $k }}{{ end }}{{ end }}){{ end }}{{ end }}
 
 {{ define "slack.default.fallback" }}
 {{ template "__subject" . }}


### PR DESCRIPTION
This adds the number of alerts in the grouping. Helpful information for few characters.
Currently this is the total number. We might want to provide an easy way to separate resolved and firing alerts in the templating.

Fixes a mis-placed `)`.

Adds label name for everything but "alertname". By default that seems more sensible.

Before:
`[firing] ManyOpenConnections dd bazooka ()))critical)`
After:
` [firing:3] ManyOpenConnections cluster=dd service=bazooka (severity=critical)`

Longer but still fits into a single PagerDuty notification. If being truncated, mostly the additional common labels would be affected, which is okay.

@brian-brazil 

Added so that "alertname" is always at the first position of `data.GroupLabelnames`.