### PR TITLE
Add production users list

### DIFF
--- a/doc/production-users.md
+++ b/doc/production-users.md
@@ -1,0 +1,23 @@
+# Production Users
+
+This document lists usages of the Alertmanager in production environments. The
+purpose of the list is to illustrate possible use case scenarios of
+Alertmanager. In addition it enables contributors to reach out to this user
+group for advice and experiences.
+
+Please feel free to contact us, if you would like to be listed here.
+
+
+## Name
+
+- **Monitored applications**: *e.g.* etcd cluster & Ruby on Rails web application
+- **Number of monitored machines**: *e.g.* 100
+- **Alertmanager cluster size**: *e.g.* 3
+- **Prometheus cluster size**: *e.g.* 2
+- **Launched**: *e.g.* 2017-07-24
+- **Platform**: *e.g.* AWS, bare metal, or ...
+- **Environment**: *e.g.* Kubernetes, self-build, or ...
+- **Integrations with**: *e.g.* Slack, PagerDuty, or ...
+- **Number of silences**: *e.g.* 20
+
+Further description ...


### PR DESCRIPTION
As discussed in [1] I would like to add a list of production users of
Alertmanager to this repo. On the one hand this would show the level of trust people
put into the project. On the other hand it gives us the ability to reach
out to this user group for advice and experience.

Please suggest other possible metrics that you would be interested in, or mention those that you would rather like to have removed.

Once we have settled on a set of metrics I will reach out to those companies that we are aware of.

[1]
https://github.com/coreos/etcd/blob/master/Documentation/production-users.md

//CC @brancz 