### PR TITLE
inhibit: Fix race in stopping inhibitor

### DIFF
--- a/inhibit/inhibit.go
+++ b/inhibit/inhibit.go
@@ -103,7 +103,9 @@ func (ih *Inhibitor) Run() {
 		ctx context.Context
 	)
 
+	ih.mtx.Lock()
 	ctx, ih.cancel = context.WithCancel(context.Background())
+	ih.mtx.Unlock()
 	gcCtx, gcCancel := context.WithCancel(ctx)
 	runCtx, runCancel := context.WithCancel(ctx)
 
@@ -129,6 +131,8 @@ func (ih *Inhibitor) Stop() {
 		return
 	}
 
+	ih.mtx.RLock()
+	defer ih.mtx.RUnlock()
 	if ih.cancel != nil {
 		ih.cancel()
 	}


### PR DESCRIPTION
The race detector has discovered a race:

```
WARNING: DATA RACE
Read at 0x00c42016fd40 by goroutine 96:
  github.com/prometheus/alertmanager/inhibit.(*Inhibitor).Stop()
      /home/brancz/go/src/github.com/prometheus/alertmanager/inhibit/inhibit.go:132 +0x4d
  main.main.func8()
      /home/brancz/go/src/github.com/prometheus/alertmanager/cmd/alertmanager/main.go:323 +0x5ae
  main.main.func9()
      /home/brancz/go/src/github.com/prometheus/alertmanager/cmd/alertmanager/main.go:386 +0x68
Previous write at 0x00c42016fd40 by goroutine 53:
  github.com/prometheus/alertmanager/inhibit.(*Inhibitor).Run()
      /home/brancz/go/src/github.com/prometheus/alertmanager/inhibit/inhibit.go:106 +0xd9
Goroutine 96 (running) created at:
  main.main()
      /home/brancz/go/src/github.com/prometheus/alertmanager/cmd/alertmanager/main.go:379 +0x2555
Goroutine 53 (running) created at:
  main.main.func8()
      /home/brancz/go/src/github.com/prometheus/alertmanager/cmd/alertmanager/main.go:340 +0x965
  main.main()
      /home/brancz/go/src/github.com/prometheus/alertmanager/cmd/alertmanager/main.go:345 +0x1bf2
```

Fortunately it was pretty exact in where it needed to be fixed. Afterwards I was not able to reproduce this race anymore, before it was detected pretty reliably on shutdown.

@stuartnelson3 @grobie 