### PR TITLE
fix panic cased by Wechat notifier

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -266,6 +266,10 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			}
 		}
 		for _, wcc := range rcv.WechatConfigs {
+			if wcc.HTTPConfig == nil {
+				wcc.HTTPConfig = c.Global.HTTPConfig
+			}
+
 			if wcc.APIURL == "" {
 				if c.Global.WeChatAPIURL == "" {
 					return fmt.Errorf("no global Wechat URL set")


### PR DESCRIPTION
```

panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x0 pc=0x95057e]

goroutine 174 [running]:
github.com/prometheus/alertmanager/vendor/github.com/prometheus/common/config.NewHTTPClientFromConfig(0x0, 0xc04207f560, 0xc042025df0, 0xc0421b29a0)
        /go/src/github.com/prometheus/alertmanager/vendor/github.com/prometheus/common/config/http_config.go:121 +0x3e
github.com/prometheus/alertmanager/notify.(*Wechat).Notify(0xc0423ff900, 0xbe3000, 0xc042469cb0, 0xc042004b48, 0x1, 0x1, 0xc0425f1b00, 0x0, 0x0)
        /go/src/github.com/prometheus/alertmanager/notify/impl.go:874 +0x380
github.com/prometheus/alertmanager/notify.(*Integration).Notify(0xc0425f1ce0, 0xbe3000, 0xc042469cb0, 0xc042004b48, 0x1, 0x1, 0x1, 0x1, 0x0)
        /go/src/github.com/prometheus/alertmanager/notify/impl.go:87 +0x1dc
github.com/prometheus/alertmanager/notify.RetryStage.Exec(0xbdb200, 0xc0423ff900, 0xbdafe0, 0xc0420500a0, 0xb56e23, 0x6, 0x0, 0xc042062674, 0xc, 0xbe3000, ...)
        /go/src/github.com/prometheus/alertmanager/notify/notify.go:608 +0x260
github.com/prometheus/alertmanager/notify.MultiStage.Exec(0xc0423953c0, 0x4, 0x4, 0xbe3000, 0xc042469170, 0xbdb280, 0xc042391470, 0xc042004b48, 0x1, 0x1, ...)
        /go/src/github.com/prometheus/alertmanager/notify/notify.go:284 +0xfb
github.com/prometheus/alertmanager/notify.FanoutStage.Exec.func1(0xbe3000, 0xc042469170, 0xbdb280, 0xc042391470, 0xc042004b48, 0x1, 0x1, 0xc0421b27e0, 0xc042450f20, 0xbdc040, ...)
        /go/src/github.com/prometheus/alertmanager/notify/notify.go:306 +0xab
created by github.com/prometheus/alertmanager/notify.FanoutStage.Exec
        /go/src/github.com/prometheus/alertmanager/notify/notify.go:305 +0x13c
```