### PR TITLE
memberlist reconnect

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -197,10 +197,6 @@ func Join(
 
 	p.setInitialFailed(resolvedPeers)
 
-	if n > 0 {
-		go p.warnIfAlone(l, 10*time.Second)
-	}
-
 	return p, nil
 }
 
@@ -407,22 +403,6 @@ func (p *Peer) peerUpdate(n *memberlist.Node) {
 
 	p.peerUpdateCounter.Inc()
 	level.Debug(p.logger).Log("msg", "peer updated", "peer", pr.Node)
-}
-
-func (p *Peer) warnIfAlone(logger log.Logger, d time.Duration) {
-	tick := time.NewTicker(d)
-	defer tick.Stop()
-
-	for {
-		select {
-		case <-p.stopc:
-			return
-		case <-tick.C:
-			if n := p.mlist.NumMembers(); n <= 1 {
-				level.Warn(logger).Log("NumMembers", n, "msg", "I appear to be alone in the cluster")
-			}
-		}
-	}
 }
 
 // AddState adds a new state that will be gossiped. It returns a channel to which

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -54,8 +54,6 @@ type PeerStatus int
 const (
 	StatusNone PeerStatus = iota
 	StatusAlive
-	StatusLeaving
-	StatusLeft
 	StatusFailed
 )
 
