### PR TITLE
Rename silence API Delete() -> Expire()

### DIFF
--- a/cli/silence_expire.go
+++ b/cli/silence_expire.go
@@ -32,7 +32,7 @@ func expire(element *kingpin.ParseElement, ctx *kingpin.ParseContext) error {
 	silenceAPI := client.NewSilenceAPI(c)
 
 	for _, id := range *expireIds {
-		err := silenceAPI.Delete(context.Background(), id)
+		err := silenceAPI.Expire(context.Background(), id)
 		if err != nil {
 			return err
 		}

--- a/client/client.go
+++ b/client/client.go
@@ -237,8 +237,8 @@ type SilenceAPI interface {
 	Get(ctx context.Context, id string) (*types.Silence, error)
 	// Set updates or creates the given silence and returns its ID.
 	Set(ctx context.Context, sil types.Silence) (string, error)
-	// Delete deletes the silence with the given ID.
-	Delete(ctx context.Context, id string) error
+	// Expire expires the silence with the given ID.
+	Expire(ctx context.Context, id string) error
 	// List returns silences matching the given filter.
 	List(ctx context.Context, filter string) ([]*types.Silence, error)
 }
@@ -270,7 +270,7 @@ func (h *httpSilenceAPI) Get(ctx context.Context, id string) (*types.Silence, er
 	return &sil, err
 }
 
-func (h *httpSilenceAPI) Delete(ctx context.Context, id string) error {
+func (h *httpSilenceAPI) Expire(ctx context.Context, id string) error {
 	u := h.client.URL(epSilence, map[string]string{
 		"id": id,
 	})

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -155,10 +155,10 @@ func TestAPI(t *testing.T) {
 			return api.Set(context.Background(), sil)
 		}
 	}
-	doSilenceDelete := func(id string) func() (interface{}, error) {
+	doSilenceExpire := func(id string) func() (interface{}, error) {
 		return func() (interface{}, error) {
 			api := httpSilenceAPI{client: client}
-			return nil, api.Delete(context.Background(), id)
+			return nil, api.Expire(context.Background(), id)
 		}
 	}
 	doSilenceList := func() (interface{}, error) {
@@ -258,14 +258,14 @@ func TestAPI(t *testing.T) {
 			err: fmt.Errorf("some error"),
 		},
 		{
-			do: doSilenceDelete("abc"),
+			do: doSilenceExpire("abc"),
 			apiRes: fakeAPIResponse{
 				path:   "/api/v1/silence/abc",
 				method: http.MethodDelete,
 			},
 		},
 		{
-			do: doSilenceDelete("abc"),
+			do: doSilenceExpire("abc"),
 			apiRes: fakeAPIResponse{
 				err:    fmt.Errorf("some error"),
 				path:   "/api/v1/silence/abc",


### PR DESCRIPTION
Within alertmanager, expire is the term used,
since silences still "exist" but aren't in effect.