### PR TITLE
Refactor silence constants

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -620,11 +620,11 @@ func (api *API) listSilences(w http.ResponseWriter, r *http.Request) {
 
 	for _, s := range sils {
 		switch s.Status.State {
-		case "active":
+		case types.SilenceStateActive:
 			active = append(active, s)
-		case "pending":
+		case types.SilenceStatePending:
 			pending = append(pending, s)
-		case "expired":
+		case types.SilenceStateExpired:
 			expired = append(expired, s)
 		}
 	}

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -362,7 +362,7 @@ func (n *SilenceStage) Exec(ctx context.Context, l log.Logger, alerts ...*types.
 		// TODO(fabxc): increment total alerts counter.
 		// Do not send the alert if the silencer mutes it.
 		sils, err := n.silences.Query(
-			silence.QState(silence.StateActive),
+			silence.QState(types.SilenceStateActive),
 			silence.QMatches(a.Labels),
 		)
 		if err != nil {

--- a/silence/silence_test.go
+++ b/silence/silence_test.go
@@ -434,7 +434,7 @@ func TestQState(t *testing.T) {
 
 	cases := []struct {
 		sil    *pb.Silence
-		states []SilenceState
+		states []types.SilenceState
 		keep   bool
 	}{
 		{
@@ -442,7 +442,7 @@ func TestQState(t *testing.T) {
 				StartsAt: now.Add(time.Minute),
 				EndsAt:   now.Add(time.Hour),
 			},
-			states: []SilenceState{StateActive, StateExpired},
+			states: []types.SilenceState{types.SilenceStateActive, types.SilenceStateExpired},
 			keep:   false,
 		},
 		{
@@ -450,7 +450,7 @@ func TestQState(t *testing.T) {
 				StartsAt: now.Add(time.Minute),
 				EndsAt:   now.Add(time.Hour),
 			},
-			states: []SilenceState{StatePending},
+			states: []types.SilenceState{types.SilenceStatePending},
 			keep:   true,
 		},
 		{
@@ -458,7 +458,7 @@ func TestQState(t *testing.T) {
 				StartsAt: now.Add(time.Minute),
 				EndsAt:   now.Add(time.Hour),
 			},
-			states: []SilenceState{StateExpired, StatePending},
+			states: []types.SilenceState{types.SilenceStateExpired, types.SilenceStatePending},
 			keep:   true,
 		},
 	}
@@ -778,7 +778,7 @@ func TestSilenceExpire(t *testing.T) {
 		},
 	}
 
-	count, err := s.CountState(StatePending)
+	count, err := s.CountState(types.SilenceStatePending)
 	require.NoError(t, err)
 	require.Equal(t, 1, count)
 
@@ -799,7 +799,7 @@ func TestSilenceExpire(t *testing.T) {
 		UpdatedAt: now,
 	}, sil)
 
-	count, err = s.CountState(StatePending)
+	count, err = s.CountState(types.SilenceStatePending)
 	require.NoError(t, err)
 	require.Equal(t, 0, count)
 


### PR DESCRIPTION
Clean up silence constants duplicated; I chose to keep the ones declared inside the types package because it's where the silence struct is also declared. 

@stuartnelson3 @brancz 