### PR TITLE
Validate Slack field config and only allow the necessary input

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -220,6 +220,31 @@ func (c *PagerdutyConfig) UnmarshalYAML(unmarshal func(interface{}) error) error
 	return nil
 }
 
+// SlackField configures a single Slack field that is sent with each notification.
+// Each field must contain a title, value, and optionally, a boolean value to indicate if the field
+// is short enough to be displayed next to other fields designated as short.
+// See https://api.slack.com/docs/message-attachments#fields for more information.
+type SlackField struct {
+	Title string `yaml:"title,omitempty" json:"title,omitempty"`
+	Value string `yaml:"value,omitempty" json:"value,omitempty"`
+	Short *bool  `yaml:"short,omitempty" json:"short,omitempty"`
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface for SlackField.
+func (c *SlackField) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type plain SlackField
+	if err := unmarshal((*plain)(c)); err != nil {
+		return err
+	}
+	if c.Title == "" {
+		return fmt.Errorf("missing title in Slack field configuration")
+	}
+	if c.Value == "" {
+		return fmt.Errorf("missing value in Slack field configuration")
+	}
+	return nil
+}
+
 // SlackConfig configures notifications via Slack.
 type SlackConfig struct {
 	NotifierConfig `yaml:",inline" json:",inline"`
@@ -233,17 +258,17 @@ type SlackConfig struct {
 	Username string `yaml:"username,omitempty" json:"username,omitempty"`
 	Color    string `yaml:"color,omitempty" json:"color,omitempty"`
 
-	Title       string              `yaml:"title,omitempty" json:"title,omitempty"`
-	TitleLink   string              `yaml:"title_link,omitempty" json:"title_link,omitempty"`
-	Pretext     string              `yaml:"pretext,omitempty" json:"pretext,omitempty"`
-	Text        string              `yaml:"text,omitempty" json:"text,omitempty"`
-	Fields      []map[string]string `yaml:"fields,omitempty" json:"fields,omitempty"`
-	ShortFields bool                `yaml:"short_fields,omitempty" json:"short_fields,omitempty"`
-	Footer      string              `yaml:"footer,omitempty" json:"footer,omitempty"`
-	Fallback    string              `yaml:"fallback,omitempty" json:"fallback,omitempty"`
-	IconEmoji   string              `yaml:"icon_emoji,omitempty" json:"icon_emoji,omitempty"`
-	IconURL     string              `yaml:"icon_url,omitempty" json:"icon_url,omitempty"`
-	LinkNames   bool                `yaml:"link_names,omitempty" json:"link_names,omitempty"`
+	Title       string        `yaml:"title,omitempty" json:"title,omitempty"`
+	TitleLink   string        `yaml:"title_link,omitempty" json:"title_link,omitempty"`
+	Pretext     string        `yaml:"pretext,omitempty" json:"pretext,omitempty"`
+	Text        string        `yaml:"text,omitempty" json:"text,omitempty"`
+	Fields      []*SlackField `yaml:"fields,omitempty" json:"fields,omitempty"`
+	ShortFields bool          `yaml:"short_fields,omitempty" json:"short_fields,omitempty"`
+	Footer      string        `yaml:"footer,omitempty" json:"footer,omitempty"`
+	Fallback    string        `yaml:"fallback,omitempty" json:"fallback,omitempty"`
+	IconEmoji   string        `yaml:"icon_emoji,omitempty" json:"icon_emoji,omitempty"`
+	IconURL     string        `yaml:"icon_url,omitempty" json:"icon_url,omitempty"`
+	LinkNames   bool          `yaml:"link_names,omitempty" json:"link_names,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/config/notifiers_test.go
+++ b/config/notifiers_test.go
@@ -253,3 +253,120 @@ token: ''
 		t.Errorf("\nexpected:\n%v\ngot:\n%v", expected, err.Error())
 	}
 }
+
+func TestSlackFieldConfigValidation(t *testing.T) {
+	var tests = []struct {
+		in       string
+		expected string
+	}{
+		{
+			in: `
+fields:
+- title: first
+  value: hello
+- title: second
+`,
+			expected: "missing value in Slack field configuration",
+		},
+		{
+			in: `
+fields:
+- title: first
+  value: hello
+  short: true
+- value: world
+  short: true
+`,
+			expected: "missing title in Slack field configuration",
+		},
+		{
+			in: `
+fields:
+- title: first
+  value: hello
+  short: true
+- title: second
+  value: world
+`,
+			expected: "",
+		},
+	}
+
+	for _, rt := range tests {
+		var cfg SlackConfig
+		err := yaml.UnmarshalStrict([]byte(rt.in), &cfg)
+
+		// Check if an error occurred when it was NOT expected to.
+		if rt.expected == "" && err != nil {
+			t.Fatalf("\nerror returned when none expected, error:\n%v", err)
+		}
+		// Check that an error occurred if one was expected to.
+		if rt.expected != "" && err == nil {
+			t.Fatalf("\nno error returned, expected:\n%v", rt.expected)
+		}
+		// Check that the error that occurred was what was expected.
+		if err != nil && err.Error() != rt.expected {
+			t.Errorf("\nexpected:\n%v\ngot:\n%v", rt.expected, err.Error())
+		}
+	}
+}
+
+func TestSlackFieldConfigUnmarshalling(t *testing.T) {
+	in := `
+fields:
+- title: first
+  value: hello
+  short: true
+- title: second
+  value: world
+- title: third
+  value: slack field test
+  short: false
+`
+	expected := []*SlackField{
+		&SlackField{
+			Title: "first",
+			Value: "hello",
+			Short: newBoolPointer(true),
+		},
+		&SlackField{
+			Title: "second",
+			Value: "world",
+			Short: nil,
+		},
+		&SlackField{
+			Title: "third",
+			Value: "slack field test",
+			Short: newBoolPointer(false),
+		},
+	}
+
+	var cfg SlackConfig
+	err := yaml.UnmarshalStrict([]byte(in), &cfg)
+	if err != nil {
+		t.Fatalf("\nerror returned when none expected, error:\n%v", err)
+	}
+
+	for index, field := range cfg.Fields {
+		exp := expected[index]
+		if field.Title != exp.Title {
+			t.Errorf("\nexpected:\n%v\ngot:\n%v", exp.Title, field.Title)
+		}
+		if field.Value != exp.Value {
+			t.Errorf("\nexpected:\n%v\ngot:\n%v", exp.Value, field.Value)
+		}
+		if exp.Short == nil && field.Short != nil {
+			t.Errorf("\nexpected:\n%v\ngot:\n%v", exp.Short, *field.Short)
+		}
+		if exp.Short != nil && field.Short == nil {
+			t.Errorf("\nexpected:\n%v\ngot:\n%v", *exp.Short, field.Short)
+		}
+		if exp.Short != nil && *exp.Short != *field.Short {
+			t.Errorf("\nexpected:\n%v\ngot:\n%v", *exp.Short, *field.Short)
+		}
+	}
+}
+
+func newBoolPointer(b bool) *bool {
+	return &b
+}


### PR DESCRIPTION
Resolves the comments on the PR [#1002](https://github.com/prometheus/docs/pull/1002) to update the documentation for Slack fields. Currently, any arbitrary key/value pairs can be defined; however, per the Slack documentation for defining fields [[1](https://api.slack.com/docs/message-attachments#fields)] only the properties `title`, `value`, and `short` can be defined with the first two being required for each field. This updates the Slack field configuration to only allow the aforementioned three properties as well as validates that both a title and value are defined for each property in the `yaml.Unmarshaler` interface. Moreover, this allows the value for `short` to be defined on a per-field basis.