### PR TITLE
Add common labels and annotations to victorOps alert payload

### DIFF
--- a/notify/impl.go
+++ b/notify/impl.go
@@ -1144,11 +1144,13 @@ const (
 )
 
 type victorOpsMessage struct {
-	MessageType       string `json:"message_type"`
-	EntityID          string `json:"entity_id"`
-	EntityDisplayName string `json:"entity_display_name"`
-	StateMessage      string `json:"state_message"`
-	MonitoringTool    string `json:"monitoring_tool"`
+	MessageType       string         `json:"message_type"`
+	EntityID          string         `json:"entity_id"`
+	EntityDisplayName string         `json:"entity_display_name"`
+	StateMessage      string         `json:"state_message"`
+	MonitoringTool    string         `json:"monitoring_tool"`
+	Labels            model.LabelSet `json:"labels,omitempty"`
+	Annotations       model.LabelSet `json:"annotations,omitempty"`
 }
 
 // Notify implements the Notifier interface.
@@ -1193,6 +1195,8 @@ func (n *VictorOps) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 		EntityDisplayName: tmpl(n.conf.EntityDisplayName),
 		StateMessage:      stateMessage,
 		MonitoringTool:    tmpl(n.conf.MonitoringTool),
+		Labels:            alerts[0].Labels.Clone(),
+		Annotations:       alerts[0].Annotations.Clone(),
 	}
 
 	if err != nil {


### PR DESCRIPTION
This PR injects the common annotations and labels of the prometheus alert into the payload of the message sent to the VictorOps REST Endpoint.

It makes use of the fact that the VictorOps REST Endpoint does not forbid including custom fields in the payload, as documented in [this paragraph](https://help.victorops.com/knowledge-base/victorops-restendpoint-integration/#recommended-fields):
> keep in mind that you can also include any number of additional, custom fields that you may find useful

The consequence is that with this PR all annotations and labels of the prometheus alert will be available within VictorOps for use in webhooks and other integrations.

Sample VictorOps alert payload before this PR:
```json
{
  "message_type": "WARNING",
  "entity_id": "782328bf7e449cccf0ef051d95ad050130181c6a6a87e27371669932672247fd",
  "entity_display_name": "[FIRING:1] 17090 dev my-service (17090.example.net warning)",
  "state_message": "Summary: High latency is high!",
  "monitoring_tool": "AlertManager"
}
```

Sample VictorOps alert payload with this PR:
```json
{
  "message_type": "WARNING",
  "entity_id": "782328bf7e449cccf0ef051d95ad050130181c6a6a87e27371669932672247fd",
  "entity_display_name": "[FIRING:1] 17090 dev my-service (17090.example.net warning)",
  "state_message": "Summary: High latency is high!",
  "monitoring_tool": "AlertManager",
  "annotations": {
    "summary": "High latency is high!",
    "description": "High latency is high, very high",
  },
  "labels": {
    "severity": "warning",
    "cluster": "dev",
    "service": "my-service",
    "instance": "17090.example.net"
  },
}
```

In VictorOps, the labels and annotations custom fields will be available as `ALERT.labels.$label` and `ALERT.annotations .$annotation`.