### PR TITLE
Expose alert fingerprint in the API

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -346,7 +346,7 @@ func (api *API) listAlerts(w http.ResponseWriter, r *http.Request) {
 			Alert:       &a.Alert,
 			Status:      status,
 			Receivers:   receivers,
-			Fingerprint: fmt.Sprintf("%x", a.Fingerprint()),
+			Fingerprint: a.Fingerprint().String(),
 		}
 
 		res = append(res, apiAlert)

--- a/api/api.go
+++ b/api/api.go
@@ -346,6 +346,7 @@ func (api *API) listAlerts(w http.ResponseWriter, r *http.Request) {
 			Alert:     &a.Alert,
 			Status:    status,
 			Receivers: receivers,
+			ID:        fmt.Sprintf("%x", a.Fingerprint()),
 		}
 
 		res = append(res, apiAlert)

--- a/api/api.go
+++ b/api/api.go
@@ -343,10 +343,10 @@ func (api *API) listAlerts(w http.ResponseWriter, r *http.Request) {
 		}
 
 		apiAlert := &dispatch.APIAlert{
-			Alert:     &a.Alert,
-			Status:    status,
-			Receivers: receivers,
-			ID:        fmt.Sprintf("%x", a.Fingerprint()),
+			Alert:       &a.Alert,
+			Status:      status,
+			Receivers:   receivers,
+			Fingerprint: fmt.Sprintf("%x", a.Fingerprint()),
 		}
 
 		res = append(res, apiAlert)

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -80,9 +80,9 @@ type AlertBlock struct {
 // annotated with silencing and inhibition info.
 type APIAlert struct {
 	*model.Alert
-	Status    types.AlertStatus `json:"status"`
-	Receivers []string          `json:"receivers"`
-	ID        string            `json:"id"`
+	Status      types.AlertStatus `json:"status"`
+	Receivers   []string          `json:"receivers"`
+	Fingerprint string            `json:"fingerprint"`
 }
 
 // AlertGroup is a list of alert blocks grouped by the same label set.
@@ -137,9 +137,9 @@ func (d *Dispatcher) Groups(matchers []*labels.Matcher) AlertOverview {
 				}
 				status := d.marker.Status(a.Fingerprint())
 				aa := &APIAlert{
-					Alert:  a,
-					Status: status,
-					ID:     fmt.Sprintf("%d", a.Fingerprint()),
+					Alert:       a,
+					Status:      status,
+					Fingerprint: fmt.Sprintf("%x", a.Fingerprint()),
 				}
 
 				if !matchesFilterLabels(aa, matchers) {

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -139,7 +139,7 @@ func (d *Dispatcher) Groups(matchers []*labels.Matcher) AlertOverview {
 				aa := &APIAlert{
 					Alert:       a,
 					Status:      status,
-					Fingerprint: fmt.Sprintf("%x", a.Fingerprint()),
+					Fingerprint: a.Fingerprint().String(),
 				}
 
 				if !matchesFilterLabels(aa, matchers) {

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -82,6 +82,7 @@ type APIAlert struct {
 	*model.Alert
 	Status    types.AlertStatus `json:"status"`
 	Receivers []string          `json:"receivers"`
+	ID        string            `json:"id"`
 }
 
 // AlertGroup is a list of alert blocks grouped by the same label set.
@@ -138,6 +139,7 @@ func (d *Dispatcher) Groups(matchers []*labels.Matcher) AlertOverview {
 				aa := &APIAlert{
 					Alert:  a,
 					Status: status,
+					ID:     fmt.Sprintf("%d", a.Fingerprint()),
 				}
 
 				if !matchesFilterLabels(aa, matchers) {


### PR DESCRIPTION
Alert fingerprint is already provided as the value of status.inhibitedBy[] attribute that inhibited alerts have, but there's no way to get back to the alert that's inhibiting it as the fingerprint is not exposed.

I'm not sure if using fingerprints is desirable, but that's currently the value of `inhibitedBy` @stuartnelson3 
The goal here is to be able to link back from inhibited to inhibiting alert based on the API response, which isn't currently doable. 