### PR TITLE
Add command wrapper to handle printing errors for any subcommands Fixes #721

### DIFF
--- a/cli/alert.go
+++ b/cli/alert.go
@@ -63,7 +63,7 @@ var alertCmd = &cobra.Command{
   	(similar to prometheus) is used to represent a regex match. Regex matching
   	can be used in combination with a direct match.
 	`,
-	RunE: queryAlerts,
+	Run: CommandWrapper(queryAlerts),
 }
 
 var alertQueryCmd = &cobra.Command{

--- a/cli/silence.go
+++ b/cli/silence.go
@@ -21,7 +21,7 @@ var silenceCmd = &cobra.Command{
 	Use:   "silence",
 	Short: "Manage silences",
 	Long:  `Add, expire or view silences. For more information and additional flags see query help`,
-	RunE:  query,
+	Run:   CommandWrapper(query),
 }
 
 func init() {

--- a/cli/silence_add.go
+++ b/cli/silence_add.go
@@ -52,7 +52,7 @@ var addCmd = &cobra.Command{
 	(similar to prometheus) is used to represent a regex match. Regex matching
 	can be used in combination with a direct match.
 	`,
-	RunE: add,
+	Run: CommandWrapper(add),
 }
 
 func init() {

--- a/cli/silence_expire.go
+++ b/cli/silence_expire.go
@@ -13,7 +13,7 @@ var expireCmd = &cobra.Command{
 	Use:   "expire",
 	Short: "expire silence",
 	Long:  `expire an alertmanager silence`,
-	RunE:  expire,
+	Run:   CommandWrapper(expire),
 }
 
 func expire(cmd *cobra.Command, args []string) error {

--- a/cli/silence_query.go
+++ b/cli/silence_query.go
@@ -45,7 +45,7 @@ var queryCmd = &cobra.Command{
   	(similar to prometheus) is used to represent a regex match. Regex matching
   	can be used in combination with a direct match.
 				`,
-	RunE: query,
+	Run: CommandWrapper(query),
 }
 
 func init() {

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
 	"github.com/prometheus/alertmanager/pkg/parse"
@@ -84,4 +85,13 @@ func TypeMatcher(matcher labels.Matcher) (types.Matcher, error) {
 		return types.Matcher{}, fmt.Errorf("invalid match type for creation operation: %s", matcher.Type)
 	}
 	return *typeMatcher, nil
+}
+
+func CommandWrapper(command func(*cobra.Command, []string) error) func(*cobra.Command, []string) {
+	return func(cmd *cobra.Command, args []string) {
+		err := command(cmd, args)
+		if err != nil {
+			fmt.Printf("Error: %s\n", err)
+		}
+	}
 }


### PR DESCRIPTION
I was using the RunE method of cobra.Command which does things with an
error returned from a function. I doesn't seem possible to keep it from
printing usage every time, so I've make a wrapper to use the other
function.