### PR TITLE
Anchor silence regex rules

### DIFF
--- a/types/match.go
+++ b/types/match.go
@@ -37,7 +37,7 @@ func (m *Matcher) Init() error {
 	if !m.IsRegex {
 		return nil
 	}
-	re, err := regexp.Compile(m.Value)
+	re, err := regexp.Compile("^(?:" + m.Value + ")$")
 	if err == nil {
 		m.regex = re
 	}


### PR DESCRIPTION
When user creates a new silence with regex match it's left to the user to anchor it, which is not consistent with Prometheus regex handling (promql/functions.go#L818).

CC @stuartnelson3 