### PR TITLE
Slack: Use the text template processor for the text field

### DIFF
--- a/notify/impl.go
+++ b/notify/impl.go
@@ -481,14 +481,13 @@ func (n *Slack) Notify(ctx context.Context, as ...*types.Alert) error {
 	var (
 		data     = n.tmpl.Data(receiver(ctx), groupLabels(ctx), as...)
 		tmplText = tmplText(n.tmpl, data, &err)
-		tmplHTML = tmplHTML(n.tmpl, data, &err)
 	)
 
 	attachment := &slackAttachment{
 		Title:     tmplText(n.conf.Title),
 		TitleLink: tmplText(n.conf.TitleLink),
 		Pretext:   tmplText(n.conf.Pretext),
-		Text:      tmplHTML(n.conf.Text),
+		Text:      tmplText(n.conf.Text),
 		Fallback:  tmplText(n.conf.Fallback),
 		Color:     tmplText(n.conf.Color),
 		MrkdwnIn:  []string{"fallback", "pretext", "text"},


### PR DESCRIPTION
In #207, I speculated that the golang json encoder was overescaping the values sent to slack, but slack's API handles the escaped json fine. The real culprit is the html template call that is being used for text which is turning `<` into `&lt;`.

Using alertmanager with this patch, I can use the following configuration:
```
receivers:
- name: 'debug-slack'
  slack_configs:
  - api_url: "https://hooks.slack.com/services/crypto/crypto"
    username: "{{ .GroupLabels.instance }}"
    channel: "#prometheus-debug"
    text: "{{ range .Alerts }}*{{ .Annotations.description }}* <{{ .Annotations.generatorURL }}|View in Prometheus>\n{{ end }}"
```

and then running:
```
curl -XPOST http://localhost:9093/api/v1/alerts -d '[{"labels": {
        "alertname": "DMcLain Testing",
        "severity": "warning",
        "instance": "qa-dmclain-flaming-bourbon"
    },
    "annotations": {
        "summary": "High latency is high!",
        "description": "qa-dmclain-flaming-bourbon has 0.02316945256093281 days of disk left on rootfs mounted at /",
        "generatorURL": "http://infra-prometheus-happy-pbr:9090/graph#%5B%7B%22expr%22%3A%22node_filesystem_avail%20%2F%20node_filesystem_size%20%3C%200.5%20and%20node_filesystem_avail%20%2F%20-delta%28node_filesystem_avail%5B1d%5D%29%20%3E%200%20%3C%207%22%2C%22tab%22%3A0%7D%5D"
    }
}]'
```

I got a message like the following in Slack:
<img width="725" alt="slack" src="https://cloud.githubusercontent.com/assets/536102/12899676/67f0d008-ceaa-11e5-929f-81f6b1c67e87.png">

With the "View In Prometheus" linking to the generatorURL as hoped/expected.