### PR TITLE
add option to automatically link named @user/@team in Slack notifications and turn on full slack message parsing

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -69,6 +69,7 @@ var (
 		Text:      `{{ template "slack.default.text" . }}`,
 		Fallback:  `{{ template "slack.default.fallback" . }}`,
 		LinkNames: true,
+		Parse:     "",
 	}
 
 	// DefaultHipchatConfig defines default values for Hipchat configurations.
@@ -218,6 +219,7 @@ type SlackConfig struct {
 	IconEmoji string `yaml:"icon_emoji" json:"icon_emoji"`
 	IconURL   string `yaml:"icon_url" json:"icon_url"`
 	LinkNames bool   `yaml:"link_names" json:"link_names"`
+	Parse     string `yaml:"parse" json:"parse"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline" json:"-"`

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -68,6 +68,7 @@ var (
 		Pretext:   `{{ template "slack.default.pretext" . }}`,
 		Text:      `{{ template "slack.default.text" . }}`,
 		Fallback:  `{{ template "slack.default.fallback" . }}`,
+		LinkNames: true,
 	}
 
 	// DefaultHipchatConfig defines default values for Hipchat configurations.
@@ -216,6 +217,7 @@ type SlackConfig struct {
 	Fallback  string `yaml:"fallback" json:"fallback"`
 	IconEmoji string `yaml:"icon_emoji" json:"icon_emoji"`
 	IconURL   string `yaml:"icon_url" json:"icon_url"`
+	LinkNames bool   `yaml:"link_names" json:"link_names"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline" json:"-"`

--- a/notify/impl.go
+++ b/notify/impl.go
@@ -469,6 +469,7 @@ type slackReq struct {
 	IconURL     string            `json:"icon_url,omitempty"`
 	Attachments []slackAttachment `json:"attachments"`
 	LinkNames   bool              `json:"link_names,omitempty"`
+	Parse       string            `json:"parse,ommitempty"`
 }
 
 // slackAttachment is used to display a richly-formatted message block.
@@ -514,6 +515,7 @@ func (n *Slack) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 		IconURL:     tmplText(n.conf.IconURL),
 		Attachments: []slackAttachment{*attachment},
 		LinkNames:   n.conf.LinkNames,
+		Parse:       n.conf.Parse,
 	}
 	if err != nil {
 		return false, err

--- a/notify/impl.go
+++ b/notify/impl.go
@@ -468,6 +468,7 @@ type slackReq struct {
 	IconEmoji   string            `json:"icon_emoji,omitempty"`
 	IconURL     string            `json:"icon_url,omitempty"`
 	Attachments []slackAttachment `json:"attachments"`
+	LinkNames   bool              `json:"link_names,omitempty"`
 }
 
 // slackAttachment is used to display a richly-formatted message block.
@@ -512,6 +513,7 @@ func (n *Slack) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 		IconEmoji:   tmplText(n.conf.IconEmoji),
 		IconURL:     tmplText(n.conf.IconURL),
 		Attachments: []slackAttachment{*attachment},
+		LinkNames:   n.conf.LinkNames,
 	}
 	if err != nil {
 		return false, err


### PR DESCRIPTION
link_names option is turned on by default as this is what most
people would expect, but can be disabled in configuration in those rare
instances when autolinking causes problems

should close: #586
cc: @juliusv

EDIT: This builds and passes rudimentary checks. I still need to  deploy it in our testing  to check how it behaves in real environment. 