### PR TITLE
*: switch group key to matcher serialization

### DIFF
--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -88,7 +88,7 @@ type APIAlert struct {
 // AlertGroup is a list of alert blocks grouped by the same label set.
 type AlertGroup struct {
 	Labels   model.LabelSet `json:"labels"`
-	GroupKey uint64         `json:"groupKey"`
+	GroupKey string         `json:"groupKey"`
 	Blocks   []*AlertBlock  `json:"blocks"`
 }
 
@@ -256,7 +256,7 @@ func (d *Dispatcher) processAlert(alert *types.Alert, route *Route) {
 	// If the group does not exist, create it.
 	ag, ok := groups[fp]
 	if !ok {
-		ag = newAggrGroup(d.ctx, group, &route.RouteOpts, d.timeout)
+		ag = newAggrGroup(d.ctx, group, route, d.timeout)
 		groups[fp] = ag
 
 		go ag.run(func(ctx context.Context, alerts ...*types.Alert) bool {
@@ -275,10 +275,10 @@ func (d *Dispatcher) processAlert(alert *types.Alert, route *Route) {
 // common set of routing options applies.
 // It emits notifications in the specified intervals.
 type aggrGroup struct {
-	labels  model.LabelSet
-	opts    *RouteOpts
-	routeFP model.Fingerprint
-	log     log.Logger
+	labels   model.LabelSet
+	opts     *RouteOpts
+	log      log.Logger
+	routeKey string
 
 	ctx     context.Context
 	cancel  func()
@@ -292,15 +292,16 @@ type aggrGroup struct {
 }
 
 // newAggrGroup returns a new aggregation group.
-func newAggrGroup(ctx context.Context, labels model.LabelSet, opts *RouteOpts, to func(time.Duration) time.Duration) *aggrGroup {
+func newAggrGroup(ctx context.Context, labels model.LabelSet, r *Route, to func(time.Duration) time.Duration) *aggrGroup {
 	if to == nil {
 		to = func(d time.Duration) time.Duration { return d }
 	}
 	ag := &aggrGroup{
-		labels:  labels,
-		opts:    opts,
-		timeout: to,
-		alerts:  map[model.Fingerprint]*types.Alert{},
+		labels:   labels,
+		routeKey: r.Key(),
+		opts:     &r.RouteOpts,
+		timeout:  to,
+		alerts:   map[model.Fingerprint]*types.Alert{},
 	}
 	ag.ctx, ag.cancel = context.WithCancel(ctx)
 
@@ -313,8 +314,16 @@ func newAggrGroup(ctx context.Context, labels model.LabelSet, opts *RouteOpts, t
 	return ag
 }
 
+func (ag *aggrGroup) fingerprint() model.Fingerprint {
+	return ag.labels.Fingerprint()
+}
+
+func (ag *aggrGroup) GroupKey() string {
+	return fmt.Sprintf("%s:%s", ag.routeKey, ag.labels)
+}
+
 func (ag *aggrGroup) String() string {
-	return fmt.Sprint(ag.fingerprint())
+	return ag.GroupKey()
 }
 
 func (ag *aggrGroup) alertSlice() []*types.Alert {
@@ -348,7 +357,7 @@ func (ag *aggrGroup) run(nf notifyFunc) {
 			ctx = notify.WithNow(ctx, now)
 
 			// Populate context with information needed along the pipeline.
-			ctx = notify.WithGroupKey(ctx, model.Fingerprint(ag.GroupKey()))
+			ctx = notify.WithGroupKey(ctx, ag.GroupKey())
 			ctx = notify.WithGroupLabels(ctx, ag.labels)
 			ctx = notify.WithReceiverName(ctx, ag.opts.Receiver)
 			ctx = notify.WithRepeatInterval(ctx, ag.opts.RepeatInterval)
@@ -375,14 +384,6 @@ func (ag *aggrGroup) stop() {
 	// and the run() loop.
 	ag.cancel()
 	<-ag.done
-}
-
-func (ag *aggrGroup) fingerprint() model.Fingerprint {
-	return ag.labels.Fingerprint()
-}
-
-func (ag *aggrGroup) GroupKey() uint64 {
-	return uint64(ag.labels.Fingerprint() ^ ag.routeFP)
 }
 
 // insert inserts the alert into the aggregation group. If the aggregation group

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -100,6 +100,9 @@ func TestAggrGroup(t *testing.T) {
 		GroupInterval:  300 * time.Millisecond,
 		RepeatInterval: 1 * time.Hour,
 	}
+	route := &Route{
+		RouteOpts: *opts,
+	}
 
 	var (
 		a1 = &types.Alert{
@@ -173,7 +176,7 @@ func TestAggrGroup(t *testing.T) {
 	}
 
 	// Test regular situation where we wait for group_wait to send out alerts.
-	ag := newAggrGroup(context.Background(), lset, opts, nil)
+	ag := newAggrGroup(context.Background(), lset, route, nil)
 	go ag.run(ntfy)
 
 	ag.insert(a1)
@@ -221,7 +224,7 @@ func TestAggrGroup(t *testing.T) {
 	// immediate flushing.
 	// Finally, set all alerts to be resolved. After successful notify the aggregation group
 	// should empty itself.
-	ag = newAggrGroup(context.Background(), lset, opts, nil)
+	ag = newAggrGroup(context.Background(), lset, route, nil)
 	go ag.run(ntfy)
 
 	ag.insert(a1)

--- a/dispatch/route.go
+++ b/dispatch/route.go
@@ -130,8 +130,7 @@ func (r *Route) Match(lset model.LabelSet) []*Route {
 		}
 	}
 
-	// If no child nodes were matches, the current node itself is
-	// a match.
+	// If no child nodes were matches, the current node itself is a match.
 	if len(all) == 0 {
 		all = append(all, r)
 	}
@@ -139,32 +138,15 @@ func (r *Route) Match(lset model.LabelSet) []*Route {
 	return all
 }
 
-// SquashMatchers returns the total set of matchers on the path of the tree
-// that have to apply to reach the route.
-func (r *Route) SquashMatchers() types.Matchers {
-	var res types.Matchers
-	res = append(res, r.Matchers...)
+// Key returns a key for the route. It does not uniquely identify a the route in general.
+func (r *Route) Key() string {
+	b := make([]byte, 0, 1024)
 
-	if r.parent == nil {
-		return res
+	if r.parent != nil {
+		b = append(b, r.parent.Key()...)
+		b = append(b, '/')
 	}
-
-	pm := r.parent.SquashMatchers()
-	res = append(pm, res...)
-
-	return res
-}
-
-// Fingerprint returns a hash of the Route based on its grouping labels,
-// routing options and the total set of matchers necessary to reach this route.
-func (r *Route) Fingerprint() model.Fingerprint {
-	lset := make(model.LabelSet, len(r.RouteOpts.GroupBy))
-
-	for ln := range r.RouteOpts.GroupBy {
-		lset[ln] = ""
-	}
-
-	return r.SquashMatchers().Fingerprint() ^ lset.Fingerprint()
+	return string(append(b, r.Matchers.String()...))
 }
 
 // RouteOpts holds various routing options necessary for processing alerts

--- a/nflog/nflog_test.go
+++ b/nflog/nflog_test.go
@@ -103,7 +103,7 @@ func TestNlogSnapshot(t *testing.T) {
 		}
 		// Setup internal state manually.
 		for _, e := range c.entries {
-			l1.st[stateKey(e.Entry.GroupKey, e.Entry.Receiver)] = e
+			l1.st[stateKey(string(e.Entry.GroupKey), e.Entry.Receiver)] = e
 		}
 		_, err = l1.Snapshot(f)
 		require.NoError(t, err, "creating snapshot failed")
@@ -253,7 +253,7 @@ func TestGossipDataCoding(t *testing.T) {
 		// Create gossip data from input.
 		in := gossipData{}
 		for _, e := range c.entries {
-			in[stateKey(e.Entry.GroupKey, e.Entry.Receiver)] = e
+			in[stateKey(string(e.Entry.GroupKey), e.Entry.Receiver)] = e
 		}
 		msg := in.Encode()
 		require.Equal(t, 1, len(msg), "expected single message for input")

--- a/nflog/nflogpb/nflog.proto
+++ b/nflog/nflogpb/nflog.proto
@@ -23,7 +23,7 @@ message Receiver {
 // Entry holds information about a successful notification
 // sent to a receiver.
 message Entry {
-// The key identifying the dispatching group.
+  // The key identifying the dispatching group.
   bytes group_key = 1;
   // The receiver that was notified.
   Receiver receiver = 2;

--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -55,14 +55,14 @@ type testNflog struct {
 	qres []*nflogpb.Entry
 	qerr error
 
-	logFunc func(r *nflogpb.Receiver, gkey []byte, firingAlerts, resolvedAlerts []uint64) error
+	logFunc func(r *nflogpb.Receiver, gkey string, firingAlerts, resolvedAlerts []uint64) error
 }
 
 func (l *testNflog) Query(p ...nflog.QueryParam) ([]*nflogpb.Entry, error) {
 	return l.qres, l.qerr
 }
 
-func (l *testNflog) Log(r *nflogpb.Receiver, gkey []byte, firingAlerts, resolvedAlerts []uint64) error {
+func (l *testNflog) Log(r *nflogpb.Receiver, gkey string, firingAlerts, resolvedAlerts []uint64) error {
 	return l.logFunc(r, gkey, firingAlerts, resolvedAlerts)
 }
 
@@ -171,7 +171,7 @@ func TestDedupStage(t *testing.T) {
 	_, _, err := s.Exec(ctx)
 	require.EqualError(t, err, "group key missing")
 
-	ctx = WithGroupKey(ctx, 1)
+	ctx = WithGroupKey(ctx, "1")
 
 	_, _, err = s.Exec(ctx)
 	require.EqualError(t, err, "repeat interval missing")
@@ -384,7 +384,7 @@ func TestSetNotifiesStage(t *testing.T) {
 	require.Nil(t, res)
 	require.NotNil(t, resctx)
 
-	ctx = WithGroupKey(ctx, 1)
+	ctx = WithGroupKey(ctx, "1")
 
 	resctx, res, err = s.Exec(ctx, alerts...)
 	require.EqualError(t, err, "firing alerts missing")
@@ -400,9 +400,9 @@ func TestSetNotifiesStage(t *testing.T) {
 
 	ctx = WithResolvedAlerts(ctx, []uint64{})
 
-	tnflog.logFunc = func(r *nflogpb.Receiver, gkey []byte, firingAlerts, resolvedAlerts []uint64) error {
+	tnflog.logFunc = func(r *nflogpb.Receiver, gkey string, firingAlerts, resolvedAlerts []uint64) error {
 		require.Equal(t, s.recv, r)
-		require.Equal(t, []byte{0, 0, 0, 0, 0, 0, 0, 1}, gkey)
+		require.Equal(t, "1", gkey)
 		require.Equal(t, []uint64{0, 1, 2}, firingAlerts)
 		require.Equal(t, []uint64{}, resolvedAlerts)
 		return nil
@@ -415,9 +415,9 @@ func TestSetNotifiesStage(t *testing.T) {
 	ctx = WithFiringAlerts(ctx, []uint64{})
 	ctx = WithResolvedAlerts(ctx, []uint64{0, 1, 2})
 
-	tnflog.logFunc = func(r *nflogpb.Receiver, gkey []byte, firingAlerts, resolvedAlerts []uint64) error {
+	tnflog.logFunc = func(r *nflogpb.Receiver, gkey string, firingAlerts, resolvedAlerts []uint64) error {
 		require.Equal(t, s.recv, r)
-		require.Equal(t, []byte{0, 0, 0, 0, 0, 0, 0, 1}, gkey)
+		require.Equal(t, "1", gkey)
 		require.Equal(t, []uint64{}, firingAlerts)
 		require.Equal(t, []uint64{0, 1, 2}, resolvedAlerts)
 		return nil

--- a/types/match.go
+++ b/types/match.go
@@ -18,6 +18,8 @@ import (
 	"regexp"
 	"sort"
 
+	"bytes"
+
 	"github.com/prometheus/common/model"
 )
 
@@ -44,9 +46,24 @@ func (m *Matcher) Init() error {
 
 func (m *Matcher) String() string {
 	if m.IsRegex {
-		return fmt.Sprintf("<RegexMatcher %s:%q>", m.Name, m.Value)
+		return fmt.Sprintf("%s=~%q", m.Name, m.Value)
 	}
-	return fmt.Sprintf("<Matcher %s:%q>", m.Name, m.Value)
+	return fmt.Sprintf("%s=%q", m.Name, m.Value)
+}
+
+// Validate returns true iff all fields of the matcher have valid values.
+func (m *Matcher) Validate() error {
+	if !model.LabelName(m.Name).IsValid() {
+		return fmt.Errorf("invalid name %q", m.Name)
+	}
+	if m.IsRegex {
+		if _, err := regexp.Compile(m.Value); err != nil {
+			return fmt.Errorf("invalid regular expression %q", m.Value)
+		}
+	} else if !model.LabelValue(m.Value).IsValid() || len(m.Value) == 0 {
+		return fmt.Errorf("invalid value %q", m.Value)
+	}
+	return nil
 }
 
 // Match checks whether the label of the matcher has the specified
@@ -139,28 +156,17 @@ func (ms Matchers) Match(lset model.LabelSet) bool {
 	return true
 }
 
-// Validate returns true iff all fields of the matcher have valid values.
-func (m *Matcher) Validate() error {
-	if !model.LabelName(m.Name).IsValid() {
-		return fmt.Errorf("invalid name %q", m.Name)
-	}
-	if m.IsRegex {
-		if _, err := regexp.Compile(m.Value); err != nil {
-			return fmt.Errorf("invalid regular expression %q", m.Value)
+func (ms Matchers) String() string {
+	var buf bytes.Buffer
+
+	buf.WriteByte('{')
+	for i, m := range ms {
+		if i > 0 {
+			buf.WriteByte(',')
 		}
-	} else if !model.LabelValue(m.Value).IsValid() || len(m.Value) == 0 {
-		return fmt.Errorf("invalid value %q", m.Value)
+		buf.WriteString(m.String())
 	}
-	return nil
-}
+	buf.WriteByte('}')
 
-// Fingerprint returns a quasi-unique fingerprint for the matchers.
-func (ms Matchers) Fingerprint() model.Fingerprint {
-	lset := make(model.LabelSet, 3*len(ms))
-
-	for _, m := range ms {
-		lset[model.LabelName(fmt.Sprintf("%s-%s-%v", m.Name, m.Value, m.IsRegex))] = ""
-	}
-
-	return lset.Fingerprint()
+	return buf.String()
 }


### PR DESCRIPTION
Turn the GroupKey into a string that is composed of the matchers if the
path in the routing tree and the grouping labels.
Only hash it at the very end to ensure we don't exceed size limits of
integration APIs.

As described in #718 

@brian-brazil 