### PR TITLE
nflog: Copy and replace gossipData instead of modifying it in place

### DIFF
--- a/nflog/nflog_test.go
+++ b/nflog/nflog_test.go
@@ -195,16 +195,17 @@ func TestGossipDataMerge(t *testing.T) {
 		res := ca.Merge(cb)
 
 		require.Equal(t, c.final, res, "Merge result should match expectation")
-		require.Equal(t, c.final, ca, "Merge should apply changes to original state")
 		require.Equal(t, c.b, cb, "Merged state should remain unmodified")
+		require.NotEqual(t, c.final, ca, "Merge should not change original state")
 
 		ca, cb = c.a.clone(), c.b.clone()
 
-		delta := ca.mergeDelta(cb)
+		res, delta := ca.mergeDelta(cb)
 
 		require.Equal(t, c.delta, delta, "Merge delta should match expectation")
-		require.Equal(t, c.final, ca, "Merge should apply changes to original state")
+		require.Equal(t, c.final, res, "Merge should apply changes to original state")
 		require.Equal(t, c.b, cb, "Merged state should remain unmodified")
+		require.NotEqual(t, res, ca, "Merge should not change original state")
 	}
 }
 


### PR DESCRIPTION
It's very hard to prove, but I think this may fix #1037. Even if not, this makes it a lot easier to reason about the modification of `gossipData`, as it is not modified in place, but rather copied and then modified, and then the entire variable is replaced. That way we can be sure that nothing within the `Merge` and `mergeDelta` functions modify the receiver itself.

What I do not know is how this may impact performance of the system. Fundamentally we don't know what Alertmanager can handle today, so it's hard to tell how much worse this is.

I have tried to reproduce the race originally reported in #1037, but haven't been able to. It's questionable what this means, as it was not easy to reproduce it even without this patch.

@stuartnelson3 @grobie @fabxc 