### PR TITLE
cli alert query: Expose --active and --unprocessed

### DIFF
--- a/cli/alert.go
+++ b/cli/alert.go
@@ -42,6 +42,10 @@ amtool alert query 'alertname=~foo.*'
 	As well as direct equality, regex matching is also supported. The '=~' syntax
 	(similar to prometheus) is used to represent a regex match. Regex matching
 	can be used in combination with a direct match.
+
+Amtool supports several flags for filtering the returned alerts by state
+(inhibited, silenced, active, unprocessed). If none of these flags is given,
+only active alerts are returned.
 `
 
 func configureAlertCmd(app *kingpin.Application) {

--- a/client/client.go
+++ b/client/client.go
@@ -154,7 +154,7 @@ func (h *httpStatusAPI) Get(ctx context.Context) (*ServerStatus, error) {
 // AlertAPI provides bindings for the Alertmanager's alert API.
 type AlertAPI interface {
 	// List returns all the active alerts.
-	List(ctx context.Context, filter string, silenced, inhibited bool) ([]*ExtendedAlert, error)
+	List(ctx context.Context, filter string, silenced, inhibited, active, unprocessed bool) ([]*ExtendedAlert, error)
 	// Push sends a list of alerts to the Alertmanager.
 	Push(ctx context.Context, alerts ...Alert) error
 }
@@ -194,7 +194,7 @@ type httpAlertAPI struct {
 	client api.Client
 }
 
-func (h *httpAlertAPI) List(ctx context.Context, filter string, silenced, inhibited bool) ([]*ExtendedAlert, error) {
+func (h *httpAlertAPI) List(ctx context.Context, filter string, silenced, inhibited, active, unprocessed bool) ([]*ExtendedAlert, error) {
 	u := h.client.URL(epAlerts, nil)
 	params := url.Values{}
 	if filter != "" {
@@ -202,6 +202,8 @@ func (h *httpAlertAPI) List(ctx context.Context, filter string, silenced, inhibi
 	}
 	params.Add("silenced", fmt.Sprintf("%t", silenced))
 	params.Add("inhibited", fmt.Sprintf("%t", inhibited))
+	params.Add("active", fmt.Sprintf("%t", active))
+	params.Add("unprocessed", fmt.Sprintf("%t", unprocessed))
 	u.RawQuery = params.Encode()
 
 	req, _ := http.NewRequest(http.MethodGet, u.String(), nil)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -118,7 +118,7 @@ func TestAPI(t *testing.T) {
 	}
 	doAlertList := func() (interface{}, error) {
 		api := httpAlertAPI{client: client}
-		return api.List(context.Background(), "", false, false)
+		return api.List(context.Background(), "", false, false, false, false)
 	}
 	doAlertPush := func() (interface{}, error) {
 		api := httpAlertAPI{client: client}


### PR DESCRIPTION
Support the new filter options in the alerts api
endpoint introduced by https://github.com/prometheus/alertmanager/pull/1366

Signed-off-by: stuart nelson <stuartnelson3@gmail.com>

requested in #1369 

@simonpasquier 