### PR TITLE
Refactor inhibit stage

### DIFF
--- a/notify/notify.go
+++ b/notify/notify.go
@@ -215,7 +215,7 @@ func BuildPipeline(
 ) RoutingStage {
 	rs := RoutingStage{}
 
-	is := NewInhibitStage(muter, marker)
+	is := NewInhibitStage(muter)
 	ss := NewSilenceStage(silences, marker)
 
 	for _, rc := range confs {
@@ -318,11 +318,8 @@ type InhibitStage struct {
 }
 
 // NewInhibitStage return a new InhibitStage.
-func NewInhibitStage(m types.Muter, mk types.Marker) *InhibitStage {
-	return &InhibitStage{
-		muter:  m,
-		marker: mk,
-	}
+func NewInhibitStage(m types.Muter) *InhibitStage {
+	return &InhibitStage{muter: m}
 }
 
 // Exec implements the Stage interface.

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -28,7 +28,6 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/prometheus/alertmanager/config"
-	"github.com/prometheus/alertmanager/inhibit"
 	"github.com/prometheus/alertmanager/nflog"
 	"github.com/prometheus/alertmanager/nflog/nflogpb"
 	"github.com/prometheus/alertmanager/silence"
@@ -208,7 +207,7 @@ func BuildPipeline(
 	confs []*config.Receiver,
 	tmpl *template.Template,
 	wait func() time.Duration,
-	inhibitor *inhibit.Inhibitor,
+	muter types.Muter,
 	silences *silence.Silences,
 	notificationLog nflog.Log,
 	marker types.Marker,
@@ -216,7 +215,7 @@ func BuildPipeline(
 ) RoutingStage {
 	rs := RoutingStage{}
 
-	is := NewInhibitStage(inhibitor, marker)
+	is := NewInhibitStage(muter, marker)
 	ss := NewSilenceStage(silences, marker)
 
 	for _, rc := range confs {

--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -494,8 +494,7 @@ func TestInhibitStage(t *testing.T) {
 		return ok
 	})
 
-	marker := types.NewMarker()
-	inhibitor := NewInhibitStage(muter, marker)
+	inhibitor := NewInhibitStage(muter)
 
 	in := []model.LabelSet{
 		{},
@@ -520,10 +519,6 @@ func TestInhibitStage(t *testing.T) {
 			Alert: model.Alert{Labels: lset},
 		})
 	}
-
-	// Set the second alert as previously inhibited. It is expected to have
-	// the WasInhibited flag set to true afterwards.
-	marker.SetInhibited(inAlerts[1].Fingerprint(), "123")
 
 	_, alerts, err := inhibitor.Exec(nil, log.NewNopLogger(), inAlerts...)
 	if err != nil {


### PR DESCRIPTION
- `BuildPipeline` does not use the `*Inhibitor` fully. Only cares about the fact that it implements a `Muter`.
- `marker` is not used inside the `InhibitStage` anymore