### PR TITLE
Prevent panic on failed config load

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -127,7 +127,7 @@ func (api *API) Register(r *route.Router) {
 }
 
 // Update sets the configuration string to a new value.
-func (api *API) Update(cfg string, resolveTimeout time.Duration) {
+func (api *API) Update(cfg string, resolveTimeout time.Duration) error {
 	api.mtx.Lock()
 	defer api.mtx.Unlock()
 
@@ -137,8 +137,11 @@ func (api *API) Update(cfg string, resolveTimeout time.Duration) {
 	configJSON, err := config.Load(cfg)
 	if err != nil {
 		log.Errorf("error: %v", err)
+		return err
 	}
+
 	api.configJSON = *configJSON
+	return nil
 }
 
 type errorType string

--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -208,7 +208,10 @@ func main() {
 			return err
 		}
 
-		apiv.Update(conf.String(), time.Duration(conf.Global.ResolveTimeout))
+		err = apiv.Update(conf.String(), time.Duration(conf.Global.ResolveTimeout))
+		if err != nil {
+			return err
+		}
 
 		tmpl, err = template.FromGlobs(conf.Templates...)
 		if err != nil {


### PR DESCRIPTION
Prevent Alertmanager from panicking when the configuration cannot be
loaded.

Spotted in version 0.4.2:

    INFO[0000] Starting alertmanager (version=0.4.2, branch=HEAD, revision=9a5ab2fa63dd7951f4f202b0846d4f4d8e9615b0)  source=main.go:84
    INFO[0000] Build context (go=go1.7.3, user=root@45f28166fed1, date=20170117-13:50:50)  source=main.go:85
    INFO[0000] Loading configuration file                    file=alertmanager.yml source=main.go:156
    ERRO[0000] error: yaml: line 64: could not find expected ':'  source=api.go:115
    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x401adb]

    goroutine 1 [running]:
    panic(0x83e240, 0xc42000e020)
            /usr/local/go/src/runtime/panic.go:500 +0x1a1
    main.(*API).Update(0xc4200b20f0, 0xc42019f800, 0x17e7, 0x45d964b800)
            /go/src/github.com/prometheus/alertmanager/api.go:117 +0xcb
    main.main.func3(0x0, 0x0)
            /go/src/github.com/prometheus/alertmanager/main.go:172 +0x226
    main.main()
            /go/src/github.com/prometheus/alertmanager/main.go:192 +0x97a
    make: *** [run] Error 2