### PR TITLE
Fix logging for the mesh component

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -465,7 +465,7 @@ type printfLogger struct {
 }
 
 func (l printfLogger) Printf(f string, args ...interface{}) {
-	level.Debug(l).Log(fmt.Sprintf(f, args...))
+	level.Debug(l).Log("msg", fmt.Sprintf(f, args...))
 }
 
 func extURL(listen, external string) (*url.URL, error) {


### PR DESCRIPTION
Found while troubleshooting my setup, no information regarding the mesh was logged. This has probably felt through the cracks when fixing #1040.