### PR TITLE
Adding support for slack icon_emoji in slack receiver config.

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -62,6 +62,7 @@ var (
 		Username:  `{{ template "slack.default.username" . }}`,
 		Title:     `{{ template "slack.default.title" . }}`,
 		TitleLink: `{{ template "slack.default.titlelink" . }}`,
+		IconEmoji: `{{ template "slack.default.iconemoji" . }}`,
 		Pretext:   `{{ template "slack.default.pretext" . }}`,
 		Text:      `{{ template "slack.default.text" . }}`,
 		Fallback:  `{{ template "slack.default.fallback" . }}`,
@@ -182,6 +183,7 @@ type SlackConfig struct {
 	Pretext   string `yaml:"pretext"`
 	Text      string `yaml:"text"`
 	Fallback  string `yaml:"fallback"`
+	IconEmoji string `yaml:"icon_emoji"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline"`

--- a/notify/impl.go
+++ b/notify/impl.go
@@ -450,6 +450,7 @@ func (*Slack) name() string { return "slack" }
 type slackReq struct {
 	Channel     string            `json:"channel,omitempty"`
 	Username    string            `json:"username,omitempty"`
+	IconEmoji   string            `json:"icon_emoji,omitempty"`
 	Attachments []slackAttachment `json:"attachments"`
 }
 
@@ -492,6 +493,7 @@ func (n *Slack) Notify(ctx context.Context, as ...*types.Alert) error {
 	req := &slackReq{
 		Channel:     tmplText(n.conf.Channel),
 		Username:    tmplText(n.conf.Username),
+		IconEmoji:   tmplText(n.conf.IconEmoji),
 		Attachments: []slackAttachment{*attachment},
 	}
 	if err != nil {

--- a/template/default.tmpl
+++ b/template/default.tmpl
@@ -17,6 +17,7 @@
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
 {{ define "slack.default.titlelink" }}{{ template "__alertmanagerURL" . }}{{ end }}
+{{ define "slack.default.iconemoji" }}{{ end }}
 {{ define "slack.default.text" }}{{ end }}
 
 


### PR DESCRIPTION
As it may be useful to quickly identify notifications in a channel stream, we needed support for "icon_emoji" in the slack receiver configuration.

Configuration look like this :
```
slack_configs:
  - send_resolved: true
    username: 'Prometheus'
    channel: '#monitoring'
    icon_emoji: ':prometheus:'
    api_url: 'https://hooks.slack.com/services/<token>'
```

@fabxc, is this small addition ok for you ? Thanks in advance for your feedback.