### PR TITLE
add runcommand receiver

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -430,14 +430,15 @@ type Receiver struct {
 	// A unique identifier for this receiver.
 	Name string `yaml:"name" json:"name"`
 
-	EmailConfigs     []*EmailConfig     `yaml:"email_configs,omitempty" json:"email_configs,omitempty"`
-	PagerdutyConfigs []*PagerdutyConfig `yaml:"pagerduty_configs,omitempty" json:"pagerduty_configs,omitempty"`
-	HipchatConfigs   []*HipchatConfig   `yaml:"hipchat_configs,omitempty" json:"hipchat_configs,omitempty"`
-	SlackConfigs     []*SlackConfig     `yaml:"slack_configs,omitempty" json:"slack_configs,omitempty"`
-	WebhookConfigs   []*WebhookConfig   `yaml:"webhook_configs,omitempty" json:"webhook_configs,omitempty"`
-	OpsGenieConfigs  []*OpsGenieConfig  `yaml:"opsgenie_configs,omitempty" json:"opsgenie_configs,omitempty"`
-	PushoverConfigs  []*PushoverConfig  `yaml:"pushover_configs,omitempty" json:"pushover_configs,omitempty"`
-	VictorOpsConfigs []*VictorOpsConfig `yaml:"victorops_configs,omitempty" json:"victorops_configs,omitempty"`
+	EmailConfigs      []*EmailConfig      `yaml:"email_configs,omitempty" json:"email_configs,omitempty"`
+	PagerdutyConfigs  []*PagerdutyConfig  `yaml:"pagerduty_configs,omitempty" json:"pagerduty_configs,omitempty"`
+	HipchatConfigs    []*HipchatConfig    `yaml:"hipchat_configs,omitempty" json:"hipchat_configs,omitempty"`
+	SlackConfigs      []*SlackConfig      `yaml:"slack_configs,omitempty" json:"slack_configs,omitempty"`
+	WebhookConfigs    []*WebhookConfig    `yaml:"webhook_configs,omitempty" json:"webhook_configs,omitempty"`
+	OpsGenieConfigs   []*OpsGenieConfig   `yaml:"opsgenie_configs,omitempty" json:"opsgenie_configs,omitempty"`
+	PushoverConfigs   []*PushoverConfig   `yaml:"pushover_configs,omitempty" json:"pushover_configs,omitempty"`
+	VictorOpsConfigs  []*VictorOpsConfig  `yaml:"victorops_configs,omitempty" json:"victorops_configs,omitempty"`
+	RunCommandConfigs []*RunCommandConfig `yaml:"runcommand_configs,omitempty" json:"runcommand_configs,omitempty"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline" json:"-"`

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -35,6 +35,13 @@ var (
 		HTML: `{{ template "email.default.html" . }}`,
 	}
 
+	// DefaultRunCommandConfig defines default values for RunCommand configurations.
+	DefaultRunCommandConfig = RunCommandConfig{
+		NotifierConfig: NotifierConfig{
+			VSendResolved: false,
+		},
+	}
+
 	// DefaultEmailSubject defines the default Subject header of an Email.
 	DefaultEmailSubject = `{{ template "email.default.subject" . }}`
 
@@ -284,6 +291,27 @@ func (c *WebhookConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return fmt.Errorf("missing URL in webhook config")
 	}
 	return checkOverflow(c.XXX, "webhook config")
+}
+
+// RunCommandConfig configures notifications via a generic webhook.
+type RunCommandConfig struct {
+	NotifierConfig `yaml:",inline" json:",inline"`
+
+	// Script to execute.
+	Script string `yaml:"script" json:"script"`
+
+	// Catches all undefined fields and must be empty after parsing.
+	XXX map[string]interface{} `yaml:",inline" json:"-"`
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (c *RunCommandConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	*c = DefaultRunCommandConfig
+	type plain RunCommandConfig
+	if err := unmarshal((*plain)(c)); err != nil {
+		return err
+	}
+	return checkOverflow(c.XXX, "runcommand config")
 }
 
 // OpsGenieConfig configures notifications via OpsGenie.

--- a/notify/impl.go
+++ b/notify/impl.go
@@ -27,7 +27,10 @@ import (
 	"net/mail"
 	"net/smtp"
 	"net/url"
+	"os"
+	"os/exec"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/prometheus/common/log"
@@ -128,6 +131,10 @@ func BuildReceiverIntegrations(nc *config.Receiver, tmpl *template.Template) []I
 	for i, c := range nc.PushoverConfigs {
 		n := NewPushover(c, tmpl)
 		add("pushover", i, n, c)
+	}
+	for i, c := range nc.RunCommandConfigs {
+		n := NewRunCommand(c, tmpl)
+		add("runcommand", i, n, c)
 	}
 	return integrations
 }
@@ -929,6 +936,78 @@ func (n *Pushover) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 			return false, err
 		}
 		return false, fmt.Errorf("unexpected status code %v (body: %s)", resp.StatusCode, string(body))
