### PR TITLE
Fixes #746

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -74,12 +74,10 @@ func fetchConfig() (Config, error) {
 	}
 
 	defer res.Body.Close()
-	decoder := json.NewDecoder(res.Body)
 
-	err = decoder.Decode(&configResponse)
+	err = json.NewDecoder(res.Body).Decode(&configResponse)
 	if err != nil {
-		panic(err)
-		return Config{}, err
+		return configResponse.Data, err
 	}
 
 	if configResponse.Status != "success" {

--- a/config/config.go
+++ b/config/config.go
@@ -503,7 +503,7 @@ func (re *Regexp) UnmarshalJSON(data []byte) error {
 }
 
 // MarshalJSON implements the json.Marshaler interface.
-func (re *Regexp) MarshalJSON() ([]byte, error) {
+func (re Regexp) MarshalJSON() ([]byte, error) {
 	if re.Regexp != nil {
 		return json.Marshal(re.String())
 	}


### PR DESCRIPTION
Found that we are only defining MarshalJSON for the Regexp type for
references not for the direct object removing the `*` fixes the issue

Also took the time to simplify the json.Unmarshal usage in cli/config.go