### PR TITLE
Support more cross-build platforms

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -2,6 +2,7 @@ go: 1.6.2
 repository:
     path: github.com/prometheus/alertmanager
 build:
+    flags: -a -tags netgo
     ldflags: |
         -X {{repoPath}}/vendor/github.com/prometheus/common/version.Version={{.Version}}
         -X {{repoPath}}/vendor/github.com/prometheus/common/version.Revision={{.Revision}}
@@ -21,5 +22,17 @@ crossbuild:
         - darwin/386
         - windows/amd64
         - windows/386
+        - freebsd/amd64
+        - freebsd/386
+        - openbsd/amd64
+        - openbsd/386
+        - netbsd/amd64
+        - netbsd/386
+        - dragonfly/amd64
         - linux/arm
         - linux/arm64
+        - freebsd/arm
+        - openbsd/arm
+        - netbsd/arm
+        - linux/ppc64
+        - linux/ppc64le


### PR DESCRIPTION
With the sqlite to boltdb move, we can now cross-build alertmanager on almost all platforms supported by promu.

Missing platforms are `linux/mips64` and `linux/mips64le`, builds breaks with the following error:
```
# github.com/prometheus/alertmanager/vendor/github.com/boltdb/bolt
/go/src/github.com/prometheus/alertmanager/vendor/github.com/boltdb/bolt/db.go:98: undefined: maxMapSize
/go/src/github.com/prometheus/alertmanager/vendor/github.com/boltdb/bolt/db.go:98: invalid array bound maxMapSize
[2] /go/src/github.com/prometheus/alertmanager/vendor/github.com/boltdb/bolt/db.go:98: invalid array bound maxMapSize
```