### PR TITLE
Add mesh metrics

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -391,7 +391,7 @@ func NewMeshCollector(router *mesh.Router) *meshCollector {
 		connDesc: prometheus.NewDesc(
 			"alertmanager_peer_connection",
 			"State of the connection between the Alertmanager instance and a peer.",
-			[]string{"peer", "nick"},
+			[]string{"peer"},
 			prometheus.Labels{},
 		),
 		posDesc: prometheus.NewDesc(
@@ -433,7 +433,7 @@ func (c *meshCollector) Collect(ch chan<- prometheus.Metric) {
 				c.connDesc,
 				prometheus.GaugeValue,
 				v,
-				conn.Name, conn.NickName,
+				conn.Name,
 			)
 		}
 	}


### PR DESCRIPTION
This change adds 2 new metrics for the mesh:

* alertmanager_peer_connection, state of the connection between the
  Alertmanager instance and a peer.
* alertmanager_peer_terminations_total, total number of terminated
  connection.

It also moves the gathering of the alertmanager_peer_position metric
outside of the meshWait() function so that the metric is computed
accurately even when no alerting group fires.

Fixes #1219.