### PR TITLE
make tls option "InsecureSkipVerify" configurable by alertmanager

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ services:
 go:
 - 1.8.1
 
+branches:
+  only:
+  - 1211
+
 script:
 # test front-end
 - make clean

--- a/config/config.go
+++ b/config/config.go
@@ -159,6 +159,12 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		if _, ok := names[rcv.Name]; ok {
 			return fmt.Errorf("notification config name %q is not unique", rcv.Name)
 		}
+
+		if ec.InsecureSkipVerify == nil { 
+			ec.InsecureSkipVerify = new(bool)
+                        *ec.InsecureSkipVerify = c.Global.InsecureSkipVerify
+                }
+
 		for _, ec := range rcv.EmailConfigs {
 			if ec.Smarthost == "" {
 				if c.Global.SMTPSmarthost == "" {
@@ -326,6 +332,7 @@ var DefaultGlobalConfig = GlobalConfig{
 	OpsGenieAPIURL:  "https://api.opsgenie.com/",
 	WeChatAPIURL:    "https://qyapi.weixin.qq.com/cgi-bin/",
 	VictorOpsAPIURL: "https://alert.victorops.com/integrations/generic/20131114/alert/",
+	InsecureSkipVerify:  false,
 }
 
 // GlobalConfig defines configuration parameters that are valid globally
@@ -353,6 +360,7 @@ type GlobalConfig struct {
 	WeChatAPICorpID  string `yaml:"wechat_api_corp_id,omitempty" json:"wechat_api_corp_id,omitempty"`
 	VictorOpsAPIURL  string `yaml:"victorops_api_url,omitempty" json:"victorops_api_url,omitempty"`
 	VictorOpsAPIKey  Secret `yaml:"victorops_api_key,omitempty" json:"victorops_api_key,omitempty"`
+	InsecureSkipVerify bool `yaml:"insecure_skip_verify,omitempty" json:"insecure_skip_verify",omitempty"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline" json:"-"`
@@ -489,6 +497,7 @@ type Receiver struct {
 	WechatConfigs    []*WechatConfig    `yaml:"wechat_configs,omitempty" json:"wechat_configs,omitempty"`
 	PushoverConfigs  []*PushoverConfig  `yaml:"pushover_configs,omitempty" json:"pushover_configs,omitempty"`
 	VictorOpsConfigs []*VictorOpsConfig `yaml:"victorops_configs,omitempty" json:"victorops_configs,omitempty"`
+	InsecureSkipVerify     *bool        `yaml:"insecure_skip_verify,omitempty" json:"insecure_skip_verify,omitempty"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline" json:"-"`


### PR DESCRIPTION
When we try to send mails to notify clients, and if it requires TLS, the  TLS option InsecureSkipVerify should be configurable with alertmanager's configuration. This PR is to add InsecureSkipVerify into alertmanager's global configuration.