### PR TITLE
test: enable race detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ all: format build test
 
 test:
 	@echo ">> running tests"
-	@$(GO) test -short $(pkgs)
+	@$(GO) test -race -short $(pkgs)
 
 style:
 	@echo ">> checking code style"


### PR DESCRIPTION
This change enables race detection when running the tests. It also fixes
a couple of existing race conditions.

Inspired by https://github.com/prometheus/prometheus/pull/3884 from @krasi-georgiev :smile: