### PR TITLE
Re-implement pushover notifications

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -389,6 +389,7 @@ type Receiver struct {
 	SlackConfigs     []*SlackConfig     `yaml:"slack_configs,omitempty"`
 	WebhookConfigs   []*WebhookConfig   `yaml:"webhook_configs,omitempty"`
 	OpsGenieConfigs  []*OpsGenieConfig  `yaml:"opsgenie_configs,omitempty"`
+	PushoverConfigs  []*PushoverConfig  `yaml:"pushover_configs,omitempty"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline"`

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -16,6 +16,7 @@ package config
 import (
 	"fmt"
 	"strings"
+	"time"
 )
 
 var (
@@ -88,6 +89,19 @@ var (
 		Description: `{{ template "opsgenie.default.description" . }}`,
 		Source:      `{{ template "opsgenie.default.source" . }}`,
 		// TODO: Add a details field with all the alerts.
+	}
+
+	// DefaultPushoverConfig defines default values for Pushover configurations.
+	DefaultPushoverConfig = PushoverConfig{
+		NotifierConfig: NotifierConfig{
+			VSendResolved: true,
+		},
+		Title:    `{{ template "pushover.default.title" . }}`,
+		Message:  `{{ template "pushover.default.message" . }}`,
+		URL:      `{{ template "pushover.default.url" . }}`,
+		Priority: `{{ if eq .Status "firing" }}2{{ else }}0{{ end }}`, // emergency (firing) or normal
+		Retry:    duration(1 * time.Minute),
+		Expire:   duration(1 * time.Hour),
 	}
 )
 
@@ -282,4 +296,50 @@ func (c *OpsGenieConfig) UnmarshalYAML(unmarshal func(interface{}) error) error 
 		return fmt.Errorf("missing API key in OpsGenie config")
 	}
 	return checkOverflow(c.XXX, "opsgenie config")
+}
+
+type duration time.Duration
+
+func (d *duration) UnmarshalText(text []byte) error {
+	parsed, err := time.ParseDuration(string(text))
+	if err == nil {
+		*d = duration(parsed)
+	}
+	return err
+}
+
+func (d duration) MarshalText() ([]byte, error) {
+	return []byte(time.Duration(d).String()), nil
+}
+
+type PushoverConfig struct {
+	NotifierConfig `yaml:",inline"`
+
+	UserKey  Secret   `yaml:"user_key"`
+	Token    Secret   `yaml:"token"`
+	Title    string   `yaml:"title"`
+	Message  string   `yaml:"message"`
+	URL      string   `yaml:"url"`
+	Priority string   `yaml:"priority"`
+	Retry    duration `yaml:"retry"`
+	Expire   duration `yaml:"expire"`
+
+	// Catches all undefined fields and must be empty after parsing.
+	XXX map[string]interface{} `yaml:",inline"`
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (c *PushoverConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	*c = DefaultPushoverConfig
+	type plain PushoverConfig
+	if err := unmarshal((*plain)(c)); err != nil {
+		return err
+	}
+	if c.UserKey == "" {
+		return fmt.Errorf("missing user key in Pushover config")
+	}
+	if c.Token == "" {
+		return fmt.Errorf("missing token in Pushover config")
+	}
+	return checkOverflow(c.XXX, "pushover config")
 }

--- a/template/default.tmpl
+++ b/template/default.tmpl
@@ -162,3 +162,8 @@ SOFTWARE.
 </html>
 
 {{ end }}
+
+{{ define "pushover.default.title" }}{{ template "__subject" . }}{{ end }}
+{{ define "pushover.default.message" }}{{ .CommonAnnotations.SortedPairs.Values | join " " }}
+{{ template "__text_alert_list" .Alerts.Firing }}{{ end }}
+{{ define "pushover.default.url" }}{{ template "__alertmanagerURL" . }}{{ end }}


### PR DESCRIPTION
This feature was dropped during the rewrite, but I use and like
Pushover.

The resulting notification looks like this:
![screenshot_20160226-093434](https://cloud.githubusercontent.com/assets/55506/13347208/886169a4-dc6c-11e5-8c90-7803dc007e96.png)