### PR TITLE
Fix OpsGenie Teams field

### DIFF
--- a/notify/impl.go
+++ b/notify/impl.go
@@ -784,19 +784,15 @@ func NewOpsGenie(c *config.OpsGenieConfig, t *template.Template, l log.Logger) *
 }
 
 type opsGenieCreateMessage struct {
-	Alias       string            `json:"alias"`
-	Message     string            `json:"message"`
-	Description string            `json:"description,omitempty"`
-	Details     map[string]string `json:"details"`
-	Source      string            `json:"source"`
-	Teams       []opsGenieTeam    `json:"teams,omitempty"`
-	Tags        string            `json:"tags,omitempty"`
-	Note        string            `json:"note,omitempty"`
-	Priority    string            `json:"priority,omitempty"`
-}
-
-type opsGenieTeam struct {
-	Name string `json:"name,omitempty"`
+	Alias       string              `json:"alias"`
+	Message     string              `json:"message"`
+	Description string              `json:"description,omitempty"`
+	Details     map[string]string   `json:"details"`
+	Source      string              `json:"source"`
+	Teams       []map[string]string `json:"teams,omitempty"`
+	Tags        string              `json:"tags,omitempty"`
+	Note        string              `json:"note,omitempty"`
+	Priority    string              `json:"priority,omitempty"`
 }
 
 type opsGenieCloseMessage struct {
@@ -839,9 +835,9 @@ func (n *OpsGenie) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		}
 
 		apiURL = n.conf.APIURL + "v2/alerts"
-		var teams []opsGenieTeam
+		var teams []map[string]string
 		for _, t := range strings.Split(string(tmpl(n.conf.Teams)), ",") {
-			teams = append(teams, opsGenieTeam{Name: t})
+			teams = append(teams, map[string]string{"name": t})
 		}
 		msg = &opsGenieCreateMessage{
 			Alias:       alias,

--- a/notify/impl.go
+++ b/notify/impl.go
@@ -789,10 +789,14 @@ type opsGenieCreateMessage struct {
 	Description string            `json:"description,omitempty"`
 	Details     map[string]string `json:"details"`
 	Source      string            `json:"source"`
-	Teams       string            `json:"teams,omitempty"`
+	Teams       []opsGenieTeam    `json:"teams,omitempty"`
 	Tags        string            `json:"tags,omitempty"`
 	Note        string            `json:"note,omitempty"`
 	Priority    string            `json:"priority,omitempty"`
+}
+
+type opsGenieTeam struct {
+	Name string `json:"name,omitempty"`
 }
 
 type opsGenieCloseMessage struct {
@@ -835,13 +839,17 @@ func (n *OpsGenie) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		}
 
 		apiURL = n.conf.APIURL + "v2/alerts"
+		var teams []opsGenieTeam
+		for _, t := range strings.Split(string(tmpl(n.conf.Teams)), ",") {
+			teams = append(teams, opsGenieTeam{Name: t})
+		}
 		msg = &opsGenieCreateMessage{
 			Alias:       alias,
 			Message:     message,
 			Description: tmpl(n.conf.Description),
 			Details:     details,
 			Source:      tmpl(n.conf.Source),
-			Teams:       tmpl(n.conf.Teams),
+			Teams:       teams,
 			Tags:        tmpl(n.conf.Tags),
 			Note:        tmpl(n.conf.Note),
 			Priority:    tmpl(n.conf.Priority),


### PR DESCRIPTION
#1061 broke the OpsGenie Teams field.

The structure of this field has in fact changed between v1 and v2.

[OpsGenie Documentation](https://docs.opsgenie.com/docs/alert-api#section-create-alert)

## Tests
* No team config set. ✓
* One team value set. ✓
* Multiple team values set. ✓

----

I apologise for missing this in #1061.