### PR TITLE
fix set initial failed peers

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -200,7 +200,7 @@ func Join(
 	}
 	p.mlist = ml
 
-	p.setInitialFailed(resolvedPeers)
+	p.setInitialFailed(resolvedPeers, bindAddr)
 
 	n, err := ml.Join(resolvedPeers)
 	if err != nil {
@@ -221,13 +221,18 @@ func Join(
 
 // All peers are initially added to the failed list. They will be removed from
 // this list in peerJoin when making their initial connection.
-func (p *Peer) setInitialFailed(peers []string) {
+func (p *Peer) setInitialFailed(peers []string, myAddr string) {
 	if len(peers) == 0 {
 		return
 	}
 
 	now := time.Now()
 	for _, peerAddr := range peers {
+		if peerAddr == myAddr {
+			// Don't add ourselves to the initially failing list,
+			// we don't connect to ourselves.
+			continue
+		}
 		ip, port, err := net.SplitHostPort(peerAddr)
 		if err != nil {
 			continue

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -200,7 +200,7 @@ func Join(
 	}
 	p.mlist = ml
 
-	p.setInitialFailed(resolvedPeers, bindAddr)
+	p.setInitialFailed(resolvedPeers, fmt.Sprintf("%s:%d", advertiseHost, advertisePort))
 
 	n, err := ml.Join(resolvedPeers)
 	if err != nil {

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -228,9 +228,22 @@ func (p *Peer) setInitialFailed(peers []string) {
 
 	now := time.Now()
 	for _, peerAddr := range peers {
+		ip, port, err := net.SplitHostPort(peerAddr)
+		if err != nil {
+			continue
+		}
+		portUint, err := strconv.ParseUint(port, 10, 16)
+		if err != nil {
+			continue
+		}
+
 		pr := peer{
 			status:    StatusNone,
 			leaveTime: now,
+			Node: &memberlist.Node{
+				Addr: net.ParseIP(ip),
+				Port: uint16(portUint),
+			},
 		}
 		p.failedPeers = append(p.failedPeers, pr)
 		p.peers[peerAddr] = pr

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -238,7 +238,7 @@ func (p *Peer) setInitialFailed(peers []string) {
 		}
 
 		pr := peer{
-			status:    StatusNone,
+			status:    StatusFailed,
 			leaveTime: now,
 			Node: &memberlist.Node{
 				Addr: net.ParseIP(ip),
@@ -386,7 +386,7 @@ func (p *Peer) peerJoin(n *memberlist.Node) {
 
 	if oldStatus == StatusFailed {
 		level.Debug(p.logger).Log("msg", "peer rejoined", "peer", pr.Node)
-		p.failedPeers = removeOldPeer(p.failedPeers, pr.Name)
+		p.failedPeers = removeOldPeer(p.failedPeers, pr.Address())
 	}
 }
 
@@ -710,10 +710,10 @@ func retry(interval time.Duration, stopc <-chan struct{}, f func() error) error 
 	}
 }
 
-func removeOldPeer(old []peer, name string) []peer {
+func removeOldPeer(old []peer, addr string) []peer {
 	new := make([]peer, 0, len(old))
 	for _, p := range old {
-		if p.Name != name {
+		if p.Address() != addr {
 			new = append(new, p)
 		}
 	}

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -203,7 +203,8 @@ func TestInitiallyFailingPeers(t *testing.T) {
 	for _, addr := range peerAddrs {
 		pr, ok := p.peers[addr]
 		require.True(t, ok)
-		require.Equal(t, StatusNone, pr.status)
+		require.Equal(t, StatusFailed.String(), pr.status.String())
 		require.Equal(t, addr, pr.Address())
+		require.Equal(t, len(peerAddrs)-1, len(removeOldPeer(p.failedPeers, pr.Address())))
 	}
 }

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -205,6 +205,8 @@ func TestInitiallyFailingPeers(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, StatusFailed.String(), pr.status.String())
 		require.Equal(t, addr, pr.Address())
-		require.Equal(t, len(peerAddrs)-1, len(removeOldPeer(p.failedPeers, pr.Address())))
+		expectedLen := len(p.failedPeers) - 1
+		p.peerJoin(pr.Node)
+		require.Equal(t, expectedLen, len(p.failedPeers))
 	}
 }

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -204,5 +204,6 @@ func TestInitiallyFailingPeers(t *testing.T) {
 		pr, ok := p.peers[addr]
 		require.True(t, ok)
 		require.Equal(t, StatusNone, pr.status)
+		require.Equal(t, addr, pr.Address())
 	}
 }


### PR DESCRIPTION
initially failed peers weren't being set correctly, which caused a panic (!) and prevented them from being removed.

@simonpasquier 