### PR TITLE
cmd: remove unused code

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -399,14 +399,6 @@ func clusterWait(p *cluster.Peer, timeout time.Duration) func() time.Duration {
 	}
 }
 
-type printfLogger struct {
-	log.Logger
-}
-
-func (l printfLogger) Printf(f string, args ...interface{}) {
-	level.Debug(l).Log("msg", fmt.Sprintf(f, args...))
-}
-
 func extURL(listen, external string) (*url.URL, error) {
 	if external == "" {
 		hostname, err := os.Hostname()


### PR DESCRIPTION
This code was used for to get the logs from the mesh library.