### PR TITLE
test: add reload test

### DIFF
--- a/test/mock.go
+++ b/test/mock.go
@@ -238,6 +238,7 @@ func NewWebhook(c *Collector) *MockWebhook {
 	wh := &MockWebhook{
 		listener:  l,
 		collector: c,
+		opts:      c.opts,
 	}
 	go http.Serve(l, wh)
 


### PR DESCRIPTION
This test reloads the Alertmanager to verify, that it properly keeps
state and sends notifications correctly across reloads.