### PR TITLE
Allow route receiver to be inherited

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -225,6 +225,9 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if c.Route == nil {
 		return fmt.Errorf("No routes provided")
 	}
+	if len(c.Route.Receiver) == 0 {
+		return fmt.Errorf("Root route must specify a default receiver")
+	}
 	if len(c.Route.Match) > 0 || len(c.Route.MatchRE) > 0 {
 		return fmt.Errorf("Root route must not have any matchers")
 	}
@@ -240,6 +243,9 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 // checkReceiver returns an error if a node in the routing tree
 // references a receiver not in the given map.
 func checkReceiver(r *Route, receivers map[string]struct{}) error {
+	if r.Receiver == "" {
+		return nil
+	}
 	if _, ok := receivers[r.Receiver]; !ok {
 		return fmt.Errorf("Undefined receiver %q used in route", r.Receiver)
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,39 @@
+// Copyright 2016 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+func TestDefaultReceiverExists(t *testing.T) {
+	in := `
+route:
+   group_wait: 30s
+`
+
+	conf := &Config{}
+	err := yaml.Unmarshal([]byte(in), conf)
+
+	expected := "Root route must specify a default receiver"
+
+	if err == nil {
+		t.Fatalf("no error returned, expected:\n%v", expected)
+	}
+	if err.Error() != expected {
+		t.Errorf("\nexpected:\n%v\ngot:\n%v", expected, err.Error())
+	}
+}

--- a/route_test.go
+++ b/route_test.go
@@ -65,6 +65,19 @@ routes:
   group_by: ['foo', 'bar']
   group_wait: 2m
   receiver: 'notify-BC'
+
+- match:
+    group_by: 'role'
+  group_by: ['role']
+
+  routes:
+  - match:
+      env: 'testing'
+    receiver: 'notify-testing'
+    routes:
+    - match:
+        wait: 'long'
+      group_wait: 2m
 `
 
 	var ctree config.Route
@@ -164,6 +177,51 @@ routes:
 					GroupWait:      30 * time.Second,
 					GroupInterval:  5 * time.Minute,
 					RepeatInterval: 1 * time.Hour,
+				},
+			},
+		},
+		{
+			input: model.LabelSet{
+				"group_by": "role",
+			},
+			result: []*RouteOpts{
+				{
+					Receiver:       "notify-def",
+					GroupBy:        lset("role"),
+					GroupWait:      def.GroupWait,
+					GroupInterval:  def.GroupInterval,
+					RepeatInterval: def.RepeatInterval,
+				},
+			},
+		},
+		{
+			input: model.LabelSet{
+				"env":      "testing",
+				"group_by": "role",
+			},
+			result: []*RouteOpts{
+				{
+					Receiver:       "notify-testing",
+					GroupBy:        lset("role"),
+					GroupWait:      def.GroupWait,
+					GroupInterval:  def.GroupInterval,
+					RepeatInterval: def.RepeatInterval,
+				},
+			},
+		},
+		{
+			input: model.LabelSet{
+				"env":      "testing",
+				"group_by": "role",
+				"wait":     "long",
+			},
+			result: []*RouteOpts{
+				{
+					Receiver:       "notify-testing",
+					GroupBy:        lset("role"),
+					GroupWait:      2 * time.Minute,
+					GroupInterval:  def.GroupInterval,
+					RepeatInterval: def.RepeatInterval,
 				},
 			},
 		},


### PR DESCRIPTION
This is useful when you're using a label to determine the receiver but
want to override other options such as `group_by`. Currently you'd have
to duplicate the matchers for the receivers to be able to do this.

`checkReceiver()` now returns no error if a receiver is empty and we add
a check to ensure that the root route has a receiver defined. I've added
a test for this.

This brings the `receiver` option into line with the other options
(`group_by`, `group_wait`, etc) in the sense that routes can now inherit
the receiver from the parent node.

From https://prometheus.io/docs/alerting/configuration/:

> A route block defines a node in a routing tree and its children. Its
> optional configuration parameters are inherited from its parent node
> if not set.

Also, add tests for:
- inheriting a receiver from the default route
- overriding the receiver when the parent route has not set one
- inheriting a receiver from a parent route that's not the default

To be sure of edge case behaviour, we test inheriting the receiver
from a child route. Hopefully no one would actually implement this edge
case in reality as it's overly complex but we test anyway to be sure
that it doesn't trigger unexpected behaviour.