### PR TITLE
Updated webhook notifier config name in UnmarshalYAML.

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -274,7 +274,7 @@ func (c *WebhookConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if c.URL == "" {
 		return fmt.Errorf("missing URL in webhook config")
 	}
-	return checkOverflow(c.XXX, "slack config")
+	return checkOverflow(c.XXX, "webhook config")
 }
 
 // OpsGenieConfig configures notifications via OpsGenie.


### PR DESCRIPTION
Going over the notifier's code noticed that the config name was set to slack in the webhook unmarshaler function.