### PR TITLE
Support adding custom fields to VictorOps notifications

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -506,6 +506,15 @@ func (c *VictorOpsConfig) UnmarshalYAML(unmarshal func(interface{}) error) error
 	if c.RoutingKey == "" {
 		return fmt.Errorf("missing Routing key in VictorOps config")
 	}
+
+	reservedFields := []string{"routing_key", "message_type", "state_message", "entity_display_name", "monitoring_tool", "entity_id", "entity_state"}
+
+	for _, v := range reservedFields {
+		if _, ok := c.CustomFields[v]; ok {
+			return fmt.Errorf("VictorOps config contains custom field %s which cannot be used as it conflicts with the fixed/static fields", v)
+		}
+	}
+
 	return nil
 }
 

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -486,13 +486,14 @@ type VictorOpsConfig struct {
 
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
-	APIKey            Secret `yaml:"api_key" json:"api_key"`
-	APIURL            *URL   `yaml:"api_url" json:"api_url"`
-	RoutingKey        string `yaml:"routing_key" json:"routing_key"`
-	MessageType       string `yaml:"message_type" json:"message_type"`
-	StateMessage      string `yaml:"state_message" json:"state_message"`
-	EntityDisplayName string `yaml:"entity_display_name" json:"entity_display_name"`
-	MonitoringTool    string `yaml:"monitoring_tool" json:"monitoring_tool"`
+	APIKey            Secret            `yaml:"api_key" json:"api_key"`
+	APIURL            *URL              `yaml:"api_url" json:"api_url"`
+	RoutingKey        string            `yaml:"routing_key" json:"routing_key"`
+	MessageType       string            `yaml:"message_type" json:"message_type"`
+	StateMessage      string            `yaml:"state_message" json:"state_message"`
+	EntityDisplayName string            `yaml:"entity_display_name" json:"entity_display_name"`
+	MonitoringTool    string            `yaml:"monitoring_tool" json:"monitoring_tool"`
+	CustomFields      map[string]string `yaml:"custom_fields,omitempty" json:"custom_fields,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/config/notifiers_test.go
+++ b/config/notifiers_test.go
@@ -287,6 +287,49 @@ routing_key: ''
 	}
 }
 
+func TestVictorOpsCustomFieldsValidation(t *testing.T) {
+	in := `
+routing_key: 'test'
+custom_fields:
+  entity_state: 'state_message'
+`
+	var cfg VictorOpsConfig
+	err := yaml.UnmarshalStrict([]byte(in), &cfg)
+
+	expected := "VictorOps config contains custom field entity_state which cannot be used as it conflicts with the fixed/static fields"
+
+	if err == nil {
+		t.Fatalf("no error returned, expected:\n%v", expected)
+	}
+	if err.Error() != expected {
+		t.Errorf("\nexpected:\n%v\ngot:\n%v", expected, err.Error())
+	}
+
+	in = `
+routing_key: 'test'
+custom_fields:
+  my_special_field: 'special_label'
+`
+
+	err = yaml.UnmarshalStrict([]byte(in), &cfg)
+
+	expected = "special_label"
+
+	if err != nil {
+		t.Fatalf("Unexpected error returned, got:\n%v", err.Error())
+	}
+
+	val, ok := cfg.CustomFields["my_special_field"]
+
+	if !ok {
+		t.Fatalf("Expected Custom Field to have value %v set, field is empty", expected)
+	}
+	if val != expected {
+		t.Errorf("\nexpected custom field my_special_field value:\n%v\ngot:\n%v", expected, val)
+	}
+
+}
+
 func TestPushoverUserKeyIsPresent(t *testing.T) {
 	in := `
 user_key: ''

--- a/notify/impl.go
+++ b/notify/impl.go
@@ -1316,7 +1316,7 @@ func (n *VictorOps) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 	return n.retry(resp.StatusCode)
 }
 
