### PR TITLE
Expire pending silence and move to expired state

### DIFF
--- a/silence/silence.go
+++ b/silence/silence.go
@@ -455,7 +455,9 @@ func (s *Silences) expire(id string) error {
 	case StateActive:
 		sil.EndsAt = now
 	case StatePending:
-		sil.EndsAt = sil.StartsAt
+		// Set both to now to make Silence move to "expired" state
+		sil.StartsAt = now
+		sil.EndsAt = now
 	}
 
 	return s.setSilence(sil)

--- a/silence/silence_test.go
+++ b/silence/silence_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	pb "github.com/prometheus/alertmanager/silence/silencepb"
+	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/mesh"
@@ -752,10 +753,14 @@ func TestSilenceExpire(t *testing.T) {
 	require.Equal(t, &pb.Silence{
 		Id:        "pending",
 		Matchers:  []*pb.Matcher{m},
-		StartsAt:  now.Add(time.Minute),
-		EndsAt:    now.Add(time.Minute),
+		StartsAt:  now,
+		EndsAt:    now,
 		UpdatedAt: now,
 	}, sil)
+	// Expiring a pending Silence should make the API return the
+	// SilenceStateExpired Silence state.
+	silenceState := types.CalcSilenceState(sil.StartsAt, sil.EndsAt)
+	require.Equal(t, silenceState, types.SilenceStateExpired)
 
 	sil, err = s.QueryOne(QIDs("active"))
 	require.NoError(t, err)


### PR DESCRIPTION
Instead of setting endsAt to startsAt we can set both to now. Thereby
the Silence will get the expired state by default.

Fixes #783.