### PR TITLE
Added possibility to have a global victorops api_key

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -244,6 +244,12 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			if !strings.HasSuffix(voc.APIURL, "/") {
 				voc.APIURL += "/"
 			}
+			if voc.APIKey == "" {
+				if c.Global.VictorOpsAPIKey == "" {
+					return fmt.Errorf("no global VictorOps API Key set")
+				}
+				voc.APIKey = c.Global.VictorOpsAPIKey
+			}
 		}
 		names[rcv.Name] = struct{}{}
 	}
@@ -316,6 +322,7 @@ type GlobalConfig struct {
 	HipchatAuthToken Secret `yaml:"hipchat_auth_token,omitempty" json:"hipchat_auth_token,omitempty"`
 	OpsGenieAPIHost  string `yaml:"opsgenie_api_host,omitempty" json:"opsgenie_api_host,omitempty"`
 	VictorOpsAPIURL  string `yaml:"victorops_api_url,omitempty" json:"victorops_api_url,omitempty"`
+	VictorOpsAPIKey  Secret `yaml:"victorops_api_key,omitempty" json:"victorops_api_key,omitempty"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline" json:"-"`

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@
 package config
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -21,8 +22,6 @@ import (
 	"regexp"
 	"strings"
 	"time"
-
-	"encoding/json"
 
 	"github.com/prometheus/common/model"
 	"gopkg.in/yaml.v2"

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -131,7 +131,6 @@ func TestJSONUnmarshalMarshaled(t *testing.T) {
 }
 
 func TestEmptyFieldsAndRegex(t *testing.T) {
-
 	boolFoo := true
 	var regexpFoo Regexp
 	regexpFoo.Regexp, _ = regexp.Compile("^(?:^(foo1|foo2|baz)$)$")
@@ -203,5 +202,30 @@ func TestEmptyFieldsAndRegex(t *testing.T) {
 
 	if !reflect.DeepEqual(configGot, configExp) {
 		t.Fatalf("%s: unexpected config result: \n\n%s\n expected\n\n%s", "testdata/conf.empty-fields.yml", configGot, configExp)
+	}
+}
+
+func TestVictorOpsDefaultAPIKey(t *testing.T) {
+	conf, _, err := LoadFile("testdata/conf.victorops-default-apikey.yml")
+	if err != nil {
+		t.Errorf("Error parsing %s: %s", "testdata/conf.victorops-default-apikey.yml", err)
+	}
+
+	var defaultKey = conf.Global.VictorOpsAPIKey
+	if defaultKey != conf.Receivers[0].VictorOpsConfigs[0].APIKey {
+		t.Errorf("Invalid victorops key: %s\nExpected: %s", conf.Receivers[0].VictorOpsConfigs[0].APIKey, defaultKey)
+	}
+	if defaultKey == conf.Receivers[1].VictorOpsConfigs[0].APIKey {
+		t.Errorf("Invalid victorops key: %s\nExpected: %s", conf.Receivers[0].VictorOpsConfigs[0].APIKey, "qwe456")
+	}
+}
+
+func TestVictorOpsNoAPIKey(t *testing.T) {
+	_, _, err := LoadFile("testdata/conf.victorops-no-apikey.yml")
+	if err == nil {
+		t.Errorf("Expected an error parsing %s: %s", "testdata/conf.victorops-no-apikey.yml", err)
+	}
+	if err.Error() != "no global VictorOps API Key set" {
+		t.Errorf("Expected: %s\nGot: %s", "no global VictorOps API Key set", err.Error())
 	}
 }

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -340,9 +340,6 @@ func (c *VictorOpsConfig) UnmarshalYAML(unmarshal func(interface{}) error) error
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
-	if c.APIKey == "" {
-		return fmt.Errorf("missing API key in VictorOps config")
-	}
 	if c.RoutingKey == "" {
 		return fmt.Errorf("missing Routing key in VictorOps config")
 	}

--- a/config/testdata/conf.victorops-default-apikey.yml
+++ b/config/testdata/conf.victorops-default-apikey.yml
@@ -1,0 +1,22 @@
+global:
+  victorops_api_key: asd132
+
+route:
+  group_by: ['alertname', 'cluster', 'service']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 3h
+  receiver: team-Y-victorops
+  routes:
+  - match:
+      service: foo
+    receiver: team-X-victorops
+
+receivers:
+- name: 'team-X-victorops'
+  victorops_configs:
+  - routing_key: 'team-X'
+- name: 'team-Y-victorops'
+  victorops_configs:
+  - routing_key: 'team-Y'
+    api_key: qwe456

--- a/config/testdata/conf.victorops-no-apikey.yml
+++ b/config/testdata/conf.victorops-no-apikey.yml
@@ -1,0 +1,15 @@
+route:
+  group_by: ['alertname', 'cluster', 'service']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 3h
+  receiver: team-X-victorops
+  routes:
+  - match:
+      service: foo
+    receiver: team-X-victorops
+
+receivers:
+- name: 'team-X-victorops'
+  victorops_configs:
+  - routing_key: 'team-X'


### PR DESCRIPTION
If the idea is to setup one victorops_receiver per team or something like that, this would allow the user to not repeat the API key for each of them.

Since the API key is the same for all integrations, this seemed like a good idea.

I didn't added a test for that because there is none already, but I can add new tests if you want :)

Thanks for the awesome tools btw 🍻 