### PR TITLE
Move SMTP auth to the config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,6 @@ This is an example configuration that should cover most relevant aspects of the 
 ```yaml
 global:
   # The smarthost and SMTP sender used for mail notifications.
-  # If the host requires authentication, set SMTP_AUTH_USERNAME and SMTP_AUTH_PASSWORD
-  # environment variables.
   smtp_smarthost: 'localhost:25'
   smtp_from: 'alertmanager@example.org'
 

--- a/config/config.go
+++ b/config/config.go
@@ -26,7 +26,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-var patAuthLine = regexp.MustCompile(`((?:api_key|service_key|api_url|token|user_key):\s+)(".+"|'.+'|[^\s]+)`)
+var patAuthLine = regexp.MustCompile(`((?:api_key|service_key|api_url|token|user_key|password|secret):\s+)(".+"|'.+'|[^\s]+)`)
 
 // Secret is a string that must not be revealed on marshaling.
 type Secret string
@@ -160,6 +160,18 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 				}
 				ec.From = c.Global.SMTPFrom
 			}
+			if ec.AuthUsername == "" {
+				ec.AuthUsername = c.Global.SMTPAuthUsername
+			}
+			if ec.AuthPassword == "" {
+				ec.AuthPassword = c.Global.SMTPAuthPassword
+			}
+			if ec.AuthSecret == "" {
+				ec.AuthSecret = c.Global.SMTPAuthSecret
+			}
+			if ec.AuthIdentity == "" {
+				ec.AuthIdentity = c.Global.SMTPAuthIdentity
+			}
 		}
 		for _, sc := range rcv.SlackConfigs {
 			if sc.APIURL == "" {
@@ -257,6 +269,10 @@ type GlobalConfig struct {
 
 	SMTPFrom         string `yaml:"smtp_from"`
 	SMTPSmarthost    string `yaml:"smtp_smarthost"`
+	SMTPAuthUsername string `yaml:"smtp_auth_username"`
+	SMTPAuthPassword Secret `yaml:"smtp_auth_password"`
+	SMTPAuthSecret   Secret `yaml:"smtp_auth_secret"`
+	SMTPAuthIdentity string `yaml:"smtp_auth_identity"`
 	SlackAPIURL      Secret `yaml:"slack_api_url"`
 	PagerdutyURL     string `yaml:"pagerduty_url"`
 	HipchatURL       string `yaml:"hipchat_url"`

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -120,12 +120,16 @@ type EmailConfig struct {
 	NotifierConfig `yaml:",inline"`
 
 	// Email address to notify.
-	To         string            `yaml:"to"`
-	From       string            `yaml:"from"`
-	Smarthost  string            `yaml:"smarthost,omitempty"`
-	Headers    map[string]string `yaml:"headers"`
-	HTML       string            `yaml:"html"`
-	RequireTLS bool              `yaml:"require_tls"`
+	To           string            `yaml:"to"`
+	From         string            `yaml:"from"`
+	Smarthost    string            `yaml:"smarthost,omitempty"`
+	AuthUsername string            `yaml:"auth_username"`
+	AuthPassword Secret            `yaml:"auth_password"`
+	AuthSecret   Secret            `yaml:"auth_secret"`
+	AuthIdentity string            `yaml:"auth_identity"`
+	Headers      map[string]string `yaml:"headers"`
+	HTML         string            `yaml:"html"`
+	RequireTLS   bool              `yaml:"require_tls"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline"`

--- a/doc/examples/simple.yml
+++ b/doc/examples/simple.yml
@@ -1,9 +1,9 @@
 global:
   # The smarthost and SMTP sender used for mail notifications.
-  # If the host requires authentication, set SMTP_AUTH_USERNAME and SMTP_AUTH_PASSWORD
-  # environment variables.
   smtp_smarthost: 'localhost:25'
   smtp_from: 'alertmanager@example.org'
+  smtp_auth_username: 'alertmanager'
+  smtp_auth_password: 'password'
   # The auth token for Hipchat.
   hipchat_auth_token: '1234556789'
   # Alternative host for Hipchat.

--- a/notify/impl.go
+++ b/notify/impl.go
@@ -26,7 +26,6 @@ import (
 	"net/mail"
 	"net/smtp"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 
@@ -228,23 +227,23 @@ func (*Email) name() string { return "email" }
 
 // auth resolves a string of authentication mechanisms.
 func (n *Email) auth(mechs string) (smtp.Auth, error) {
-	username := os.Getenv("SMTP_AUTH_USERNAME")
+	username := n.conf.AuthUsername
 
 	for _, mech := range strings.Split(mechs, " ") {
 		switch mech {
 		case "CRAM-MD5":
-			secret := os.Getenv("SMTP_AUTH_SECRET")
+			secret := string(n.conf.AuthSecret)
 			if secret == "" {
 				continue
 			}
 			return smtp.CRAMMD5Auth(username, secret), nil
 
 		case "PLAIN":
-			password := os.Getenv("SMTP_AUTH_PASSWORD")
+			password := string(n.conf.AuthPassword)
 			if password == "" {
 				continue
 			}
-			identity := os.Getenv("SMTP_AUTH_IDENTITY")
+			identity := n.conf.AuthIdentity
 
 			// We need to know the hostname for both auth and TLS.
 			host, _, err := net.SplitHostPort(n.conf.Smarthost)


### PR DESCRIPTION
Implements enhancement proposed in #306.

Note: I have left support for environment variables as a fallback since we probably don't want people's alerts to break if they pull down master and don't move their credentials from env variables to the config file.

Documentation additionally updated to reflect the fact that the config file is the preferred place to store creds.