### PR TITLE
Fix OpsGenie Tags field

### DIFF
--- a/notify/impl.go
+++ b/notify/impl.go
@@ -790,7 +790,7 @@ type opsGenieCreateMessage struct {
 	Details     map[string]string   `json:"details"`
 	Source      string              `json:"source"`
 	Teams       []map[string]string `json:"teams,omitempty"`
-	Tags        string              `json:"tags,omitempty"`
+	Tags        []string            `json:"tags,omitempty"`
 	Note        string              `json:"note,omitempty"`
 	Priority    string              `json:"priority,omitempty"`
 }
@@ -846,7 +846,7 @@ func (n *OpsGenie) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 			Details:     details,
 			Source:      tmpl(n.conf.Source),
 			Teams:       teams,
-			Tags:        tmpl(n.conf.Tags),
+			Tags:        strings.Split(string(tmpl(n.conf.Tags)), ","),
 			Note:        tmpl(n.conf.Note),
 			Priority:    tmpl(n.conf.Priority),
 		}


### PR DESCRIPTION
#1061 broke the OpsGenie Tags field.

The structure of this field has in fact changed between v1 and v2.

[OpsGenie Documentation](https://docs.opsgenie.com/docs/alert-api#section-create-alert)

I have used strings.Split to preserve functionality without changing config.

## Tests
* No tag config set. ✓
* One tag value set. ✓
* Multiple tags set. ✓

----

I apologise for missing this in #1061.