### PR TITLE
silence: fix skipped test

### DIFF
--- a/silence/silence.go
+++ b/silence/silence.go
@@ -732,14 +732,6 @@ func (s *Silences) SetBroadcast(f func([]byte)) {
 
 type state map[string]*pb.MeshSilence
 
-func (s state) clone() state {
-	c := make(state, len(s))
-	for k, v := range s {
-		c[k] = v
-	}
-	return c
-}
-
 func (s state) merge(e *pb.MeshSilence) {
 	// Comments list was moved to a single comment. Apply upgrade
 	// on silences received from peers.

--- a/silence/silence_test.go
+++ b/silence/silence_test.go
@@ -982,56 +982,47 @@ func TestValidateSilence(t *testing.T) {
 	}
 }
 
-func TeststateMerge(t *testing.T) {
+func TestStateMerge(t *testing.T) {
 	now := utcNow()
 
 	// We only care about key names and timestamps for the
 	// merging logic.
-	newSilence := func(ts time.Time) *pb.MeshSilence {
+	newSilence := func(id string, ts time.Time) *pb.MeshSilence {
 		return &pb.MeshSilence{
-			Silence: &pb.Silence{UpdatedAt: ts},
+			Silence: &pb.Silence{Id: id, UpdatedAt: ts},
 		}
 	}
 
 	cases := []struct {
-		a, b         state
-		final, delta state
+		a, b  state
+		final state
 	}{
 		{
 			a: state{
-				"a1": newSilence(now),
-				"a2": newSilence(now),
-				"a3": newSilence(now),
+				"a1": newSilence("a1", now),
+				"a2": newSilence("a2", now),
+				"a3": newSilence("a3", now),
 			},
 			b: state{
-				"b1": newSilence(now),                   // new key, should be added
-				"a2": newSilence(now.Add(-time.Minute)), // older timestamp, should be dropped
-				"a3": newSilence(now.Add(time.Minute)),  // newer timestamp, should overwrite
+				"b1": newSilence("b1", now),                   // new key, should be added
+				"a2": newSilence("a2", now.Add(-time.Minute)), // older timestamp, should be dropped
+				"a3": newSilence("a3", now.Add(time.Minute)),  // newer timestamp, should overwrite
 			},
 			final: state{
-				"a1": newSilence(now),
-				"a2": newSilence(now),
-				"a3": newSilence(now.Add(time.Minute)),
-				"b1": newSilence(now),
-			},
-			delta: state{
-				"b1": newSilence(now),
-				"a3": newSilence(now.Add(time.Minute)),
+				"a1": newSilence("a1", now),
+				"a2": newSilence("a2", now),
+				"a3": newSilence("a3", now.Add(time.Minute)),
+				"b1": newSilence("b1", now),
 			},
 		},
 	}
 
 	for _, c := range cases {
-		ca, cb := c.a.clone(), c.b.clone()
-
-		res := ca.clone()
-		for _, e := range cb {
-			res.merge(e)
+		for _, e := range c.b {
+			c.a.merge(e)
 		}
 
-		require.Equal(t, c.final, res, "Merge result should match expectation")
-		require.Equal(t, c.final, ca, "Merge should apply changes to original state")
-		require.Equal(t, c.b, cb, "Merged state should remain unmodified")
+		require.Equal(t, c.final, c.a, "Merge result should match expectation")
 	}
 }
 


### PR DESCRIPTION
TestStateMerge() was skipped because of a typo. Fixing the name revealed
that the test itself needed to be updated following the switch to the
memberlist library.