### PR TITLE
Revert "Use golang-builder base image for tests in CircleCI"

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   environment:
     DOCKER_IMAGE_NAME: prom/alertmanager
     QUAY_IMAGE_NAME: quay.io/prometheus/alertmanager
-    DOCKER_TEST_IMAGE_NAME: quay.io/prometheus/golang-builder:1.6-base
+    DOCKER_TEST_IMAGE_NAME: quay.io/prometheus/golang-builder:1.6-main
     REPO_PATH: github.com/prometheus/alertmanager
   pre:
     - sudo curl -L -o /usr/bin/docker 'https://s3-external-1.amazonaws.com/circle-downloads/docker-1.9.1-circleci'


### PR DESCRIPTION
Reverts prometheus/alertmanager#496

Should have merge it in release-0.4 first and then merge release-0.4 into master.