### PR TITLE
Remove old silence code

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -14,8 +14,6 @@
 package types
 
 import (
-	"fmt"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -379,72 +377,4 @@ func CalcSilenceState(start, end time.Time) SilenceState {
 		return SilenceStateActive
 	}
 	return SilenceStateExpired
-}
-
-// Validate returns true iff all fields of the silence have valid values.
-func (s *Silence) Validate() error {
-	if s.ID == "" {
-		return fmt.Errorf("ID missing")
-	}
-	if len(s.Matchers) == 0 {
-		return fmt.Errorf("at least one matcher required")
-	}
-	for _, m := range s.Matchers {
-		if err := m.Validate(); err != nil {
-			return fmt.Errorf("invalid matcher: %s", err)
-		}
-	}
-	if s.StartsAt.IsZero() {
-		return fmt.Errorf("start time missing")
-	}
-	if s.EndsAt.IsZero() {
-		return fmt.Errorf("end time missing")
-	}
-	if s.EndsAt.Before(s.StartsAt) {
-		return fmt.Errorf("start time must be before end time")
-	}
-	if s.CreatedBy == "" {
-		return fmt.Errorf("creator information missing")
-	}
-	if s.Comment == "" {
-		return fmt.Errorf("comment missing")
-	}
-	// if s.CreatedAt.IsZero() {
-	//	return fmt.Errorf("creation timestamp missing")
-	// }
-	return nil
-}
-
-// Init initializes a silence. Must be called before using Mutes.
-func (s *Silence) Init() error {
-	for _, m := range s.Matchers {
-		if err := m.Init(); err != nil {
-			return err
-		}
-	}
-	sort.Sort(s.Matchers)
-	return nil
-}
-
-// Mutes implements the Muter interface.
-//
-// TODO(fabxc): consider making this a function accepting a
-// timestamp and returning a Muter, i.e. s.Muter(ts).Mutes(lset).
-func (s *Silence) Mutes(lset model.LabelSet) bool {
-	var now time.Time
-	if s.now != nil {
-		now = s.now()
-	} else {
-		now = time.Now()
-	}
-	if now.Before(s.StartsAt) || now.After(s.EndsAt) {
-		return false
-	}
-	return s.Matchers.Match(lset)
-}
-
-// Deleted returns whether a silence is deleted. Semantically this means it had no effect
-// on history at any point.
-func (s *Silence) Deleted() bool {
-	return s.StartsAt.Equal(s.EndsAt)
 }


### PR DESCRIPTION
The `(silence) Delete()` method was added at this commit https://github.com/prometheus/alertmanager/commit/c0103dd8c61a9e9e57a3c888a9ae579e24a09b8d a code related to the old silence provider, that was deleted at this commit https://github.com/prometheus/alertmanager/commit/3b5dfa8aba9db19c4c175360d69cce8f0c3d9b74, and now it not used anymore.

But more importantly for me is that the semantically now this method should be called `Expired()` https://github.com/prometheus/alertmanager/blob/master/silence/silence.go#L493, maybe instead of removing I should just rename it.

what do you think?
@stuartnelson3 @brancz 