### PR TITLE
Allow export of regex from label parser

### DIFF
--- a/vendor/github.com/prometheus/prometheus/pkg/labels/matcher.go
+++ b/vendor/github.com/prometheus/prometheus/pkg/labels/matcher.go
@@ -60,6 +60,11 @@ func (m *Matcher) String() string {
 	return fmt.Sprintf("%s%s%q", m.Name, m.Type, m.Value)
 }
 
+// Allow fetching of regex for conversion to internal types
+func (m *Matcher) Regexp() *regexp.Regexp {
+	return m.re
+}
+
 // Matches returns whether the matcher matches the given string value.
 func (m *Matcher) Matches(s string) bool {
 	switch m.Type {


### PR DESCRIPTION
Small addition to filtering

This is useful when trying to translate a label.Matcher to a type.Matcher (Case of using the parser to create new silences). 

Currently I would need to duplicate the regex logic and that feels unsavory.