### PR TITLE
Don't return alerts in the API (alerts/groups) until they are cross-c…

### DIFF
--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -137,7 +137,7 @@ func (d *Dispatcher) Groups(matchers []*labels.Matcher) AlertOverview {
 				}
 				aa := &APIAlert{
 					Alert:     a,
-					Inhibited: d.marker.Inhibited(a.Fingerprint()),
+					Inhibited: d.marker.Status(a.Fingerprint(), types.InhibitedStatus),
 				}
 
 				if !matchesFilterLabels(aa, matchers) {

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -132,6 +132,11 @@ func (d *Dispatcher) Groups(matchers []*labels.Matcher) AlertOverview {
 
 			var apiAlerts []*APIAlert
 			for _, a := range types.Alerts(ag.alertSlice()...) {
+				// skip alerts that were not yet processed by notify and so we don't
+				// know if they are silenced or not
+				if !d.marker.Status(a.Fingerprint(), types.ProcessedStatus) {
+					continue
+				}
 				if !a.EndsAt.IsZero() && a.EndsAt.Before(now) {
 					continue
 				}

--- a/inhibit/inhibit.go
+++ b/inhibit/inhibit.go
@@ -117,11 +117,11 @@ func (ih *Inhibitor) Mutes(lset model.LabelSet) bool {
 
 	for _, r := range ih.rules {
 		if r.TargetMatchers.Match(lset) && r.hasEqual(lset) {
-			ih.marker.SetInhibited(fp, true)
+			ih.marker.SetStatus(fp, types.InhibitedStatus, true)
 			return true
 		}
 	}
-	ih.marker.SetInhibited(fp, false)
+	ih.marker.SetStatus(fp, types.InhibitedStatus, false)
 	return false
 
 }

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -300,7 +300,7 @@ func NewInhibitStage(m types.Muter, mk types.Marker) *InhibitStage {
 func (n *InhibitStage) Exec(ctx context.Context, alerts ...*types.Alert) (context.Context, []*types.Alert, error) {
 	var filtered []*types.Alert
 	for _, a := range alerts {
-		ok := n.marker.Inhibited(a.Fingerprint())
+		ok := n.marker.Status(a.Fingerprint(), types.InhibitedStatus)
 		// TODO(fabxc): increment total alerts counter.
 		// Do not send the alert if the silencer mutes it.
 		if !n.muter.Mutes(a.Labels) {

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -351,6 +351,7 @@ func (n *SilenceStage) Exec(ctx context.Context, alerts ...*types.Alert) (contex
 		} else {
 			n.marker.SetSilenced(a.Labels.Fingerprint(), sils[0].Id)
 		}
+		n.marker.SetStatus(a.Fingerprint(), types.ProcessedStatus, true)
 	}
 
 	return ctx, filtered, nil

--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -504,7 +504,7 @@ func TestInhibitStage(t *testing.T) {
 
 	// Set the second alert as previously inhibited. It is expected to have
 	// the WasInhibited flag set to true afterwards.
-	marker.SetInhibited(inAlerts[1].Fingerprint(), true)
+	marker.SetStatus(inAlerts[1].Fingerprint(), types.InhibitedStatus, true)
 
 	_, alerts, err := inhibitor.Exec(nil, inAlerts...)
 	if err != nil {

--- a/types/types.go
+++ b/types/types.go
@@ -45,6 +45,9 @@ const (
 	// InhibitedStatus bit is set on memMarker->status when linked alert is
 	// inhibited
 	InhibitedStatus = 1
+	// ProcessedStatus bit is set on memMarker->status when linked alert is
+	// processed by notify code
+	ProcessedStatus = 2
 )
 
 type memMarker struct {


### PR DESCRIPTION
…hecked with silences

alerts/groups API endpoint provides "silenced" key for all alerts, which is set if any silence for this alert exist.
Due to how silences are matched with alerts, which happens out of band from API perspective, alerts/groups will return all alerts as soon as they created and only after silences are matched with an alert a "silenced" key will be added to the object in API response. This means that API clients that wants to rely on that key can't trust it, as the absence of "silenced" key doesn't guarantee that given alerts isn't silenced. This change fixes that by tracking which alert was matched against silences and only returning those alerts that were checked.
Fixes #609