### PR TITLE
Remove template section from example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,6 @@ global:
   smtp_smarthost: 'localhost:25'
   smtp_from: 'alertmanager@example.org'
 
-# The directory from which notification templates are read.
-templates: 
-- 'template/*.tmpl'
-
 # The root route on which each incoming alert enters.
 route:
   # The labels by which incoming alerts are grouped together. For example,


### PR DESCRIPTION
Since our default templates are now compiled into the binary, this is only
relevant to advanced users and will cause trouble when running a derivative
of the example config within the repository directory.

@RichiH @brian-brazil 