### PR TITLE
*: integrate nflog

### DIFF
--- a/test/acceptance/send_test.go
+++ b/test/acceptance/send_test.go
@@ -36,7 +36,7 @@ route:
   group_by: []
   group_wait:      1s
   group_interval:  1s
-  repeat_interval: 1s
+  repeat_interval: 0s
 
 receivers:
 - name: "default"
@@ -112,7 +112,7 @@ route:
   group_by: []
   group_wait:      1s
   group_interval:  1s
-  repeat_interval: 1s
+  repeat_interval: 0s 
 
 receivers:
 - name: "default"

--- a/test/acceptance/silence_test.go
+++ b/test/acceptance/silence_test.go
@@ -30,7 +30,7 @@ route:
   group_by: []
   group_wait:      1s
   group_interval:  1s
-  repeat_interval: 1s
+  repeat_interval: 0s
 
 receivers:
 - name: "default"
@@ -82,7 +82,7 @@ route:
   group_by: []
   group_wait:      1s
   group_interval:  1s
-  repeat_interval: 1s
+  repeat_interval: 0s
 
 receivers:
 - name: "default"


### PR DESCRIPTION
This commit replaces the previous NotifyInfo provider with the new
nflog package. It needs adjustments in the behavior of the deduping
stage.
The nflog stores notification digests per receiver per alert aggregation
group rather than one entry for alert per receiver. This drastically
reduces the number of entries and removes interference
across aggregation groups.

@brancz 