### PR TITLE
Remove 'assets' from default target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ ifdef DEBUG
 endif
 
 
-all: assets format build test
+all: format build test
 
 test:
 	@echo ">> running tests"


### PR DESCRIPTION
There are issues with changing timestamps for unmodified files
in go-bindata+git.

@beorn7 