### PR TITLE
gossip large messages via SendReliable

### DIFF
--- a/cluster/channel.go
+++ b/cluster/channel.go
@@ -1,0 +1,128 @@
+// Copyright 2018 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"sync"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/gogo/protobuf/proto"
+	"github.com/hashicorp/memberlist"
+	"github.com/prometheus/alertmanager/cluster/clusterpb"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Channel allows clients to send messages for a specific state type that will be
+// broadcasted in a best-effort manner.
+type Channel struct {
+	key          string
+	send         func([]byte)
+	peers        func() []*memberlist.Node
+	sendOversize func(*memberlist.Node, []byte) error
+
+	msgc   chan []byte
+	logger log.Logger
+
+	oversizeGossipMessageFailureTotal prometheus.Counter
+	oversizeGossipDuration            prometheus.Histogram
+}
+
+// NewChannel creates a new Channel struct, which handles sending normal and
+// oversize messages to peers.
+func NewChannel(
+	key string,
+	send func([]byte),
+	peers func() []*memberlist.Node,
+	sendOversize func(*memberlist.Node, []byte) error,
+	logger log.Logger,
+	stopc chan struct{},
+	reg prometheus.Registerer,
+) *Channel {
+	oversizeGossipMessageFailureTotal := prometheus.NewCounter(prometheus.CounterOpts{
+		Name:        "alertmanager_oversized_gossip_message_failure_total",
+		Help:        "Number notification log received queries that failed.",
+		ConstLabels: prometheus.Labels{"key": key},
+	})
+	oversizeGossipDuration := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:        "alertmanager_oversize_gossip_duration_seconds",
+		Help:        "Duration of oversized gossip message requests.",
+		ConstLabels: prometheus.Labels{"key": key},
+	})
+
+	reg.MustRegister(oversizeGossipDuration, oversizeGossipMessageFailureTotal)
+
+	c := &Channel{
+		key:                               key,
+		send:                              send,
+		peers:                             peers,
+		logger:                            logger,
+		msgc:                              make(chan []byte, 200),
+		sendOversize:                      sendOversize,
+		oversizeGossipMessageFailureTotal: oversizeGossipMessageFailureTotal,
+		oversizeGossipDuration:            oversizeGossipDuration,
+	}
+
+	go c.handleOverSizedMessages(stopc)
+
+	return c
+}
+
+// handleOverSizedMessages prevents memberlist from opening too many parallel
+// TCP connections to its peers.
+func (c *Channel) handleOverSizedMessages(stopc chan struct{}) {
+	var wg sync.WaitGroup
+	for {
+		select {
+		case b := <-c.msgc:
+			for _, n := range c.peers() {
+				go func(n *memberlist.Node) {
+					wg.Add(1)
+					defer wg.Done()
+
+					start := time.Now()
+					if err := c.sendOversize(n, b); err != nil {
+						level.Debug(c.logger).Log("msg", "failed to send reliable", "key", c.key, "node", n, "err", err)
+						c.oversizeGossipMessageFailureTotal.Inc()
+						return
+					}
+					c.oversizeGossipDuration.Observe(time.Since(start).Seconds())
+				}(n)
+			}
+
+			wg.Wait()
+		case <-stopc:
+			return
+		}
+	}
+}
+
+// Broadcast enqueues a message for broadcasting.
+func (c *Channel) Broadcast(b []byte) {
+	b, err := proto.Marshal(&clusterpb.Part{Key: c.key, Data: b})
+	if err != nil {
+		return
+	}
+
+	if OversizedMessage(b) {
+		c.msgc <- b
+	} else {
+		c.send(b)
+	}
+}
+
+func OversizedMessage(b []byte) bool {
+	return len(b) > maxGossipPacketSize/2
+}

--- a/cluster/channel.go
+++ b/cluster/channel.go
@@ -134,7 +134,7 @@ func (c *Channel) Broadcast(b []byte) {
 		select {
 		case c.msgc <- b:
 		default:
-			level.Warn(c.logger).Log("msg", "oversized gossip channel full")
+			level.Debug(c.logger).Log("msg", "oversized gossip channel full")
 			c.oversizeGossipMessageDroppedTotal.Inc()
 		}
 	} else {

--- a/cluster/channel.go
+++ b/cluster/channel.go
@@ -123,6 +123,8 @@ func (c *Channel) Broadcast(b []byte) {
 	}
 }
 
