### PR TITLE
remove checking auth token in config/notifiers.go

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -228,10 +228,6 @@ func (c *HipchatConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return fmt.Errorf("missing room id in Hipchat config")
 	}
 
-	if c.AuthToken == "" {
-		return fmt.Errorf("missing auth token in Hipchat config")
-	}
-
 	return checkOverflow(c.XXX, "hipchat config")
 }
 


### PR DESCRIPTION
I found a bug, if you configure a global `hipchat_auth_token`, then it doesnt start and print the message `missing auth token in Hipchat config`. So in the global configuration is the handling implemented which overrides the token.