### PR TITLE
Make source link in emails more prominent

### DIFF
--- a/template/email.html
+++ b/template/email.html
@@ -325,7 +325,7 @@ a {
           <tr>
             <td class="alert alert-warning">
               {{ .Alerts | len }} alert{{ if gt (len .Alerts) 1 }}s{{ end }} for {{ range .GroupLabels.SortedPairs }}
-                {{ .Name }}={{ .Value }} 
+                {{ .Name }}={{ .Value }}
               {{ end }}
             </td>
           </tr>
@@ -335,6 +335,7 @@ a {
                 <tr>
                   <td class="content-block">
                     <a href='{{ template "__alertmanagerURL" . }}' class="btn-primary">View in {{ template "__alertmanager" . }}</a>
+                    <a href="{{ .GeneratorURL }}" class="btn-primary">Source</a>
                   </td>
                 </tr>
                 {{ if gt (len .Alerts.Firing) 0 }}
@@ -351,7 +352,6 @@ a {
                     {{ range .Labels.SortedPairs }}{{ .Name }} = {{ .Value }}<br />{{ end }}
                     {{ if gt (len .Annotations) 0 }}<strong>Annotations</strong><br />{{ end }}
                     {{ range .Annotations.SortedPairs }}{{ .Name }} = {{ .Value }}<br />{{ end }}
-                    <a href="{{ .GeneratorURL }}">Source</a><br />
                   </td>
                 </tr>
                 {{ end }}


### PR DESCRIPTION
The huge improvement of Prometheus alerting is that it provides me with
a history of the alert expression over time. One of my most common
actions after receiving an alert is to gather more information in the
prometheus graph explorer.

@fabxc 

I don't know how to test this? What do you usually do?