### PR TITLE
[WIP] check availability of templates when loading the config

### DIFF
--- a/main.go
+++ b/main.go
@@ -169,6 +169,36 @@ func main() {
 		}
 		tmpl.ExternalURL = amURL
 
+
+
+		for _, recv := range conf.Receivers {
+			for _, ec := range recv.EmailConfigs {
+				if ec.HTML != config.DefaultEmailConfig.HTML {
+					if err := tmpl.CheckTemplateExistence("html", ec.HTML); err != nil {
+						return err
+					}
+				}
+			}
+//			for pc := range recv.PagerdutyConfigs {
+//
+//			}
+//			for hc := range recv.HipchatConfigs {
+//
+//			}
+//			for sc := range recv.SlackConfigs {
+//
+//			}
+//			for wc := range recv.WebhookConfigs {
+//
+//			}
+//			for ogc := range recv.OpsGenieConfigs {
+//
+//			}
+//			for pc := range recv.PushoverConfigs {
+//
+//			}
+		}
+
 		disp.Stop()
 
 		inhibitor = NewInhibitor(alerts, conf.InhibitRules, marker)

--- a/template/template.go
+++ b/template/template.go
@@ -15,6 +15,7 @@ package template
 
 import (
 	"bytes"
+	"fmt"
 	"net/url"
 	"path/filepath"
 	"sort"
@@ -36,6 +37,28 @@ type Template struct {
 	html *tmplhtml.Template
 
 	ExternalURL *url.URL
+}
+
+// checkTemplateExistence checks if a given template name exists for a given
+// type in a prometheus-template-struct
+func (tmpl *Template) CheckTemplateExistence(tmplType string, name string) error {
+	switch tmplType {
+	case "html":
+		if t := tmpl.html.Lookup(name); t == nil {
+			return fmt.Errorf("Template '%s' not found", name)
+		} else {
+			return nil
+		}
+
+	case "text":
+		if t := tmpl.html.Lookup(name); t == nil {
+			return fmt.Errorf("Template '%s' not found", name)
+		} else {
+			return nil
+		}
+	default:
+		return fmt.Errorf("There are no Templates of type '%s'", tmplType)
+	}
 }
 
 // FromGlobs calls ParseGlob on all path globs provided and returns the


### PR DESCRIPTION
### Work in progress, do not merge yet!

This is proof-of-concept-code to be discussed with upstream.
Fixes #311 when finished and merged.
@fabxc 

## Problem diagnosis
When sending out alerts, Prometheus tries sending the alert and if that fails with an error, it tries again with exponential backoff. Unfortunately, an error that can cause this is, besides others, the use of a nonexistent template, which (at least for mail) results in AM flooding the receivers inbox by repeatedly trying (and succeeding) sending mails. This has primarily been tested for mail, but might occur as well for other notification types.

## Basic idea for fixing
There are two options to fix this: 
1) fall back onto the default template when a template is not found
2) Check upon loading of the config that all templates in use are actually found

in the current structure, `1)` would require internal silencing of errors due to the mechanics of the used notification module when falling back onto the default, which could be done, but is highly unelegant.
So we went for `2)` and verify the integrity of the entire config set by checking it upon loading and make config-loading throw an error for inconsistent configurations.

## State of this PR
This PR implements a general Proof-of-concept of fixing the issue mentioned above to be discussed with upstream, to find the optimal solution for this before carrying out work that might end up being unnecessary and wasting time. For this reason, currently only the `html`-field of the mail-configs is checked for invalid templates. For other notification methods the code will be fairly similar.

## Further plans to be discussed besides the obvious

* Currently the significant part of the fix lives directly in `main.go`, it might be a reasonable choice to move it into the `config`-package and just call that package from within `main.go`.


Feedback is highly appreciated so that we can finish fixing this issue. :)

Shoutout to @joker234 with whom I debugged and fixed this!
