### PR TITLE
Add ellipsis to truncated messages

### DIFF
--- a/notify/impl.go
+++ b/notify/impl.go
@@ -953,11 +953,11 @@ func (n *Pushover) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	message := tmpl(n.conf.Message)
 	parameters.Add("title", title)
 	if len(title) > 512 {
-		title = title[:512]
+		title = title[:509] + "..."
 		log.With("incident", key).Debugf("Truncated title to %q due to Pushover message limit", title)
 	}
 	if len(title)+len(message) > 512 {
-		message = message[:512-len(title)]
+		message = message[:509-len(title)] + "..."
 		log.With("incident", key).Debugf("Truncated message to %q due to Pushover message limit", message)
 	}
 	message = strings.TrimSpace(message)


### PR DESCRIPTION
UX change, ellipsis gives context to the user that the msg was truncated.