### PR TITLE
Fixes AM wrongly counting alerts with EndTimes in the future as resolved

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -493,7 +493,8 @@ func (api *API) insertAlerts(w http.ResponseWriter, r *http.Request, alerts ...*
 		if alert.EndsAt.IsZero() {
 			alert.Timeout = true
 			alert.EndsAt = now.Add(resolveTimeout)
-
+		}
+		if alert.EndsAt.After(time.Now()) {
 			numReceivedAlerts.WithLabelValues("firing").Inc()
 		} else {
 			numReceivedAlerts.WithLabelValues("resolved").Inc()


### PR DESCRIPTION
As far as I can tell Prometheus may send a time stamp in the future for the end time of an alert meaning AM shouldn't automatically mark this alert.