### PR TITLE
Improve PagerDuty templating

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -340,7 +340,7 @@ func (c *Receiver) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return checkOverflow(c.XXX, "receiver config")
 }
 
-// Regexp encapsulates a regexp.Regexp and makes it YAML marshallable.
+// Regexp encapsulates a regexp.Regexp and makes it YAML marshalable.
 type Regexp struct {
 	*regexp.Regexp
 }

--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/prometheus/common/model"
 	"gopkg.in/yaml.v2"
@@ -181,6 +182,8 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // DefaultGlobalConfig provides global default values.
 var DefaultGlobalConfig = GlobalConfig{
+	ResolveTimeout: model.Duration(5 * time.Minute),
+
 	PagerdutyURL:    "https://events.pagerduty.com/generic/2010-04-15/create_event.json",
 	OpsGenieAPIHost: "https://api.opsgenie.com/",
 }
@@ -188,6 +191,10 @@ var DefaultGlobalConfig = GlobalConfig{
 // GlobalConfig defines configuration parameters that are valid globally
 // unless overwritten.
 type GlobalConfig struct {
+	// ResolveTimeout is the time after which an alert is declared resolved
+	// if it has not been updated.
+	ResolveTimeout model.Duration `yaml:"resolve_timeout"`
+
 	SMTPFrom        string `yaml:"smtp_from"`
 	SMTPSmarthost   string `yaml:"smtp_smarthost"`
 	SlackURL        string `yaml:"slack_url"`

--- a/config/notifies.go
+++ b/config/notifies.go
@@ -21,10 +21,11 @@ import (
 var (
 	// DefaultEmailConfig defines default values for Email configurations.
 	DefaultEmailConfig = EmailConfig{
-		HTML: `{{template "email.default.html" .}}`,
+		HTML: `{{ template "email.default.html" . }}`,
 	}
-	// DefaultEmailSubject is a template used if no email subject has been provided.
-	DefaultEmailSubject = `{{template "email.default.subject" .}}`
+
+	// DefaultEmailSubject defines the default Subject header of an Email.
+	DefaultEmailSubject = `{{ template "email.default.subject" . }}`
 
 	// DefaultHipchatConfig defines default values for Hipchat configurations.
 	DefaultHipchatConfig = HipchatConfig{
@@ -34,23 +35,31 @@ var (
 
 	// DefaultPagerdutyConfig defines default values for PagerDuty configurations.
 	DefaultPagerdutyConfig = PagerdutyConfig{
-		Description: `{{template "pagerduty.default.description" .}}`,
-		// TODO: Add a details field with all the alerts.
+		Description: `{{ template "pagerduty.default.description" .}}`,
+		Client:      `{{ template "pagerduty.default.client" . }}`,
+		ClientURL:   `{{ template "pagerduty.default.clientURL" . }}`,
+		Details: map[string]string{
+			"firing":       `{{ template "pagerduty.default.instances" (.Alerts | firing) }}`,
+			"resolved":     `{{ template "pagerduty.default.instances" (.Alerts | resolved) }}`,
+			"num_firing":   `{{ .Alerts | firing | len }}`,
+			"num_resolved": `{{ .Alerts | resolved | len }}`,
+		},
 	}
 
 	// DefaultSlackConfig defines default values for Slack configurations.
 	DefaultSlackConfig = SlackConfig{
 		Color:     `{{ if eq .Status "firing" }}warning{{ else }}good{{ end }}`,
-		Title:     `{{template "slack.default.title" . }}`,
-		TitleLink: `{{template "slack.default.title_link" . }}`,
-		Pretext:   `{{template "slack.default.pretext" . }}`,
-		Text:      `{{template "slack.default.text" . }}`,
-		Fallback:  `{{template "slack.default.fallback" . }}`,
+		Title:     `{{ template "slack.default.title" . }}`,
+		TitleLink: `{{ template "slack.default.title_link" . }}`,
+		Pretext:   `{{ template "slack.default.pretext" . }}`,
+		Text:      `{{ template "slack.default.text" . }}`,
+		Fallback:  `{{ template "slack.default.fallback" . }}`,
 	}
 
 	// DefaultOpsGenieConfig defines default values for OpsGenie configurations.
 	DefaultOpsGenieConfig = OpsGenieConfig{
-		Description: `{{template "opsgenie.default.description" .}}`,
+		Description: `{{ template "opsgenie.default.description" . }}`,
+		Source:      `{{ template "opsgenie.default.source" }}`,
 		// TODO: Add a details field with all the alerts.
 	}
 )
@@ -186,6 +195,8 @@ func (c *HipchatConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 type PagerdutyConfig struct {
 	ServiceKey  string            `yaml:"service_key"`
 	URL         string            `yaml:"url"`
+	Client      string            `yaml:"client"`
+	ClientURL   string            `yaml:"client_url"`
 	Description string            `yaml:"description"`
 	Details     map[string]string `yaml:"details"`
 
@@ -292,6 +303,7 @@ type OpsGenieConfig struct {
 	APIKey      string            `yaml:"api_key"`
 	APIHost     string            `yaml:"api_host"`
 	Description string            `yaml:"description"`
+	Source      string            `yaml:"source"`
 	Details     map[string]string `yaml:"details"`
 
 	// Catches all undefined fields and must be empty after parsing.

--- a/dispatch.go
+++ b/dispatch.go
@@ -15,11 +15,6 @@ import (
 	"github.com/prometheus/alertmanager/types"
 )
 
-// ResolveTimeout is the time after which an alert is declared resolved
-// if it has not been updated.
-// TODO(fabxc): Make it configurable.
-const ResolveTimeout = 5 * time.Minute
-
 // Dispatcher sorts incoming alerts into aggregation groups and
 // assigns the correct notifiers to each.
 type Dispatcher struct {

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"syscall"
 	tmpltext "text/template"
+	"time"
 
 	"github.com/prometheus/common/log"
 	"github.com/prometheus/common/route"
@@ -133,7 +134,7 @@ func main() {
 			return err
 		}
 
-		api.Update(conf.String())
+		api.Update(conf.String(), time.Duration(conf.Global.ResolveTimeout))
 
 		tmpl, err = template.FromGlobs(conf.Templates...)
 		if err != nil {

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -74,6 +74,14 @@ func WithNow(ctx context.Context, t time.Time) context.Context {
 	return context.WithValue(ctx, keyNow, t)
 }
 
+func receiver(ctx context.Context) string {
+	recv, ok := Receiver(ctx)
+	if !ok {
+		log.Error("missing receiver")
+	}
+	return recv
+}
+
 // Receiver extracts a receiver from the context. Iff none exists, the
 // second argument is false.
 func Receiver(ctx context.Context) (string, bool) {

--- a/template/default.tmpl
+++ b/template/default.tmpl
@@ -1,22 +1,36 @@
 {{ define "__alertmanager" }}AlertManager{{ end }}
-{{ define "__alertmanagerURL" }}{{ .ExternalURL }}{{ end }}
-{{ define "__subject" }}{{$dot := .}}[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts | firing | len }}{{ end }}] {{ range $i, $p := .GroupLabels | sortedPairs }}{{ $p.Value }} {{ end }}{{if gt (len .CommonLabels) (len .GroupLabels) }}({{ range $i, $p := .CommonLabels | sortedPairs }}{{ if eq "" (index $dot.GroupLabels $p.Name) }}{{ $p.Value }} {{ end }}{{ end }}){{ end }}{{ end }}
-{{ define "__description" }}TODO{{ end }}
+{{ define "__alertmanagerURL" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}{{ end }}
+
+
+{{ define "__subject" }}{{$dot := .}}[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts | firing | len }}{{ end }}] {{ range .GroupLabels | sortedPairs }}{{ .Value }} {{ end }}{{ if gt (len .CommonLabels) (len .GroupLabels) }}({{ range .CommonLabels | sortedPairs }}{{ if eq "" (index $dot.GroupLabels .Name) }}{{ .Value }} {{ end }}{{ end }}){{ end }}{{ end }}
+{{ define "__description" }}{{ end }}
+
+{{ define "__text_alert_list" }}{{ range . }}Labels: 
+{{ range .Labels | sortedPairs }} - {{ .Name }} = {{ .Value }}
+{{ end }}Annotations: 
+{{ range .Annotations | sortedPairs }} - {{ .Name }} = {{ .Value }}
+{{ end}}
+{{ end }}{{ end }}
+
 
 {{ define "slack.default.title" }}{{ template "__subject" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "__subject" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
-{{ define "slack.default.titlelink" }}{{ template "__alertmanagerURL" }}/something{{ end }}
+{{ define "slack.default.titlelink" }}{{ template "__alertmanagerURL" . }}{{ end }}
 {{ define "slack.default.text" }}{{ template "__subject" . }}{{ end }}
+
 
 {{ define "pagerduty.default.description" }}{{ template "__subject" . }}{{ end }}
 {{ define "pagerduty.default.client" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "pagerduty.default.clientURL" }}{{ template "__alertmanagerURL" . }}{{ end }}
+{{ define "pagerduty.default.instances" }}{{ template "__text_alert_list" . }}{{ end }}
 
-{{ define "email.default.subject" }}{{ template "__subject" . }}{{ end }}
 
 {{ define "opsgenie.default.description" }}{{ template "__subject" . }}{{ end }}
+{{ define "opsgenie.default.source" }}{{ template "__alertmanagerURL" . }}{{ end }}
 
+
+{{ define "email.default.subject" }}{{ template "__subject" . }}{{ end }}
 {{ define "email.default.html" }}
 {{/*
 


### PR DESCRIPTION
WIP on some nits.

@brian-brazil thoughts on that as a default level of information?

This stuff a string list of alerts into a single field. Having full JSON objects might be an option too. But more complicated and not generally supported by clients (e.g. OpsGenie).