### PR TITLE
Remove .WasInhibited and .WasSilenced fields of Alert type

### DIFF
--- a/notify/notify.go
+++ b/notify/notify.go
@@ -311,14 +311,11 @@ func NewInhibitStage(m types.Muter, mk types.Marker) *InhibitStage {
 func (n *InhibitStage) Exec(ctx context.Context, alerts ...*types.Alert) (context.Context, []*types.Alert, error) {
 	var filtered []*types.Alert
 	for _, a := range alerts {
-		_, ok := n.marker.Inhibited(a.Fingerprint())
 		// TODO(fabxc): increment total alerts counter.
 		// Do not send the alert if the silencer mutes it.
 		if !n.muter.Mutes(a.Labels) {
 			// TODO(fabxc): increment muted alerts counter.
 			filtered = append(filtered, a)
-			// Store whether a previously inhibited alert is firing again.
-			a.WasInhibited = ok
 		}
 	}
 
@@ -343,7 +340,6 @@ func NewSilenceStage(s *silence.Silences, mk types.Marker) *SilenceStage {
 func (n *SilenceStage) Exec(ctx context.Context, alerts ...*types.Alert) (context.Context, []*types.Alert, error) {
 	var filtered []*types.Alert
 	for _, a := range alerts {
-		_, ok := n.marker.Silenced(a.Fingerprint())
 		// TODO(fabxc): increment total alerts counter.
 		// Do not send the alert if the silencer mutes it.
 		sils, err := n.silences.Query(
@@ -358,8 +354,6 @@ func (n *SilenceStage) Exec(ctx context.Context, alerts ...*types.Alert) (contex
 			// TODO(fabxc): increment muted alerts counter.
 			filtered = append(filtered, a)
 			n.marker.SetSilenced(a.Labels.Fingerprint())
-			// Store whether a previously silenced alert is firing again.
-			a.WasSilenced = ok
 		} else {
 			ids := make([]string, len(sils))
 			for i, s := range sils {

--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -477,11 +477,8 @@ func TestSilenceStage(t *testing.T) {
 	}
 
 	var got []model.LabelSet
-	for i, a := range alerts {
+	for _, a := range alerts {
 		got = append(got, a.Labels)
-		if a.WasSilenced != (i == 1) {
-			t.Errorf("Expected WasSilenced to be %v for %d, was %v", i == 1, i, a.WasSilenced)
-		}
 	}
 
 	if !reflect.DeepEqual(got, out) {
@@ -533,11 +530,8 @@ func TestInhibitStage(t *testing.T) {
 	}
 
 	var got []model.LabelSet
-	for i, a := range alerts {
+	for _, a := range alerts {
 		got = append(got, a.Labels)
-		if a.WasInhibited != (i == 1) {
-			t.Errorf("Expected WasInhibited to be %v for %d, was %v", i == 1, i, a.WasInhibited)
-		}
 	}
 
 	if !reflect.DeepEqual(got, out) {

--- a/types/types.go
+++ b/types/types.go
@@ -261,10 +261,8 @@ type Alert struct {
 	model.Alert
 
 	// The authoritative timestamp.
-	UpdatedAt    time.Time
-	Timeout      bool
-	WasSilenced  bool `json:"-"`
-	WasInhibited bool `json:"-"`
+	UpdatedAt time.Time
+	Timeout   bool
 }
 
 // AlertSlice is a sortable slice of Alerts.


### PR DESCRIPTION
This fixes the race condition reported in #1013.

As I was fixing this, I noticed, that I couldn't find where or if this is actually used anywhere, as it's not rendered in the json response, and otherwise not used at all either. If we can confirm this we can probably remove it entirely. I know there was some work around this relatively recently, but don't remember exactly anymore what.

Fixes #1013

@stuartnelson3 @fabxc @mxinden 