### PR TITLE
main: fix argument order for cluster.Join()

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -154,8 +154,8 @@ func main() {
 			*clusterAdvertiseAddr,
 			*peers,
 			true,
-			*gossipInterval,
 			*pushPullInterval,
+			*gossipInterval,
 		)
 		if err != nil {
 			level.Error(logger).Log("msg", "Unable to initialize gossip mesh", "err", err)


### PR DESCRIPTION
This might help for #1282.

https://github.com/prometheus/alertmanager/blob/d63c25a8559f0ea208e2aff78b32923b0b56975f/cluster/cluster.go#L43-L52

https://github.com/prometheus/alertmanager/blob/d63c25a8559f0ea208e2aff78b32923b0b56975f/cmd/alertmanager/main.go#L152-L159

cc @fabxc @stuartnelson3 