### PR TITLE
provider/boltmem: make alerts purely in-memory.

### DIFF
--- a/test/acceptance/send_test.go
+++ b/test/acceptance/send_test.go
@@ -87,15 +87,16 @@ receivers:
 
 	// Test against a bug which ocurrec after a restart. The previous occurrence of
 	// the alert was sent rather than the most recent one.
-	at.Do(At(6.7), func() {
-		am.Terminate()
-		am.Start()
-	})
+	// XXX(fabxc): temporarily disable while alerts are not persisted.
+	// at.Do(At(6.7), func() {
+	//	am.Terminate()
+	//	am.Start()
+	// })
 
 	// On restart the alert is flushed right away as the group_wait has already passed.
 	// However, it must be caught in the deduplication stage.
 	// The next attempt will be 1s later and won't be filtered in deduping.
-	co.Want(Between(7.7, 8), Alert("alertname", "test").Active(5.3))
+	// co.Want(Between(7.7, 8), Alert("alertname", "test").Active(5.3))
 
 	at.Run()
 }
@@ -138,10 +139,11 @@ receivers:
 	// Times are provided in fractions of seconds.
 	am.Push(At(1), Alert("alertname", "test").Active(1))
 
-	at.Do(At(1.2), func() {
-		am.Terminate()
-		am.Start()
-	})
+	// XXX(fabxc): disabled as long as alerts are not persisted.
+	// at.Do(At(1.2), func() {
+	//	am.Terminate()
+	//	am.Start()
+	// })
 	am.Push(At(3.5), Alert("alertname", "test").Active(1, 3))
 
 	// Declare which alerts are expected to arrive at the collector within


### PR DESCRIPTION
Initial testing has shown BoltDB in plain usage to be a bottleneck
at a few thousand alerts or more (especially JSON decoding.
This commit actually makes them purely memory.

@beorn7 