### PR TITLE
Clarify SMTP authentication in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ This is an example configuration that should cover most relevant aspects of the 
 ```yaml
 global:
   # The smarthost and SMTP sender used for mail notifications.
+  # If the host requires authentication, set SMTP_AUTH_USERNAME and SMTP_AUTH_PASSWORD
+  # environment variables.
   smtp_smarthost: 'localhost:25'
   smtp_from: 'alertmanager@example.org'
 

--- a/doc/examples/simple.yml
+++ b/doc/examples/simple.yml
@@ -1,5 +1,7 @@
 global:
   # The smarthost and SMTP sender used for mail notifications.
+  # If the host requires authentication, set SMTP_AUTH_USERNAME and SMTP_AUTH_PASSWORD
+  # environment variables.
   smtp_smarthost: 'localhost:25'
   smtp_from: 'alertmanager@example.org'
   # The auth token for Hipchat.


### PR DESCRIPTION
Wasn't initially clear to me what was needed to authenticate with e.g. Mandrill, Mailgun, etc..

Seems some others likely had [similar issues](https://github.com/prometheus/alertmanager/issues/275)