### PR TITLE
Fix flaky TestBatching acceptance test

### DIFF
--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -347,7 +347,7 @@ func (ag *aggrGroup) run(nf notifyFunc) {
 	for {
 		select {
 		case now := <-ag.next.C:
-			// Give the notifcations time until the next flush to
+			// Give the notifications time until the next flush to
 			// finish before terminating them.
 			ctx, cancel := context.WithTimeout(ag.ctx, ag.timeout(ag.opts.GroupInterval))
 

--- a/test/acceptance/send_test.go
+++ b/test/acceptance/send_test.go
@@ -215,7 +215,8 @@ route:
   group_by: []
   group_wait:      1s
   group_interval:  1s
-  repeat_interval: 5s
+  # use a value slightly below the 5s interval to avoid timing issues
+  repeat_interval: 4900ms
 
 receivers:
 - name: "default"


### PR DESCRIPTION
Fix for #427.

This change decreases the repeat_interval parameter from 5s to 4.9s to
make sure that the alerts are effectively sent after 5 seconds.

The workflow is:
- The dispatcher flushes the alerts at t0, sends the notification and
marks the notification log at t0+epsilon.
- The dispatcher flushes the alerts at t1, t2, t3 and t4 and doesn't
send the notifications as expected.
- At t5, the dispatcher flushes the alerts because current_time - (t0+epsilon)
is less then repeat_interval.

If repeat_interval is exactly 5s, there is a little chance that it is
greater than current_time - (t0+epsilon).