### PR TITLE
Add support for heartbeat

### DIFF
--- a/config/heartbeats.go
+++ b/config/heartbeats.go
@@ -1,0 +1,52 @@
+// Copyright 2015 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+	"time"
+)
+
+var (
+	DefaultHeartbeatOpsGenieConfig = HeartbeatOpsGenieConfig{
+		Interval: duration(1 * time.Minute),
+	}
+)
+
+// HeartbeatOpsGenieConfig configures heartbeats to OpsGenie.
+type HeartbeatOpsGenieConfig struct {
+	APIKey   Secret   `yaml:"api_key"`
+	APIHost  string   `yaml:"api_host"`
+	Name     string   `yaml:"name"`
+	Interval duration `yaml:"interval,omitempty"`
+
+	// Catches all undefined fields and must be empty after parsing.
+	XXX map[string]interface{} `yaml:",inline"`
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (c *HeartbeatOpsGenieConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	*c = DefaultHeartbeatOpsGenieConfig
+	type plain HeartbeatOpsGenieConfig
+	if err := unmarshal((*plain)(c)); err != nil {
+		return err
+	}
+	if c.Name == "" {
+		return fmt.Errorf("missing hearbeat name in OpsGenie heartbeat config")
+	}
+	if c.APIKey == "" {
+		return fmt.Errorf("missing API key in OpsGenie heartbeat config")
+	}
+	return checkOverflow(c.XXX, "opsgenie heartbeat config")
+}

--- a/heartbeat/heartbeat.go
+++ b/heartbeat/heartbeat.go
@@ -1,0 +1,83 @@
+// Copyright 2016 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package heartbeat
+
+import (
+	"time"
+
+	"github.com/prometheus/common/log"
+)
+
+type Fanout map[string]Heartbeat
+
+type Heartbeat interface {
+	Interval() time.Duration
+	SendHeartbeat() error
+}
+
+// NewHeartbeatRunner returns a new HeartbeatRunner that runs a list of
+// HeartbeatSender.
+type HeartbeatRunner struct {
+	senders map[string]Fanout
+	done    map[string]chan struct{}
+
+	log log.Logger
+}
+
+// NewHeartbeatSender returns a new HeartbeatSender.
+func NewHeartbeatRunner(senders map[string]Fanout) *HeartbeatRunner {
+	runner := &HeartbeatRunner{
+		senders: senders,
+		log:     log.With("component", "heartbeat_runner"),
+		done:    make(map[string]chan struct{}),
+	}
+	return runner
+}
+
+func (r *HeartbeatRunner) Run() {
+	for _, t := range r.senders {
+		for k, s := range t {
+			r.done[k] = make(chan struct{})
+			go func(h Heartbeat, done chan struct{}) {
+				var err error
+				c := time.NewTicker(h.Interval())
+				defer c.Stop()
+
+				for {
+					select {
+					case <-c.C:
+						err = h.SendHeartbeat()
+						if err != nil {
+							log.Error(err)
+						}
+
+					case <-done:
+						return
+					}
+				}
+			}(s, r.done[k])
+		}
+	}
+}
+
+func (r *HeartbeatRunner) Stop() {
+	if r == nil {
+		return
+	}
+	for _, t := range r.senders {
+		for k, _ := range t {
+			close(r.done[k])
+		}
+	}
+}

--- a/heartbeat/impl.go
+++ b/heartbeat/impl.go
@@ -1,0 +1,106 @@
+// Copyright 2016 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package heartbeat
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/prometheus/alertmanager/config"
+	"github.com/prometheus/common/log"
+)
+
+type integration interface {
+	Heartbeat
+	name() string
+}
+
+const contentTypeJSON = "application/json"
+
+func Build(confs []*config.Heartbeat) map[string]Fanout {
+	res := map[string]Fanout{}
+
+	for _, nc := range confs {
+		var (
+			hb  = Fanout{}
+			add = func(i int, on integration) { hb[fmt.Sprintf("%s/%d", on.name(), i)] = on }
+		)
+
+		for i, c := range nc.OpsGenieConfigs {
+			n := NewOpsGenie(c)
+			add(i, n)
+		}
+		res[nc.Name] = hb
+	}
+	return res
+
+}
+
+// OpsGenie represents a OpsGenie implementation of Heartbeat
+type OpsGenie struct {
+	conf *config.HeartbeatOpsGenieConfig
+	done chan struct{}
+
+	log log.Logger
+}
+
+// Returns a new OpsGenie object
+func NewOpsGenie(conf *config.HeartbeatOpsGenieConfig) *OpsGenie {
+	return &OpsGenie{
+		conf: conf,
+		done: make(chan struct{}),
+		log:  log.With("component", "opsgenie_heartbeat"),
+	}
+}
+
+func (o *OpsGenie) name() string { return fmt.Sprintf("[%s] %s", "opsgenie", o.conf.Name) }
+
+// Represents an OpsGenie heartbeat message
+type opsGenieHeartBeatMessage struct {
+	APIKey string `json:"apiKey"`
+	Name   string `json:"name"`
+}
+
+func (o *OpsGenie) Interval() time.Duration {
+	return time.Duration(o.conf.Interval)
+}
+
+func (o *OpsGenie) SendHeartbeat() error {
+	var msg = &opsGenieHeartBeatMessage{
+		APIKey: string(o.conf.APIKey),
+		Name:   o.conf.Name,
+	}
+	apiURL := o.conf.APIHost + "v1/json/heartbeat/send"
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(msg); err != nil {
+		return err
+	}
+	log.Debugf("Sending heartbeat to %s: %s", o.conf.APIHost, buf.String())
+
+	resp, err := http.Post(apiURL, contentTypeJSON, &buf)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("unexpected status code %v from %s", resp.StatusCode, apiURL)
+	}
+
+	return nil
+}


### PR DESCRIPTION
- Send an HTTP request to specific hosts so they know the current instance is
  running
- Only implements OpsGenie API

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prometheus/alertmanager/444)

<!-- Reviewable:end -->
