### PR TITLE
improved error when victorops fails

### DIFF
--- a/notify/notify.go
+++ b/notify/notify.go
@@ -16,6 +16,7 @@ package notify
 import (
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -604,7 +605,7 @@ func (r RetryStage) Exec(ctx context.Context, l log.Logger, alerts ...*types.Ale
 				for _, al := range alerts {
 					alertnames = append(alertnames, al.Name())
 				}
-				level.Debug(l).Log("msg", "Notify attempt failed", "attempt", i, "integration", r.integration.name, "alerts", alertnames, "err", err)
+				level.Debug(l).Log("msg", "Notify attempt failed", "attempt", i, "integration", r.integration.name, "alerts", strings.Join(alertnames, ", "), "err", err)
 				if !retry {
 					return ctx, alerts, fmt.Errorf("cancelling notify retry for %q due to unrecoverable error: %s", r.integration.name, err)
 				}

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -600,7 +600,7 @@ func (r RetryStage) Exec(ctx context.Context, l log.Logger, alerts ...*types.Ale
 		case <-tick.C:
 			if retry, err := r.integration.Notify(ctx, alerts...); err != nil {
 				numFailedNotifications.WithLabelValues(r.integration.name).Inc()
-				var alertnames []string
+				alertnames := make([]string, 0, len(alerts))
 				for _, al := range alerts {
 					alertnames = append(alertnames, al.Name())
 				}

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -16,6 +16,7 @@ package notify
 import (
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -602,7 +603,11 @@ func (r RetryStage) Exec(ctx context.Context, l log.Logger, alerts ...*types.Ale
 				numFailedNotifications.WithLabelValues(r.integration.name).Inc()
 				level.Debug(l).Log("msg", "Notify attempt failed", "attempt", i, "integration", r.integration.name, "err", err)
 				if !retry {
-					return ctx, alerts, fmt.Errorf("cancelling notify retry for %q due to unrecoverable error: %s", r.integration.name, err)
+					var alertnames []string
+					for _, al := range alerts {
+						alertnames = append(alertnames, al.Name())
+					}
+					return ctx, alerts, fmt.Errorf("cancelling notify retry for %q (alerts: %s) due to unrecoverable error: %s", r.integration.name, strings.Join(alertnames, ", "), err)
 				}
 
 				// Save this error to be able to return the last seen error by an


### PR DESCRIPTION
I am getting errors like this:

```
level=error ts=2018-01-25T11:14:09.509893874Z caller=dispatch.go:266 component=dispatcher msg="Notify for alerts failed" num_alerts=1 err="cancelling notify retry for \"victorops\" due to unrecoverable error: unexpected status code 404"
level=error ts=2018-01-25T11:14:11.027745774Z caller=notify.go:302 component=dispatcher msg="Error on notify" err="cancelling notify retry for \"victorops\" due to unrecoverable error: unexpected status code 404"
level=error ts=2018-01-25T11:14:11.027791108Z caller=dispatch.go:266 component=dispatcher msg="Notify for alerts failed" num_alerts=1 err="cancelling notify retry for \"victorops\" due to unrecoverable error: unexpected status code 404"
level=error ts=2018-01-25T11:14:11.038292052Z caller=notify.go:302 component=dispatcher msg="Error on notify" err="cancelling notify retry for \"victorops\" due to unrecoverable error: unexpected status code 404"
level=error ts=2018-01-25T11:14:11.038324649Z caller=dispatch.go:266 component=dispatcher msg="Notify for alerts failed" num_alerts=1 err="cancelling notify retry for \"victorops\" due to unrecoverable error: unexpected status code 404"
```

its hard to find out which alerts are erroring, I thought that maybe improve the error adding the alert names might help...