### PR TITLE
Adjust slack notifier default config to match documentation

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -57,7 +57,7 @@ var (
 	// DefaultSlackConfig defines default values for Slack configurations.
 	DefaultSlackConfig = SlackConfig{
 		NotifierConfig: NotifierConfig{
-			VSendResolved: false,
+			VSendResolved: true,
 		},
 		Color:     `{{ if eq .Status "firing" }}danger{{ else }}good{{ end }}`,
 		Username:  `{{ template "slack.default.username" . }}`,


### PR DESCRIPTION
Docs:
```
Slack receiver <slack_config>

Slack notifications are sent via Slack webhooks.

# Whether or not to notify about resolved alerts.
[ send_resolved: <boolean> | default = true ]
```

Implementation (https://github.com/prometheus/alertmanager/blob/1748a0e304a928a4238375bb142ae4627bdddade/config/notifiers.go#L60):
```
	VSendResolved: false,
```