-// Create the json payload to be sent to victorops api.
+// Create the JSON payload to be sent to the VictorOps API.
 func (n *VictorOps) createVictorOpsPayload(ctx context.Context, as ...*types.Alert) (*bytes.Buffer, error) {
 	victorOpsAllowedEvents := map[string]bool{
 		"INFO":     true,

--- a/notify/impl.go
+++ b/notify/impl.go
@@ -1315,7 +1315,7 @@ func (n *VictorOps) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 	return n.retry(resp.StatusCode)
 }
 
-//Create the json payload to be sent to victorops api
+// Create the json payload to be sent to victorops api
 func (n *VictorOps) createVictorOpsPayload(ctx context.Context, as ...*types.Alert) (*bytes.Buffer, error) {
 	victorOpsAllowedEvents := map[string]bool{
 		"INFO":     true,
@@ -1366,14 +1366,14 @@ func (n *VictorOps) createVictorOpsPayload(ctx context.Context, as ...*types.Ale
 
 	for k, v := range n.conf.CustomFields {
 
-		//Validate if the custom field is not one of the fixed fields above.
-		if _, ok := msg[k]; !ok {
-			msg[k] = tmpl(v)
-			if err != nil {
-				return nil, fmt.Errorf("templating error: %s", err)
-			}
-		} else {
-			level.Debug(n.logger).Log("msg", "Ignoring custom field %q as it is already defined as a fixed field", "omitted_field", k, "incident", key)
+		// Validate if the custom field is not one of the fixed fields above.
+		if _, ok := msg[k]; ok {
+			level.Debug(n.logger).Log("msg", "Ignoring custom field as it is already defined as a fixed field", "omitted_field", k, "incident", key)
+			continue
+		}
+		msg[k] = tmpl(v)
+		if err != nil {
+			return nil, fmt.Errorf("templating error: %s", err)
 		}
 	}
 

--- a/notify/impl.go
+++ b/notify/impl.go
@@ -1364,13 +1364,8 @@ func (n *VictorOps) createVictorOpsPayload(ctx context.Context, as ...*types.Ale
 		return nil, fmt.Errorf("templating error: %s", err)
 	}
 
+	// Add custom fields to the payload.
 	for k, v := range n.conf.CustomFields {
-
-		// Validate if the custom field is not one of the fixed fields above.
-		if _, ok := msg[k]; ok {
-			level.Debug(n.logger).Log("msg", "Ignoring custom field as it is already defined as a fixed field", "omitted_field", k, "incident", key)
-			continue
-		}
 		msg[k] = tmpl(v)
 		if err != nil {
 			return nil, fmt.Errorf("templating error: %s", err)

--- a/notify/impl_test.go
+++ b/notify/impl_test.go
@@ -337,8 +337,6 @@ func TestVictorOpsCustomFields(t *testing.T) {
 		MonitoringTool:    `AM`,
 		CustomFields: map[string]string{
 			"Field_A": "{{ .CommonLabels.Message }}",
-			//A field that should be ignored
-			"state_message": "discarded",
 		},
 	}
 
@@ -364,9 +362,6 @@ func TestVictorOpsCustomFields(t *testing.T) {
 	err = json.Unmarshal(msg.Bytes(), &m)
 
 	require.NoError(t, err)
-
-	//Verify the invalid custom field didn't override the static field
-	require.Equal(t, "message", m["state_message"])
 
 	//Verify that a custom field was added to the payload and templatized
 	require.Equal(t, "message", m["Field_A"])

--- a/notify/impl_test.go
+++ b/notify/impl_test.go
@@ -327,9 +327,14 @@ func TestEmailConfigMissingAuthParam(t *testing.T) {
 func TestVictorOpsCustomFields(t *testing.T) {
 	logger := log.NewNopLogger()
 	tmpl := createTmpl(t)
+
+	url, err := url.Parse("http://nowhere.com")
+
+	require.NoError(t, err, "unexpected error parsing mock url")
+
 	conf := &config.VictorOpsConfig{
 		APIKey:            `12345`,
-		APIURL:            `http://nowhere.com`,
+		APIURL:            &config.URL{url},
 		EntityDisplayName: `{{ .CommonLabels.Message }}`,
 		StateMessage:      `{{ .CommonLabels.Message }}`,
 		RoutingKey:        `test`,
@@ -363,6 +368,6 @@ func TestVictorOpsCustomFields(t *testing.T) {
 
 	require.NoError(t, err)
 
-	//Verify that a custom field was added to the payload and templatized
+	// Verify that a custom field was added to the payload and templatized.
 	require.Equal(t, "message", m["Field_A"])
 }


### PR DESCRIPTION
This PR is a followup to another PR that was opened #1315.

These changes allow users to define additional fields they would like to pass on to VictorOps and use templates to set the values of those fields.

Example:

```
- name: default
  victorops_configs:
  - entity_display_name: '{{ .CommonAnnotations.summary}}'
    message_type: '{{ .CommonLabels.severity }}'
    routing_key: default
    state_message: '{{ .CommonAnnotations.description }}'
    custom_fields:
      tier: '{{ .CommonLabels.tier }}'
      storage: '{{ .CommonLabels.storage }}'
```

Logic has been added to prevent a custom field colliding with/overriding a statically defined field. When this occurs, the field will simply be ignored and a debug level log message will notify of this.