### PR TITLE
tell users opening issues to use alertmanager  --version

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -25,7 +25,7 @@
 
 * Alertmanager version:
 
-	insert output of `alertmanager -version` here
+	insert output of `alertmanager --version` here
 
 * Prometheus version:
 


### PR DESCRIPTION
`-version` doesn't work as of 0.15-rc.1 so users should run `alertmanager  --version`