### PR TITLE
Show AM health based on mesh status

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -186,6 +186,12 @@ func (p *Peer) Ready() bool {
 	return false
 }
 
+// Healthy implements the web.healthIndicator interface. It is used to indicate
+// whether the mesh is settled or not.
+func (p *Peer) Healthy() bool {
+	return p.Ready()
+}
+
 // Wait until Settle() has finished.
 func (p *Peer) WaitReady() {
 	<-p.readyc

--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -368,7 +368,7 @@ func main() {
 
 	webReload := make(chan chan error)
 
-	ui.Register(router, webReload, logger)
+	ui.Register(router, webReload, peer, logger)
 
 	apiv.Register(router.WithPrefix("/api"))
 


### PR DESCRIPTION
Conditionally return OK or NOT HEALTHY based on
whether the mesh is settled or not.

This is a coarse indicator. In the future, a
more detailed check of the health of an instance
can be implemented.

Discussed this briefly with @grobie 

This check wasn't added to the ready endpoint because a running alertmanager should always be ready to accept alerts (taking the kubernetes terminology), but health indicates its current running status.