### PR TITLE
Refresh every 30 seconds (fixes #524).

### DIFF
--- a/ui/app/src/Main.elm
+++ b/ui/app/src/Main.elm
@@ -26,6 +26,7 @@ import Views.SilenceList.Updates
 import Views.SilenceForm.Types exposing (initSilenceForm)
 import Views.Status.Types exposing (StatusModel, initStatusModel)
 import Updates exposing (update)
+import Subscriptions exposing (subscriptions)
 
 
 main : Program Never Model Msg
@@ -91,13 +92,3 @@ urlUpdate location =
 
             NotFoundRoute ->
                 NavigateToNotFound
-
-
-
--- SUBSCRIPTIONS
--- TODO: Poll API for changes.
-
-
-subscriptions : Model -> Sub Msg
-subscriptions model =
-    Sub.none

--- a/ui/app/src/Subscriptions.elm
+++ b/ui/app/src/Subscriptions.elm
@@ -1,0 +1,22 @@
+module Subscriptions exposing (subscriptions)
+
+import Types exposing (Model, Msg(MsgForAlertList, MsgForSilenceList, Noop), Route(AlertsRoute, SilenceListRoute))
+import Views.AlertList.Types exposing (AlertListMsg(FetchAlertGroups))
+import Views.SilenceList.Types exposing (SilenceListMsg(FetchSilences))
+import Time
+
+
+subscriptions : Model -> Sub Msg
+subscriptions model =
+    Time.every (30 * Time.second)
+        (\_ ->
+            case model.route of
+                AlertsRoute _ ->
+                    MsgForAlertList FetchAlertGroups
+
+                SilenceListRoute _ ->
+                    MsgForSilenceList FetchSilences
+
+                _ ->
+                    Noop
+        )


### PR DESCRIPTION
More of a short spike than anything, this commit
refreshes whichever list page a user is on once
every 30 seconds.

Not sure if we want to think about this more at the moment. One of the main issues is that silences aren't received from the API in a specific order, so if the user is scrolling through the list, a refresh will cause them to lose their spot.

If this is something to pursue, I would force a sort order on incoming data from the API and then we can try this out.