### PR TITLE
Add crypted password for smtp AUTH LOGIN

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -172,6 +172,9 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			if ec.AuthIdentity == "" {
 				ec.AuthIdentity = c.Global.SMTPAuthIdentity
 			}
+			if ec.AuthPemFile == "" {
+				ec.AuthPemFile = c.Global.SMTPAuthPemFile
+			}
 		}
 		for _, sc := range rcv.SlackConfigs {
 			if sc.APIURL == "" {
@@ -279,6 +282,7 @@ type GlobalConfig struct {
 	SMTPAuthPassword Secret `yaml:"smtp_auth_password"`
 	SMTPAuthSecret   Secret `yaml:"smtp_auth_secret"`
 	SMTPAuthIdentity string `yaml:"smtp_auth_identity"`
+	SMTPAuthPemFile  string `yaml:"smtp_auth_pem_file"`
 	SlackAPIURL      Secret `yaml:"slack_api_url"`
 	PagerdutyURL     string `yaml:"pagerduty_url"`
 	HipchatURL       string `yaml:"hipchat_url"`

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -127,6 +127,7 @@ type EmailConfig struct {
 	AuthPassword Secret            `yaml:"auth_password"`
 	AuthSecret   Secret            `yaml:"auth_secret"`
 	AuthIdentity string            `yaml:"auth_identity"`
+	AuthPemFile  string            `yaml:"auth_pem_file"`
 	Headers      map[string]string `yaml:"headers"`
 	HTML         string            `yaml:"html"`
 	RequireTLS   bool              `yaml:"require_tls"`

--- a/notify/impl.go
+++ b/notify/impl.go
@@ -15,10 +15,17 @@ package notify
 
 import (
 	"bytes"
+	"crypto/md5"
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"fmt"
+	"hash"
 	"io"
 	"io/ioutil"
 	"mime"
@@ -257,7 +264,8 @@ func (n *Email) auth(mechs string) (smtp.Auth, error) {
 			if password == "" {
 				continue
 			}
-			return LoginAuth(username, password), nil
+			pemFile := string(n.conf.AuthPemFile)
+			return LoginAuth(username, password, pemFile), nil
 		}
 	}
 	return nil, nil
@@ -822,11 +830,11 @@ func tmplHTML(tmpl *template.Template, data *template.Data, err *error) func(str
 }
 
 type loginAuth struct {
-	username, password string
+	username, password, pemFile string
 }
 
-func LoginAuth(username, password string) smtp.Auth {
-	return &loginAuth{username, password}
+func LoginAuth(username, password, pemFile string) smtp.Auth {
+	return &loginAuth{username, password, pemFile}
 }
 
 func (a *loginAuth) Start(server *smtp.ServerInfo) (string, []byte, error) {
@@ -840,10 +848,50 @@ func (a *loginAuth) Next(fromServer []byte, more bool) ([]byte, error) {
 		case "Username:":
 			return []byte(a.username), nil
 		case "Password:":
-			return []byte(a.password), nil
+			if a.pemFile == "" {
+				return []byte(a.password), nil
+			}
+			return decrypt(a.password, a.pemFile), nil
 		default:
 			return nil, errors.New("unexpected server challenge")
 		}
 	}
 	return nil, nil
+}
+
+func decrypt(stringToDecrypt, pemFile string) (decrypted []byte) {
+
+	var err error
+	var block *pem.Block
+	var private_key *rsa.PrivateKey
+	var pem_data []byte
+
+	if pem_data, err = ioutil.ReadFile(pemFile); err != nil {
+		log.Fatalf("Error reading pem file: %s", err)
+	}
+
+	if block, _ = pem.Decode(pem_data); block == nil || block.Type != "RSA PRIVATE KEY" {
+		log.Fatal("No valid PEM data found")
+	}
+
+	if private_key, err = x509.ParsePKCS1PrivateKey(block.Bytes); err != nil {
+		log.Fatalf("Private key can't be decoded: %s", err)
+	}
+
+	encrypted, _ := base64.StdEncoding.DecodeString(stringToDecrypt)
+	decrypted = decrypt_oaep(private_key, encrypted)
+
+	return
+}
+
+func decrypt_oaep(private_key *rsa.PrivateKey, encrypted []byte) (decrypted []byte) {
+	var err error
+	var md5_hash hash.Hash
+	var label []byte
+
+	md5_hash = md5.New()
+	if decrypted, err = rsa.DecryptOAEP(md5_hash, rand.Reader, private_key, encrypted, label); err != nil {
+		log.Fatal(err)
+	}
+	return
 }


### PR DESCRIPTION
What do you think about to use an encrypted password for stmp auth ? In this case I use public key/private key mechanism (x509 certificate, very usefull in enterprise).

It is an **optional parameter**. 
If you put the parameter **smtp_auth_pem_file** in the configuration, you can put a crypted password in the **smtp_auth_password**.
Otherwise, it's the current use case.

Example:

```
smtp_from: 'xxx@domain.com'
smtp_auth_username: 'myuser'
smtp_auth_password: 'jJxNXYoVs0lQn/PyJO8zO3JtXmJ09wUx13T6rnY+kYWZnCfP/E+wmTJfCfWCpUXxxB5UyYWgt1w1S0LVo='
smtp_auth_pem_file: '/my/path/rsa.pem'
```

In this case, no more decrypted password in the configuration file.
