### PR TITLE
#1196 Implement ability to get createdBy from header

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -523,6 +523,13 @@ func (api *API) setSilence(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// FEAT(#1196) Overwrite createdBy if value is passed in `AuthHeader` variable
+	// defaults to (x-auth-username)
+	creator, ok := r.Header[api.config.Global.AuthHeader]
+	if ok {
+		sil.CreatedBy = creator[0]
+	}
+
 	// This is an API only validation, it cannot be done internally
 	// because the expired silence is semantically important.
 	// But one should not be able to create expired silences, that

--- a/config/config.go
+++ b/config/config.go
@@ -342,6 +342,7 @@ var DefaultGlobalConfig = GlobalConfig{
 	ResolveTimeout: model.Duration(5 * time.Minute),
 	HTTPConfig:     &commoncfg.HTTPClientConfig{},
 
+	AuthHeader:      "X-Auth-Username",
 	SMTPHello:       "localhost",
 	SMTPRequireTLS:  true,
 	PagerdutyURL:    "https://events.pagerduty.com/v2/enqueue",
@@ -359,6 +360,8 @@ type GlobalConfig struct {
 	ResolveTimeout model.Duration `yaml:"resolve_timeout" json:"resolve_timeout"`
 
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
+
+	AuthHeader string `yaml:"auth_header,omitempty" json:"auth_header,omitempty"`
 
 	SMTPFrom         string `yaml:"smtp_from,omitempty" json:"smtp_from,omitempty"`
 	SMTPHello        string `yaml:"smtp_hello,omitempty" json:"smtp_hello,omitempty"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -320,6 +320,7 @@ func TestEmptyFieldsAndRegex(t *testing.T) {
 		Global: &GlobalConfig{
 			HTTPConfig:       &commoncfg.HTTPClientConfig{},
 			ResolveTimeout:   model.Duration(5 * time.Minute),
+			AuthHeader:       "X-Auth-Username",
 			SMTPSmarthost:    "localhost:25",
 			SMTPFrom:         "alertmanager@example.org",
 			HipchatAuthToken: "mysecret",


### PR DESCRIPTION
If a header is provided (most likely by a load balancer) that states who
the user is then we should use that value for the createdBy field for
proper accounting/auditability of silence creation.

The header used can be configured by setting the `auth_header` option in
the global context. The feature can be disabled by setting `auth_header:
""`.

The value set for `auth_header` must match the output from the go http
request parser

```
HTTP defines that header names are case-insensitive. The
request parser implements this by using CanonicalHeaderKey,
making the first character and any characters following a
hyphen uppercase and the rest lowercase.
```