+	}
+
+	return false, nil
+}
+
+// RunCommand implements a Notifier for RunCommand notifications.
+type RunCommand struct {
+	conf *config.RunCommandConfig
+	tmpl *template.Template
+}
+
+// NewRunCommand returns a new RunCommand notification handler.
+func NewRunCommand(c *config.RunCommandConfig, t *template.Template) *RunCommand {
+	return &RunCommand{
+		conf: c,
+		tmpl: t,
+	}
+}
+
+// RunCommandConf is the request for sending a RunCommand notification.
+type RunCommandConf struct {
+	Script string `json:"script"`
+}
+
+// Notify implements the Notifier interface.
+func (n *RunCommand) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
+
+	var err error
+
+	data := n.tmpl.Data(receiverName(ctx), groupLabels(ctx), as...)
+	tmplText := tmplText(n.tmpl, data, &err)
+
+	runCommandConf := &RunCommandConf{
+		Script: tmplText(n.conf.Script),
+	}
+
+	runCommandWithArgs := strings.Fields(runCommandConf.Script)
+	command := runCommandWithArgs[0]
+	args := runCommandWithArgs[1:len(runCommandWithArgs)]
+
+	cmd := exec.Command(command, args...)
+
+	env := os.Environ()
+
+	for k, v := range data.CommonAnnotations {
+		env = append(env, fmt.Sprintf("PROMETHEUS_ANNOTATIONS_%s=%s", strings.ToUpper(k), v))
+	}
+	for k, v := range data.CommonLabels {
+		env = append(env, fmt.Sprintf("PROMETHEUS_COMMONLABEL_%s=%s", strings.ToUpper(k), v))
+	}
+	for k, v := range data.GroupLabels {
+		env = append(env, fmt.Sprintf("PROMETHEUS_GROUPLABEL_%s=%s", strings.ToUpper(k), v))
+	}
+
+	env = append(env, fmt.Sprintf("PROMETHEUS_RECEIVER=%s", data.Receiver))
+	env = append(env, fmt.Sprintf("PROMETHEUS_STATUS=%s", data.Status))
+	env = append(env, fmt.Sprintf("PROMETHEUS_EXTERNALURL=%s", data.ExternalURL))
+
+	cmd.Env = env
+
+	if err := cmd.Start(); err != nil {
+		return false, fmt.Errorf("cmd.Start error: %v", err)
+	}
+	if err := cmd.Wait(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			// The command has exited with an exit code != 0
+			if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
+				return false, fmt.Errorf("exit status code: %v", status.ExitStatus())
+			}
+		} else {
+			return false, fmt.Errorf("cmd.Wait error: %v", err)
+		}
 	}
 
 	return false, nil


### PR DESCRIPTION
this implements the receiver `runcommand`, which enables the enduser to extend the functionality of a receiver with any script.
This might be useful for lots of people, which the notifiers are not added yet.

Configuration used for testing:

```yaml
global:

route:
  group_by: ['alertname']
  group_wait: 10s
  group_interval: 15s
  repeat_interval: 30s
  receiver: run-custom-scripts

receivers:
- name: 'run-custom-scripts'
  runcommand_configs:
  - script: 'sh /tmp/make-a-call.sh 911'
  - script: '/tmp/notify-zabbix.sh'

```

In addition is set some environment variable to the script:

```bash
PROMETHEUS_ANNOTATIONS_DESCRIPTION=This is a description of process fds
PROMETHEUS_ANNOTATIONS_SUMMARY=Process File Descriptor
PROMETHEUS_COMMONLABEL_ALERTNAME=ProcessFds Test
PROMETHEUS_COMMONLABEL_INSTANCE=172.17.0.3:9090
PROMETHEUS_COMMONLABEL_JOB=prometheus
PROMETHEUS_COMMONLABEL_MONITOR=codelab-monitor
PROMETHEUS_COMMONLABEL_SEVERITY=low
PROMETHEUS_EXTERNALURL=http://a298bedb1f71:9093
PROMETHEUS_GROUPLABEL_ALERTNAME=ProcessFds
PROMETHEUS_RECEIVER=runcommand
PROMETHEUS_STATUS=firing
```

hey @fabxc if you guys approve this, I am glad to provide the docs for it.