@@ -65,10 +63,6 @@ func (s PeerStatus) String() string {
 		return "none"
 	case StatusAlive:
 		return "alive"
-	case StatusLeaving:
-		return "leaving"
-	case StatusLeft:
-		return "left"
 	case StatusFailed:
 		return "failed"
 	default:
@@ -292,7 +286,7 @@ func (p *Peer) peerJoin(n *memberlist.Node) {
 
 	p.peers[n.Name] = pr
 
-	if oldStatus == StatusFailed || oldStatus == StatusLeft {
+	if oldStatus == StatusFailed {
 		level.Debug(p.logger).Log("msg", "peer rejoined", "peer", pr.Node)
 		p.failedPeers = removeOldPeer(p.failedPeers, pr.Name)
 	}

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -296,10 +296,11 @@ func (p *Peer) handleReconnect(d time.Duration) {
 
 func (p *Peer) reconnect() {
 	p.peerLock.RLock()
-	defer p.peerLock.RUnlock()
+	failedPeers := p.failedPeers
+	p.peerLock.RUnlock()
 
 	logger := log.With(p.logger, "msg", "reconnect")
-	for _, pr := range p.failedPeers {
+	for _, pr := range failedPeers {
 		// No need to do book keeping on failedPeers here. If a
 		// reconnect is successful, they will be announced in
 		// peerJoin().

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -272,8 +272,8 @@ func (p *Peer) reconnect() {
 }
 
 func (p *Peer) peerJoin(n *memberlist.Node) {
-	p.peerLock.RLock()
-	defer p.peerLock.RUnlock()
+	p.peerLock.Lock()
+	defer p.peerLock.Unlock()
 
 	var oldStatus PeerStatus
 	pr, ok := p.peers[n.Name]
@@ -299,8 +299,8 @@ func (p *Peer) peerJoin(n *memberlist.Node) {
 }
 
 func (p *Peer) peerLeave(n *memberlist.Node) {
-	p.peerLock.RLock()
-	defer p.peerLock.RUnlock()
+	p.peerLock.Lock()
+	defer p.peerLock.Unlock()
 
 	pr, ok := p.peers[n.Name]
 	if !ok {
@@ -320,8 +320,8 @@ func (p *Peer) peerLeave(n *memberlist.Node) {
 }
 
 func (p *Peer) peerUpdate(n *memberlist.Node) {
-	p.peerLock.RLock()
-	defer p.peerLock.RUnlock()
+	p.peerLock.Lock()
+	defer p.peerLock.Unlock()
 
 	pr, ok := p.peers[n.Name]
 	if !ok {

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -271,6 +271,9 @@ func (p *Peer) removeFailedPeers(timeout time.Duration) {
 	for _, pr := range p.failedPeers {
 		if pr.leaveTime.Add(timeout).After(now) {
 			keep = append(keep, pr)
+		} else {
+			level.Debug(p.logger).Log("msg", "failed peer has timed out", "peer", pr.Node, "addr", pr.Address())
+			delete(p.peers, pr.Name)
 		}
 	}
 

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -2,7 +2,7 @@ package cluster
 
 import (
 	"context"
-	"io/ioutil"
+	"fmt"
 	"math/rand"
 	"net"
 	"sort"
@@ -32,15 +32,57 @@ type Peer struct {
 	stopc  chan struct{}
 	readyc chan struct{}
 
+	peerLock    sync.RWMutex
+	peers       map[string]peer
+	failedPeers []peer
+
 	logger log.Logger
 }
 
+// peer is an internal type used for bookkeeping. It holds the state of peers
+// in the cluster.
+type peer struct {
+	status    PeerStatus
+	leaveTime time.Time
+
+	*memberlist.Node
+}
+
+// PeerStatus is the state that a peer is in.
+type PeerStatus int
+
 const (
-	DefaultPushPullInterval = 60 * time.Second
-	DefaultGossipInterval   = 200 * time.Millisecond
-	DefaultTcpTimeout       = 10 * time.Second
-	DefaultProbeTimeout     = 500 * time.Millisecond
-	DefaultProbeInterval    = 1 * time.Second
+	StatusNone PeerStatus = iota
+	StatusAlive
+	StatusLeaving
+	StatusLeft
+	StatusFailed
+)
+
+func (s PeerStatus) String() string {
+	switch s {
+	case StatusNone:
+		return "none"
+	case StatusAlive:
+		return "alive"
+	case StatusLeaving:
+		return "leaving"
+	case StatusLeft:
+		return "left"
+	case StatusFailed:
+		return "failed"
+	default:
+		panic(fmt.Sprintf("unknown PeerStatus: %d", s))
+	}
+}
+
+const (
+	DefaultPushPullInterval  = 60 * time.Second
+	DefaultGossipInterval    = 200 * time.Millisecond
+	DefaultTcpTimeout        = 10 * time.Second
+	DefaultProbeTimeout      = 500 * time.Millisecond
+	DefaultProbeInterval     = 1 * time.Second
+	DefaultReconnectInterval = 10 * time.Second
 )
 
 func Join(
@@ -55,6 +97,7 @@ func Join(
 	tcpTimeout time.Duration,
 	probeTimeout time.Duration,
 	probeInterval time.Duration,
+	reconnectInterval time.Duration,
 ) (*Peer, error) {
 	bindHost, bindPortStr, err := net.SplitHostPort(bindAddr)
 	if err != nil {
@@ -106,6 +149,7 @@ func Join(
 		stopc:  make(chan struct{}),
 		readyc: make(chan struct{}),
 		logger: l,
+		peers:  map[string]peer{},
 	}
 	p.delegate = newDelegate(l, reg, p)
 
@@ -120,7 +164,7 @@ func Join(
 	cfg.TCPTimeout = tcpTimeout
 	cfg.ProbeTimeout = probeTimeout
 	cfg.ProbeInterval = probeInterval
-	cfg.LogOutput = ioutil.Discard
+	cfg.LogOutput = &logWriter{l: l}
 
 	if advertiseAddr != "" {
 		cfg.AdvertiseAddr = advertiseHost
@@ -143,7 +187,121 @@ func Join(
 	if n > 0 {
 		go p.warnIfAlone(l, 10*time.Second)
 	}
+
+	if reconnectInterval != 0 {
+		go p.handleReconnect(reconnectInterval)
+	}
+	// TODO: Add a gc interval for failedPeers.
+
 	return p, nil
+}
+
+type logWriter struct {
+	l log.Logger
+}
+
+func (l *logWriter) Write(b []byte) (int, error) {
+	return len(b), level.Debug(l.l).Log("memberlist", string(b))
+}
+
+func (p *Peer) handleReconnect(d time.Duration) {
+	tick := time.NewTicker(d)
+	defer tick.Stop()
+
+	for {
+		select {
+		case <-p.stopc:
+			return
+		case <-tick.C:
+			p.reconnect()
+		}
+	}
+}
+
+func (p *Peer) reconnect() {
+	p.peerLock.RLock()
+	defer p.peerLock.RUnlock()
+
+	logger := log.With(p.logger, "msg", "reconnect")
+	for _, pr := range p.failedPeers {
+		// No need to do book keeping on failedPeers here. If a
+		// reconnect is successful, they will be announced in
+		// peerJoin().
+		if _, err := p.mlist.Join([]string{pr.Address()}); err != nil {
+			// TODO: failedReconnectionsCounter
+			level.Debug(logger).Log("result", "failure", "peer", pr.Node, "addr", pr.Address())
+		} else {
+			// TODO: successfulReconnectionsCounter
+			level.Debug(logger).Log("result", "success", "peer", pr.Node, "addr", pr.Address())
+		}
+	}
+}
+
+func (p *Peer) peerJoin(n *memberlist.Node) {
+	p.peerLock.RLock()
+	defer p.peerLock.RUnlock()
+
+	var oldStatus PeerStatus
+	pr, ok := p.peers[n.Name]
+	if !ok {
+		oldStatus = StatusNone
+		pr = peer{
+			status: StatusAlive,
+			Node:   n,
+		}
+	} else {
+		oldStatus = pr.status
+		pr.Node = n
+		pr.status = StatusAlive
+		pr.leaveTime = time.Time{}
+	}
+
+	p.peers[n.Name] = pr
+
+	if oldStatus == StatusFailed || oldStatus == StatusLeft {
+		level.Debug(p.logger).Log("msg", "peer rejoined", "peer", pr.Node)
+		p.failedPeers = removeOldPeer(p.failedPeers, pr.Name)
+	}
+}
+
+func (p *Peer) peerLeave(n *memberlist.Node) {
+	p.peerLock.RLock()
+	defer p.peerLock.RUnlock()
+
+	pr, ok := p.peers[n.Name]
+	if !ok {
+		// Why are we receiving a leave notification from a node that
+		// never joined?
+		// unknownPeerLeaveCounter
+		return
+	}
+
+	pr.status = StatusFailed
+	pr.leaveTime = time.Now()
+	p.failedPeers = append(p.failedPeers, pr)
+	p.peers[n.Name] = pr
+
+	// TODO: peerLeaveCounter
+	level.Debug(p.logger).Log("msg", "peer left", "peer", pr.Node)
+}
+
+func (p *Peer) peerUpdate(n *memberlist.Node) {
+	p.peerLock.RLock()
+	defer p.peerLock.RUnlock()
+
+	pr, ok := p.peers[n.Name]
+	if !ok {
+		// Why are we receiving an update from a node that never
+		// joined?
+		// unknownPeerUpdateCounter
+		return
+	}
+
+	pr.Node = n
+	p.peers[n.Name] = pr
+
+	// TODO: peerUpdateCounter
+	level.Debug(p.logger).Log("msg", "peer updated", "peer", pr.Node)
 }
 
 func (p *Peer) warnIfAlone(logger log.Logger, d time.Duration) {
@@ -172,6 +330,7 @@ func (p *Peer) AddState(key string, s State) *Channel {
 // Leave the cluster, waiting up to timeout.
 func (p *Peer) Leave(timeout time.Duration) error {
 	close(p.stopc)
+	level.Debug(p.logger).Log("msg", "leaving cluster")
 	return p.mlist.Leave(timeout)
 }
 
@@ -323,184 +482,6 @@ func (c *Channel) Broadcast(b []byte) {
 
 // delegate implements memberlist.Delegate and memberlist.EventDelegate
 // and broadcasts its peer's state in the cluster.
-type delegate struct {
-	*Peer
-
-	logger log.Logger
-	bcast  *memberlist.TransmitLimitedQueue
-
-	messagesReceived     *prometheus.CounterVec
-	messagesReceivedSize *prometheus.CounterVec
-	messagesSent         *prometheus.CounterVec
-	messagesSentSize     *prometheus.CounterVec
-}
-
-func newDelegate(l log.Logger, reg prometheus.Registerer, p *Peer) *delegate {
-	bcast := &memberlist.TransmitLimitedQueue{
-		NumNodes:       p.ClusterSize,
-		RetransmitMult: 3,
-	}
-	messagesReceived := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "alertmanager_cluster_messages_received_total",
-		Help: "Total number of cluster messsages received.",
-	}, []string{"msg_type"})
-	messagesReceivedSize := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "alertmanager_cluster_messages_received_size_total",
-		Help: "Total size of cluster messages received.",
-	}, []string{"msg_type"})
-	messagesSent := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "alertmanager_cluster_messages_sent_total",
-		Help: "Total number of cluster messsages sent.",
-	}, []string{"msg_type"})
-	messagesSentSize := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "alertmanager_cluster_messages_sent_size_total",
-		Help: "Total size of cluster messages sent.",
-	}, []string{"msg_type"})
-	gossipClusterMembers := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "alertmanager_cluster_members",
-		Help: "Number indicating current number of members in cluster.",
-	}, func() float64 {
-		return float64(p.ClusterSize())
-	})
-	peerPosition := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "alertmanager_peer_position",
-		Help: "Position the Alertmanager instance believes it's in. The position determines a peer's behavior in the cluster.",
-	}, func() float64 {
-		return float64(p.Position())
-	})
-	healthScore := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "alertmanager_cluster_health_score",
-		Help: "Health score of the cluster. Lower values are better and zero means 'totally healthy'.",
-	}, func() float64 {
-		return float64(p.mlist.GetHealthScore())
-	})
-	messagesQueued := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "alertmanager_cluster_messages_queued",
-		Help: "Number of cluster messsages which are queued.",
-	}, func() float64 {
-		return float64(bcast.NumQueued())
-	})
-
-	messagesReceived.WithLabelValues("full_state")
-	messagesReceivedSize.WithLabelValues("full_state")
-	messagesReceived.WithLabelValues("update")
-	messagesReceivedSize.WithLabelValues("update")
-	messagesSent.WithLabelValues("full_state")
-	messagesSentSize.WithLabelValues("full_state")
-	messagesSent.WithLabelValues("update")
-	messagesSentSize.WithLabelValues("update")
-
-	reg.MustRegister(messagesReceived, messagesReceivedSize, messagesSent, messagesSentSize,
-		gossipClusterMembers, peerPosition, healthScore, messagesQueued)
-
-	return &delegate{
-		logger:               l,
-		Peer:                 p,
-		bcast:                bcast,
-		messagesReceived:     messagesReceived,
-		messagesReceivedSize: messagesReceivedSize,
-		messagesSent:         messagesSent,
-		messagesSentSize:     messagesSentSize,
-	}
-}
-
-// NodeMeta retrieves meta-data about the current node when broadcasting an alive message.
-func (d *delegate) NodeMeta(limit int) []byte {
-	return []byte{}
-}
-
-// NotifyMsg is the callback invoked when a user-level gossip message is received.
-func (d *delegate) NotifyMsg(b []byte) {
-	d.messagesReceived.WithLabelValues("update").Inc()
-	d.messagesReceivedSize.WithLabelValues("update").Add(float64(len(b)))
-
-	var p clusterpb.Part
-	if err := proto.Unmarshal(b, &p); err != nil {
-		level.Warn(d.logger).Log("msg", "decode broadcast", "err", err)
-		return
-	}
-	s, ok := d.states[p.Key]
-	if !ok {
-		return
-	}
-	if err := s.Merge(p.Data); err != nil {
-		level.Warn(d.logger).Log("msg", "merge broadcast", "err", err, "key", p.Key)
-		return
-	}
-}
-
-// GetBroadcasts is called when user data messages can be broadcasted.
-func (d *delegate) GetBroadcasts(overhead, limit int) [][]byte {
-	msgs := d.bcast.GetBroadcasts(overhead, limit)
-	d.messagesSent.WithLabelValues("update").Add(float64(len(msgs)))
-	for _, m := range msgs {
-		d.messagesSentSize.WithLabelValues("update").Add(float64(len(m)))
-	}
-	return msgs
-}
-
-// LocalState is called when gossip fetches local state.
-func (d *delegate) LocalState(_ bool) []byte {
-	all := &clusterpb.FullState{
-		Parts: make([]clusterpb.Part, 0, len(d.states)),
-	}
-	for key, s := range d.states {
-		b, err := s.MarshalBinary()
-		if err != nil {
-			level.Warn(d.logger).Log("msg", "encode local state", "err", err, "key", key)
-			return nil
-		}
-		all.Parts = append(all.Parts, clusterpb.Part{Key: key, Data: b})
-	}
-	b, err := proto.Marshal(all)
-	if err != nil {
-		level.Warn(d.logger).Log("msg", "encode local state", "err", err)
-		return nil
-	}
-	d.messagesSent.WithLabelValues("full_state").Inc()
-	d.messagesSentSize.WithLabelValues("full_state").Add(float64(len(b)))
-	return b
-}
-
-func (d *delegate) MergeRemoteState(buf []byte, _ bool) {
-	d.messagesReceived.WithLabelValues("full_state").Inc()
-	d.messagesReceivedSize.WithLabelValues("full_state").Add(float64(len(buf)))
-
-	var fs clusterpb.FullState
-	if err := proto.Unmarshal(buf, &fs); err != nil {
-		level.Warn(d.logger).Log("msg", "merge remote state", "err", err)
-		return
-	}
-	d.mtx.RLock()
-	defer d.mtx.RUnlock()
-
-	for _, p := range fs.Parts {
-		s, ok := d.states[p.Key]
-		if !ok {
-			continue
-		}
-		if err := s.Merge(p.Data); err != nil {
-			level.Warn(d.logger).Log("msg", "merge remote state", "err", err, "key", p.Key)
-			return
-		}
-	}
-}
-
-// NotifyJoin is called if a peer joins the cluster.
-func (d *delegate) NotifyJoin(n *memberlist.Node) {
-	level.Debug(d.logger).Log("received", "NotifyJoin", "node", n.Name, "addr", n.Address())
-}
-
-// NotifyLeave is called if a peer leaves the cluster.
-func (d *delegate) NotifyLeave(n *memberlist.Node) {
-	level.Debug(d.logger).Log("received", "NotifyLeave", "node", n.Name, "addr", n.Address())
-}
-
-// NotifyUpdate is called if a cluster peer gets updated.
-func (d *delegate) NotifyUpdate(n *memberlist.Node) {
-	level.Debug(d.logger).Log("received", "NotifyUpdate", "node", n.Name, "addr", n.Address())
-}
-
 func resolvePeers(ctx context.Context, peers []string, myAddress string, res net.Resolver, waitIfEmpty bool) ([]string, error) {
 	var resolvedPeers []string
 
@@ -612,4 +593,15 @@ func retry(interval time.Duration, stopc <-chan struct{}, f func() error) error 
 		case <-tick.C:
 		}
 	}
+}
+
+func removeOldPeer(old []peer, name string) []peer {
+	new := make([]peer, 0, len(old))
+	for _, p := range old {
+		if p.Name != name {
+			new = append(new, p)
+		}
+	}
+
+	return new
 }

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -319,7 +319,7 @@ func (p *Peer) peerJoin(n *memberlist.Node) {
 	defer p.peerLock.Unlock()
 
 	var oldStatus PeerStatus
-	pr, ok := p.peers[n.Name]
+	pr, ok := p.peers[n.Address()]
 	if !ok {
 		oldStatus = StatusNone
 		pr = peer{
@@ -333,7 +333,7 @@ func (p *Peer) peerJoin(n *memberlist.Node) {
 		pr.leaveTime = time.Time{}
 	}
 
-	p.peers[n.Name] = pr
+	p.peers[n.Address()] = pr
 	p.peerJoinCounter.Inc()
 
 	if oldStatus == StatusFailed {
@@ -346,7 +346,7 @@ func (p *Peer) peerLeave(n *memberlist.Node) {
 	p.peerLock.Lock()
 	defer p.peerLock.Unlock()
 
-	pr, ok := p.peers[n.Name]
+	pr, ok := p.peers[n.Address()]
 	if !ok {
 		// Why are we receiving a leave notification from a node that
 		// never joined?
@@ -356,7 +356,7 @@ func (p *Peer) peerLeave(n *memberlist.Node) {
 	pr.status = StatusFailed
 	pr.leaveTime = time.Now()
 	p.failedPeers = append(p.failedPeers, pr)
-	p.peers[n.Name] = pr
+	p.peers[n.Address()] = pr
 
 	p.peerLeaveCounter.Inc()
 	level.Debug(p.logger).Log("msg", "peer left", "peer", pr.Node)
@@ -366,7 +366,7 @@ func (p *Peer) peerUpdate(n *memberlist.Node) {
 	p.peerLock.Lock()
 	defer p.peerLock.Unlock()
 
-	pr, ok := p.peers[n.Name]
+	pr, ok := p.peers[n.Address()]
 	if !ok {
 		// Why are we receiving an update from a node that never
 		// joined?
@@ -374,7 +374,7 @@ func (p *Peer) peerUpdate(n *memberlist.Node) {
 	}
 
 	pr.Node = n
-	p.peers[n.Name] = pr
+	p.peers[n.Address()] = pr
 
 	p.peerUpdateCounter.Inc()
 	level.Debug(p.logger).Log("msg", "peer updated", "peer", pr.Node)

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -36,11 +36,11 @@ type Peer struct {
 	peers       map[string]peer
 	failedPeers []peer
 
-	failedReconnectionsCounter     prometheus.Counter
-	successfulReconnectionsCounter prometheus.Counter
-	peerLeaveCounter               prometheus.Counter
-	peerUpdateCounter              prometheus.Counter
-	peerJoinCounter                prometheus.Counter
+	failedReconnectionsCounter prometheus.Counter
+	reconnectionsCounter       prometheus.Counter
+	peerLeaveCounter           prometheus.Counter
+	peerUpdateCounter          prometheus.Counter
+	peerJoinCounter            prometheus.Counter
 
 	logger log.Logger
 }
@@ -246,29 +246,29 @@ func (p *Peer) register(reg prometheus.Registerer) {
 		return float64(len(p.failedPeers))
 	})
 	p.failedReconnectionsCounter = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "alertmanager_cluster_failed_reconnections",
+		Name: "alertmanager_cluster_failed_reconnections_total",
 		Help: "A counter of the number of failed cluster peer reconnection attempts.",
 	})
 
-	p.successfulReconnectionsCounter = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "alertmanager_cluster_successful_reconnections",
+	p.reconnectionsCounter = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "alertmanager_cluster_reconnections_total",
 		Help: "A counter of the number of successful cluster peer reconnections.",
 	})
 
 	p.peerLeaveCounter = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "alertmanager_cluster_peers_left",
+		Name: "alertmanager_cluster_peers_left_total",
 		Help: "A counter of the number of peers that have left.",
 	})
 	p.peerUpdateCounter = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "alertmanager_cluster_peers_update",
+		Name: "alertmanager_cluster_peers_update_total",
 		Help: "A counter of the number of peers that have updated metadata.",
 	})
 	p.peerJoinCounter = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "alertmanager_cluster_peers_joined",
+		Name: "alertmanager_cluster_peers_joined_total",
 		Help: "A counter of the number of peers that have joined.",
 	})
 
-	reg.MustRegister(clusterFailedPeers, p.failedReconnectionsCounter, p.successfulReconnectionsCounter,
+	reg.MustRegister(clusterFailedPeers, p.failedReconnectionsCounter, p.reconnectionsCounter,
 		p.peerLeaveCounter, p.peerUpdateCounter, p.peerJoinCounter)
 }
 
@@ -333,7 +333,7 @@ func (p *Peer) reconnect() {
 			p.failedReconnectionsCounter.Inc()
 			level.Debug(logger).Log("result", "failure", "peer", pr.Node, "addr", pr.Address())
 		} else {
-			p.successfulReconnectionsCounter.Inc()
+			p.reconnectionsCounter.Inc()
 			level.Debug(logger).Log("result", "success", "peer", pr.Node, "addr", pr.Address())
 		}
 	}

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -38,6 +38,7 @@ func TestJoin(t *testing.T) {
 		0*time.Second,
 		0*time.Second,
 		0*time.Second,
+		0*time.Second,
 	)
 	require.NoError(t, err)
 	require.False(t, p == nil)

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -24,27 +24,110 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func TestJoin(t *testing.T) {
+func TestJoinLeave(t *testing.T) {
 	logger := log.NewNopLogger()
-	p, err := Join(logger,
-		prometheus.DefaultRegisterer,
+	p, err := Join(
+		logger,
+		prometheus.NewRegistry(),
 		"0.0.0.0:0",
 		"",
 		[]string{},
 		true,
-		0*time.Second,
-		0*time.Second,
-		0*time.Second,
-		0*time.Second,
-		0*time.Second,
-		0*time.Second,
-		0*time.Second,
+		DefaultPushPullInterval,
+		DefaultGossipInterval,
+		DefaultTcpTimeout,
+		DefaultProbeTimeout,
+		DefaultProbeInterval,
+		DefaultReconnectInterval,
+		DefaultReconnectTimeout,
 	)
 	require.NoError(t, err)
-	require.False(t, p == nil)
+	require.NotNil(t, p)
 	require.False(t, p.Ready())
 	require.Equal(t, p.Status(), "settling")
 	go p.Settle(context.Background(), 0*time.Second)
 	p.WaitReady()
 	require.Equal(t, p.Status(), "ready")
+
+	// Create the peer who joins the first.
+	p2, err := Join(
+		logger,
+		prometheus.NewRegistry(),
+		"0.0.0.0:0",
+		"",
+		[]string{p.Self().Address()},
+		true,
+		DefaultPushPullInterval,
+		DefaultGossipInterval,
+		DefaultTcpTimeout,
+		DefaultProbeTimeout,
+		DefaultProbeInterval,
+		DefaultReconnectInterval,
+		DefaultReconnectTimeout,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, p2)
+	go p2.Settle(context.Background(), 0*time.Second)
+
+	require.Equal(t, 2, p.ClusterSize())
+	p2.Leave(0 * time.Second)
+	require.Equal(t, 1, p.ClusterSize())
+	require.Equal(t, 1, len(p.failedPeers))
+	require.Equal(t, p2.Self().Address(), p.peers[p2.Name()].Node.Address())
+	require.Equal(t, p2.Name(), p.failedPeers[0].Name)
+}
+
+func TestReconnect(t *testing.T) {
+	logger := log.NewNopLogger()
+	p, err := Join(
+		logger,
+		prometheus.NewRegistry(),
+		"0.0.0.0:0",
+		"",
+		[]string{},
+		true,
+		DefaultPushPullInterval,
+		DefaultGossipInterval,
+		DefaultTcpTimeout,
+		DefaultProbeTimeout,
+		DefaultProbeInterval,
+		DefaultReconnectInterval,
+		DefaultReconnectTimeout,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	go p.Settle(context.Background(), 0*time.Second)
+	p.WaitReady()
+
+	p2, err := Join(
+		logger,
+		prometheus.NewRegistry(),
+		"0.0.0.0:0",
+		"",
+		[]string{},
+		true,
+		DefaultPushPullInterval,
+		DefaultGossipInterval,
+		DefaultTcpTimeout,
+		DefaultProbeTimeout,
+		DefaultProbeInterval,
+		DefaultReconnectInterval,
+		DefaultReconnectTimeout,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, p2)
+	go p2.Settle(context.Background(), 0*time.Second)
+	p2.WaitReady()
+
+	p.peerJoin(p2.Self())
+	p.peerLeave(p2.Self())
+
+	require.Equal(t, 1, p.ClusterSize())
+	require.Equal(t, 1, len(p.failedPeers))
+
+	p.reconnect()
+
+	require.Equal(t, 2, p.ClusterSize())
+	require.Equal(t, 0, len(p.failedPeers))
+	require.Equal(t, StatusAlive, p.peers[p2.Name()].status)
 }

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -203,6 +203,6 @@ func TestInitiallyFailingPeers(t *testing.T) {
 	for _, addr := range peerAddrs {
 		pr, ok := p.peers[addr]
 		require.True(t, ok)
-		require.Equal(t, StatusFailed, pr.status)
+		require.Equal(t, StatusNone, pr.status)
 	}
 }

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -73,7 +73,7 @@ func TestJoinLeave(t *testing.T) {
 	p2.Leave(0 * time.Second)
 	require.Equal(t, 1, p.ClusterSize())
 	require.Equal(t, 1, len(p.failedPeers))
-	require.Equal(t, p2.Self().Address(), p.peers[p2.Name()].Node.Address())
+	require.Equal(t, p2.Self().Address(), p.peers[p2.Self().Address()].Node.Address())
 	require.Equal(t, p2.Name(), p.failedPeers[0].Name)
 }
 
@@ -129,7 +129,7 @@ func TestReconnect(t *testing.T) {
 
 	require.Equal(t, 2, p.ClusterSize())
 	require.Equal(t, 0, len(p.failedPeers))
-	require.Equal(t, StatusAlive, p.peers[p2.Name()].status)
+	require.Equal(t, StatusAlive, p.peers[p2.Self().Address()].status)
 }
 
 func TestRemoveFailedPeers(t *testing.T) {

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -175,3 +175,34 @@ func TestRemoveFailedPeers(t *testing.T) {
 	require.Equal(t, 1, len(p.failedPeers))
 	require.Equal(t, p1, p.failedPeers[0])
 }
+
+func TestInitiallyFailingPeers(t *testing.T) {
+	logger := log.NewNopLogger()
+	peerAddrs := []string{"1.2.3.4:5000", "2.3.4.5:5000", "3.4.5.6:5000"}
+	p, err := Join(
+		logger,
+		prometheus.NewRegistry(),
+		"0.0.0.0:0",
+		"",
+		[]string{},
+		true,
+		DefaultPushPullInterval,
+		DefaultGossipInterval,
+		DefaultTcpTimeout,
+		DefaultProbeTimeout,
+		DefaultProbeInterval,
+		DefaultReconnectInterval,
+		DefaultReconnectTimeout,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+
+	p.setInitialFailed(peerAddrs)
+
+	require.Equal(t, len(peerAddrs), len(p.failedPeers))
+	for _, addr := range peerAddrs {
+		pr, ok := p.peers[addr]
+		require.True(t, ok)
+		require.Equal(t, StatusFailed, pr.status)
+	}
+}

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -37,6 +37,7 @@ func TestJoin(t *testing.T) {
 		0*time.Second,
 		0*time.Second,
 		0*time.Second,
+		0*time.Second,
 	)
 	require.NoError(t, err)
 	require.False(t, p == nil)

--- a/cluster/delegate.go
+++ b/cluster/delegate.go
@@ -1,0 +1,193 @@
+package cluster
+
+import (
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/gogo/protobuf/proto"
+	"github.com/hashicorp/memberlist"
+	"github.com/prometheus/alertmanager/cluster/clusterpb"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type delegate struct {
+	*Peer
+
+	logger log.Logger
+	bcast  *memberlist.TransmitLimitedQueue
+
+	messagesReceived     *prometheus.CounterVec
+	messagesReceivedSize *prometheus.CounterVec
+	messagesSent         *prometheus.CounterVec
+	messagesSentSize     *prometheus.CounterVec
+}
+
+func newDelegate(l log.Logger, reg prometheus.Registerer, p *Peer) *delegate {
+	bcast := &memberlist.TransmitLimitedQueue{
+		NumNodes:       p.ClusterSize,
+		RetransmitMult: 3,
+	}
+	messagesReceived := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "alertmanager_cluster_messages_received_total",
+		Help: "Total number of cluster messsages received.",
+	}, []string{"msg_type"})
+	messagesReceivedSize := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "alertmanager_cluster_messages_received_size_total",
+		Help: "Total size of cluster messages received.",
+	}, []string{"msg_type"})
+	messagesSent := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "alertmanager_cluster_messages_sent_total",
+		Help: "Total number of cluster messsages sent.",
+	}, []string{"msg_type"})
+	messagesSentSize := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "alertmanager_cluster_messages_sent_size_total",
+		Help: "Total size of cluster messages sent.",
+	}, []string{"msg_type"})
+	gossipClusterMembers := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "alertmanager_cluster_members",
+		Help: "Number indicating current number of members in cluster.",
+	}, func() float64 {
+		return float64(p.ClusterSize())
+	})
+	peerPosition := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "alertmanager_peer_position",
+		Help: "Position the Alertmanager instance believes it's in. The position determines a peer's behavior in the cluster.",
+	}, func() float64 {
+		return float64(p.Position())
+	})
+	healthScore := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "alertmanager_cluster_health_score",
+		Help: "Health score of the cluster. Lower values are better and zero means 'totally healthy'.",
+	}, func() float64 {
+		return float64(p.mlist.GetHealthScore())
+	})
+	messagesQueued := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "alertmanager_cluster_messages_queued",
+		Help: "Number of cluster messsages which are queued.",
+	}, func() float64 {
+		return float64(bcast.NumQueued())
+	})
+
+	messagesReceived.WithLabelValues("full_state")
+	messagesReceivedSize.WithLabelValues("full_state")
+	messagesReceived.WithLabelValues("update")
+	messagesReceivedSize.WithLabelValues("update")
+	messagesSent.WithLabelValues("full_state")
+	messagesSentSize.WithLabelValues("full_state")
+	messagesSent.WithLabelValues("update")
+	messagesSentSize.WithLabelValues("update")
+
+	reg.MustRegister(messagesReceived, messagesReceivedSize, messagesSent, messagesSentSize,
+		gossipClusterMembers, peerPosition, healthScore, messagesQueued)
+
+	return &delegate{
+		logger:               l,
+		Peer:                 p,
+		bcast:                bcast,
+		messagesReceived:     messagesReceived,
+		messagesReceivedSize: messagesReceivedSize,
+		messagesSent:         messagesSent,
+		messagesSentSize:     messagesSentSize,
+	}
+}
+
+// NodeMeta retrieves meta-data about the current node when broadcasting an alive message.
+func (d *delegate) NodeMeta(limit int) []byte {
+	return []byte{}
+}
+
+// NotifyMsg is the callback invoked when a user-level gossip message is received.
+// NOTE: This is where a node could notify others of its intent to leave, and
+// avoid being marked as failed.
+func (d *delegate) NotifyMsg(b []byte) {
+	d.messagesReceived.WithLabelValues("update").Inc()
+	d.messagesReceivedSize.WithLabelValues("update").Add(float64(len(b)))
+
+	var p clusterpb.Part
+	if err := proto.Unmarshal(b, &p); err != nil {
+		level.Warn(d.logger).Log("msg", "decode broadcast", "err", err)
+		return
+	}
+	s, ok := d.states[p.Key]
+	if !ok {
+		return
+	}
+	if err := s.Merge(p.Data); err != nil {
+		level.Warn(d.logger).Log("msg", "merge broadcast", "err", err, "key", p.Key)
+		return
+	}
+}
+
+// GetBroadcasts is called when user data messages can be broadcasted.
+func (d *delegate) GetBroadcasts(overhead, limit int) [][]byte {
+	msgs := d.bcast.GetBroadcasts(overhead, limit)
+	d.messagesSent.WithLabelValues("update").Add(float64(len(msgs)))
+	for _, m := range msgs {
+		d.messagesSentSize.WithLabelValues("update").Add(float64(len(m)))
+	}
+	return msgs
+}
+
+// LocalState is called when gossip fetches local state.
+func (d *delegate) LocalState(_ bool) []byte {
+	all := &clusterpb.FullState{
+		Parts: make([]clusterpb.Part, 0, len(d.states)),
+	}
+	for key, s := range d.states {
+		b, err := s.MarshalBinary()
+		if err != nil {
+			level.Warn(d.logger).Log("msg", "encode local state", "err", err, "key", key)
+			return nil
+		}
+		all.Parts = append(all.Parts, clusterpb.Part{Key: key, Data: b})
+	}
+	b, err := proto.Marshal(all)
+	if err != nil {
+		level.Warn(d.logger).Log("msg", "encode local state", "err", err)
+		return nil
+	}
+	d.messagesSent.WithLabelValues("full_state").Inc()
+	d.messagesSentSize.WithLabelValues("full_state").Add(float64(len(b)))
+	return b
+}
+
+func (d *delegate) MergeRemoteState(buf []byte, _ bool) {
+	d.messagesReceived.WithLabelValues("full_state").Inc()
+	d.messagesReceivedSize.WithLabelValues("full_state").Add(float64(len(buf)))
+
+	var fs clusterpb.FullState
+	if err := proto.Unmarshal(buf, &fs); err != nil {
+		level.Warn(d.logger).Log("msg", "merge remote state", "err", err)
+		return
+	}
+	d.mtx.RLock()
+	defer d.mtx.RUnlock()
+
+	for _, p := range fs.Parts {
+		s, ok := d.states[p.Key]
+		if !ok {
+			continue
+		}
+		if err := s.Merge(p.Data); err != nil {
+			level.Warn(d.logger).Log("msg", "merge remote state", "err", err, "key", p.Key)
+			return
+		}
+	}
+}
+
+// NotifyJoin is called if a peer joins the cluster.
+func (d *delegate) NotifyJoin(n *memberlist.Node) {
+	level.Debug(d.logger).Log("received", "NotifyJoin", "node", n.Name, "addr", n.Address())
+	d.Peer.peerJoin(n)
+}
+
+// NotifyLeave is called if a peer leaves the cluster.
+func (d *delegate) NotifyLeave(n *memberlist.Node) {
+	level.Debug(d.logger).Log("received", "NotifyLeave", "node", n.Name, "addr", n.Address())
+	d.Peer.peerLeave(n)
+}
+
+// NotifyUpdate is called if a cluster peer gets updated.
+func (d *delegate) NotifyUpdate(n *memberlist.Node) {
+	level.Debug(d.logger).Log("received", "NotifyUpdate", "node", n.Name, "addr", n.Address())
+	d.Peer.peerUpdate(n)
+}

