### PR TITLE
Reduce runtime context dependencies

### DIFF
--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -325,7 +325,7 @@ func (ag *aggrGroup) run(nf notifyFunc) {
 			// Populate context with information needed along the pipeline.
 			ctx = notify.WithGroupKey(ctx, ag.labels.Fingerprint()^ag.routeFP)
 			ctx = notify.WithGroupLabels(ctx, ag.labels)
-			ctx = notify.WithReceiver(ctx, ag.opts.Receiver)
+			ctx = notify.WithReceiverName(ctx, ag.opts.Receiver)
 			ctx = notify.WithRepeatInterval(ctx, ag.opts.RepeatInterval)
 
 			// Wait the configured interval before calling flush again.

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -82,7 +82,7 @@ func TestAggrGroup(t *testing.T) {
 		if lbls, ok := notify.GroupLabels(ctx); !ok || !reflect.DeepEqual(lbls, lset) {
 			t.Errorf("wrong group labels: %q", lbls)
 		}
-		if rcv, ok := notify.Receiver(ctx); !ok || rcv != opts.Receiver {
+		if rcv, ok := notify.ReceiverName(ctx); !ok || rcv != opts.Receiver {
 			t.Errorf("wrong receiver: %q", rcv)
 		}
 		if ri, ok := notify.RepeatInterval(ctx); !ok || ri != opts.RepeatInterval {

--- a/notify/impl.go
+++ b/notify/impl.go
@@ -138,7 +138,7 @@ type WebhookMessage struct {
 
 // Notify implements the Notifier interface.
 func (w *Webhook) Notify(ctx context.Context, alerts ...*types.Alert) error {
-	data := w.tmpl.Data(receiver(ctx), groupLabels(ctx), alerts...)
+	data := w.tmpl.Data(receiverName(ctx), groupLabels(ctx), alerts...)
 
 	groupKey, ok := GroupKey(ctx)
 	if !ok {
@@ -264,7 +264,7 @@ func (n *Email) Notify(ctx context.Context, as ...*types.Alert) error {
 	}
 
 	var (
-		data = n.tmpl.Data(receiver(ctx), groupLabels(ctx), as...)
+		data = n.tmpl.Data(receiverName(ctx), groupLabels(ctx), as...)
 		tmpl = tmplText(n.tmpl, data, &err)
 		from = tmpl(n.conf.From)
 		to   = tmpl(n.conf.To)
@@ -363,7 +363,7 @@ func (n *PagerDuty) Notify(ctx context.Context, as ...*types.Alert) error {
 	var err error
 	var (
 		alerts    = types.Alerts(as...)
-		data      = n.tmpl.Data(receiver(ctx), groupLabels(ctx), as...)
+		data      = n.tmpl.Data(receiverName(ctx), groupLabels(ctx), as...)
 		tmpl      = tmplText(n.tmpl, data, &err)
 		eventType = pagerDutyEventTrigger
 	)
@@ -456,7 +456,7 @@ type slackAttachmentField struct {
 func (n *Slack) Notify(ctx context.Context, as ...*types.Alert) error {
 	var err error
 	var (
-		data     = n.tmpl.Data(receiver(ctx), groupLabels(ctx), as...)
+		data     = n.tmpl.Data(receiverName(ctx), groupLabels(ctx), as...)
 		tmplText = tmplText(n.tmpl, data, &err)
 	)
 
@@ -526,7 +526,7 @@ func (n *Hipchat) Notify(ctx context.Context, as ...*types.Alert) error {
 	var err error
 	var msg string
 	var (
-		data     = n.tmpl.Data(receiver(ctx), groupLabels(ctx), as...)
+		data     = n.tmpl.Data(receiverName(ctx), groupLabels(ctx), as...)
 		tmplText = tmplText(n.tmpl, data, &err)
 		tmplHTML = tmplHTML(n.tmpl, data, &err)
 		url      = fmt.Sprintf("%sv2/room/%s/notification?auth_token=%s", n.conf.APIURL, n.conf.RoomID, n.conf.AuthToken)
@@ -611,7 +611,7 @@ func (n *OpsGenie) Notify(ctx context.Context, as ...*types.Alert) error {
 	if !ok {
 		return fmt.Errorf("group key missing")
 	}
-	data := n.tmpl.Data(receiver(ctx), groupLabels(ctx), as...)
+	data := n.tmpl.Data(receiverName(ctx), groupLabels(ctx), as...)
 
 	log.With("incident", key).Debugln("notifying OpsGenie")
 
@@ -734,7 +734,7 @@ func (n *VictorOps) Notify(ctx context.Context, as ...*types.Alert) error {
 	var err error
 	var (
 		alerts      = types.Alerts(as...)
-		data        = n.tmpl.Data(receiver(ctx), groupLabels(ctx), as...)
+		data        = n.tmpl.Data(receiverName(ctx), groupLabels(ctx), as...)
 		tmpl        = tmplText(n.tmpl, data, &err)
 		apiURL      = fmt.Sprintf("%s%s/%s", n.conf.APIURL, n.conf.APIKey, n.conf.RoutingKey)
 		messageType = n.conf.MessageType
@@ -804,7 +804,7 @@ func (n *Pushover) Notify(ctx context.Context, as ...*types.Alert) error {
 	if !ok {
 		return fmt.Errorf("group key missing")
 	}
-	data := n.tmpl.Data(receiver(ctx), groupLabels(ctx), as...)
+	data := n.tmpl.Data(receiverName(ctx), groupLabels(ctx), as...)
 
 	log.With("incident", key).Debugln("notifying Pushover")
 

--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -216,7 +216,7 @@ func TestRoutingStage(t *testing.T) {
 		"not": failStage{},
 	}
 
-	ctx := WithReceiver(context.Background(), "name")
+	ctx := WithReceiverName(context.Background(), "name")
 
 	alerts, err := stage.Exec(ctx, alerts1...)
 	if err != nil {
@@ -236,7 +236,7 @@ func TestDedupStage(t *testing.T) {
 	)
 	now := time.Now()
 
-	ctx = WithReceiver(ctx, "name")
+	ctx = WithReceiverName(ctx, "name")
 	ctx = WithRepeatInterval(ctx, time.Duration(100*time.Minute))
 	ctx = WithNow(ctx, now)
 


### PR DESCRIPTION
@brancz 

This uses the first object of the new `nflog` package (separate PR which is the base of this one). As we built the pipeline per receiver on configuration load, there's no need to make these runtime dependencies.
After all, `context.Context` should not be used as a disguise for `interface{}` (or Python kwargs).
As a consequence, the fanout stage is now truly just executing stages in parallel, without knowledge about integrations.

Thought about where to draw the boundary. There are other values in the context too. We could also build a static pipeline as a new aggregation group gets created in the dispatcher. I figured a reasonably boundary would be that we build the pipeline on configuration load time and build static pipelines only based on the information we have at this point in time.

I also removed the logging stages, as they we didn't want to keep these around anyway.