### PR TITLE
*: restructure package tree

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -2,6 +2,9 @@ go: 1.6.2
 repository:
     path: github.com/prometheus/alertmanager
 build:
+    binaries:
+        - name: alertmanager
+          path: ./cmd/alertmanager
     flags: -a -tags netgo
     ldflags: |
         -X {{repoPath}}/vendor/github.com/prometheus/common/version.Version={{.Version}}

--- a/api/api.go
+++ b/api/api.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package api
 
 import (
 	"encoding/json"
@@ -28,6 +28,7 @@ import (
 	"github.com/satori/go.uuid"
 	"golang.org/x/net/context"
 
+	"github.com/prometheus/alertmanager/dispatch"
 	"github.com/prometheus/alertmanager/provider"
 	"github.com/prometheus/alertmanager/types"
 )
@@ -59,15 +60,15 @@ type API struct {
 	resolveTimeout time.Duration
 	uptime         time.Time
 
-	groups func() AlertOverview
+	groups func() dispatch.AlertOverview
 
 	// context is an indirection for testing.
 	context func(r *http.Request) context.Context
 	mtx     sync.RWMutex
 }
 
-// NewAPI returns a new API.
-func NewAPI(alerts provider.Alerts, silences provider.Silences, gf func() AlertOverview) *API {
+// New returns a new API.
+func New(alerts provider.Alerts, silences provider.Silences, gf func() dispatch.AlertOverview) *API {
 	return &API{
 		context:  route.Context,
 		alerts:   alerts,

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -1,4 +1,4 @@
-package main
+package dispatch
 
 import (
 	"fmt"

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -1,4 +1,4 @@
-package main
+package dispatch
 
 import (
 	"reflect"

--- a/dispatch/route.go
+++ b/dispatch/route.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package dispatch
 
 import (
 	"encoding/json"

--- a/dispatch/route_test.go
+++ b/dispatch/route_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package dispatch
 
 import (
 	"reflect"

--- a/inhibit/inhibit.go
+++ b/inhibit/inhibit.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package inhibit
 
 import (
 	"sync"

--- a/inhibit/inhibit_test.go
+++ b/inhibit/inhibit_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package inhibit
 
 import (
 	"reflect"

--- a/ui/web.go
+++ b/ui/web.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package ui
 
 import (
 	"bytes"
@@ -23,18 +23,16 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"
 	"github.com/prometheus/common/route"
-
-	"github.com/prometheus/alertmanager/ui"
 )
 
 func serveAsset(w http.ResponseWriter, req *http.Request, fp string) {
-	info, err := ui.AssetInfo(fp)
+	info, err := AssetInfo(fp)
 	if err != nil {
 		log.Warn("Could not get file: ", err)
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
-	file, err := ui.Asset(fp)
+	file, err := Asset(fp)
 	if err != nil {
 		if err != io.EOF {
 			log.With("file", fp).Warn("Could not get file: ", err)
@@ -46,8 +44,8 @@ func serveAsset(w http.ResponseWriter, req *http.Request, fp string) {
 	http.ServeContent(w, req, info.Name(), info.ModTime(), bytes.NewReader(file))
 }
 
-// RegisterWeb registers handlers to serve files for the web interface.
-func RegisterWeb(r *route.Router, reloadCh chan<- struct{}) {
+// Register registers handlers to serve files for the web interface.
+func Register(r *route.Router, reloadCh chan<- struct{}) {
 	ihf := prometheus.InstrumentHandlerFunc
 
 	r.Get("/app/*filepath", ihf("app_files",


### PR DESCRIPTION
This commit packages up individual modules and removes the top-level
main package.

Aligns the rough structure with Prometheus and first step to allow us running several AMs in the same binary for better e2e tests.