### PR TITLE
allow a binary name to be passed to make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ vet:
 # Will only build the back-end
 build: promu
 	@echo ">> building binaries"
-	@$(PROMU) build --prefix $(PREFIX)
+	@$(PROMU) build --prefix $(PREFIX) $(BINARIES)
 
 # Will build both the front-end as well as the back-end
 build-all: assets build

--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ $ make build
 $ ./alertmanager -config.file=<your_file>
 ```
 
+You can also build just one of the binaries in this repo by passing a name to the build function:
+```
+$ make build BINARIES=amtool
+```
+
 ## Example
 
 This is an example configuration that should cover most relevant aspects of the new YAML configuration format. The full documentation of the configuration can be found [here](https://prometheus.io/docs/alerting/configuration/).


### PR DESCRIPTION
While working on promtool and prometheus I often went back and forth commenting out binaries in the `.promu.yml` file in order to only rebuild the binary I wanted to rebuild. The alertmanager repo also builds two binaries. 

In this pr: https://github.com/prometheus/promu/pull/77 I added the option to pass a binary name to promu's build function. This is controlled by setting the `BINARIES` var.

For example: 
```
$make build BINARIES=amtool
>> building binaries
 >   amtool
```

In this PR we simply pass `BINARIES` to promu. If it's not set, promu will build all binaries from the YAML file as normal.
```
$make build
>> building binaries
 >   alertmanager
 >   amtool
```
