### PR TITLE
Fix updating silence comments

### DIFF
--- a/cli/silence_update.go
+++ b/cli/silence_update.go
@@ -103,8 +103,8 @@ func updateSilence(silence *types.Silence) (*types.Silence, error) {
 		silence.EndsAt = *updateExpiresOn
 	}
 
-	if *comment != "" {
-		silence.Comment = *comment
+	if *updateComment != "" {
+		silence.Comment = *updateComment
 	}
 
 	// addSilence can also be used to update an existing silence


### PR DESCRIPTION
Possibly another regression introduced by #976 . We use the wrong
variable to update comments in the `amtool silence update` command
which causes us to fail silently. This fixes that.