### PR TITLE
Fix config name inconsistency

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -202,10 +202,10 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 		for _, hc := range rcv.HipchatConfigs {
 			if hc.APIURL == "" {
-				if c.Global.HipchatURL == "" {
+				if c.Global.HipchatAPIURL == "" {
 					return fmt.Errorf("no global Hipchat API URL set")
 				}
-				hc.APIURL = c.Global.HipchatURL
+				hc.APIURL = c.Global.HipchatAPIURL
 			}
 			if !strings.HasSuffix(hc.APIURL, "/") {
 				hc.APIURL += "/"
@@ -299,7 +299,7 @@ var DefaultGlobalConfig = GlobalConfig{
 
 	SMTPRequireTLS:  true,
 	PagerdutyURL:    "https://events.pagerduty.com/v2/enqueue",
-	HipchatURL:      "https://api.hipchat.com/",
+	HipchatAPIURL:   "https://api.hipchat.com/",
 	OpsGenieAPIHost: "https://api.opsgenie.com/",
 	VictorOpsAPIURL: "https://alert.victorops.com/integrations/generic/20131114/alert/",
 }
@@ -321,7 +321,7 @@ type GlobalConfig struct {
 	SMTPRequireTLS   bool   `yaml:"smtp_require_tls,omitempty" json:"smtp_require_tls,omitempty"`
 	SlackAPIURL      Secret `yaml:"slack_api_url,omitempty" json:"slack_api_url,omitempty"`
 	PagerdutyURL     string `yaml:"pagerduty_url,omitempty" json:"pagerduty_url,omitempty"`
-	HipchatURL       string `yaml:"hipchat_url,omitempty" json:"hipchat_url,omitempty"`
+	HipchatAPIURL    string `yaml:"hipchat_api_url,omitempty" json:"hipchat_api_url,omitempty"`
 	HipchatAuthToken Secret `yaml:"hipchat_auth_token,omitempty" json:"hipchat_auth_token,omitempty"`
 	OpsGenieAPIHost  string `yaml:"opsgenie_api_host,omitempty" json:"opsgenie_api_host,omitempty"`
 	VictorOpsAPIURL  string `yaml:"victorops_api_url,omitempty" json:"victorops_api_url,omitempty"`

--- a/config/config.go
+++ b/config/config.go
@@ -226,14 +226,14 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			}
 		}
 		for _, ogc := range rcv.OpsGenieConfigs {
-			if ogc.APIHost == "" {
-				if c.Global.OpsGenieAPIHost == "" {
+			if ogc.APIURL == "" {
+				if c.Global.OpsGenieAPIURL == "" {
 					return fmt.Errorf("no global OpsGenie URL set")
 				}
-				ogc.APIHost = c.Global.OpsGenieAPIHost
+				ogc.APIURL = c.Global.OpsGenieAPIURL
 			}
-			if !strings.HasSuffix(ogc.APIHost, "/") {
-				ogc.APIHost += "/"
+			if !strings.HasSuffix(ogc.APIURL, "/") {
+				ogc.APIURL += "/"
 			}
 		}
 		for _, voc := range rcv.VictorOpsConfigs {
@@ -300,7 +300,7 @@ var DefaultGlobalConfig = GlobalConfig{
 	SMTPRequireTLS:  true,
 	PagerdutyURL:    "https://events.pagerduty.com/v2/enqueue",
 	HipchatAPIURL:   "https://api.hipchat.com/",
-	OpsGenieAPIHost: "https://api.opsgenie.com/",
+	OpsGenieAPIURL:  "https://api.opsgenie.com/",
 	VictorOpsAPIURL: "https://alert.victorops.com/integrations/generic/20131114/alert/",
 }
 
@@ -323,7 +323,7 @@ type GlobalConfig struct {
 	PagerdutyURL     string `yaml:"pagerduty_url,omitempty" json:"pagerduty_url,omitempty"`
 	HipchatAPIURL    string `yaml:"hipchat_api_url,omitempty" json:"hipchat_api_url,omitempty"`
 	HipchatAuthToken Secret `yaml:"hipchat_auth_token,omitempty" json:"hipchat_auth_token,omitempty"`
-	OpsGenieAPIHost  string `yaml:"opsgenie_api_host,omitempty" json:"opsgenie_api_host,omitempty"`
+	OpsGenieAPIURL   string `yaml:"opsgenie_api_url,omitempty" json:"opsgenie_api_url,omitempty"`
 	VictorOpsAPIURL  string `yaml:"victorops_api_url,omitempty" json:"victorops_api_url,omitempty"`
 	VictorOpsAPIKey  Secret `yaml:"victorops_api_key,omitempty" json:"victorops_api_key,omitempty"`
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -284,7 +284,7 @@ func TestEmptyFieldsAndRegex(t *testing.T) {
 			SlackAPIURL:      "mysecret",
 			SMTPRequireTLS:   true,
 			PagerdutyURL:     "https://events.pagerduty.com/v2/enqueue",
-			OpsGenieAPIHost:  "https://api.opsgenie.com/",
+			OpsGenieAPIURL:   "https://api.opsgenie.com/",
 			VictorOpsAPIURL:  "https://alert.victorops.com/integrations/generic/20131114/alert/",
 		},
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -280,7 +280,7 @@ func TestEmptyFieldsAndRegex(t *testing.T) {
 			SMTPSmarthost:    "localhost:25",
 			SMTPFrom:         "alertmanager@example.org",
 			HipchatAuthToken: "mysecret",
-			HipchatURL:       "https://hipchat.foobar.org/",
+			HipchatAPIURL:    "https://hipchat.foobar.org/",
 			SlackAPIURL:      "mysecret",
 			SMTPRequireTLS:   true,
 			PagerdutyURL:     "https://events.pagerduty.com/v2/enqueue",

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -300,7 +300,7 @@ type OpsGenieConfig struct {
 	NotifierConfig `yaml:",inline" json:",inline"`
 
 	APIKey      Secret            `yaml:"api_key,omitempty" json:"api_key,omitempty"`
-	APIHost     string            `yaml:"api_host,omitempty" json:"api_host,omitempty"`
+	APIURL      string            `yaml:"api_url,omitempty" json:"api_url,omitempty"`
 	Message     string            `yaml:"message,omitempty" json:"message,omitempty"`
 	Description string            `yaml:"description,omitempty" json:"description,omitempty"`
 	Source      string            `yaml:"source,omitempty" json:"source,omitempty"`

--- a/config/testdata/conf.empty-fields.yml
+++ b/config/testdata/conf.empty-fields.yml
@@ -5,7 +5,7 @@ global:
   smtp_auth_password: ''
   smtp_hello: ''
   hipchat_auth_token: 'mysecret'
-  hipchat_url: 'https://hipchat.foobar.org/'
+  hipchat_api_url: 'https://hipchat.foobar.org/'
   slack_api_url: 'mysecret'
 
 

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -8,7 +8,7 @@ global:
   # The auth token for Hipchat.
   hipchat_auth_token: "mysecret"
   # Alternative host for Hipchat.
-  hipchat_url: 'https://hipchat.foobar.org/'
+  hipchat_api_url: 'https://hipchat.foobar.org/'
   slack_api_url: "mysecret"
 
 

--- a/doc/examples/simple.yml
+++ b/doc/examples/simple.yml
@@ -7,7 +7,7 @@ global:
   # The auth token for Hipchat.
   hipchat_auth_token: '1234556789'
   # Alternative host for Hipchat.
-  hipchat_url: 'https://hipchat.foobar.org/'
+  hipchat_api_url: 'https://hipchat.foobar.org/'
 
 # The directory from which notification templates are read.
 templates: 

--- a/notify/impl.go
+++ b/notify/impl.go
@@ -825,7 +825,7 @@ func (n *OpsGenie) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	)
 	switch alerts.Status() {
 	case model.AlertResolved:
-		apiURL = fmt.Sprintf("%sv2/alerts/%s/close?identifierType=alias", n.conf.APIHost, alias)
+		apiURL = fmt.Sprintf("%sv2/alerts/%s/close?identifierType=alias", n.conf.APIURL, alias)
 		msg = &opsGenieCloseMessage{Source: tmpl(n.conf.Source)}
 	default:
 		message := tmpl(n.conf.Message)
@@ -834,7 +834,7 @@ func (n *OpsGenie) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 			level.Debug(n.logger).Log("msg", "Truncated message to %q due to OpsGenie message limit", "truncated_message", message, "incident", key)
 		}
 
-		apiURL = n.conf.APIHost + "v2/alerts"
+		apiURL = n.conf.APIURL + "v2/alerts"
 		msg = &opsGenieCreateMessage{
 			Alias:       alias,
 			Message:     message,


### PR DESCRIPTION
This PR renames configuration from 3 different notifiers to make it consistent with others. Basically, global configurations will be named `<notifier>_api_url`, and local configurations per notifier `api_url`. 

This are **breaking changes**.

Fixes https://github.com/prometheus/alertmanager/issues/680 and https://github.com/prometheus/alertmanager/issues/875

@stuartnelson3 @brancz @brian-brazil @juliusv 