### PR TITLE
Send the prom gen url as alert source

### DIFF
--- a/notify/impl.go
+++ b/notify/impl.go
@@ -501,14 +501,11 @@ func (n *PagerDuty) notifyV2(ctx context.Context, eventType, key string, tmpl fu
 	if eventType == pagerDutyEventTrigger {
 		payload = &pagerDutyPayload{
 			Summary:       tmpl(n.conf.Description),
+			Source:        tmpl(n.conf.Client),
 			Severity:      n.conf.Severity,
 			CustomDetails: details,
 			Component:     n.conf.Component,
 			Group:         n.conf.Group,
-		}
-
-		if len(as) > 0 {
-			payload.Source = as[0].GeneratorURL
 		}
 	}
 

--- a/notify/impl.go
+++ b/notify/impl.go
@@ -501,11 +501,14 @@ func (n *PagerDuty) notifyV2(ctx context.Context, eventType, key string, tmpl fu
 	if eventType == pagerDutyEventTrigger {
 		payload = &pagerDutyPayload{
 			Summary:       tmpl(n.conf.Description),
-			Source:        n.conf.Client,
 			Severity:      n.conf.Severity,
 			CustomDetails: details,
 			Component:     n.conf.Component,
 			Group:         n.conf.Group,
+		}
+
+		if len(as) > 0 {
+			payload.Source = as[0].GeneratorURL
 		}
 	}
 


### PR DESCRIPTION
From the documentation at
https://v2.developer.pagerduty.com/docs/send-an-event-events-api-v2
```
payload.source: required string

The unique location of the affected system, preferably a hostname or FQDN.
```
Sending the generatorURL isn't technically the
affected system, but an event sent to PD can
encompass multiple alerts. The generatorURL seems
like the correct way to help users debug this.

addresses #1116 