### PR TITLE
Don't send resolved to Slack by default

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -56,7 +56,7 @@ var (
 	// DefaultSlackConfig defines default values for Slack configurations.
 	DefaultSlackConfig = SlackConfig{
 		NotifierConfig: NotifierConfig{
-			VSendResolved: true,
+			VSendResolved: false,
 		},
 		Color:     `{{ if eq .Status "firing" }}danger{{ else }}good{{ end }}`,
 		Username:  `{{ template "slack.default.username" . }}`,


### PR DESCRIPTION
Slack is a general chat system, it has no notion
of resolved messages. Default it to false to avoid
spamming people as we do with all other such systems.

@fabxc 