### PR TITLE
Fix crash when no mesh router is configured

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -221,7 +221,10 @@ func main() {
 		log.Fatal(err)
 	}
 
-	waitFunc := meshWait(mrouter, 5*time.Second)
+	waitFunc := func() time.Duration { return 0 }
+	if *meshListen != "" {
+		waitFunc = meshWait(mrouter, 5*time.Second)
+	}
 	timeoutFunc := func(d time.Duration) time.Duration {
 		if d < notify.MinTimeout {
 			d = notify.MinTimeout

--- a/template/internal/deftmpl/bindata.go
+++ b/template/internal/deftmpl/bindata.go
@@ -182,6 +182,7 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
+
 var _bintree = &bintree{nil, map[string]*bintree{
 	"template": &bintree{nil, map[string]*bintree{
 		"default.tmpl": &bintree{templateDefaultTmpl, map[string]*bintree{}},
@@ -234,4 +235,3 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
-

--- a/template/internal/deftmpl/bindata.go
+++ b/template/internal/deftmpl/bindata.go
@@ -182,7 +182,6 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
-
 var _bintree = &bintree{nil, map[string]*bintree{
 	"template": &bintree{nil, map[string]*bintree{
 		"default.tmpl": &bintree{templateDefaultTmpl, map[string]*bintree{}},
@@ -235,3 +234,4 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
+


### PR DESCRIPTION
This adds a check for `meshListen != ""` around the waitFunc code as we
have around the other mesh-related code parts above.

Fixes https://github.com/prometheus/alertmanager/issues/914