### PR TITLE
Iterate over templating

### DIFF
--- a/notify/notify.go
+++ b/notify/notify.go
@@ -102,6 +102,14 @@ func GroupKey(ctx context.Context) (model.Fingerprint, bool) {
 	return v, ok
 }
 
+func groupLabels(ctx context.Context) model.LabelSet {
+	groupLabels, ok := GroupLabels(ctx)
+	if !ok {
+		log.Error("missing group labels")
+	}
+	return groupLabels
+}
+
 // GroupLabels extracts grouping label set from the context. Iff none exists, the
 // second argument is false.
 func GroupLabels(ctx context.Context) (model.LabelSet, bool) {

--- a/template/default.tmpl
+++ b/template/default.tmpl
@@ -1,19 +1,17 @@
-{{ define "__subject" }}{{$dot := .}}[{{ .Status }}:{{ .Alerts | len }}] {{ range $k := .GroupLabelnames }}{{ index $dot.GroupLabels $k }} {{ end }}{{if gt (len .AlertCommonLabels) (len .GroupLabels) }}({{ range $k := .AlertCommonLabelnames }}{{ if eq "" (index $dot.GroupLabels $k) }}{{ index $dot.AlertCommonLabels $k }}{{ end }} {{ end }}){{ end }}{{ end }}
+{{ define "__alertmanager" }}AlertManager{{ end }}
+{{ define "__alertmanagerURL" }}{{ .ExternalURL }}{{ end }}
+{{ define "__subject" }}{{$dot := .}}[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts | firing | len }}{{ end }}] {{ range $i, $p := .GroupLabels | sortedPairs }}{{ $p.Value }} {{ end }}{{if gt (len .CommonLabels) (len .GroupLabels) }}({{ range $i, $p := .CommonLabels | sortedPairs }}{{ if eq "" (index $dot.GroupLabels $p.Name) }}{{ $p.Value }} {{ end }}{{ end }}){{ end }}{{ end }}
+{{ define "__description" }}TODO{{ end }}
 
