### PR TITLE
Allow enabling mutex and block profiles

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -103,6 +104,11 @@ func newMarkerMetrics(marker types.Marker) {
 }
 
 func main() {
+	if os.Getenv("DEBUG") != "" {
+		runtime.SetBlockProfileRate(20)
+		runtime.SetMutexProfileFraction(20)
+	}
+
 	var (
 		showVersion = flag.Bool("version", false, "Print version information.")
 


### PR DESCRIPTION
Similar to [Prometheus](https://github.com/prometheus/prometheus/blob/bf6db1bc3b6715a61f0485bcb973ecd76e6b0ce8/cmd/prometheus/main.go#L74-L75) it's often useful to enable mutex profiling in load and correctness testing. I'm open to other methods of enabling it, but thought it makes sense to do it consistently with Prometheus.

@stuartnelson3 @juliusv @josedonizetti 