### PR TITLE
Use title rather than toTitle.

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -93,7 +93,7 @@ type FuncMap map[string]interface{}
 var DefaultFuncs = FuncMap{
 	"toUpper": strings.ToUpper,
 	"toLower": strings.ToLower,
-	"toTitle": strings.ToTitle,
+	"title":   strings.Title,
 	// sortedPairs allows for in-order iteration of key/value pairs.
 	"sortedPairs": func(m map[string]string) []Pair {
 		var (


### PR DESCRIPTION
It turns out that 'title case' is a thing in unicode,
in the same way upper/lower case is.

What our users will want is the first character of a word
being titlecased, which `title` will do.

@fabxc 

I don't think we should expose `toTitle`, as I'd expect most users are actually looking for `title` and this would just cause confusion.