### PR TITLE
inhibitrule: defer Unlock to fix race

### DIFF
--- a/inhibit/inhibit.go
+++ b/inhibit/inhibit.go
@@ -184,7 +184,7 @@ func NewInhibitRule(cr *config.InhibitRule) *InhibitRule {
 // set the alert in the source cache.
 func (r *InhibitRule) set(a *types.Alert) {
 	r.mtx.Lock()
-	r.mtx.Unlock()
+	defer r.mtx.Unlock()
 
 	r.scache[a.Fingerprint()] = a
 }


### PR DESCRIPTION
There's a typo in InhibitRule.set, the defer keyword is missing.  Found with a -race build.