### PR TITLE
Add support for overriding the icon_url slack parameter

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -65,6 +65,7 @@ var (
 		Title:     `{{ template "slack.default.title" . }}`,
 		TitleLink: `{{ template "slack.default.titlelink" . }}`,
 		IconEmoji: `{{ template "slack.default.iconemoji" . }}`,
+		IconURL:   `{{ template "slack.default.iconurl" . }}`,
 		Pretext:   `{{ template "slack.default.pretext" . }}`,
 		Text:      `{{ template "slack.default.text" . }}`,
 		Fallback:  `{{ template "slack.default.fallback" . }}`,
@@ -204,6 +205,7 @@ type SlackConfig struct {
 	Text      string `yaml:"text"`
 	Fallback  string `yaml:"fallback"`
 	IconEmoji string `yaml:"icon_emoji"`
+	IconURL   string `yaml:"icon_url"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline"`

--- a/notify/impl.go
+++ b/notify/impl.go
@@ -463,6 +463,7 @@ type slackReq struct {
 	Channel     string            `json:"channel,omitempty"`
 	Username    string            `json:"username,omitempty"`
 	IconEmoji   string            `json:"icon_emoji,omitempty"`
+	IconURL     string            `json:"icon_url,omitempty"`
 	Attachments []slackAttachment `json:"attachments"`
 }
 
@@ -506,6 +507,7 @@ func (n *Slack) Notify(ctx context.Context, as ...*types.Alert) error {
 		Channel:     tmplText(n.conf.Channel),
 		Username:    tmplText(n.conf.Username),
 		IconEmoji:   tmplText(n.conf.IconEmoji),
+		IconURL:     tmplText(n.conf.IconURL),
 		Attachments: []slackAttachment{*attachment},
 	}
 	if err != nil {

--- a/template/default.tmpl
+++ b/template/default.tmpl
@@ -18,6 +18,7 @@
 {{ define "slack.default.pretext" }}{{ end }}
 {{ define "slack.default.titlelink" }}{{ template "__alertmanagerURL" . }}{{ end }}
 {{ define "slack.default.iconemoji" }}{{ end }}
+{{ define "slack.default.iconurl" }}{{ end }}
 {{ define "slack.default.text" }}{{ end }}
 
 


### PR DESCRIPTION
Using alertmanager with this patch, I can templatize the icon_url parameter. For example, if I use the following configuration:
```
route:
  group_by: ['instance', 'alertname']
  receiver: debug-slack
receivers:
- name: 'debug-slack'
  slack_configs:
  - api_url: "https://hooks.slack.com/services/crypto/crypto"
    username: "{{ .GroupLabels.instance }}"
    icon_url: "https://robohash.org/{{ .GroupLabels.instance }}.jpeg?set=set3"
    channel: "#prometheus-debug"
```

and then running:
```
curl -XPOST http://localhost:9093/api/v1/alerts -d '[{"labels": {
        "alertname": "DMcLain Testing",
        "severity": "warning",
        "instance": "qa-dmclain-spicy-bourbon"
    },
    "annotations": {
        "summary": "High latency is high!",
        "description": "qa-dmclain-spicy-bourbon has 0.02316945256093281 days of disk left on rootfs mounted at /",
        "generatorURL": "http://infra-prometheus-happy-pbr:9090/graph#%5B%7B%22expr%22%3A%22node_filesystem_avail%20%2F%20node_filesystem_size%20%3C%200.5%20and%20node_filesystem_avail%20%2F%20-delta%28node_filesystem_avail%5B1d%5D%29%20%3E%200%20%3C%207%22%2C%22tab%22%3A0%7D%5D"
    }
}]'
```

I got a message like the following in Slack:
<img width="599" alt="slack" src="https://cloud.githubusercontent.com/assets/536102/12899877/5cbcb688-ceab-11e5-9982-9b72ca41c751.png">

Where the cute robot head will be a different, but consistent image from the https://robohash.org/ website.