### PR TITLE
api: Deprecate `api/alerts` endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -133,16 +133,10 @@ func (api *API) Register(r *route.Router) {
 
 	r.Options("/*path", wrap(func(w http.ResponseWriter, r *http.Request) {}))
 
-	// Register legacy forwarder for alert pushing.
-	r.Post("/alerts", wrap(api.legacyAddAlerts))
-
-	// Register actual API.
-	r = r.WithPrefix("/v1")
-
 	r.Get("/status", wrap(api.status))
 	r.Get("/receivers", wrap(api.receivers))
-	r.Get("/alerts/groups", wrap(api.alertGroups))
 
+	r.Get("/alerts/groups", wrap(api.alertGroups))
 	r.Get("/alerts", wrap(api.listAlerts))
 	r.Post("/alerts", wrap(api.addAlerts))
 

--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -370,7 +370,7 @@ func main() {
 
 	ui.Register(router, webReload, logger)
 
-	apiv.Register(router.WithPrefix("/api"))
+	apiv.Register(router.WithPrefix("/api/v1"))
 
 	level.Info(logger).Log("msg", "Listening", "address", *listenAddress)
 	go listen(*listenAddress, router, logger)


### PR DESCRIPTION
With prometheus/prometheus commit
e114ce0ff7a1ae06b24fdc479ffc7422074c1ebe [1] Prometheus switches from
using `api/alerts` to `api/v1/alerts`. This commit is included starting
from Prometheus v0.17.0. As discussed on the prometheus-developers
mailing list [2] the deprecation period is long over.

[1] github.com/prometheus/prometheus/commit/e114ce0ff7a1ae06b24fdc479ffc7422074c1ebe
[2]
https://groups.google.com/d/msg/prometheus-developers/2CCuFTMbmAg/Qg58rvyzAQAJ

//CC @stuartnelson3  @brian-brazil