### PR TITLE
manager: Guard agg.Rule against dereferencing when nil.

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -279,7 +279,9 @@ func (s *memoryAlertManager) removeExpiredAggregates() {
 
 		if time.Since(agg.LastRefreshed) > s.minRefreshInterval {
 			delete(s.aggregates, agg.Alert.Fingerprint())
-			s.notifier.QueueNotification(agg.Alert, notificationOpResolve, agg.Rule.NotificationConfigName)
+			if agg.Rule != nil {
+				s.notifier.QueueNotification(agg.Alert, notificationOpResolve, agg.Rule.NotificationConfigName)
+			}
 			s.needsNotificationRefresh = true
 		} else {
 			heap.Push(&s.aggregatesByLastRefreshed, agg)


### PR DESCRIPTION
This bug has been around since at least July, and multiple people have reported it in #82, #122 and #131. I hope that pulling this despite the rewrite is easier than closing yet another duplicate.