### PR TITLE
new smtp conf parameters: skip certs verification & custom root ca

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -197,6 +197,9 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 				ec.RequireTLS = new(bool)
 				*ec.RequireTLS = c.Global.SMTPRequireTLS
 			}
+			if ec.TLSConfig == nil {
+				ec.TLSConfig = c.Global.SMTPTLSConfig
+			}
 		}
 		for _, sc := range rcv.SlackConfigs {
 			if sc.HTTPConfig == nil {
@@ -397,6 +400,8 @@ type GlobalConfig struct {
 	WeChatAPICorpID  string `yaml:"wechat_api_corp_id,omitempty" json:"wechat_api_corp_id,omitempty"`
 	VictorOpsAPIURL  string `yaml:"victorops_api_url,omitempty" json:"victorops_api_url,omitempty"`
 	VictorOpsAPIKey  Secret `yaml:"victorops_api_key,omitempty" json:"victorops_api_key,omitempty"`
+
+	SMTPTLSConfig *commoncfg.TLSConfig `yaml:"smtp_tls_config"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline" json:"-"`

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -163,6 +163,8 @@ type EmailConfig struct {
 	Text         string            `yaml:"text,omitempty" json:"text,omitempty"`
 	RequireTLS   *bool             `yaml:"require_tls,omitempty" json:"require_tls,omitempty"`
 
+	TLSConfig *commoncfg.TLSConfig `yaml:"tls_config"`
+
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline" json:"-"`
 }

--- a/doc/examples/simple.yml
+++ b/doc/examples/simple.yml
@@ -4,6 +4,12 @@ global:
   smtp_from: 'alertmanager@example.org'
   smtp_auth_username: 'alertmanager'
   smtp_auth_password: 'password'
+  # sample tls configuration
+  #smtp_tls_config:
+  #  ca_file: "tls_root_ca.pem"
+  #  cert_file: "cert.pem"
+  #  key_file: "cert.pem"
+  #  insecure_skip_verify: true
   # The auth token for Hipchat.
   hipchat_auth_token: '1234556789'
   # Alternative host for Hipchat.
@@ -97,6 +103,9 @@ receivers:
 - name: 'team-X-mails'
   email_configs:
   - to: 'team-X+alerts@example.org'
+    # optional tls config; see global sample
+    #tls_config:
+    #  insecure_skip_verify: true
 
 - name: 'team-X-pager'
   email_configs:

--- a/notify/impl.go
+++ b/notify/impl.go
@@ -315,7 +315,16 @@ func (n *Email) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 		if ok, _ := c.Extension("STARTTLS"); !ok {
 			return true, fmt.Errorf("require_tls: true (default), but %q does not advertise the STARTTLS extension", n.conf.Smarthost)
 		}
-		tlsConf := &tls.Config{ServerName: host}
+		var tlsConf *tls.Config
+		if n.conf.TLSConfig == nil {
+			tlsConf = &tls.Config{}
+		} else {
+			tlsConf, err = commoncfg.NewTLSConfig(n.conf.TLSConfig)
+			if err != nil {
+				return true, fmt.Errorf("generate TLS configuration failed: %s", err)
+			}
+		}
+		tlsConf.ServerName = host
 		if err := c.StartTLS(tlsConf); err != nil {
 			return true, fmt.Errorf("starttls failed: %s", err)
 		}


### PR DESCRIPTION
Two new configuration parameters related to smtp with tls:
smtp_tls_skip_verify / tls_skip_verify - do not verify certificates
smtp_tls_root_ca / tls_root_ca - use custom certificate for smtp server from pem file

@stuartnelson3 
