### PR TITLE
Fix disappearing alerts

### DIFF
--- a/api.go
+++ b/api.go
@@ -235,7 +235,7 @@ func (api *API) insertAlerts(w http.ResponseWriter, r *http.Request, alerts ...*
 		// is marked resolved if it is not updated.
 		if alert.EndsAt.IsZero() {
 			alert.Timeout = true
-			alert.EndsAt = alert.StartsAt.Add(api.resolveTimeout)
+			alert.EndsAt = now.Add(api.resolveTimeout)
 
 			numReceivedAlerts.WithLabelValues("firing").Inc()
 		} else {
@@ -256,7 +256,6 @@ func (api *API) insertAlerts(w http.ResponseWriter, r *http.Request, alerts ...*
 		}
 		validAlerts = append(validAlerts, a)
 	}
-
 	if err := api.alerts.Put(validAlerts...); err != nil {
 		respondError(w, apiError{
 			typ: errorInternal,

--- a/types/types.go
+++ b/types/types.go
@@ -183,7 +183,7 @@ func (a *Alert) Merge(o *Alert) *Alert {
 		res.StartsAt = a.StartsAt
 	}
 
-	// An non-timeout resolved timestamp always rules.
+	// A non-timeout resolved timestamp always rules.
 	// The latest explicit resolved timestamp wins.
 	if a.EndsAt.After(o.EndsAt) && !a.Timeout {
 		res.EndsAt = a.EndsAt

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -1,0 +1,63 @@
+// Copyright 2015 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+)
+
+func TestAlertMerge(t *testing.T) {
+	now := time.Now()
+
+	pairs := []struct {
+		A, B, Res *Alert
+	}{
+		{
+			A: &Alert{
+				Alert: model.Alert{
+					StartsAt: now.Add(-time.Minute),
+					EndsAt:   now.Add(2 * time.Minute),
+				},
+				UpdatedAt: now,
+				Timeout:   true,
+			},
+			B: &Alert{
+				Alert: model.Alert{
+					StartsAt: now.Add(-time.Minute),
+					EndsAt:   now.Add(3 * time.Minute),
+				},
+				UpdatedAt: now.Add(time.Minute),
+				Timeout:   true,
+			},
+			Res: &Alert{
+				Alert: model.Alert{
+					StartsAt: now.Add(-time.Minute),
+					EndsAt:   now.Add(3 * time.Minute),
+				},
+				UpdatedAt: now.Add(time.Minute),
+				Timeout:   true,
+			},
+		},
+	}
+
+	for _, p := range pairs {
+		if res := p.A.Merge(p.B); !reflect.DeepEqual(p.Res, res) {
+			t.Errorf("unexpected merged alert %#v", res)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #231 
This only happened with the changed Integration in the upcoming Prometheus version. So with Prometheus clients 0.16.2 and earlier it didn't cause issues.

@juliusv can you verify?