### PR TITLE
Add web.alert-url parameter so we can run behind reverse-proxy

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -91,6 +91,10 @@ func main() {
 	flag.Var(peers, "mesh.peer", "initial peers (may be repeated)")
 	flag.Parse()
 
+	if *alertURL == "" {
+		alertURL = externalURL
+	}
+
 	if *hwaddr == "" {
 		*hwaddr = mustHardwareAddr()
 	}

--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -80,6 +80,7 @@ func main() {
 		retention  = flag.Duration("data.retention", 5*24*time.Hour, "How long to keep data for.")
 
 		externalURL   = flag.String("web.external-url", "", "The URL under which Alertmanager is externally reachable (for example, if Alertmanager is served via a reverse proxy). Used for generating relative and absolute links back to Alertmanager itself. If the URL has a path portion, it will be used to prefix all HTTP endpoints served by Alertmanager. If omitted, relevant URL components will be derived automatically.")
+		alertURL      = flag.String("web.alert-url", "", "The URL which is prefixed to the Alertmanager alert URLs, for example when accessing via a reverse proxy.")
 		listenAddress = flag.String("web.listen-address", ":9093", "Address to listen on for the web interface and API.")
 
 		meshListen = flag.String("mesh.listen-address", net.JoinHostPort("0.0.0.0", strconv.Itoa(mesh.Port)), "mesh listen address")
@@ -222,7 +223,11 @@ func main() {
 		if err != nil {
 			return err
 		}
-		tmpl.ExternalURL = amURL
+		alertingURL, err := extURL(*listenAddress, *alertURL)
+		if err != nil {
+			log.Fatal(err)
+		}
+		tmpl.ExternalURL = alertingURL
 
 		inhibitor.Stop()
 		disp.Stop()


### PR DESCRIPTION
In our deployment of prometheus we make the dashboards available through a reverse-proxy, this means that the alerts that come up in Slack or PagerDuty need to contain a different URL from the one that Alertmanager runs on.

Setting `web.external-url` to this externally visible URL doesn't work (see #528).

If the new `web.alert-url` parameter isn't set we default to the `web.external-url` value, so this change should be transparent.