### PR TITLE
Fix for #1282

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -153,8 +153,8 @@ func main() {
 			*clusterAdvertiseAddr,
 			*peers,
 			true,
-			*gossipInterval,
 			*pushPullInterval,
+			*gossipInterval,
 		)
 		if err != nil {
 			level.Error(logger).Log("msg", "Unable to initialize gossip mesh", "err", err)

--- a/silence/silence_test.go
+++ b/silence/silence_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
+	"github.com/matttproud/golang_protobuf_extensions/pbutil"
 	pb "github.com/prometheus/alertmanager/silence/silencepb"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
@@ -187,7 +187,8 @@ func TestSilencesSetSilence(t *testing.T) {
 	done := make(chan bool)
 	s.broadcast = func(b []byte) {
 		var e pb.MeshSilence
-		err := proto.Unmarshal(b, &e)
+		r := bytes.NewReader(b)
+		_, err := pbutil.ReadDelimited(r, &e)
 		require.NoError(t, err)
 
 		require.Equal(t, want["some_id"], &e)


### PR DESCRIPTION
Fixes #1282.

The code could be refactored (in particular `marshalMeshEntry()` can be shared between silence and nflog) but I felt it could be done later.

I've also added new cluster metrics that were helpful when troubleshooting the issue.

cc @fabxc @stuartnelson3 