### PR TITLE
Templating the Slack API URL

### DIFF
--- a/notify/impl.go
+++ b/notify/impl.go
@@ -711,7 +711,7 @@ func (n *Slack) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 		return false, err
 	}
 
-	resp, err := ctxhttp.Post(ctx, c, string(n.conf.APIURL), contentTypeJSON, &buf)
+	resp, err := ctxhttp.Post(ctx, c, tmplText(string(n.conf.APIURL)), contentTypeJSON, &buf)
 	if err != nil {
 		return true, err
 	}


### PR DESCRIPTION
I'd like to be able to template parts of the Slack API URL. This PR allows that.

/cc @stuartnelson3

Signed-off-by: Dave Henderson <dhenderson@gmail.com>