### PR TITLE
Support for custom SMTP hello string

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -172,6 +172,9 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 				}
 				ec.From = c.Global.SMTPFrom
 			}
+			if ec.Hello == "" {
+				ec.Hello = c.Global.SMTPHello
+			}
 			if ec.AuthUsername == "" {
 				ec.AuthUsername = c.Global.SMTPAuthUsername
 			}
@@ -309,6 +312,7 @@ type GlobalConfig struct {
 	ResolveTimeout model.Duration `yaml:"resolve_timeout" json:"resolve_timeout"`
 
 	SMTPFrom         string `yaml:"smtp_from,omitempty" json:"smtp_from,omitempty"`
+	SMTPHello        string `yaml:"smtp_hello,omitempty" json:"smtp_hello,omitempty"`
 	SMTPSmarthost    string `yaml:"smtp_smarthost,omitempty" json:"smtp_smarthost,omitempty"`
 	SMTPAuthUsername string `yaml:"smtp_auth_username,omitempty" json:"smtp_auth_username,omitempty"`
 	SMTPAuthPassword Secret `yaml:"smtp_auth_password,omitempty" json:"smtp_auth_password,omitempty"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -205,6 +205,19 @@ func TestEmptyFieldsAndRegex(t *testing.T) {
 	}
 }
 
+func TestSMTPHello(t *testing.T) {
+	c, _, err := LoadFile("testdata/conf.good.yml")
+	if err != nil {
+		t.Errorf("Error parsing %s: %s", "testdata/conf.good.yml", err)
+	}
+
+	const refValue = "host.example.org"
+	var hostName = c.Global.SMTPHello
+	if hostName != refValue {
+		t.Errorf("Invalid SMTP Hello hostname: %s\nExpected: %s", hostName, refValue)
+	}
+}
+
 func TestVictorOpsDefaultAPIKey(t *testing.T) {
 	conf, _, err := LoadFile("testdata/conf.victorops-default-apikey.yml")
 	if err != nil {

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -134,6 +134,7 @@ type EmailConfig struct {
 	// Email address to notify.
 	To           string            `yaml:"to,omitempty" json:"to,omitempty"`
 	From         string            `yaml:"from,omitempty" json:"from,omitempty"`
+	Hello        string            `yaml:"hello,omitempty" json:"hello,omitempty"`
 	Smarthost    string            `yaml:"smarthost,omitempty" json:"smarthost,omitempty"`
 	AuthUsername string            `yaml:"auth_username,omitempty" json:"auth_username,omitempty"`
 	AuthPassword Secret            `yaml:"auth_password,omitempty" json:"auth_password,omitempty"`

--- a/config/testdata/conf.empty-fields.yml
+++ b/config/testdata/conf.empty-fields.yml
@@ -3,6 +3,7 @@ global:
   smtp_from: 'alertmanager@example.org'
   smtp_auth_username: ''
   smtp_auth_password: ''
+  smtp_hello: ''
   hipchat_auth_token: 'mysecret'
   hipchat_url: 'https://hipchat.foobar.org/'
   slack_api_url: 'mysecret'

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -4,6 +4,7 @@ global:
   smtp_from: 'alertmanager@example.org'
   smtp_auth_username: 'alertmanager'
   smtp_auth_password: "multiline\nmysecret"
+  smtp_hello: "host.example.org"
   # The auth token for Hipchat.
   hipchat_auth_token: "mysecret"
   # Alternative host for Hipchat.

--- a/notify/impl.go
+++ b/notify/impl.go
@@ -290,6 +290,13 @@ func (n *Email) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 	}
 	defer c.Quit()
 
+	if n.conf.Hello != "" {
+		err := c.Hello(n.conf.Hello)
+		if err != nil {
+			return true, err
+		}
+	}
+
 	// Global Config guarantees RequireTLS is not nil
 	if *n.conf.RequireTLS {
 		if ok, _ := c.Extension("STARTTLS"); !ok {


### PR DESCRIPTION
Some MTAs insist that they be greeted with a fully qualified domain
name. The default provided by the net/smtp library, "HELLO localhost",
is not sufficient and will result in rejected messages.

This changeset adds a new configuration option that allows the
alertmanager to do its job in such an environment.

Considering that this is a rather trivial PR, I am following the guidelines for contributing by addressing @stuartnelson3.