### PR TITLE
Use localhost for tests

### DIFF
--- a/test/acceptance.go
+++ b/test/acceptance.go
@@ -86,7 +86,7 @@ func NewAcceptanceTest(t *testing.T, opts *AcceptanceOpts) *AcceptanceTest {
 func freeAddress() string {
 	// Let the OS allocate a free address, close it and hope
 	// it is still free when starting Alertmanager.
-	l, err := net.Listen("tcp4", ":0")
+	l, err := net.Listen("tcp4", "localhost:0")
 	if err != nil {
 		panic(err)
 	}

--- a/test/mock.go
+++ b/test/mock.go
@@ -227,7 +227,7 @@ type MockWebhook struct {
 }
 
 func NewWebhook(c *Collector) *MockWebhook {
-	l, err := net.Listen("tcp4", ":0")
+	l, err := net.Listen("tcp4", "localhost:0")
 	if err != nil {
 		// TODO(fabxc): if shutdown of mock destinations ever becomes a concern
 		// we want to shut them down after test completion. Then we might want to


### PR DESCRIPTION
Previously, the tests would listen on all available interfaces.

Instead, have the tests use localhost only; using all available
interfaces is unnecessary.

On Mac OS X with the builtin firewall enabled, it triggers annoying
prompts to allow the tests to listen on all interfaces.