### PR TITLE
notify: move resolved alert filtering to integration

### DIFF
--- a/notify/impl.go
+++ b/notify/impl.go
@@ -62,6 +62,23 @@ type Integration struct {
 
 // Notify implements the Notifier interface.
 func (i *Integration) Notify(ctx context.Context, alerts ...*types.Alert) (bool, error) {
+	var res []*types.Alert
+
+	// Resolved alerts have to be filtered only at this point, because they need
+	// to end up unfiltered in the SetNotifiesStage.
+	if i.conf.SendResolved() {
+		res = alerts
+	} else {
+		for _, a := range alerts {
+			if a.Status() != model.AlertResolved {
+				res = append(res, a)
+			}
+		}
+	}
+	if len(res) == 0 {
+		return false, nil
+	}
+
 	return i.notifier.Notify(ctx, alerts...)
 }
 

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -206,7 +206,6 @@ func createStage(rc *config.Receiver, tmpl *template.Template, wait func() time.
 		}
 		var s MultiStage
 		s = append(s, NewWaitStage(wait))
-		s = append(s, NewFilterResolvedStage(i.conf))
 		s = append(s, NewDedupStage(notificationLog, recv))
 		s = append(s, NewRetryStage(i))
 		s = append(s, NewSetNotifiesStage(notificationLog, recv))
@@ -378,36 +377,6 @@ func (ws *WaitStage) Exec(ctx context.Context, alerts ...*types.Alert) (context.
 		return ctx, nil, ctx.Err()
 	}
 	return ctx, alerts, nil
-}
-
-// FilterResolvedStage filters alerts based on a given notifierConfig. Either
-// returns all alerts or only those that are not resolved.
-type FilterResolvedStage struct {
-	conf notifierConfig
-}
-
-// NewFilterRecolvedStage returns a new instance of a FilterResolvedStage.
-func NewFilterResolvedStage(conf notifierConfig) *FilterResolvedStage {
-	return &FilterResolvedStage{
-		conf: conf,
-	}
-}
-
-// Exec implements the Stage interface.
-func (fr *FilterResolvedStage) Exec(ctx context.Context, alerts ...*types.Alert) (context.Context, []*types.Alert, error) {
-	var res []*types.Alert
-
-	if fr.conf.SendResolved() {
-		res = alerts
-	} else {
-		for _, a := range alerts {
-			if a.Status() != model.AlertResolved {
-				res = append(res, a)
-			}
-		}
-	}
-
-	return ctx, res, nil
 }
 
 // DedupStage filters alerts.


### PR DESCRIPTION
notify: move resolved alert filtering to integration

Resolved alerts, even when filtered, have to end up in the
SetNotifiesStage, otherwise when an alert fires again it is ambiguous
whether it was resolved in between or not.
    
fixes #523

@fabxc @johto 