### PR TITLE
silence: add metrics

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -131,6 +131,7 @@ func main() {
 		SnapshotFile: filepath.Join(*dataDir, "silences"),
 		Retention:    *retention,
 		Logger:       logger.With("component", "silences"),
+		Metrics:      prometheus.DefaultRegisterer,
 		Gossip: func(g mesh.Gossiper) mesh.Gossip {
 			return mrouter.NewGossip("silences", g)
 		},

--- a/silence/silence_test.go
+++ b/silence/silence_test.go
@@ -139,7 +139,7 @@ func TestSilencesSnapshot(t *testing.T) {
 		f, err := ioutil.TempFile("", "snapshot")
 		require.NoError(t, err, "creating temp file failed")
 
-		s1 := &Silences{st: gossipData{}}
+		s1 := &Silences{st: gossipData{}, metrics: newMetrics(nil)}
 		// Setup internal state manually.
 		for _, e := range c.entries {
 			s1.st[e.Silence.Id] = e


### PR DESCRIPTION
This adds metrics for querying as it is done internally and critical. The create/modification actions are basically covered by the API handler instrumentation and would just bloat here.

@discordianfish 