### PR TITLE
Remove openbsd/arm builds

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -18,3 +18,26 @@ tarball:
         - doc/examples/simple.yml
         - LICENSE
         - NOTICE
+crossbuild:
+    platforms:
+        - linux/amd64
+        - linux/386
+        - darwin/amd64
+        - darwin/386
+        - windows/amd64
+        - windows/386
+        - freebsd/amd64
+        - freebsd/386
+        - openbsd/amd64
+        - openbsd/386
+        - netbsd/amd64
+        - netbsd/386
+        - dragonfly/amd64
+        - linux/arm
+        - linux/arm64
+        - freebsd/arm
+        - netbsd/arm
+        - linux/ppc64
+        - linux/ppc64le
+        - linux/mips64
+        - linux/mips64le


### PR DESCRIPTION
golang.org/x/sys/unix is failing for the various
arm builds.

tested locally, once this succeeds on circleci I'm going to go ahead and merge it