### PR TITLE
notify: truncate HipChat from field

### DIFF
--- a/notify/impl.go
+++ b/notify/impl.go
@@ -584,7 +584,7 @@ func (n *Hipchat) Notify(ctx context.Context, as ...*types.Alert) error {
 	}
 
 	req := &hipchatReq{
-		From:          tmplText(n.conf.From),
+		From:          truncate(tmplText(n.conf.From), 64),
 		Notify:        n.conf.Notify,
 		Message:       msg,
 		MessageFormat: n.conf.MessageFormat,
@@ -956,4 +956,11 @@ func (a *loginAuth) Next(fromServer []byte, more bool) ([]byte, error) {
 		}
 	}
 	return nil, nil
+}
+
+func truncate(s string, l int) string {
+	if l <= 10 {
+		return s[:l]
+	}
+	return fmt.Sprintf("%s...", s[:l-3])
 }

--- a/notify/impl_test.go
+++ b/notify/impl_test.go
@@ -1,0 +1,32 @@
+// Copyright 2016 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package notify
+
+import "testing"
+
+func TestTruncate(t *testing.T) {
+	cases := []struct {
+		in, out string
+		len     int
+	}{
+		{in: "a", len: 0, out: ""},
+		{in: "0123456789abcdef", len: 10, out: "0123456789"},
+		{in: "0123456789abcdef", len: 11, out: "01234567..."},
+	}
+	for _, c := range cases {
+		if have := truncate(c.in, c.len); have != c.out {
+			t.Errorf("Expected result %q for %q to length %d, got %q", c.out, c.in, c.len, have)
+		}
+	}
+}


### PR DESCRIPTION
This commite truncates the `from` field in the HipChat REST call
to the maximum of 64 characters.

Closes #295 

@brian-brazil @brancz 
