### PR TITLE
Limit 'from' length to 64 chars to ensure conformity with the Hipchat API

### DIFF
--- a/notify/impl.go
+++ b/notify/impl.go
@@ -573,8 +573,13 @@ func (n *Hipchat) Notify(ctx context.Context, as ...*types.Alert) error {
 		msg = tmplText(n.conf.Message)
 	}
 
+	from := tmplText(n.conf.From)
+	if len(from) > 64 {
+		from = from[:64]
+	}
+
 	req := &hipchatReq{
-		From:          tmplText(n.conf.From),
+		From:          from,
 		Notify:        n.conf.Notify,
 		Message:       msg,
 		MessageFormat: n.conf.MessageFormat,


### PR DESCRIPTION
@fabxc : 'from' can be longer than 64 chars which results in a bad request to the Hipchat API and a dropped notification. This change is supposed to cap the length of 'from' to ensure that the alertmanager never sends something that is too long and does not comply with the API.

Still very new to go so if there is a way to solve this better I'm happy to look into it. :)