### PR TITLE
Wait for test server to be ready before running tests

### DIFF
--- a/test/acceptance.go
+++ b/test/acceptance.go
@@ -270,6 +270,19 @@ func (am *Alertmanager) Start() {
 	}()
 
 	time.Sleep(50 * time.Millisecond)
+	for i := 0; i < 10; i++ {
+		resp, err := http.Get(fmt.Sprintf("http://%s/status", am.addr))
+		if err == nil {
+			_, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				panic(err)
+			}
+			resp.Body.Close()
+			return
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	am.t.Fatalf("Starting alertmanager failed: timeout")
 }
 
 // Terminate kills the underlying Alertmanager process and remove intermediate

--- a/test/acceptance.go
+++ b/test/acceptance.go
@@ -275,7 +275,7 @@ func (am *Alertmanager) Start() {
 		if err == nil {
 			_, err := ioutil.ReadAll(resp.Body)
 			if err != nil {
-				panic(err)
+				am.t.Fatalf("Starting alertmanager failed: %s", err)
 			}
 			resp.Body.Close()
 			return


### PR DESCRIPTION
This fixes problems when running the acceptance tests in slow or CPU-starved
machines, as mentioned in #472.