--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -160,6 +160,7 @@ func main() {
 		probeTimeout         = kingpin.Flag("cluster.probe-timeout", "Timeout to wait for an ack from a probed node before assuming it is unhealthy. This should be set to 99-percentile of RTT (round-trip time) on your network.").Default(cluster.DefaultProbeTimeout.String()).Duration()
 		probeInterval        = kingpin.Flag("cluster.probe-interval", "Interval between random node probes. Setting this lower (more frequent) will cause the cluster to detect failed nodes more quickly at the expense of increased bandwidth usage.").Default(cluster.DefaultProbeInterval.String()).Duration()
 		settleTimeout        = kingpin.Flag("cluster.settle-timeout", "Maximum time to wait for cluster connections to settle before evaluating notifications.").Default(cluster.DefaultPushPullInterval.String()).Duration()
+		reconnectInterval    = kingpin.Flag("cluster.reconnect-interval", "Interval between attempting to reconnect to lost peers.").Default(cluster.DefaultReconnectInterval.String()).Duration()
 	)
 
 	kingpin.Version(version.Print("alertmanager"))
@@ -190,6 +191,7 @@ func main() {
 			*tcpTimeout,
 			*probeTimeout,
 			*probeInterval,
+			*reconnectInterval,
 		)
 		if err != nil {
 			level.Error(logger).Log("msg", "Unable to initialize gossip mesh", "err", err)

--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -161,6 +161,7 @@ func main() {
 		probeInterval        = kingpin.Flag("cluster.probe-interval", "Interval between random node probes. Setting this lower (more frequent) will cause the cluster to detect failed nodes more quickly at the expense of increased bandwidth usage.").Default(cluster.DefaultProbeInterval.String()).Duration()
 		settleTimeout        = kingpin.Flag("cluster.settle-timeout", "Maximum time to wait for cluster connections to settle before evaluating notifications.").Default(cluster.DefaultPushPullInterval.String()).Duration()
 		reconnectInterval    = kingpin.Flag("cluster.reconnect-interval", "Interval between attempting to reconnect to lost peers.").Default(cluster.DefaultReconnectInterval.String()).Duration()
+		peerReconnectTimeout = kingpin.Flag("cluster.reconnect-timeout", "Length of time to attempt to reconnect to a lost peer.").Default(cluster.DefaultReconnectTimeout.String()).Duration()
 	)
 
 	kingpin.Version(version.Print("alertmanager"))
@@ -192,6 +193,7 @@ func main() {
 			*probeTimeout,
 			*probeInterval,
 			*reconnectInterval,
+			*peerReconnectTimeout,
 		)
 		if err != nil {
 			level.Error(logger).Log("msg", "Unable to initialize gossip mesh", "err", err)

--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -182,7 +182,9 @@ func main() {
 
 	var peer *cluster.Peer
 	if *clusterBindAddr != "" {
-		peer, err = cluster.Join(log.With(logger, "component", "cluster"), prometheus.DefaultRegisterer,
+		peer, err = cluster.Join(
+			log.With(logger, "component", "cluster"),
+			prometheus.DefaultRegisterer,
 			*clusterBindAddr,
 			*clusterAdvertiseAddr,
 			*peers,


### PR DESCRIPTION
add reconnection support for dead peers

todo:

- [x] tests (only verified manually so far)
- [x] metrics
- [x] cleanup extra unused bits (most of this code is taken from https://github.com/hashicorp/serf/blob/80ab48778d/serf/serf.go)
- [x] decide on "smart" defaults for `DefaultReconnectInterval` and `DefaultReconnectTimeout`

edit:

I also included the `logWriter{}` wrapper I was using to expose memberlist logging. It's very verbose, and doesn't really conform to how we've been logging, so I'm not sure how best to expose it (or if I should just remove it from this PR).