### PR TITLE
*: consider mesh wait in notification timeouts

### DIFF
--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -98,7 +98,7 @@ func TestAggrGroup(t *testing.T) {
 	}
 
 	// Test regular situation where we wait for group_wait to send out alerts.
-	ag := newAggrGroup(context.Background(), lset, opts)
+	ag := newAggrGroup(context.Background(), lset, opts, nil)
 	go ag.run(ntfy)
 
 	ag.insert(a1)
@@ -146,7 +146,7 @@ func TestAggrGroup(t *testing.T) {
 	// immediate flushing.
 	// Finally, set all alerts to be resolved. After successful notify the aggregation group
 	// should empty itself.
-	ag = newAggrGroup(context.Background(), lset, opts)
+	ag = newAggrGroup(context.Background(), lset, opts, nil)
 	go ag.run(ntfy)
 
 	ag.insert(a1)


### PR DESCRIPTION
This adds the peer wait duration to the standard timeout to avoid
terminating a notification prematurely while being in failover
wait status.

Fixes #488 

@brancz @beorn7 