### PR TITLE
Add usage question note to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Prometheus uses GitHub to manage reviews of pull requests.
+Alertmanager uses GitHub to manage reviews of pull requests.
 
 * If you have a trivial fix or improvement, go ahead and create a pull request,
   addressing (with `@...`) the maintainer of this repository (see


### PR DESCRIPTION
Usage questions should not be discussed via GitHub issues but instead in
the Prometheus users Google group. Redirecting users from GitHub issues
to the Prometheus users Google group is happening quite often. To make
things easier for maintainers and users this patch adds a note to
CONTRIBUTING.md in the repo. When opening up a new issue in GitHub,
there is a link to the CONTRIBUTING.md file at the top of the dialog.

@stuartnelson3 what do you think?