### PR TITLE
Do not expose resolved alerts & do not send resolved if never firing

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -300,6 +300,11 @@ func (api *API) listAlerts(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
+		// Continue if alert is resolved
+		if !a.Alert.EndsAt.IsZero() && a.Alert.EndsAt.Before(time.Now()) {
+			continue
+		}
+
 		status := api.getAlertStatus(a.Fingerprint())
 
 		if !showSilenced && len(status.SilencedBy) != 0 {

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -474,7 +474,7 @@ func (n *DedupStage) needsUpdate(entry *nflogpb.Entry, firing, resolved map[uint
 	// If we haven't notified about the alert group before, notify right away
 	// unless we only have resolved alerts.
 	if entry == nil {
-		return ((len(firing) > 0) || (n.sendResolved && len(resolved) > 0)), nil
+		return len(firing) > 0, nil
 	}
 
 	if !entry.IsFiringSubset(firing) {


### PR DESCRIPTION
Do not expose resolved alerts on the /alerts endpoint. Do not send
resolved alerts to receivers if the alerts have never been fired before.

This is related to #815, but does not resolve the specified issue.