### PR TITLE
Making slack color configurable via templates

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -59,7 +59,7 @@ var (
 		NotifierConfig: NotifierConfig{
 			VSendResolved: false,
 		},
-		Color:     `{{ if eq .Status "firing" }}danger{{ else }}good{{ end }}`,
+		Color:     `{{ template "slack.default.color" }}`,
 		Username:  `{{ template "slack.default.username" . }}`,
 		Title:     `{{ template "slack.default.title" . }}`,
 		TitleLink: `{{ template "slack.default.titlelink" . }}`,

--- a/template/default.tmpl
+++ b/template/default.tmpl
@@ -20,6 +20,7 @@
 {{ define "slack.default.iconemoji" }}{{ end }}
 {{ define "slack.default.iconurl" }}{{ end }}
 {{ define "slack.default.text" }}{{ end }}
+{{ define "slack.default.color" }}{{ if eq .Status "firing" }}danger{{ else }}good{{ end }}{{end}}
 
 
 {{ define "hipchat.default.from" }}{{ template "__alertmanager" . }}{{ end }}


### PR DESCRIPTION
The default value for color was not referring to a template variable.
This change ensures that colors can be easily overwritten via a custom template.

This is needed when one wants to use different color for low severity alerts.

@fabxc 