### PR TITLE
api: Expose mesh status

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -180,7 +180,7 @@ func main() {
 
 	apiv := api.New(alerts, silences, func() dispatch.AlertOverview {
 		return disp.Groups()
-	})
+	}, mrouter)
 
 	amURL, err := extURL(*listenAddress, *externalURL)
 	if err != nil {


### PR DESCRIPTION
The weaveworks mesh package reveals information about the current status
of the mesh network between alertmanager instances. This commit exposes
the current address and connection status of each instance connected to
the targeted alertmanager instance via the /status API endpoint.