### PR TITLE
Check for advertise host when setting failed peers

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -197,6 +197,9 @@ func Join(
 	if advertiseHost != "" {
 		cfg.AdvertiseAddr = advertiseHost
 		cfg.AdvertisePort = advertisePort
+		p.setInitialFailed(resolvedPeers, fmt.Sprintf("%s:%d", advertiseHost, advertisePort))
+	} else {
+		p.setInitialFailed(resolvedPeers, bindAddr)
 	}
 
 	ml, err := memberlist.Create(cfg)
@@ -204,8 +207,6 @@ func Join(
 		return nil, errors.Wrap(err, "create memberlist")
 	}
 	p.mlist = ml
-
-	p.setInitialFailed(resolvedPeers, fmt.Sprintf("%s:%d", advertiseHost, advertisePort))
 
 	n, err := ml.Join(resolvedPeers)
 	if err != nil {


### PR DESCRIPTION
When setting initially failing peers, if we don't
have a value for the advertise address, use the
bindAddr.

the current code results in adding a failed peer that cannot be reconnected to if advertiseAddr isn't set, but bindAddr is a full IP addr. This results in a lot of `full_state` syncs because of the attempted reconnects to a node that cannot be reconnected to.

@simonpasquier 