### PR TITLE
Add support for configuring and sending contexts to PagerDuty when triggering alerts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /.build
 /.release
 /.tarballs
+/.idea
 
 !/doc/examples/simple.yml
 !/circle.yml

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -178,12 +178,22 @@ func (c *EmailConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 type PagerdutyConfig struct {
 	NotifierConfig `yaml:",inline" json:",inline"`
 
-	ServiceKey  Secret            `yaml:"service_key,omitempty" json:"service_key,omitempty"`
-	URL         string            `yaml:"url,omitempty" json:"url,omitempty"`
-	Client      string            `yaml:"client,omitempty" json:"client,omitempty"`
-	ClientURL   string            `yaml:"client_url,omitempty" json:"client_url,omitempty"`
-	Description string            `yaml:"description,omitempty" json:"description,omitempty"`
-	Details     map[string]string `yaml:"details,omitempty" json:"details,omitempty"`
+	ServiceKey  Secret             `yaml:"service_key,omitempty" json:"service_key,omitempty"`
+	URL         string             `yaml:"url,omitempty" json:"url,omitempty"`
+	Client      string             `yaml:"client,omitempty" json:"client,omitempty"`
+	ClientURL   string             `yaml:"client_url,omitempty" json:"client_url,omitempty"`
+	Description string             `yaml:"description,omitempty" json:"description,omitempty"`
+	Details     map[string]string  `yaml:"details,omitempty" json:"details,omitempty"`
+	Contexts    []PagerdutyContext `yaml:"contexts,omitempty" json:"contexts,omitempty"`
+
+	// Catches all undefined fields and must be empty after parsing.
+	XXX map[string]interface{} `yaml:",inline" json:"-"`
+}
+
+type PagerdutyContext struct {
+	Type string `yaml:"type,omitempty" json:"type,omitempty"`
+	Href string `yaml:"href,omitempty" json:"href,omitempty"`
+	Text string `yaml:"text,omitempty" json:"text,omitempty"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline" json:"-"`

--- a/notify/impl.go
+++ b/notify/impl.go
@@ -434,13 +434,20 @@ const (
 )
 
 type pagerDutyMessage struct {
-	ServiceKey  string            `json:"service_key"`
-	IncidentKey string            `json:"incident_key"`
-	EventType   string            `json:"event_type"`
-	Description string            `json:"description"`
-	Client      string            `json:"client,omitempty"`
-	ClientURL   string            `json:"client_url,omitempty"`
-	Details     map[string]string `json:"details,omitempty"`
+	ServiceKey  string             `json:"service_key"`
+	IncidentKey string             `json:"incident_key"`
+	EventType   string             `json:"event_type"`
+	Description string             `json:"description"`
+	Client      string             `json:"client,omitempty"`
+	ClientURL   string             `json:"client_url,omitempty"`
+	Details     map[string]string  `json:"details,omitempty"`
+	Contexts    []pagerDutyContext `json:"contexts,omitempty"`
+}
+
+type pagerDutyContext struct {
+	Type string `json:"type"`
+	Href string `json:"href"`
+	Text string `json:"text"`
 }
 
 // Notify implements the Notifier interface.
@@ -480,6 +487,16 @@ func (n *PagerDuty) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 	if eventType == pagerDutyEventTrigger {
 		msg.Client = tmpl(n.conf.Client)
 		msg.ClientURL = tmpl(n.conf.ClientURL)
+
+		var contexts []pagerDutyContext
+		for _, c := range n.conf.Contexts {
+			contexts = append(contexts, pagerDutyContext{
+				Type:  tmpl(c.Type),
+				Href:  tmpl(c.Href),
+				Text:  tmpl(c.Text),
+			})
+		}
+		msg.Contexts = contexts
 	}
 	if err != nil {
 		return false, err


### PR DESCRIPTION
When Alertmanager creates PagerDuty incidents it appends all of the alert data as custom details.  Links within the custom details are clickable, but they are not easily discoverable.  Alertmanager should support populating the Contexts element (from [PagerDuty Event API V1 ](https://v2.developer.pagerduty.com/docs/trigger-events))  and Links/Images when [PagerDuty Event API V2](https://v2.developer.pagerduty.com/docs/send-an-event-events-api-v2) supported.

This PR is still a work in progress, but the goal is to populate the Links section in the PagerDuty UI as shown below.
<img width="268" alt="screen shot 2017-10-19 at 1 44 40 am" src="https://user-images.githubusercontent.com/1904898/31762133-201846c4-b46f-11e7-9cea-8653cbb25c69.png">
