### PR TITLE
config: set global SMTP hello to "localhost" by default

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -356,6 +356,7 @@ var DefaultGlobalConfig = GlobalConfig{
 	ResolveTimeout: model.Duration(5 * time.Minute),
 	HTTPConfig:     &commoncfg.HTTPClientConfig{},
 
+	SMTPHello:       "localhost",
 	SMTPRequireTLS:  true,
 	PagerdutyURL:    "https://events.pagerduty.com/v2/enqueue",
 	HipchatAPIURL:   "https://api.hipchat.com/",


### PR DESCRIPTION
Following feedback from https://github.com/prometheus/docs/pull/988.