### PR TITLE
Modify SMTP login auth bug.

### DIFF
--- a/notify/impl.go
+++ b/notify/impl.go
@@ -946,10 +946,10 @@ func (a *loginAuth) Start(server *smtp.ServerInfo) (string, []byte, error) {
 // Used for AUTH LOGIN. (Maybe password should be encrypted)
 func (a *loginAuth) Next(fromServer []byte, more bool) ([]byte, error) {
 	if more {
-		switch string(fromServer) {
-		case "Username:":
+		switch strings.ToLower(string(fromServer)) {
+		case "username:":
 			return []byte(a.username), nil
-		case "Password:":
+		case "password:":
 			return []byte(a.password), nil
 		default:
 			return nil, errors.New("unexpected server challenge")


### PR DESCRIPTION
Hi:
I found a bug in v0.3.0 when i testing. 
When AM send mail it always log "unexpected server challenge".
I think fromServer sometime like "username:", but the code compare like this "Username:"
Maybe password the same issue.
Testing mail server: "smtp.163.com:25"

Am i correct?

```
gofile: impl.go 
line: 949 
switch string(fromServer) {
case "Username:"
        return []byte(a.username), nil
case "Password:"
        return []byte(a.password), nil
default:
        return nil, errors.New("unexpected server challenge")
}
```

see #450 