### PR TITLE
notify: always check context before retrying

### DIFF
--- a/notify/notify.go
+++ b/notify/notify.go
@@ -186,6 +186,12 @@ func (n *RetryNotifier) Notify(ctx context.Context, alerts ...*types.Alert) erro
 
 	for {
 		i++
+		// Always check the context first to not notify again.
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
 
 		select {
 		case <-tick.C:


### PR DESCRIPTION
This addresses the misleading error messages reported in #282
Explanation: https://github.com/prometheus/alertmanager/issues/282#issuecomment-237784895

Fixes #282

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prometheus/alertmanager/446)
<!-- Reviewable:end -->
