### PR TITLE
Fixing Pushover issue with message length

### DIFF
--- a/notify/impl.go
+++ b/notify/impl.go
@@ -752,8 +752,12 @@ func (n *Pushover) Notify(ctx context.Context, as ...*types.Alert) error {
 	title := tmpl(n.conf.Title)
 	message := tmpl(n.conf.Message)
 	parameters.Add("title", title)
+	if len(title) > 512 {
+		title = title[:512]
+		log.With("incident", key).Debugf("Truncated title to %q due to Pushover message limit", title)
+	}
 	if len(title)+len(message) > 512 {
-		message = message[:512]
+		message = message[:512-len(title)]
 		log.With("incident", key).Debugf("Truncated message to %q due to Pushover message limit", message)
 	}
 	if message == "" {


### PR DESCRIPTION
thanks to @Merovius for helping me with this solution and writing the patch.

@fabxc 

The Problem was, that I got this error when running the alertmanager:

```
alertmanager, version  (branch: , revision: )
  build user:       
  build date:       
  go version:       go1.6
time="2016-04-09T22:11:13+02:00" level=info msg="Loading configuration file" file="/etc/alertmanager/alertmanager.yml" source="main.go:150" 
panic: runtime error: slice bounds out of range

goroutine 135 [running]:
panic(0xa27780, 0xc82000e0b0)
	/usr/lib/go/src/runtime/panic.go:464 +0x3e6
github.com/prometheus/alertmanager/notify.(*Pushover).Notify(0xc8201ab090, 0x7f84c84d7230, 0xc8205ecd50, 0xc82051e4b0, 0x1, 0x1, 0x0, 0x0)
	/home/user/gocode/src/github.com/prometheus/alertmanager/notify/impl.go:756 +0x1dd2
github.com/prometheus/alertmanager/notify.Build.func1.1(0x7f84c84d7230, 0xc8205ecd50, 0xc82051e4b0, 0x1, 0x1, 0x0, 0x0)
	/home/user/gocode/src/github.com/prometheus/alertmanager/notify/impl.go:99 +0x14e
github.com/prometheus/alertmanager/notify.NotifierFunc.Notify(0xc8202360f0, 0x7f84c84d7230, 0xc8205ecd50, 0xc82051e4b0, 0x1, 0x1, 0x0, 0x0)
	/home/user/gocode/src/github.com/prometheus/alertmanager/notify/impl.go:70 +0x5a
github.com/prometheus/alertmanager/notify.(*RetryNotifier).Notify(0xc8201ab110, 0x7f84c84d7230, 0xc8205ecd50, 0xc82051e4b0, 0x1, 0x1, 0x0, 0x0)
	/home/user/gocode/src/github.com/prometheus/alertmanager/notify/notify.go:192 +0x1dd
github.com/prometheus/alertmanager/notify.(*LogNotifier).Notify(0xc8201b32a0, 0x7f84c84d7230, 0xc8205ecd50, 0xc82051e4b0, 0x1, 0x1, 0x0, 0x0)
	/home/user/gocode/src/github.com/prometheus/alertmanager/notify/notify.go:403 +0x1bf
github.com/prometheus/alertmanager/notify.(*DedupingNotifier).Notify(0xc8201b32c0, 0x7f84c84d7230, 0xc8205ecd50, 0xc82051e4b0, 0x1, 0x1, 0x0, 0x0)
	/home/user/gocode/src/github.com/prometheus/alertmanager/notify/notify.go:290 +0x6b2
github.com/prometheus/alertmanager/notify.(*LogNotifier).Notify(0xc8201b32e0, 0x7f84c84d7230, 0xc8205ecd50, 0xc82051e4b0, 0x1, 0x1, 0x0, 0x0)
	/home/user/gocode/src/github.com/prometheus/alertmanager/notify/notify.go:403 +0x1bf
github.com/prometheus/alertmanager/notify.Fanout.Notify.func1(0x7f84c84d7230, 0xc8205ecd50, 0xc82051e4b0, 0x1, 0x1, 0xc8206586e0, 0xc8205e3e60, 0x7f84c8451148, 0xc8201b32e0)
	/home/user/gocode/src/github.com/prometheus/alertmanager/notify/notify.go:150 +0x82
created by github.com/prometheus/alertmanager/notify.Fanout.Notify
	/home/user/gocode/src/github.com/prometheus/alertmanager/notify/notify.go:155 +0x603
```
