### PR TITLE
Set User object in alertmanager url.

### DIFF
--- a/cli/utils.go
+++ b/cli/utils.go
@@ -27,11 +27,9 @@ func (s ByAlphabetical) Less(i, j int) bool {
 }
 
 func GetAlertmanagerURL(p string) url.URL {
-	return url.URL{
-		Scheme: (*alertmanagerUrl).Scheme,
-		Host:   (*alertmanagerUrl).Host,
-		Path:   path.Join((*alertmanagerUrl).Path, p),
-	}
+	amURL := **alertmanagerUrl
+	amURL.Path = path.Join((*alertmanagerUrl).Path, p)
+	return amURL
 }
 
 // Parse a list of labels (cli arguments)


### PR DESCRIPTION
Sets User object in alertmanager url to enable amtool to work with basic auth for use with proxies. Fixes #1028.