### PR TITLE
Adding check for webhook's URL formatting

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -15,6 +15,7 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -292,6 +293,14 @@ func (c *WebhookConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if c.URL == "" {
 		return fmt.Errorf("missing URL in webhook config")
 	}
+	url, err := url.Parse(c.URL)
+	if err != nil {
+		return err
+	}
+	if url.Scheme != "https" && url.Scheme != "http" {
+		return fmt.Errorf("non-absolute URL in webhook config")
+	}
+	c.URL = url.String()
 	return checkOverflow(c.XXX, "webhook config")
 }
 

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -298,7 +298,7 @@ func (c *WebhookConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 	if url.Scheme != "https" && url.Scheme != "http" {
-		return fmt.Errorf("non-absolute URL in webhook config")
+		return fmt.Errorf("scheme required for webhook url")
 	}
 	c.URL = url.String()
 	return checkOverflow(c.XXX, "webhook config")

--- a/config/notifiers_test.go
+++ b/config/notifiers_test.go
@@ -110,6 +110,23 @@ url: ''
 	}
 }
 
+func TestWebhookURLIsAbsolute(t *testing.T) {
+	in := `
+url: 'localhost:9093'
+`
+	var cfg WebhookConfig
+	err := yaml.Unmarshal([]byte(in), &cfg)
+
+	expected := "non-absolute URL in webhook config"
+
+	if err == nil {
+		t.Fatalf("no error returned, expected:\n%v", expected)
+	}
+	if err.Error() != expected {
+		t.Errorf("\nexpected:\n%v\ngot:\n%v", expected, err.Error())
+	}
+}
+
 func TestOpsGenieAPIKeyIsPresent(t *testing.T) {
 	in := `
 api_key: ''

--- a/config/notifiers_test.go
+++ b/config/notifiers_test.go
@@ -117,7 +117,7 @@ url: 'localhost:9093'
 	var cfg WebhookConfig
 	err := yaml.Unmarshal([]byte(in), &cfg)
 
-	expected := "non-absolute URL in webhook config"
+	expected := "scheme required for webhook url"
 
 	if err == nil {
 		t.Fatalf("no error returned, expected:\n%v", expected)


### PR DESCRIPTION
Since alertmanager will fail silently when trying to send to a schemaless URL, provide a way to check that a URL is properly formatted in alertmanager