### PR TITLE
Add env & expandenv template functions

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -16,6 +16,7 @@ package template
 import (
 	"bytes"
 	"net/url"
+	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -135,6 +136,8 @@ var DefaultFuncs = FuncMap{
 		re := regexp.MustCompile(pattern)
 		return re.ReplaceAllString(text, repl)
 	},
+	"env":       func(s string) string { return os.Getenv(s) },
+	"expandenv": func(s string) string { return os.ExpandEnv(s) },
 }
 
 // Pair is a key/value string pair.


### PR DESCRIPTION
Using environment variables is a common practice when deploying
docker containers. This allows for using environment variables in notifications.

This can also enable functionality described in https://github.com/prometheus/alertmanager/issues/504 after adding parsing to the `Secret` types.