### PR TITLE
Fix potential panic in decodeState()

### DIFF
--- a/nflog/nflog.go
+++ b/nflog/nflog.go
@@ -37,6 +37,9 @@ import (
 // ErrNotFound is returned for empty query results.
 var ErrNotFound = errors.New("not found")
 
+// ErrInvalidState is returned if the state isn't valid.
+var ErrInvalidState = fmt.Errorf("invalid state")
+
 // query currently allows filtering by and/or receiver group key.
 // It is configured via QueryParameter functions.
 //
@@ -239,6 +242,9 @@ func decodeState(r io.Reader) (state, error) {
 		var e pb.MeshEntry
 		_, err := pbutil.ReadDelimited(r, &e)
 		if err == nil {
+			if e.Entry == nil || e.Entry.Receiver == nil {
+				return nil, ErrInvalidState
+			}
 			st[stateKey(string(e.Entry.GroupKey), e.Entry.Receiver)] = &e
 			continue
 		}

--- a/nflog/nflog_test.go
+++ b/nflog/nflog_test.go
@@ -296,3 +296,14 @@ func TestQuery(t *testing.T) {
 	require.EqualValues(t, firingAlerts, entry.FiringAlerts)
 	require.EqualValues(t, resolvedAlerts, entry.ResolvedAlerts)
 }
+
+func TestStateDecodingError(t *testing.T) {
+	// Check whether decoding copes with erroneous data.
+	s := state{"": &pb.MeshEntry{}}
+
+	msg, err := s.MarshalBinary()
+	require.NoError(t, err)
+
+	_, err = decodeState(bytes.NewReader(msg))
+	require.Equal(t, ErrInvalidState, err)
+}

--- a/silence/silence.go
+++ b/silence/silence.go
@@ -40,6 +40,9 @@ import (
 // ErrNotFound is returned if a silence was not found.
 var ErrNotFound = fmt.Errorf("not found")
 
+// ErrInvalidState is returned if the state isn't valid.
+var ErrInvalidState = fmt.Errorf("invalid state")
+
 func utcNow() time.Time {
 	return time.Now().UTC()
 }
@@ -758,6 +761,9 @@ func decodeState(r io.Reader) (state, error) {
 		var s pb.MeshSilence
 		_, err := pbutil.ReadDelimited(r, &s)
 		if err == nil {
+			if s.Silence == nil {
+				return nil, ErrInvalidState
+			}
 			st[s.Silence.Id] = &s
 			continue
 		}

--- a/silence/silence_test.go
+++ b/silence/silence_test.go
@@ -1080,3 +1080,14 @@ func TestStateCoding(t *testing.T) {
 		require.Equal(t, in, out, "decoded data doesn't match encoded data")
 	}
 }
+
+func TestStateDecodingError(t *testing.T) {
+	// Check whether decoding copes with erroneous data.
+	s := state{"": &pb.MeshSilence{}}
+
+	msg, err := s.MarshalBinary()
+	require.NoError(t, err)
+
+	_, err = decodeState(bytes.NewReader(msg))
+	require.Equal(t, ErrInvalidState, err)
+}


### PR DESCRIPTION
I've experienced the panics while investigating #1282: at that time, the data being passed to the decoder wasn't valid (good fuzz testing!). In normal conditions it shouldn't happen but I guess that it is still better to catch those nil pointers.