### PR TITLE
Allow template in victorops routing_key field

### DIFF
--- a/notify/impl.go
+++ b/notify/impl.go
@@ -861,7 +861,7 @@ func (n *VictorOps) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 		alerts       = types.Alerts(as...)
 		data         = n.tmpl.Data(receiverName(ctx, n.logger), groupLabels(ctx, n.logger), as...)
 		tmpl         = tmplText(n.tmpl, data, &err)
-		apiURL       = fmt.Sprintf("%s%s/%s", n.conf.APIURL, n.conf.APIKey, n.conf.RoutingKey)
+		apiURL       = fmt.Sprintf("%s%s/%s", n.conf.APIURL, n.conf.APIKey, tmpl(n.conf.RoutingKey))
 		messageType  = tmpl(n.conf.MessageType)
 		stateMessage = tmpl(n.conf.StateMessage)
 	)


### PR DESCRIPTION
@stuartnelson3 

Similar to #1038 

Makes the VictorOps `routing_key` field templatable. My use case involves using a label in the alert common labels to configure the VictorOps routing key. Ideally, this allows a single receiver to route all VictorOps bound alerts, as opposed to the one receiver per routing key (team?) that is required today.

```yaml
receivers:
- name: victorops-test
  victorops_configs:
  - routing_key: "{{ .CommonLabels.team }}"
```