### PR TITLE
Provide feedback in console about port

### DIFF
--- a/main.go
+++ b/main.go
@@ -186,6 +186,7 @@ func main() {
 	RegisterWeb(router)
 	api.Register(router.WithPrefix("/api"))
 
+	log.Infof("Listening on %s", *listenAddress)
 	go listen(router)
 
 	var (


### PR DESCRIPTION
Other than by consulting the source code or looking at the suggested nginx proxy configuration [the default port isn't really documented anywhere](https://github.com/prometheus/alertmanager/search?utf8=%E2%9C%93&q=9093). As a newbie, when I started the service, I wasn't exactly sure what port it was running on. This could be helpful for some people.