### PR TITLE
api: support more query filters

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -225,7 +225,7 @@ func TestListAlerts(t *testing.T) {
 			false,
 			map[string]string{"filter": "{alertname"},
 			400,
-			[]string{"alert1", "alert2", "alert3", "alert4"},
+			[]string{},
 		},
 		{
 			false,


### PR DESCRIPTION
Fixes #1359.

This change adds 2 new query filters to the /api/v1/alerts endpoint.

- active, filter out active alerts when set to 'false' (default: 'true').
- unprocessed, filter out unprocessed alerts when set to 'false'
 (default: 'true').

The default values ensure that the API behavior remains the same as
before when the query filters aren't provided.

cc @stuartnelson3 