### PR TITLE
Improve amtool check-config use and description text

### DIFF
--- a/cli/check_config.go
+++ b/cli/check_config.go
@@ -10,10 +10,10 @@ import (
 
 // alertCmd represents the alert command
 var checkConfigCmd = &cobra.Command{
-	Use:   "check-config",
+	Use:   "check-config file1 [file2] ...",
 	Args:  cobra.MinimumNArgs(1),
-	Short: "Validate configuration files for correctness",
-	Long: `Validate configuration files for correctness
+	Short: "Validate alertmanager config files",
+	Long: `Validate alertmanager config files
 
 Will validate the syntax and schema for alertmanager config file
 and associated templates. Non existing templates will not trigger


### PR DESCRIPTION
Not sure if it's just me, but i had to look into the code to understand that check-config:

1) is used to validate alertmanager config files, and not validate amtool config files. It became clear after running `amtool check-config -h`, but it was not clear when I executed `amtool -h`, so I've changed the short description.

2) that I had to pass the config file as a cmd argument, and that it could be one or more. Changed the Use text to give more context on that.

what you think @stuartnelson3 ?