-{{ define "slack.default.fallback" }}
-{{ template "__subject" . }}
-{{ end }}
-
+{{ define "slack.default.title" }}{{ template "__subject" . }}{{ end }}
+{{ define "slack.default.fallback" }}{{ template "__subject" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
-
-{{ define "slack.default.title" }}{{ end }}
-
-{{ define "slack.default.titlelink" }}http://localhost:9090{{ end }}
-
+{{ define "slack.default.titlelink" }}{{ template "__alertmanagerURL" }}/something{{ end }}
 {{ define "slack.default.text" }}{{ template "__subject" . }}{{ end }}
 
-
 {{ define "pagerduty.default.description" }}{{ template "__subject" . }}{{ end }}
+{{ define "pagerduty.default.client" }}{{ template "__alertmanager" . }}{{ end }}
+{{ define "pagerduty.default.clientURL" }}{{ template "__alertmanagerURL" . }}{{ end }}
 
 {{ define "email.default.subject" }}{{ template "__subject" . }}{{ end }}
 

--- a/template/template.go
+++ b/template/template.go
@@ -15,9 +15,15 @@ package template
 
 import (
 	"bytes"
+	"sort"
+	"strings"
 
 	tmplhtml "html/template"
 	tmpltext "text/template"
+
+	"github.com/prometheus/common/model"
+
+	"github.com/prometheus/alertmanager/types"
 )
 
 // Template bundles a text and a html template instance.
@@ -35,6 +41,9 @@ func FromGlobs(paths ...string) (*Template, error) {
 	}
 	var err error
 
+	t.text = t.text.Funcs(tmpltext.FuncMap(DefaultFuncs))
+	t.html = t.html.Funcs(tmplhtml.FuncMap(DefaultFuncs))
+
 	for _, tp := range paths {
 		if t.text, err = t.text.ParseGlob(tp); err != nil {
 			return nil, err
@@ -43,7 +52,6 @@ func FromGlobs(paths ...string) (*Template, error) {
 			return nil, err
 		}
 	}
-
 	return t, nil
 }
 
@@ -75,4 +83,138 @@ func (t *Template) ExecuteHTMLString(html string, data interface{}) (string, err
 	var buf bytes.Buffer
 	err = tmpl.Execute(&buf, data)
 	return buf.String(), err
+}
+
+type FuncMap map[string]interface{}
+
+var DefaultFuncs = FuncMap{
+	"toUpper": strings.ToUpper,
+	"toLower": strings.ToLower,
+	"toTitle": strings.ToTitle,
+	// sortedPairs allows for in-order iteration of key/value pairs.
+	"sortedPairs": func(m map[string]string) []Pair {
+		var (
+			pairs     = make([]Pair, 0, len(m))
+			keys      = make([]string, 0, len(m))
+			sortStart = 0
+		)
+		for k := range m {
+			if k == string(model.AlertNameLabel) {
+				keys = append([]string{k}, keys...)
+				sortStart = 1
+			} else {
+				keys = append(keys, k)
+			}
+		}
+		sort.Strings(keys[sortStart:])
+
+		for _, k := range keys {
+			pairs = append(pairs, Pair{k, m[k]})
+		}
+		return pairs
+	},
+	"firing": func(alerts []Alert) []Alert {
+		res := []Alert{}
+		for _, a := range alerts {
+			if a.Status == string(model.AlertFiring) {
+				res = append(res, a)
+			}
+		}
+		return res
+	},
+	"resolved": func(alerts []Alert) []Alert {
+		res := []Alert{}
+		for _, a := range alerts {
+			if a.Status == string(model.AlertResolved) {
+				res = append(res, a)
+			}
+		}
+		return res
+	},
+}
+
+// Pair is a key/value string pair.
+type Pair struct {
+	Name, Value string
+}
+
+// Data is the data passed to notification templates.
+// End-users should not be exposed to Go's type system,
+// as this will confuse them and prevent simple things like
+// simple equality checks to fail. Map everything to float64/string.
+type Data struct {
+	Status string
+	Alerts []Alert
+
+	GroupLabels       map[string]string
+	CommonLabels      map[string]string
+	CommonAnnotations map[string]string
+
+	ExternalURL string
+}
+
+// Alert holds one alert for notification templates.
+type Alert struct {
+	Status      string
+	Labels      map[string]string
+	Annotations map[string]string
+}
+
+func NewData(groupLabels model.LabelSet, as ...*types.Alert) *Data {
+	alerts := types.Alerts(as...)
+
+	data := &Data{
+		Status:            string(alerts.Status()),
+		Alerts:            make([]Alert, 0, len(alerts)),
+		GroupLabels:       map[string]string{},
+		CommonLabels:      map[string]string{},
+		CommonAnnotations: map[string]string{},
+		ExternalURL:       "something",
+	}
+
+	for _, a := range alerts {
+		alert := Alert{
+			Status:      string(a.Status()),
+			Labels:      make(map[string]string, len(a.Labels)),
+			Annotations: make(map[string]string, len(a.Annotations)),
+		}
+		for k, v := range a.Labels {
+			alert.Labels[string(k)] = string(v)
+		}
+		for k, v := range a.Annotations {
+			alert.Annotations[string(k)] = string(v)
+		}
+		data.Alerts = append(data.Alerts, alert)
+	}
+
+	for k, v := range groupLabels {
+		data.GroupLabels[string(k)] = string(v)
+	}
+
+	if len(alerts) >= 1 {
+		var (
+			commonLabels      = alerts[0].Labels.Clone()
+			commonAnnotations = alerts[0].Annotations.Clone()
+		)
+		for _, a := range alerts[1:] {
+			for ln, lv := range commonLabels {
+				if a.Labels[ln] != lv {
+					delete(commonLabels, ln)
+				}
+			}
+			for an, av := range commonAnnotations {
+				if a.Annotations[an] != av {
+					delete(commonAnnotations, an)
+				}
+			}
+		}
+		for k, v := range commonLabels {
+			data.CommonLabels[string(k)] = string(v)
+		}
+		for k, v := range commonAnnotations {
+			data.CommonAnnotations[string(k)] = string(v)
+		}
+	}
+
+	return data
 }


### PR DESCRIPTION
I was about to do some templating and gave it another iteration. Data structures moved into `template/`.
Added some functions I consider necessary. `pairs` being a way for ordered iteration that I think is understandable to everyone and simplifies our data structure and also the usage for simple ordered iteration (no use of `index` function and reference to parent scope).

I want a first round of feedback before continuing with templates themselves.

@brian-brazil @beorn7 