### PR TITLE
Transfer template functions into types+methods

### DIFF
--- a/template/default.tmpl
+++ b/template/default.tmpl
@@ -1,14 +1,13 @@
 {{ define "__alertmanager" }}AlertManager{{ end }}
 {{ define "__alertmanagerURL" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}{{ end }}
 
-
-{{ define "__subject" }}{{$dot := .}}[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts | firing | len }}{{ end }}] {{ range .GroupLabels | sortedPairs }}{{ .Value }} {{ end }}{{ if gt (len .CommonLabels) (len .GroupLabels) }}({{ range .CommonLabels | sortedPairs }}{{ if eq "" (index $dot.GroupLabels .Name) }}{{ .Value }} {{ end }}{{ end }}){{ end }}{{ end }}
+{{ define "__subject" }}[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .GroupLabels.SortedPairs.Values | join " " }} {{ if gt (len .CommonLabels) (len .GroupLabels) }}({{ with .CommonLabels.Remove .GroupLabels.Names }}{{ .Values | join " " }}{{ end }}){{ end }}{{ end }}
 {{ define "__description" }}{{ end }}
 
 {{ define "__text_alert_list" }}{{ range . }}Labels: 
-{{ range .Labels | sortedPairs }} - {{ .Name }} = {{ .Value }}
+{{ range .Labels.SortedPairs }} - {{ .Name }} = {{ .Value }}
 {{ end }}Annotations: 
-{{ range .Annotations | sortedPairs }} - {{ .Name }} = {{ .Value }}
+{{ range .Annotations.SortedPairs }} - {{ .Name }} = {{ .Value }}
 {{ end}}
 {{ end }}{{ end }}
 


### PR DESCRIPTION
Thinking a bit, having type specific functions might not be the easiest to understand for users. This is another approach using dedicated types (based on strings only).

I expect the case of excluding certain labels etc. to be frequent enough to add a `Without` method and `strings.Join`. For the default subject this simplifies the previous conditional with scoping issues into 

`{{ with .CommonLabels.Without .GroupLabels.Names }}{{ join .Values " " }}{{ end }}`

Also reduces the need for another conditional to remove the trailing space.

@brian-brazil 
