### PR TITLE
Update build status to target master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Alertmanager [![Build Status](https://travis-ci.org/prometheus/alertmanager.svg)][travis]
+# Alertmanager [![Build Status](https://travis-ci.org/prometheus/alertmanager.svg?branch=master)][travis]
 
 [![CircleCI](https://circleci.com/gh/prometheus/alertmanager/tree/master.svg?style=shield)][circleci]
 [![Docker Repository on Quay](https://quay.io/repository/prometheus/alertmanager/status)][quay]


### PR DESCRIPTION
Instead of targeting the latest build, which could be any PR, we should target current master results.