### PR TITLE
provider/mesh: fix end timestamp for unstarted silences

### DIFF
--- a/provider/mesh/state_test.go
+++ b/provider/mesh/state_test.go
@@ -273,6 +273,32 @@ func TestSilenceStateDel(t *testing.T) {
 				id1: &types.Silence{
 					ID:        id1,
 					Matchers:  matchers,
+					StartsAt:  now.Add(time.Minute),
+					EndsAt:    now.Add(2 * time.Minute),
+					UpdatedAt: now.Add(-time.Minute),
+					CreatedBy: "x",
+					Comment:   "x",
+				},
+			},
+			// Deleting unstarted silence sets end timestamp to start time.
+			final: map[uuid.UUID]*types.Silence{
+				id1: &types.Silence{
+					ID:        id1,
+					Matchers:  matchers,
+					StartsAt:  now.Add(time.Minute),
+					EndsAt:    now.Add(time.Minute),
+					UpdatedAt: now,
+					CreatedBy: "x",
+					Comment:   "x",
+				},
+			},
+			input: id1,
+		},
+		{
+			initial: map[uuid.UUID]*types.Silence{
+				id1: &types.Silence{
+					ID:        id1,
+					Matchers:  matchers,
 					StartsAt:  now.Add(-time.Minute),
 					EndsAt:    now.Add(time.Minute),
 					UpdatedAt: now.Add(-time.Minute),


### PR DESCRIPTION
This changes the end timestamp for unstarted silences to the
start timestamp so the silence remains valid by not having the end
time before the start time.

@beorn7 @brian-brazil 