### PR TITLE
When I notify alert to slack, I want to use this option.

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -218,6 +218,7 @@ type SlackConfig struct {
 	Fallback  string `yaml:"fallback,omitempty" json:"fallback,omitempty"`
 	IconEmoji string `yaml:"icon_emoji,omitempty" json:"icon_emoji,omitempty"`
 	IconURL   string `yaml:"icon_url,omitempty" json:"icon_url,omitempty"`
+	LinkNames string `yaml:"link_names,omitempty" json:"link_names,omitempty"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline" json:"-"`

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -218,7 +218,7 @@ type SlackConfig struct {
 	Fallback  string `yaml:"fallback,omitempty" json:"fallback,omitempty"`
 	IconEmoji string `yaml:"icon_emoji,omitempty" json:"icon_emoji,omitempty"`
 	IconURL   string `yaml:"icon_url,omitempty" json:"icon_url,omitempty"`
-	LinkNames string `yaml:"link_names,omitempty" json:"link_names,omitempty"`
+	LinkNames bool   `yaml:"link_names,omitempty" json:"link_names,omitempty"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline" json:"-"`

--- a/notify/impl.go
+++ b/notify/impl.go
@@ -498,6 +498,7 @@ type slackReq struct {
 	Username    string            `json:"username,omitempty"`
 	IconEmoji   string            `json:"icon_emoji,omitempty"`
 	IconURL     string            `json:"icon_url,omitempty"`
+	LinkNames   string            `json:"link_names,omitempty"`
 	Attachments []slackAttachment `json:"attachments"`
 }
 
@@ -542,6 +543,7 @@ func (n *Slack) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 		Username:    tmplText(n.conf.Username),
 		IconEmoji:   tmplText(n.conf.IconEmoji),
 		IconURL:     tmplText(n.conf.IconURL),
+		LinkNames:   tmplText(n.conf.LinkNames),
 		Attachments: []slackAttachment{*attachment},
 	}
 	if err != nil {

--- a/notify/impl.go
+++ b/notify/impl.go
@@ -498,7 +498,7 @@ type slackReq struct {
 	Username    string            `json:"username,omitempty"`
 	IconEmoji   string            `json:"icon_emoji,omitempty"`
 	IconURL     string            `json:"icon_url,omitempty"`
-	LinkNames   string            `json:"link_names,omitempty"`
+	LinkNames   bool              `json:"link_names,omitempty"`
 	Attachments []slackAttachment `json:"attachments"`
 }
 
@@ -543,7 +543,7 @@ func (n *Slack) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 		Username:    tmplText(n.conf.Username),
 		IconEmoji:   tmplText(n.conf.IconEmoji),
 		IconURL:     tmplText(n.conf.IconURL),
-		LinkNames:   tmplText(n.conf.LinkNames),
+		LinkNames:   n.conf.LinkNames,
 		Attachments: []slackAttachment{*attachment},
 	}
 	if err != nil {


### PR DESCRIPTION
Hi.
Thank you for your effort.

I use Alertmanager with Slack.
When I received messages, I wanna use this option for slack.

**link_names**

You can check this option what is.

https://api.slack.com/methods/chat.postMessage

I updated some codes a little bit.

**Usage**

```yaml
slack_configs: 
   link_names: true
```

I think this options is so important for alerting. 
I think most people want to notify them to their owners when they receive messages on Slack.

Thanks.