### PR TITLE
Add Slack additional "fields" to notifications 

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -234,15 +234,17 @@ type SlackConfig struct {
 	Username string `yaml:"username,omitempty" json:"username,omitempty"`
 	Color    string `yaml:"color,omitempty" json:"color,omitempty"`
 
-	Title     string `yaml:"title,omitempty" json:"title,omitempty"`
-	TitleLink string `yaml:"title_link,omitempty" json:"title_link,omitempty"`
-	Pretext   string `yaml:"pretext,omitempty" json:"pretext,omitempty"`
-	Text      string `yaml:"text,omitempty" json:"text,omitempty"`
-	Footer    string `yaml:"footer,omitempty" json:"footer,omitempty"`
-	Fallback  string `yaml:"fallback,omitempty" json:"fallback,omitempty"`
-	IconEmoji string `yaml:"icon_emoji,omitempty" json:"icon_emoji,omitempty"`
-	IconURL   string `yaml:"icon_url,omitempty" json:"icon_url,omitempty"`
-	LinkNames bool   `yaml:"link_names,omitempty" json:"link_names,omitempty"`
+	Title       string              `yaml:"title,omitempty" json:"title,omitempty"`
+	TitleLink   string              `yaml:"title_link,omitempty" json:"title_link,omitempty"`
+	Pretext     string              `yaml:"pretext,omitempty" json:"pretext,omitempty"`
+	Text        string              `yaml:"text,omitempty" json:"text,omitempty"`
+	Fields      []map[string]string `yaml:"fields,omitempty" json:"fields,omitempty"`
+	ShortFields bool                `yaml:"short_fields,omitempty" json:"short_fields,omitempty"`
+	Footer      string              `yaml:"footer,omitempty" json:"footer,omitempty"`
+	Fallback    string              `yaml:"fallback,omitempty" json:"fallback,omitempty"`
+	IconEmoji   string              `yaml:"icon_emoji,omitempty" json:"icon_emoji,omitempty"`
+	IconURL     string              `yaml:"icon_url,omitempty" json:"icon_url,omitempty"`
+	LinkNames   bool                `yaml:"link_names,omitempty" json:"link_names,omitempty"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline" json:"-"`

--- a/notify/impl.go
+++ b/notify/impl.go
@@ -626,12 +626,13 @@ type slackReq struct {
 
 // slackAttachment is used to display a richly-formatted message block.
 type slackAttachment struct {
-	Title     string `json:"title,omitempty"`
-	TitleLink string `json:"title_link,omitempty"`
-	Pretext   string `json:"pretext,omitempty"`
-	Text      string `json:"text"`
-	Fallback  string `json:"fallback"`
-	Footer    string `json:"footer"`
+	Title     string                 `json:"title,omitempty"`
+	TitleLink string                 `json:"title_link,omitempty"`
+	Pretext   string                 `json:"pretext,omitempty"`
+	Text      string                 `json:"text"`
+	Fallback  string                 `json:"fallback"`
+	Fields    []slackAttachmentField `json:"fields"`
+	Footer    string                 `json:"footer"`
 
 	Color    string   `json:"color,omitempty"`
 	MrkdwnIn []string `json:"mrkdwn_in,omitempty"`
@@ -662,6 +663,20 @@ func (n *Slack) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 		Color:     tmplText(n.conf.Color),
 		MrkdwnIn:  []string{"fallback", "pretext", "text"},
 	}
+
+	var numFields = len(n.conf.Fields)
+	if numFields > 0 {
+		var fields = make([]slackAttachmentField, numFields)
+		for k, v := range n.conf.Fields {
+			fields[k] = slackAttachmentField{
+				v["title"],
+				v["value"],
+				n.conf.ShortFields,
+			}
+		}
+		attachment.Fields = fields
+	}
+
 	req := &slackReq{
 		Channel:     tmplText(n.conf.Channel),
 		Username:    tmplText(n.conf.Username),

--- a/notify/impl.go
+++ b/notify/impl.go
@@ -669,8 +669,8 @@ func (n *Slack) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 		var fields = make([]slackAttachmentField, numFields)
 		for k, v := range n.conf.Fields {
 			fields[k] = slackAttachmentField{
-				v["title"],
-				v["value"],
+				tmplText(v["title"]),
+				tmplText(v["value"]),
 				n.conf.ShortFields,
 			}
 		}


### PR DESCRIPTION
Had a go at implementing https://github.com/prometheus/alertmanager/issues/731

> The Slack notification API has added a fields parameter that allows for some additional formatting [1]. It looks like the work was started to add this additional parameter [2], but the feature was never finished so that it was available.
>[1] https://api.slack.com/docs/message-attachments#fields
>[2] https://github.com/prometheus/alertmanager/blob/v0.5.1/notify/impl.go#L485-L490