### PR TITLE
Update cache control for web assets

### DIFF
--- a/ui/web.go
+++ b/ui/web.go
@@ -40,7 +40,7 @@ func serveAsset(w http.ResponseWriter, req *http.Request, fp string) {
 		return
 	}
 
-	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 	http.ServeContent(w, req, info.Name(), info.ModTime(), bytes.NewReader(file))
 }
 


### PR DESCRIPTION
The commit [1] introduced the `cache-control` header field with the value `no-cache`. This enforces any cache to revalidate. Apparently this does not prohibit *FireFox* from caching the assets. `no-cache, no-store, must-revalidate` does by prohibiting to even save anything of the request.

[1] c3850708c1f31aad1db9cda355698ecdd4755e39

@stuartnelson3 @w0rm Did you had any issues with this on Chrome, Safari, Opera, Netscape, ...?