### PR TITLE
Removed incorrect end-of-support warning

### DIFF
--- a/notify/impl.go
+++ b/notify/impl.go
@@ -461,7 +461,6 @@ type pagerDutyPayload struct {
 }
 
 func (n *PagerDuty) notifyV1(ctx context.Context, eventType, key string, tmpl func(string) string, details map[string]string, as ...*types.Alert) (bool, error) {
-	level.Info(n.logger).Log("msg", "PagerDuty v1 API will no longer be supported: https://v2.developer.pagerduty.com/v2/docs/api-v2-frequently-asked-questions")
 
 	msg := &pagerDutyMessage{
 		ServiceKey:  string(n.conf.ServiceKey),


### PR DESCRIPTION
The PagerDuty Events API (v1), used by integrations with monitoring tools, will continue to be supported. There are currently no plans to deprecate, end support for or sunset it.

The end-of-support notice cited in the log message removed applies only to the *REST API* version 1, which PagerDuty will no longer support as of February 2018, but which Prometheus does not use.