+// OversizedMessage indicates whether or not the byte payload should be sent
+// via TCP.
 func OversizedMessage(b []byte) bool {
 	return len(b) > maxGossipPacketSize/2
 }

--- a/cluster/channel.go
+++ b/cluster/channel.go
@@ -88,8 +88,8 @@ func (c *Channel) handleOverSizedMessages(stopc chan struct{}) {
 		select {
 		case b := <-c.msgc:
 			for _, n := range c.peers() {
+				wg.Add(1)
 				go func(n *memberlist.Node) {
-					wg.Add(1)
 					defer wg.Done()
 
 					start := time.Now()

--- a/cluster/channel.go
+++ b/cluster/channel.go
@@ -57,7 +57,7 @@ func NewChannel(
 		ConstLabels: prometheus.Labels{"key": key},
 	})
 	oversizeGossipDuration := prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name:        "alertmanager_oversize_gossip_duration_seconds",
+		Name:        "alertmanager_oversize_gossip_message_duration_seconds",
 		Help:        "Duration of oversized gossip message requests.",
 		ConstLabels: prometheus.Labels{"key": key},
 	})

--- a/cluster/channel_test.go
+++ b/cluster/channel_test.go
@@ -1,0 +1,92 @@
+// Copyright 2018 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/hashicorp/memberlist"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func TestNormalMessagesGossiped(t *testing.T) {
+	var sent bool
+	c := newChannel(
+		func(_ []byte) { sent = true },
+		func() []*memberlist.Node { return nil },
+		func(_ *memberlist.Node, _ []byte) error { return nil },
+	)
+
+	c.Broadcast([]byte{})
+
+	if sent != true {
+		t.Fatalf("small message not sent")
+	}
+}
+
+func TestOversizedMessagesGossiped(t *testing.T) {
+	var sent bool
+	ctx, cancel := context.WithCancel(context.Background())
+	c := newChannel(
+		func(_ []byte) {},
+		func() []*memberlist.Node { return []*memberlist.Node{&memberlist.Node{}} },
+		func(_ *memberlist.Node, _ []byte) error { sent = true; cancel(); return nil },
+	)
+
+	f, err := os.Open("/dev/zero")
+	if err != nil {
+		t.Fatalf("failed to open /dev/zero: %v", err)
+	}
+	defer f.Close()
+
+	buf := new(bytes.Buffer)
+	toCopy := int64(800)
+	if n, err := io.CopyN(buf, f, toCopy); err != nil {
+		t.Fatalf("failed to copy bytes: %v", err)
+	} else if n != toCopy {
+		t.Fatalf("wanted to copy %d bytes, only copied %d", toCopy, n)
+	}
+
+	fmt.Println(buf.Len())
+
+	c.Broadcast(buf.Bytes())
+
+	<-ctx.Done()
+
+	if sent != true {
+		t.Fatalf("oversized message not sent")
+	}
+}
+
+func newChannel(
+	send func([]byte),
+	peers func() []*memberlist.Node,
+	sendOversize func(*memberlist.Node, []byte) error,
+) *Channel {
+	return NewChannel(
+		"test",
+		send,
+		peers,
+		sendOversize,
+		log.NewNopLogger(),
+		make(chan struct{}),
+		prometheus.NewRegistry(),
+	)
+}

--- a/cluster/channel_test.go
+++ b/cluster/channel_test.go
@@ -16,7 +16,6 @@ package cluster
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"os"
 	"testing"
@@ -63,8 +62,6 @@ func TestOversizedMessagesGossiped(t *testing.T) {
 	} else if n != toCopy {
 		t.Fatalf("wanted to copy %d bytes, only copied %d", toCopy, n)
 	}
-
-	fmt.Println(buf.Len())
 
 	c.Broadcast(buf.Bytes())
 

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -26,12 +26,10 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/memberlist"
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
 
