### PR TITLE
OpsGenie: include missing source option

### DIFF
--- a/notify/impl.go
+++ b/notify/impl.go
@@ -614,6 +614,7 @@ type opsGenieCreateMessage struct {
 	*opsGenieMessage `json:,inline`
 	Message          string            `json:"message"`
 	Details          map[string]string `json:"details"`
+	Source           string            `json:"source"`
 }
 
 type opsGenieCloseMessage struct {
@@ -658,6 +659,7 @@ func (n *OpsGenie) Notify(ctx context.Context, as ...*types.Alert) error {
 			opsGenieMessage: &apiMsg,
 			Message:         tmpl(n.conf.Description),
 			Details:         details,
+			Source:          tmpl(n.conf.Source),
 		}
 	}
 	if err != nil {


### PR DESCRIPTION
OpsGenie receiver has a source option:
```
# A backlink to the sender of the notification.
[ source: <tmpl_string> | default = '{{ template "opsgenie.default.source" . }}' ]
```
Which sets a field in OpsGenie alarm definition. `OpsGenieConfig` struct is correctly populated but the field was missing when creating a new message.