### PR TITLE
Serialize AlertStatus as 'status'

### DIFF
--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -81,9 +81,9 @@ type AlertBlock struct {
 type APIAlert struct {
 	*model.Alert
 
-	Status      types.AlertState
-	InhibitedBy []string `json:"inhibitedBy"`
-	SilencedBy  []string `json:"silencedBy"`
+	Status      types.AlertState `json:"status"`
+	InhibitedBy []string         `json:"inhibitedBy"`
+	SilencedBy  []string         `json:"silencedBy"`
 }
 
 // AlertGroup is a list of alert blocks grouped by the same label set.


### PR DESCRIPTION
AlertStatus doesn't have json tag with the field name, so it's serialized into 'Status', and it's the only uppercase field in the alert object. Tag it with 'status' name for consistency