### PR TITLE
Improve logging of API errors.

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -531,7 +531,7 @@ func respondError(w http.ResponseWriter, apiErr apiError, data interface{}) {
 	if err != nil {
 		return
 	}
-	log.Errorf("api error: %s", apiErr)
+	log.Errorf("api error: %v", apiErr.Error())
 
 	w.Write(b)
 }


### PR DESCRIPTION
Previously errors would look like:
ERRO[0008] api error: {bad_data 0xc4201caae0}
source=api.go:534

Now they look like:
ERRO[0001] api error: bad_data: json: cannot unmarshal object into Go
value of type []*types.Alert  source=api.go:534