### PR TITLE
amtool - Allow 'd', 'w', 'y' to be specified at time suffix when creating silence

### DIFF
--- a/cli/silence_add.go
+++ b/cli/silence_add.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/prometheus/alertmanager/types"
+	"github.com/prometheus/common/model"
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -18,7 +19,7 @@ import (
 
 type addResponse struct {
 	Status string `json:"status"`
-	Data   struct {
+	Data struct {
 		SilenceID string `json:"silenceId"`
 	} `json:"data,omitempty"`
 	ErrorType string `json:"errorType,omitempty"`
@@ -102,11 +103,14 @@ func add(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	} else {
-		duration, err := time.ParseDuration(expires)
+		duration, err := model.ParseDuration(expires)
 		if err != nil {
 			return err
 		}
-		endsAt = time.Now().UTC().Add(duration)
+		if duration == 0 {
+			return fmt.Errorf("silence duration must be greater than 0")
+		}
+		endsAt = time.Now().UTC().Add(time.Duration(duration))
 	}
 
 	author := viper.GetString("author")


### PR DESCRIPTION
The time.ParseDuration function refused to parse them with [the reason](https://github.com/golang/go/issues/11473#issuecomment-116964364) is that a day
can be shorter or longer than 24 hours. But they are already [accepted in
Prometheus range query](https://github.com/prometheus/prometheus/blob/master/promql/parse.go#L1131-L1140) and a custom parser is included in Prometheus
common package so there's no reason amtool cannot use that.

This will be handy in cases you need to create silence for longer periods,
which are unfortunately common.