### PR TITLE
notify: replace unfiltered with filtered alerts

### DIFF
--- a/notify/impl.go
+++ b/notify/impl.go
@@ -79,7 +79,7 @@ func (i *Integration) Notify(ctx context.Context, alerts ...*types.Alert) (bool,
 		return false, nil
 	}
 
-	return i.notifier.Notify(ctx, alerts...)
+	return i.notifier.Notify(ctx, res...)
 }
 
 // BuildReceiverIntegrations builds a list of integration notifiers off of a

--- a/test/acceptance/send_test.go
+++ b/test/acceptance/send_test.go
@@ -373,47 +373,27 @@ receivers:
 			am.Push(At(1),
 				Alert("alertname", "test", "lbl", "v1"),
 				Alert("alertname", "test", "lbl", "v2"),
-				Alert("alertname", "test", "lbl", "v3"),
 			)
 
-			am.Push(At(16),
+			am.Push(At(7),
 				Alert("alertname", "test", "lbl", "v1"),
-				Alert("alertname", "test", "lbl", "v2"),
-				Alert("alertname", "test", "lbl", "v3"),
 			)
 
 			co1.Want(Between(2, 2.5),
 				Alert("alertname", "test", "lbl", "v1").Active(1),
 				Alert("alertname", "test", "lbl", "v2").Active(1),
-				Alert("alertname", "test", "lbl", "v3").Active(1),
 			)
 			co1.Want(Between(12, 13),
-				Alert("alertname", "test", "lbl", "v1").Active(1, 11),
+				Alert("alertname", "test", "lbl", "v1").Active(1),
 				Alert("alertname", "test", "lbl", "v2").Active(1, 11),
-				Alert("alertname", "test", "lbl", "v3").Active(1, 11),
-			)
-
-			co1.Want(Between(17, 17.5),
-				Alert("alertname", "test", "lbl", "v1").Active(16),
-				Alert("alertname", "test", "lbl", "v2").Active(16),
-				Alert("alertname", "test", "lbl", "v3").Active(16),
-			)
-			co1.Want(Between(27, 28),
-				Alert("alertname", "test", "lbl", "v1").Active(16, 26),
-				Alert("alertname", "test", "lbl", "v2").Active(16, 26),
-				Alert("alertname", "test", "lbl", "v3").Active(16, 26),
 			)
 
 			co2.Want(Between(2, 2.5),
 				Alert("alertname", "test", "lbl", "v1").Active(1),
 				Alert("alertname", "test", "lbl", "v2").Active(1),
-				Alert("alertname", "test", "lbl", "v3").Active(1),
 			)
-
-			co2.Want(Between(17, 17.5),
-				Alert("alertname", "test", "lbl", "v1").Active(16),
-				Alert("alertname", "test", "lbl", "v2").Active(16),
-				Alert("alertname", "test", "lbl", "v3").Active(16),
+			co2.Want(Between(12, 13),
+				Alert("alertname", "test", "lbl", "v1").Active(1),
 			)
 
 			at.Run()


### PR DESCRIPTION
Fixes #591 

We we're actually testing the `len(res) == 0` condition in the tests so we didn't notice the problem, as we always filtered all alerts in the tests.

@fabxc @brian-brazil @alexsomesan

@ddewaele you mentioned in #591 that you would volunteer to test a fix. I'm pretty confident it works correctly now, but won't hurt to try in your environment.