### PR TITLE
Fix resolved alerts still inhibiting

### DIFF
--- a/inhibit/inhibit.go
+++ b/inhibit/inhibit.go
@@ -42,9 +42,6 @@ type Inhibitor struct {
 
 // NewInhibitor returns a new Inhibitor.
 func NewInhibitor(ap provider.Alerts, rs []*config.InhibitRule, mk types.Marker, logger log.Logger) *Inhibitor {
-	if logger == nil {
-		logger = log.NewNopLogger()
-	}
 	ih := &Inhibitor{
 		alerts: ap,
 		marker: mk,

--- a/inhibit/inhibit.go
+++ b/inhibit/inhibit.go
@@ -80,9 +80,6 @@ func (ih *Inhibitor) run(ctx context.Context) {
 				level.Error(ih.logger).Log("msg", "Error iterating alerts", "err", err)
 				continue
 			}
-			if a.Resolved() {
-				continue
-			}
 			// Update the inhibition rules' cache.
 			for _, r := range ih.rules {
 				if r.SourceMatchers.Match(a.Labels) {

--- a/inhibit/inhibit.go
+++ b/inhibit/inhibit.go
@@ -15,7 +15,6 @@ package inhibit
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -143,7 +142,7 @@ func (ih *Inhibitor) Mutes(lset model.LabelSet) bool {
 	for _, r := range ih.rules {
 		// Only inhibit if target matchers match but source matchers don't.
 		if inhibitedByFP, eq := r.hasEqual(lset); !r.SourceMatchers.Match(lset) && r.TargetMatchers.Match(lset) && eq {
-			ih.marker.SetInhibited(fp, fmt.Sprintf("%s", inhibitedByFP.String()))
+			ih.marker.SetInhibited(fp, inhibitedByFP.String())
 			return true
 		}
 	}

--- a/inhibit/inhibit_test.go
+++ b/inhibit/inhibit_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/kit/log"
 	"github.com/kylelemons/godebug/pretty"
 	"github.com/prometheus/common/model"
 
@@ -25,6 +26,8 @@ import (
 	"github.com/prometheus/alertmanager/provider"
 	"github.com/prometheus/alertmanager/types"
 )
+
+var nopLogger = log.NewNopLogger()
 
 func TestInhibitRuleHasEqual(t *testing.T) {
 	t.Parallel()
@@ -148,7 +151,7 @@ func TestInhibitRuleMatches(t *testing.T) {
 		Equal:       model.LabelNames{"e"},
 	}
 	m := types.NewMarker()
-	ih := NewInhibitor(nil, []*config.InhibitRule{&cr}, m, nil)
+	ih := NewInhibitor(nil, []*config.InhibitRule{&cr}, m, nopLogger)
 	ir := ih.rules[0]
 	now := time.Now()
 	// Active alert that matches the source filter
@@ -355,7 +358,7 @@ func TestInhibit(t *testing.T) {
 	} {
 		ap := newFakeAlerts(tc.alerts)
 		mk := types.NewMarker()
-		inhibitor := NewInhibitor(ap, []*config.InhibitRule{inhibitRule()}, mk, nil)
+		inhibitor := NewInhibitor(ap, []*config.InhibitRule{inhibitRule()}, mk, nopLogger)
 
 		go func() {
 			for ap.finished != nil {

--- a/inhibit/inhibit_test.go
+++ b/inhibit/inhibit_test.go
@@ -19,12 +19,16 @@ import (
 	"time"
 
 	"github.com/kylelemons/godebug/pretty"
-	"github.com/prometheus/alertmanager/config"
-	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
+
+	"github.com/prometheus/alertmanager/config"
+	"github.com/prometheus/alertmanager/provider"
+	"github.com/prometheus/alertmanager/types"
 )
 
 func TestInhibitRuleHasEqual(t *testing.T) {
+	t.Parallel()
+
 	now := time.Now()
 	cases := []struct {
 		initial map[model.Fingerprint]*types.Alert
@@ -135,6 +139,8 @@ func TestInhibitRuleHasEqual(t *testing.T) {
 }
 
 func TestInhibitRuleMatches(t *testing.T) {
+	t.Parallel()
+
 	// Simple inhibut rule
 	cr := config.InhibitRule{
 		SourceMatch: map[string]string{"s": "1"},
@@ -224,5 +230,153 @@ func TestInhibitRuleGC(t *testing.T) {
 	if !reflect.DeepEqual(r.scache, after) {
 		t.Errorf("Unexpected cache state after GC")
 		t.Errorf(pretty.Compare(r.scache, after))
+	}
+}
+
+type fakeAlerts struct {
+	alerts   []*types.Alert
+	finished chan struct{}
+}
+
+func newFakeAlerts(alerts []*types.Alert) *fakeAlerts {
+	return &fakeAlerts{
+		alerts:   alerts,
+		finished: make(chan struct{}),
+	}
+}
+
+func (f *fakeAlerts) GetPending() provider.AlertIterator          { return nil }
+func (f *fakeAlerts) Get(model.Fingerprint) (*types.Alert, error) { return nil, nil }
+func (f *fakeAlerts) Put(...*types.Alert) error                   { return nil }
+func (f *fakeAlerts) Subscribe() provider.AlertIterator {
+	ch := make(chan *types.Alert)
+	done := make(chan struct{})
+	go func() {
+		for _, a := range f.alerts {
+			ch <- a
+		}
+		// Send another (meaningless) alert to make sure that the inhibitor has
+		// processed everything.
+		ch <- &types.Alert{
+			Alert: model.Alert{
+				Labels:   model.LabelSet{},
+				StartsAt: time.Now(),
+			},
+		}
+		close(f.finished)
+		<-done
+	}()
+	return provider.NewAlertIterator(ch, done, nil)
+}
+
+func TestInhibit(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	inhibitRule := func() *config.InhibitRule {
+		return &config.InhibitRule{
+			SourceMatch: map[string]string{"s": "1"},
+			TargetMatch: map[string]string{"t": "1"},
+			Equal:       model.LabelNames{"e"},
+		}
+	}
+	// alertOne is muted by alertTwo when it is active.
+	alertOne := func() *types.Alert {
+		return &types.Alert{
+			Alert: model.Alert{
+				Labels:   model.LabelSet{"t": "1", "e": "f"},
+				StartsAt: now.Add(-time.Minute),
+				EndsAt:   now.Add(time.Hour),
+			},
+		}
+	}
+	alertTwo := func(resolved bool) *types.Alert {
+		var end time.Time
+		if resolved {
+			end = now.Add(-time.Second)
+		} else {
+			end = now.Add(time.Hour)
+		}
+		return &types.Alert{
+			Alert: model.Alert{
+				Labels:   model.LabelSet{"s": "1", "e": "f"},
+				StartsAt: now.Add(-time.Minute),
+				EndsAt:   end,
+			},
+		}
+	}
+
+	type exp struct {
+		lbls  model.LabelSet
+		muted bool
+	}
+	for i, tc := range []struct {
+		alerts   []*types.Alert
+		expected []exp
+	}{
+		{
+			// alertOne shouldn't be muted since alertTwo hasn't fired.
+			alerts: []*types.Alert{alertOne()},
+			expected: []exp{
+				{
+					lbls:  model.LabelSet{"t": "1", "e": "f"},
+					muted: false,
+				},
+			},
+		},
+		{
+			// alertOne should be muted by alertTwo which is active.
+			alerts: []*types.Alert{alertOne(), alertTwo(false)},
+			expected: []exp{
+				{
+					lbls:  model.LabelSet{"t": "1", "e": "f"},
+					muted: true,
+				},
+				{
+					lbls:  model.LabelSet{"s": "1", "e": "f"},
+					muted: false,
+				},
+			},
+		},
+		{
+			// alertOne shouldn't be muted since alertTwo is resolved.
+			alerts: []*types.Alert{alertOne(), alertTwo(false), alertTwo(true)},
+			expected: []exp{
+				{
+					lbls:  model.LabelSet{"t": "1", "e": "f"},
+					muted: false,
+				},
+				{
+					lbls:  model.LabelSet{"s": "1", "e": "f"},
+					muted: false,
+				},
+			},
+		},
+	} {
+		ap := newFakeAlerts(tc.alerts)
+		mk := types.NewMarker()
+		inhibitor := NewInhibitor(ap, []*config.InhibitRule{inhibitRule()}, mk, nil)
+
+		go func() {
+			for ap.finished != nil {
+				select {
+				case <-ap.finished:
+					ap.finished = nil
+				default:
+				}
+			}
+			inhibitor.Stop()
+		}()
+		inhibitor.Run()
+
+		for _, expected := range tc.expected {
+			if inhibitor.Mutes(expected.lbls) != expected.muted {
+				mute := "unmuted"
+				if expected.muted {
+					mute = "muted"
+				}
+				t.Errorf("tc: %d, expected alert with labels %q to be %s", i, expected.lbls, mute)
+			}
+		}
 	}
 }

--- a/provider/mem/mem.go
+++ b/provider/mem/mem.go
@@ -180,12 +180,6 @@ func (a *Alerts) Put(alerts ...*types.Alert) error {
 			if (alert.EndsAt.After(old.StartsAt) && alert.EndsAt.Before(old.EndsAt)) ||
 				(alert.StartsAt.After(old.StartsAt) && alert.StartsAt.Before(old.EndsAt)) {
 				alert = old.Merge(alert)
-				// Merge returns a new alert. In order to
-				// update old, we have to set the struct it
-				// points to to equal the newly merged alert.
-				// This is necessary as old may be stored in
-				// the inhibitor's rules cache.
-				*old = *alert
 			}
 		}
 

--- a/provider/mem/mem.go
+++ b/provider/mem/mem.go
@@ -180,6 +180,12 @@ func (a *Alerts) Put(alerts ...*types.Alert) error {
 			if (alert.EndsAt.After(old.StartsAt) && alert.EndsAt.Before(old.EndsAt)) ||
 				(alert.StartsAt.After(old.StartsAt) && alert.StartsAt.Before(old.EndsAt)) {
 				alert = old.Merge(alert)
+				// Merge returns a new alert. In order to
+				// update old, we have to set the struct it
+				// points to to equal the newly merged alert.
+				// This is necessary as old may be stored in
+				// the inhibitor's rules cache.
+				*old = *alert
 			}
 		}
 


### PR DESCRIPTION
Update old alert with result of merge with new
    
    On ingest, alerts with matching fingerprints are
    merged if the new alert's start and end times
    overlap with the old alert's.
    
    The merge creates a new alert, which is then
    updated in the internal alert store.
    
    The original alert is not updated (because merge
    creates a copy), so it is never marked as resolved
    in the inhibitor's reference to it.
    
    The code within the inhibitor relies on skipping
    over resolved alerts, but because the old alert is
    never updated it is never marked as resolved. Thus
    it continues to inhibit other alerts until it is
    cleaned up by the internal GC.
    
    This commit updates the struct of the old alert
    with the result of the merge with the new alert.
    
    An alternative would be to always update the
    inhibitor's internal cache of alerts regardless of
    an alert's resolve status.

This fixes #1153. Thanks to @simonpasquier for doing the bulk of the work :)

**EDIT:**
This PR has been modified to always update the inhibitors internal cache, whether the incoming alert is resolved or not.