### PR TITLE
Sort dispatched alerts by job+instance then rest by default (#1178)

### DIFF
--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -424,6 +424,26 @@ func (ag *aggrGroup) flush(notify func(...*types.Alert) bool) {
 		alertsSlice = append(alertsSlice, alert)
 	}
 
+	sort.SliceStable(alertsSlice, func(i, j int) bool {
+		// Look at labels.job, then labels.instance.
+		for _, override_key := range [...]model.LabelName{"job", "instance"} {
+			key_i, ok_i := alertsSlice[i].Labels[override_key]
+			if !ok_i {
+				return true
+			}
+			key_j, ok_j := alertsSlice[j].Labels[override_key]
+			if !ok_j {
+				return false
+			}
+
+			if key_i != key_j {
+				return key_i > key_j
+			}
+		}
+
+		return alertsSlice[i].Labels.Before(alertsSlice[j].Labels)
+	})
+
 	ag.mtx.Unlock()
 
 	level.Debug(ag.logger).Log("msg", "Flushing", "alerts", fmt.Sprintf("%v", alertsSlice))


### PR DESCRIPTION
Sort dispatched alert slice by `job` and `instance` labels, then rest. Addresses https://github.com/prometheus/alertmanager/issues/1178#issuecomment-362008207

No idea how to write a good test for this, sorry.