### PR TITLE
Fix alerting when send_resolved false

### DIFF
--- a/config/notifiers_test.go
+++ b/config/notifiers_test.go
@@ -1,8 +1,8 @@
 package config
 
 import (
-	"testing"
 	"gopkg.in/yaml.v2"
+	"testing"
 )
 
 func TestEmailToIsPresent(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/prometheus/alertmanager/issues/1063

The inconsistency when alerting with send_resolved set to false happens because the notification logs are not updated when send_resolved is false and a 'resolved' alert arrives. 
When the send_resolved is set to true and a resolved alert arrives the logs will be updated because the pipeline is not canceled at the DedupStage, it will move on until the SetNotifiesStage which will update the notification log here -> https://github.com/prometheus/alertmanager/blob/master/notify/notify.go#L652

The solution will only update the nflog if there are new resolved alerts, the sendResolved is set to false, and the pipeline would be canceled because `needsUpdate` returned false.
The check to validate if new resolved alerts exist is the same done when send_resolved is true and will or not move on with the pipeline https://github.com/prometheus/alertmanager/blob/master/notify/notify.go#L497

@juliusv @stuartnelson3 