### PR TITLE
[ui] fix regex checkbox

### DIFF
--- a/ui/app/partials/silence-form.html
+++ b/ui/app/partials/silence-form.html
@@ -40,7 +40,7 @@
       <div class="col-sm-1">
         <div class="checkbox">
           <label>
-            <input type="checkbox"> Regex
+            <input type="checkbox" ng-model="m.isRegex"> Regex
           </label>
         </div>
       </div>


### PR DESCRIPTION
Currently, alertmanager cannot update silence matchers' regex property.