### PR TITLE
Allow template in victorops message_type field

### DIFF
--- a/notify/impl.go
+++ b/notify/impl.go
@@ -859,7 +859,7 @@ func (n *VictorOps) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 		data         = n.tmpl.Data(receiverName(ctx), groupLabels(ctx), as...)
 		tmpl         = tmplText(n.tmpl, data, &err)
 		apiURL       = fmt.Sprintf("%s%s/%s", n.conf.APIURL, n.conf.APIKey, n.conf.RoutingKey)
-		messageType  = n.conf.MessageType
+		messageType  = tmpl(n.conf.MessageType)
 		stateMessage = tmpl(n.conf.StateMessage)
 	)
 


### PR DESCRIPTION
successfully tested with:

```yaml
receivers:
- name: victorops-test
  victorops_configs:
  - routing_key: somekey
    message_type: "{{ .CommonLabels.severity | toUpper }}"
```

fixes #1018