### PR TITLE
fix build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ mkdir -p $GOPATH/src/github.com/prometheus
 $ cd $GOPATH/src/github.com/prometheus
 $ git clone https://github.com/prometheus/alertmanager.git
 $ cd alertmanager
-$ make
+$ make build
 $ ./alertmanager -config.file=<your_file>
 ```
 


### PR DESCRIPTION
`make` alone doesn't work to build alertmanager, throws a pile of errors instead here. `make build` works perfectly fine, though.

@fabxc