### PR TITLE
Support OpsGenie Priority field

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -308,6 +308,7 @@ type OpsGenieConfig struct {
 	Teams       string            `yaml:"teams,omitempty" json:"teams,omitempty"`
 	Tags        string            `yaml:"tags,omitempty" json:"tags,omitempty"`
 	Note        string            `yaml:"note,omitempty" json:"note,omitempty"`
+	Priority    string            `yaml:"priority,omitempty" json:"priority,omitempty"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline" json:"-"`

--- a/notify/impl.go
+++ b/notify/impl.go
@@ -792,6 +792,7 @@ type opsGenieCreateMessage struct {
 	Teams       string            `json:"teams,omitempty"`
 	Tags        string            `json:"tags,omitempty"`
 	Note        string            `json:"note,omitempty"`
+	Priority    string            `json:"priority,omitempty"`
 }
 
 type opsGenieCloseMessage struct {
@@ -843,6 +844,7 @@ func (n *OpsGenie) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 			Teams:       tmpl(n.conf.Teams),
 			Tags:        tmpl(n.conf.Tags),
 			Note:        tmpl(n.conf.Note),
+			Priority:    tmpl(n.conf.Priority),
 		}
 	}
 	if err != nil {


### PR DESCRIPTION
Now that Alertmanager is on the OpsGenie v2 API we can use the "Priority" field.

This is a non-mandatory field [described as follows](https://docs.opsgenie.com/docs/alert-api#section-create-alert):

> Priority level of the alert. Possible values are P1, P2, P3, P4 and P5. Default value is P3.

Further information about this field can be found [here](https://docs.opsgenie.com/docs/priority-field), including information on validation:

> If an unknown value is assigned or the tool does not carry a priority information, the alert will have the default priority value, P3.

With the above in mind, this PR does not validate the value for this field. Though I could add validation if so desired.
