### PR TITLE
default values for OpsGenie Tags and Teams

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -88,6 +88,8 @@ var (
 		},
 		Description: `{{ template "opsgenie.default.description" . }}`,
 		Source:      `{{ template "opsgenie.default.source" . }}`,
+		Teams:       `{{ template "opsgenie.default.teams" . }}`,
+		Tags:        `{{ template "opsgenie.default.tags" . }}`,
 		// TODO: Add a details field with all the alerts.
 	}
 

--- a/template/default.tmpl
+++ b/template/default.tmpl
@@ -33,6 +33,8 @@
 
 {{ define "opsgenie.default.description" }}{{ template "__subject" . }}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanagerURL" . }}{{ end }}
+{{ define "opsgenie.default.tags" }}{{ end }}
+{{ define "opsgenie.default.teams" }}{{ end }}
 
 
 {{ define "email.default.subject" }}{{ template "__subject" . }}{{ end }}


### PR DESCRIPTION
Hi,

New config options for OpsGenie Tags and Teams have no default values which will cause an error if user doesn't have them in the configuration file:

```
time="2016-03-21T16:35:08Z" level=warning msg="Notify attempt 5 failed: templating error: template: : \"\" is an incomplete or empty template; defined templates are: \"__alertmanagerURL\", \"pagerduty.default.client\", \"slack.default.username\", \"pagerduty.default.description\", \"slack.default.fallback\", \"__description\", \"email.default.subject\", $
tmanager\", \"opsgenie.default.description\", \"pagerduty.default.instances\", \"opsgenie.default.source\", \"hipchat.default.from\", \"__text_alert_list\", \"email.default.html\", \"\", \"pagerduty.default.clientURL\", \"slack.default.titlelink\", \"__subject\", \"hipchat.default.message\", \"slack.default.title\", \"slack.default.iconemoji\", \"slack.default.$
ext\", \"slack.default.pretext\"" source="notify.go:193" 
```

It's caused by trying to template an empty string: https://github.com/improbable-io/alertmanager/blob/7d512eba56c7fb32ae3ec37f7bcc442f2badcc18/notify/impl.go#L670

I'm not entirely sure empty values are best defaults.

Cheers,
Luka