### PR TITLE
silences: avoid deadlock

### DIFF
--- a/silence/silence.go
+++ b/silence/silence.go
@@ -370,7 +370,9 @@ func (s *Silences) setSilence(sil *pb.Silence) error {
 	}
 
 	s.st.Merge(st)
-	s.gossip.GossipBroadcast(st)
+	// setSilence() is called with s.mtx locked, which can produce
+	// a deadlock if we call GossipBroadcast from here.
+	go s.gossip.GossipBroadcast(st)
 
 	return nil
 }


### PR DESCRIPTION
Calling gossip.GossipBroadcast() will cause a deadlock if
there is a currently executing OnBroadcast* function.

See #982