### PR TITLE
Add support for NATS as a notifier.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -406,6 +406,7 @@ type Receiver struct {
 	WebhookConfigs   []*WebhookConfig   `yaml:"webhook_configs,omitempty"`
 	OpsGenieConfigs  []*OpsGenieConfig  `yaml:"opsgenie_configs,omitempty"`
 	PushoverConfigs  []*PushoverConfig  `yaml:"pushover_configs,omitempty"`
+	NatsConfigs   	 []*NatsConfig      `yaml:"nats_configs,omitempty"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline"`

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -104,6 +104,13 @@ var (
 		Retry:    duration(1 * time.Minute),
 		Expire:   duration(1 * time.Hour),
 	}
+
+	// DefaultNatsConfig defines default values for NATS configurations.
+	DefaultNatsConfig = NatsConfig{
+		NotifierConfig: NotifierConfig{
+			VSendResolved: false,
+		},
+	}
 )
 
 // NotifierConfig contains base options common across all notifier configurations.
@@ -350,4 +357,32 @@ func (c *PushoverConfig) UnmarshalYAML(unmarshal func(interface{}) error) error 
 		return fmt.Errorf("missing token in Pushover config")
 	}
 	return checkOverflow(c.XXX, "pushover config")
+}
+
+type NatsConfig struct {
+	NotifierConfig `yaml:",inline"`
+
+	URL    	string   `yaml:"url"`
+	Topic	string   `yaml:"topic"`
+
+	// Catches all undefined fields and must be empty after parsing.
+	XXX map[string]interface{} `yaml:",inline"`
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (c *NatsConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	fmt.Printf("NatsConfig.UnmarshalYAML")
+	*c = DefaultNatsConfig
+	type plain NatsConfig
+	if err := unmarshal((*plain)(c)); err != nil {
+		return err
+	}
+	fmt.Printf("config %v+\n", c)
+	if c.URL == "" {
+		return fmt.Errorf("missing url in NATS config")
+	}
+	if c.Topic == "" {
+		return fmt.Errorf("missing topic in NATS config")
+	}
+	return checkOverflow(c.XXX, "nats config")
 }


### PR DESCRIPTION
Initial PR to add support for new NATS notifier.

NATS is a simple and fast message queue: http://nats.io/

@brian-brazil I have a couple of questions regarding adding  a new notifier:

* The WebHook notifier defines a WebhookMessage struct with a version and a group key, does the NATS notifier needs to define something similar?
* Should the VSendResolved flag be true or false for the DefaultNatsConfig?

**Please ignore the printf's since I'm still testing the code, I'm opening the PR to get some initial feedback and make sure I'm on the right track.