### PR TITLE
Add etcd notifier

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -458,6 +458,7 @@ type Receiver struct {
 	HipchatConfigs   []*HipchatConfig   `yaml:"hipchat_configs,omitempty" json:"hipchat_configs,omitempty"`
 	SlackConfigs     []*SlackConfig     `yaml:"slack_configs,omitempty" json:"slack_configs,omitempty"`
 	WebhookConfigs   []*WebhookConfig   `yaml:"webhook_configs,omitempty" json:"webhook_configs,omitempty"`
+	EtcdConfigs      []*EtcdConfig      `yaml:"etcd_configs,omitempty" json:"etcd_configs,omitempty"`
 	OpsGenieConfigs  []*OpsGenieConfig  `yaml:"opsgenie_configs,omitempty" json:"opsgenie_configs,omitempty"`
 	PushoverConfigs  []*PushoverConfig  `yaml:"pushover_configs,omitempty" json:"pushover_configs,omitempty"`
 	VictorOpsConfigs []*VictorOpsConfig `yaml:"victorops_configs,omitempty" json:"victorops_configs,omitempty"`


### PR DESCRIPTION
Add notifier that puts/deletes keys in an etcd KV store using etcd's grpc-gateway.

I’m not sure how much demand for this there is, so if you don’t think it’s worth supporting, then consider this a +1 for #701.

A sample configuration:

```
# sample etcd notifier config that writes a KV pair when an alert fires
# and deletes it when the alert is resolved
etcd_configs:
 - firing:
     url: http://localhost:2379/v3alpha/kv/put
     key_annotation: 'etcd_key'
     value_annotation: 'etcd_value'
   resolved:
     url: http://localhost:2379/v3alpha/kv/deleterange
     key_annotation: 'etcd_key'
     value_annotation: 'etcd_value'
```

And a sample rule:

```
ALERT QueueFull
  IF queue_occupancy > 0.9
  FOR 5s
  LABELS { severity = “warning” }
  ANNOTATIONS {
    summary = “…”,
    etcd_key = "/queue_occupancy/{{ $labels.queue_name }}",
    etcd_value = "{{ $value }}",
  }
```