### PR TITLE
silence|alerts: add metrics about current silences and alerts

### DIFF
--- a/silence/silence_test.go
+++ b/silence/silence_test.go
@@ -142,7 +142,7 @@ func TestSilencesSnapshot(t *testing.T) {
 		f, err := ioutil.TempFile("", "snapshot")
 		require.NoError(t, err, "creating temp file failed")
 
-		s1 := &Silences{st: newGossipData(), metrics: newMetrics(nil)}
+		s1 := &Silences{st: newGossipData(), metrics: newMetrics(nil, nil)}
 		// Setup internal state manually.
 		for _, e := range c.entries {
 			s1.st.data[e.Silence.Id] = e
@@ -778,6 +778,10 @@ func TestSilenceExpire(t *testing.T) {
 		},
 	}
 
+	count, err := s.CountState(StatePending)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+
 	require.NoError(t, s.expire("pending"))
 	require.NoError(t, s.expire("active"))
 
@@ -794,6 +798,11 @@ func TestSilenceExpire(t *testing.T) {
 		EndsAt:    now,
 		UpdatedAt: now,
 	}, sil)
+
+	count, err = s.CountState(StatePending)
+	require.NoError(t, err)
+	require.Equal(t, 0, count)
+
 	// Expiring a pending Silence should make the API return the
 	// SilenceStateExpired Silence state.
 	silenceState := types.CalcSilenceState(sil.StartsAt, sil.EndsAt)

--- a/types/types.go
+++ b/types/types.go
@@ -45,6 +45,8 @@ type Marker interface {
 	SetInhibited(alert model.Fingerprint, ids ...string)
 	SetSilenced(alert model.Fingerprint, ids ...string)
 
+	Count(...AlertState) int
+
 	Status(model.Fingerprint) AlertStatus
 	Delete(model.Fingerprint)
 
@@ -65,6 +67,27 @@ type memMarker struct {
 	m map[model.Fingerprint]*AlertStatus
 
 	mtx sync.RWMutex
+}
+
+// Count alerts of a given state.
+func (m *memMarker) Count(states ...AlertState) int {
+	count := 0
+
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+
+	if len(states) == 0 {
+		count = len(m.m)
+	} else {
+		for _, status := range m.m {
+			for _, state := range states {
+				if status.State == state {
+					count += 1
+				}
+			}
+		}
+	}
+	return count
 }
 
 // SetSilenced sets the AlertStatus to suppressed and stores the associated silence IDs.


### PR DESCRIPTION
This adds metrics that look like this:
```
alertmanager_alerts_count{state="active"} 6
alertmanager_alerts_count{state="suppressed"} 0
alertmanager_silences_count{state="active"} 1
alertmanager_silences_count{state="expired"} 1
alertmanager_silences_count{state="pending"} 0
```

This can be used to monitor alertmanager's usage and validate that
alertmanagers in a mesh have a similar number of silences and alerts.