### PR TITLE
Update webhook for new alertmanager.

### DIFF
--- a/notify/impl.go
+++ b/notify/impl.go
@@ -96,8 +96,16 @@ type WebhookMessage struct {
 func (w *Webhook) Notify(ctx context.Context, alerts ...*types.Alert) error {
 	as := types.Alerts(alerts...)
 
+	// If there are no annotations, instantiate so
+	// {} is sent rather than null.
+	for _, a := range as {
+		if a.Annotations == nil {
+			a.Annotations = model.LabelSet{}
+		}
+	}
+
 	msg := &WebhookMessage{
-		Version: "1",
+		Version: "2",
 		Status:  as.Status(),
 		Alerts:  as,
 	}


### PR DESCRIPTION
As we've a new data format the version number needs a bump.
Also make alerts with no annotations easier to handle for
users on the receiving end.

@fabxc 