### PR TITLE
OpsGenie notifier: Add support for tags, teams, and using labels as tags.

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -280,6 +280,8 @@ type OpsGenieConfig struct {
 	Description string            `yaml:"description"`
 	Source      string            `yaml:"source"`
 	Details     map[string]string `yaml:"details"`
+	Teams       string            `yaml:"teams"`
+	Tags        string            `yaml:"tags"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline"`

--- a/notify/impl.go
+++ b/notify/impl.go
@@ -620,6 +620,8 @@ type opsGenieCreateMessage struct {
 	Message string            `json:"message"`
 	Details map[string]string `json:"details"`
 	Source  string            `json:"source"`
+	Teams   string            `json:"teams,omitempty"`
+	Tags    string            `json:"tags,omitempty"`
 }
 
 type opsGenieCloseMessage struct {
@@ -665,6 +667,8 @@ func (n *OpsGenie) Notify(ctx context.Context, as ...*types.Alert) error {
 			Message:         tmpl(n.conf.Description),
 			Details:         details,
 			Source:          tmpl(n.conf.Source),
+			Teams:           tmpl(n.conf.Teams),
+			Tags:            tmpl(n.conf.Tags),
 		}
 	}
 	if err != nil {


### PR DESCRIPTION
@fabxc

This PR exposes some extra settings available in the OpsGenie alert creation API. Teams and LabelsToTags used to be available on a previous version but have since been removed.

OpsGenieConfig now has the following extra settings:
- Teams: Templated comma-separated string of teams  that this alert should be assigned to.
- Tags: Templated comma-separated string of tags that should be set on alert.

(Create Alert Api)[https://www.opsgenie.com/docs/web-api/alert-api#createAlertRequest]