### PR TITLE
make tls option InsecureSkipVerify configurable by alertmanager

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -191,6 +191,10 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 				ec.RequireTLS = new(bool)
 				*ec.RequireTLS = c.Global.SMTPRequireTLS
 			}
+			if ec.InsecureSkipVerify == nil {
+				ec.InsecureSkipVerify = new(bool)
+                        	*ec.InsecureSkipVerify = c.Global.InsecureSkipVerify
+			}
 		}
 		for _, sc := range rcv.SlackConfigs {
 			if sc.APIURL == "" {
@@ -326,6 +330,7 @@ var DefaultGlobalConfig = GlobalConfig{
 	OpsGenieAPIURL:  "https://api.opsgenie.com/",
 	WeChatAPIURL:    "https://qyapi.weixin.qq.com/cgi-bin/",
 	VictorOpsAPIURL: "https://alert.victorops.com/integrations/generic/20131114/alert/",
+	InsecureSkipVerify:  false,
 }
 
 // GlobalConfig defines configuration parameters that are valid globally
@@ -353,6 +358,7 @@ type GlobalConfig struct {
 	WeChatAPICorpID  string `yaml:"wechat_api_corp_id,omitempty" json:"wechat_api_corp_id,omitempty"`
 	VictorOpsAPIURL  string `yaml:"victorops_api_url,omitempty" json:"victorops_api_url,omitempty"`
 	VictorOpsAPIKey  Secret `yaml:"victorops_api_key,omitempty" json:"victorops_api_key,omitempty"`
+	InsecureSkipVerify bool `yaml:"insecure_skip_verify,omitempty" json:"insecure_skip_verify",omitempty"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline" json:"-"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -270,6 +270,7 @@ func TestJSONUnmarshalMarshaled(t *testing.T) {
 
 func TestEmptyFieldsAndRegex(t *testing.T) {
 	boolFoo := true
+	boolFalse := false
 	var regexpFoo Regexp
 	regexpFoo.Regexp, _ = regexp.Compile("^(?:^(foo1|foo2|baz)$)$")
 
@@ -318,6 +319,7 @@ func TestEmptyFieldsAndRegex(t *testing.T) {
 						Smarthost:  "localhost:25",
 						HTML:       "{{ template \"email.default.html\" . }}",
 						RequireTLS: &boolFoo,
+						insecure_skip_verify: &boolFalse,
 					},
 				},
 			},

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -161,6 +161,7 @@ type EmailConfig struct {
 	HTML         string            `yaml:"html,omitempty" json:"html,omitempty"`
 	Text         string            `yaml:"text,omitempty" json:"text,omitempty"`
 	RequireTLS   *bool             `yaml:"require_tls,omitempty" json:"require_tls,omitempty"`
+	InsecureSkipVerify    *bool    `yaml:"insecure_skip_verify,omitempty" json:"insecure_skip_verify,omitempty"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline" json:"-"`


### PR DESCRIPTION
When we try to send mails to notify clients, and if it requires TLS, the TLS option InsecureSkipVerify should be configurable with alertmanager's configuration. This PR is to add InsecureSkipVerify into alertmanager's global configuration.