### PR TITLE
Add Telegram notifier

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"encoding/json"
+
 	"github.com/prometheus/common/model"
 	"gopkg.in/yaml.v2"
 )
@@ -233,6 +234,23 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 				voc.APIURL += "/"
 			}
 		}
+		for _, tg := range rcv.TelegramConfigs {
+			if tg.APIURL == "" {
+				if c.Global.TelegramURL == "" {
+					return fmt.Errorf("no global Telegram API URL set")
+				}
+				tg.APIURL = c.Global.TelegramURL
+			}
+			if !strings.HasSuffix(tg.APIURL, "/") {
+				tg.APIURL += "/"
+			}
+			if tg.Token == "" {
+				if c.Global.TelegramToken == "" {
+					return fmt.Errorf("no global Telegram Token set")
+				}
+				tg.Token = c.Global.TelegramToken
+			}
+		}
 		names[rcv.Name] = struct{}{}
 	}
 
@@ -282,6 +300,7 @@ var DefaultGlobalConfig = GlobalConfig{
 	HipchatURL:      "https://api.hipchat.com/",
 	OpsGenieAPIHost: "https://api.opsgenie.com/",
 	VictorOpsAPIURL: "https://alert.victorops.com/integrations/generic/20131114/alert/",
+	TelegramURL:     "https://api.telegram.org/",
 }
 
 // GlobalConfig defines configuration parameters that are valid globally
@@ -304,6 +323,8 @@ type GlobalConfig struct {
 	HipchatAuthToken Secret `yaml:"hipchat_auth_token" json:"hipchat_auth_token"`
 	OpsGenieAPIHost  string `yaml:"opsgenie_api_host" json:"opsgenie_api_host"`
 	VictorOpsAPIURL  string `yaml:"victorops_api_url" json:"victorops_api_url"`
+	TelegramToken    Secret `yaml:"telegram_token" json:"telegram_token"`
+	TelegramURL      string `yaml:"telegram_api_url" json:"telegram_api_url"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline" json:"-"`
@@ -439,6 +460,7 @@ type Receiver struct {
 	OpsGenieConfigs  []*OpsGenieConfig  `yaml:"opsgenie_configs,omitempty" json:"opsgenie_configs,omitempty"`
 	PushoverConfigs  []*PushoverConfig  `yaml:"pushover_configs,omitempty" json:"pushover_configs,omitempty"`
 	VictorOpsConfigs []*VictorOpsConfig `yaml:"victorops_configs,omitempty" json:"victorops_configs,omitempty"`
+	TelegramConfigs  []*TelegramConfig  `yaml:"telegram_configs,omitempty" json:"telegram_configs,omitempty"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline" json:"-"`


### PR DESCRIPTION
@stuartnelson3, Telegram – popular messenger in some countries, currently has 100m users, 15b messages sends daily.

All test passed on my laptop.

Additional:

* https://telegram.org
* https://core.telegram.org/bots/api
* http://telegram.me/BotFather

## docs

### global

```
[ telegram_api_url: <string> | default = "https://api.telegram.org/" ]
[ telegram_token: <string> ]
```

### <telegram_config>

Telegram notifications are sent via the [Telegram Bot API](https://core.telegram.org/bots/api).

```
# Whether or not to notify about resolved alerts.
[ send_resolved: <boolean> | default = true ]

# The API key to use when talking to the Telegram Bot API, can be obtained from `@BotFather`.
[ token: <string> | default = global.telegram_token ]

# The chat id or user id to send notifications to.
chat_id: <string>

# The url to send Telegram Bot API requests to.
[ api_url: <string> | default = global.telegram_api_url ]

# Disables link previews for links in this message.
[ disable_web_page_preview: <boolean> | default = false ]

# Sends the message silently. iOS users will not receive a notification, Android users will receive a notification with no sound.
[ disable_notification: <boolean> | default = false ]

# Send `Markdown` or `HTML`, if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
# https://core.telegram.org/bots/api#formatting-options
[ parse_mode: <string> | default = 'HTML' ]

# Notification message.
[ text: <tmpl_string> | default = '{{ template "telegram.default.text" . }}' ]
``` 