### PR TITLE
Upgrade webhook protocol

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -200,29 +200,30 @@ func (kv KV) Values() []string {
 	return kv.SortedPairs().Values()
 }
 
-// Data is the data passed to notification templates.
-// End-users should not be exposed to Go's type system,
-// as this will confuse them and prevent simple things like
-// simple equality checks to fail. Map everything to float64/string.
+// Data is the data passed to notification templates and webhook pushes.
+//
+// End-users should not be exposed to Go's type system, as this will confuse them and prevent
+// simple things like simple equality checks to fail. Map everything to float64/string.
 type Data struct {
-	Receiver string
-	Status   string
-	Alerts   Alerts
+	Receiver string `json:"receiver"`
+	Status   string `json:"status"`
+	Alerts   Alerts `json:"alerts"`
 
-	GroupLabels       KV
-	CommonLabels      KV
-	CommonAnnotations KV
+	GroupLabels       KV `json:"groupLabels"`
+	CommonLabels      KV `json:"commonLabels"`
+	CommonAnnotations KV `json:"commonAnnotations"`
 
-	ExternalURL string
+	ExternalURL string `json:"externalURL"`
 }
 
 // Alert holds one alert for notification templates.
 type Alert struct {
-	Status       string
-	Labels       KV
-	Annotations  KV
-	WasSilenced  bool
-	WasInhibited bool
+	Status       string `json:"status"`
+	Labels       KV     `json:"labels"`
+	Annotations  KV     `json:"annotations"`
+	WasSilenced  bool   `json:"-"`
+	WasInhibited bool   `json:"-"`
+	GeneratorURL string `json:"generatorURL"`
 }
 
 // Alerts is a list of Alert objects.
@@ -269,6 +270,7 @@ func (t *Template) Data(recv string, groupLabels model.LabelSet, alerts ...*type
 			Annotations:  make(KV, len(a.Annotations)),
 			WasSilenced:  a.WasSilenced,
 			WasInhibited: a.WasInhibited,
+			GeneratorURL: a.GeneratorURL,
 		}
 		for k, v := range a.Labels {
 			alert.Labels[string(k)] = string(v)

--- a/template/template.go
+++ b/template/template.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	tmplhtml "html/template"
 	tmpltext "text/template"
@@ -218,12 +219,12 @@ type Data struct {
 
 // Alert holds one alert for notification templates.
 type Alert struct {
-	Status       string `json:"status"`
-	Labels       KV     `json:"labels"`
-	Annotations  KV     `json:"annotations"`
-	WasSilenced  bool   `json:"-"`
-	WasInhibited bool   `json:"-"`
-	GeneratorURL string `json:"generatorURL"`
+	Status       string    `json:"status"`
+	Labels       KV        `json:"labels"`
+	Annotations  KV        `json:"annotations"`
+	StartsAt     time.Time `json:"startsAt"`
+	EndsAt       time.Time `json:"endsAt"`
+	GeneratorURL string    `json:"generatorURL"`
 }
 
 // Alerts is a list of Alert objects.
@@ -263,13 +264,15 @@ func (t *Template) Data(recv string, groupLabels model.LabelSet, alerts ...*type
 		ExternalURL:       t.ExternalURL.String(),
 	}
 
-	for _, a := range alerts {
+	// The call to types.Alert is necessary to correctly resolve the internal
+	// representation to the user representation.
+	for _, a := range types.Alerts(alerts...) {
 		alert := Alert{
 			Status:       string(a.Status()),
 			Labels:       make(KV, len(a.Labels)),
 			Annotations:  make(KV, len(a.Annotations)),
-			WasSilenced:  a.WasSilenced,
-			WasInhibited: a.WasInhibited,
+			StartsAt:     a.StartsAt,
+			EndsAt:       a.EndsAt,
 			GeneratorURL: a.GeneratorURL,
 		}
 		for k, v := range a.Labels {


### PR DESCRIPTION
We basically want the same info for webhook integrations as for templating.
This will also make maintenance easier since we don't have two separate formats we have to version.

@brian-brazil 