-	"github.com/prometheus/alertmanager/cluster/clusterpb"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -97,6 +95,7 @@ const (
 	DefaultProbeInterval     = 1 * time.Second
 	DefaultReconnectInterval = 10 * time.Second
 	DefaultReconnectTimeout  = 6 * time.Hour
+	maxGossipPacketSize      = 1400
 )
 
 func Join(
@@ -193,6 +192,7 @@ func Join(
 	cfg.ProbeInterval = probeInterval
 	cfg.LogOutput = &logWriter{l: l}
 	cfg.GossipNodes = retransmit
+	cfg.UDPBufferSize = maxGossipPacketSize
 
 	if advertiseHost != "" {
 		cfg.AdvertiseAddr = advertiseHost
@@ -441,9 +441,25 @@ func (p *Peer) peerUpdate(n *memberlist.Node) {
 
 // AddState adds a new state that will be gossiped. It returns a channel to which
 // broadcast messages for the state can be sent.
-func (p *Peer) AddState(key string, s State) *Channel {
+func (p *Peer) AddState(key string, s State, reg prometheus.Registerer) *Channel {
 	p.states[key] = s
-	return &Channel{key: key, bcast: p.delegate.bcast}
+	send := func(b []byte) {
+		p.delegate.bcast.QueueBroadcast(simpleBroadcast(b))
+	}
+	peers := func() []*memberlist.Node {
+		nodes := p.Peers()
+		for i, n := range nodes {
+			if n.Name == p.Self().Name {
+				nodes = append(nodes[:i], nodes[i+1:]...)
+				break
+			}
+		}
+		return nodes
+	}
+	sendOversize := func(n *memberlist.Node, b []byte) error {
+		return p.mlist.SendReliable(n, b)
+	}
+	return NewChannel(key, send, peers, sendOversize, p.logger, p.stopc, reg)
 }
 
 // Leave the cluster, waiting up to timeout.
@@ -576,28 +592,12 @@ type State interface {
 	Merge(b []byte) error
 }
 
-// Channel allows clients to send messages for a specific state type that will be
-// broadcasted in a best-effort manner.
-type Channel struct {
-	key   string
-	bcast *memberlist.TransmitLimitedQueue
-}
-
 // We use a simple broadcast implementation in which items are never invalidated by others.
 type simpleBroadcast []byte
 
 func (b simpleBroadcast) Message() []byte                       { return []byte(b) }
 func (b simpleBroadcast) Invalidates(memberlist.Broadcast) bool { return false }
 func (b simpleBroadcast) Finished()                             {}
-
-// Broadcast enqueues a message for broadcasting.
-func (c *Channel) Broadcast(b []byte) {
-	b, err := proto.Marshal(&clusterpb.Part{Key: c.key, Data: b})
-	if err != nil {
-		return
-	}
-	c.bcast.QueueBroadcast(simpleBroadcast(b))
-}
 
 func resolvePeers(ctx context.Context, peers []string, myAddress string, res net.Resolver, waitIfEmpty bool) ([]string, error) {
 	var resolvedPeers []string

--- a/cluster/delegate.go
+++ b/cluster/delegate.go
@@ -1,3 +1,16 @@
+// Copyright 2018 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cluster
 
 import (

--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -227,7 +227,7 @@ func main() {
 		os.Exit(1)
 	}
 	if peer != nil {
-		c := peer.AddState("nfl", notificationLog)
+		c := peer.AddState("nfl", notificationLog, prometheus.DefaultRegisterer)
 		notificationLog.SetBroadcast(c.Broadcast)
 	}
 
@@ -247,7 +247,7 @@ func main() {
 		os.Exit(1)
 	}
 	if peer != nil {
-		c := peer.AddState("sil", silences)
+		c := peer.AddState("sil", silences, prometheus.DefaultRegisterer)
 		silences.SetBroadcast(c.Broadcast)
 	}
 


### PR DESCRIPTION
fixes #1412

Over a certain number of bytes (in this case, half of the allowed packet size, 700), send messages via `memberlist.SendReliable()`, which uses the TCP transport. These messages are still sent to the same interface func on our `delegate`, `delegate.NotifyMsg()`. Since we're sending the large messages to all peers by default, there's no need to gossip any received large message further (cf. the implementation for `Merge()` for `nflog` and `silence`)

@grobie @brancz @mxinden @simonpasquier 