### PR TITLE
Fixed the go install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Docker images are available on [Quay.io](https://quay.io/repository/prometheus/a
 You can either `go get` it:
 
 ```
-$ GO15VENDOREXPERIMENT=1 go get github.com/prometheus/alertmanager
+$ go get github.com/prometheus/alertmanager/cmd/...
 # cd $GOPATH/src/github.com/prometheus/alertmanager
 $ alertmanager -config.file=<your_file>
 ```

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Docker images are available on [Quay.io](https://quay.io/repository/prometheus/a
 You can either `go get` it:
 
 ```
-$ go get github.com/prometheus/alertmanager/cmd/...
+$ GO15VENDOREXPERIMENT=1 go get github.com/prometheus/alertmanager/cmd/...
 # cd $GOPATH/src/github.com/prometheus/alertmanager
 $ alertmanager -config.file=<your_file>
 ```


### PR DESCRIPTION
Removed the vendor experiment flag (it's obsolete now) and added the proper path to the main binary.