### PR TITLE
Only find MAC address if no command-line flag value given

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
-a1: ./alertmanager -log.level=debug -storage.path=$TMPDIR/a1 -web.listen-address=:9093 -mesh.hardware-address=00:00:00:00:00:01 -mesh.nickname=a -mesh.listen-address=:8001 -config.file=examples/ha/alertmanager.yaml
-a2: ./alertmanager -log.level=debug -storage.path=$TMPDIR/a2 -web.listen-address=:9094 -mesh.hardware-address=00:00:00:00:00:02 -mesh.nickname=b -mesh.listen-address=:8002 -mesh.peer=127.0.0.1:8001 -config.file=examples/ha/alertmanager.yaml
-a3: ./alertmanager -log.level=debug -storage.path=$TMPDIR/a3 -web.listen-address=:9095 -mesh.hardware-address=00:00:00:00:00:03 -mesh.nickname=c -mesh.listen-address=:8003 -mesh.peer=127.0.0.1:8001 -config.file=examples/ha/alertmanager.yaml
+a1: ./alertmanager -log.level=debug -storage.path=$TMPDIR/a1 -web.listen-address=:9093 -mesh.peer-id=00:00:00:00:00:01 -mesh.nickname=a -mesh.listen-address=:8001 -config.file=examples/ha/alertmanager.yaml
+a2: ./alertmanager -log.level=debug -storage.path=$TMPDIR/a2 -web.listen-address=:9094 -mesh.peer-id=00:00:00:00:00:02 -mesh.nickname=b -mesh.listen-address=:8002 -mesh.peer=127.0.0.1:8001 -config.file=examples/ha/alertmanager.yaml
+a3: ./alertmanager -log.level=debug -storage.path=$TMPDIR/a3 -web.listen-address=:9095 -mesh.peer-id=00:00:00:00:00:03 -mesh.nickname=c -mesh.listen-address=:8003 -mesh.peer=127.0.0.1:8001 -config.file=examples/ha/alertmanager.yaml
 wh: go run ./examples/webhook/echo.go
 

--- a/README.md
+++ b/README.md
@@ -174,12 +174,12 @@ To create a highly available cluster of the Alertmanager the instances need to
 be configured to communicate with each other. This is configured using the
 `-mesh.*` flags.
 
-- `-mesh.hardware-address` string: mesh peer ID (default "&lt;hardware-mac-address&gt;")
+- `-mesh.peer-id` string: mesh peer ID (default "&lt;hardware-mac-address&gt;")
 - `-mesh.listen-address` string: mesh listen address (default "0.0.0.0:6783")
 - `-mesh.nickname` string: mesh peer nickname (default "&lt;machine-hostname&gt;")
-- `-mesh.peer` value: initial initial peers (may be repeated)
+- `-mesh.peer` value: initial peers (may be repeated)
 
-The `mesh.hardware-address` flag is used as a unique ID among the peers. It
+The `mesh.peer-id` flag is used as a unique ID among the peers. It
 defaults to the MAC address, therefore the default value should typically be a
 good option. The same applies to the default of the `mesh.nickname` flag, as it
 defaults to the hostname. The chosen port in the `mesh.listen-address` flag is

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ route:
   # all alerts. It needs to have a receiver configured so alerts that do not
   # match any of the sub-routes are sent to someone.
   receiver: 'team-X-mails'
-  
+
   # The labels by which incoming alerts are grouped together. For example,
   # multiple alerts coming in for cluster=A and alertname=LatencyHigh would
   # be batched into a single group.
@@ -82,7 +82,7 @@ route:
   # resend them.
   repeat_interval: 3h
 
-  # All the above attributes are inherited by all child routes and can 
+  # All the above attributes are inherited by all child routes and can
   # overwritten on each.
 
   # The child route trees.
@@ -174,10 +174,10 @@ To create a highly available cluster of the Alertmanager the instances need to
 be configured to communicate with each other. This is configured using the
 `-mesh.*` flags.
 
-- `-mesh.hardware-address` string: MAC address, i.e. mesh peer ID (default "&lt;hardware-mac-address&gt;")
+- `-mesh.hardware-address` string: mesh peer ID (default "&lt;hardware-mac-address&gt;")
 - `-mesh.listen-address` string: mesh listen address (default "0.0.0.0:6783")
-- `-mesh.nickname` string: peer nickname (default "&lt;machine-hostname&gt;")
-- `-mesh.peer` value: initial peers (may be repeated)
+- `-mesh.nickname` string: mesh peer nickname (default "&lt;machine-hostname&gt;")
+- `-mesh.peer` value: initial initial peers (may be repeated)
 
 The `mesh.hardware-address` flag is used as a unique ID among the peers. It
 defaults to the MAC address, therefore the default value should typically be a

--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -82,12 +82,16 @@ func main() {
 		listenAddress = flag.String("web.listen-address", ":9093", "Address to listen on for the web interface and API.")
 
 		meshListen = flag.String("mesh.listen-address", net.JoinHostPort("0.0.0.0", strconv.Itoa(mesh.Port)), "mesh listen address")
-		hwaddr     = flag.String("mesh.hardware-address", mustHardwareAddr(), "MAC address, i.e. mesh peer ID")
-		nickname   = flag.String("mesh.nickname", mustHostname(), "peer nickname")
+		hwaddr     = flag.String("mesh.hardware-address", "", "mesh peer ID (default: MAC address)")
+		nickname   = flag.String("mesh.nickname", mustHostname(), "mesh peer nickname")
 		password   = flag.String("mesh.password", "", "password to join the peer network (empty password disables encryption)")
 	)
 	flag.Var(peers, "mesh.peer", "initial peers (may be repeated)")
 	flag.Parse()
+
+	if *hwaddr == "" {
+		*hwaddr = mustHardwareAddr()
+	}
 
 	if len(flag.Args()) > 0 {
 		log.Fatalln("Received unexpected and unparsed arguments: ", strings.Join(flag.Args(), ", "))

--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -82,7 +82,7 @@ func main() {
 		listenAddress = flag.String("web.listen-address", ":9093", "Address to listen on for the web interface and API.")
 
 		meshListen = flag.String("mesh.listen-address", net.JoinHostPort("0.0.0.0", strconv.Itoa(mesh.Port)), "mesh listen address")
-		hwaddr     = flag.String("mesh.hardware-address", "", "mesh peer ID (default: MAC address)")
+		hwaddr     = flag.String("mesh.peer-id", "", "mesh peer ID (default: MAC address)")
 		nickname   = flag.String("mesh.nickname", mustHostname(), "mesh peer nickname")
 		password   = flag.String("mesh.password", "", "password to join the peer network (empty password disables encryption)")
 	)

--- a/test/acceptance.go
+++ b/test/acceptance.go
@@ -245,7 +245,7 @@ func (am *Alertmanager) Start() {
 		"-web.listen-address", am.addr,
 		"-storage.path", am.dir,
 		"-mesh.listen-address", am.mesh,
-		"-mesh.hardware-address", am.hwaddr,
+		"-mesh.peer-id", am.hwaddr,
 		"-mesh.nickname", am.nickname,
 	)
 


### PR DESCRIPTION
Defaulting to the machine's MAC address fails
sometimes fails and causes a panic. Allow the user to
specify custom address to skip this so they can
run AlertManager.

Addresses #582 

@beorn7 @brancz @fabxc this is more or less a quick fix so that users can manually enter something while we decide how to handle this.