### PR TITLE
CHANGELOG.md: Improve [CHANGE] section of v0.15.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 * [CHANGE] Replace deprecated InstrumentHandler() (#1302)
 * [CHANGE] Validate Slack field config and only allow the necessary input (#1334)
 * [CHANGE] Remove legacy alert ingest endpoint (#1362)
-* [CHANGE] Moved to memberlist as underlying gossip protocol
+* [CHANGE] Move to memberlist as underlying gossip protocol including cluster flag changes from --mesh.xxx to --cluster.xxx (#1232)
+* [CHANGE] Move Alertmanager working directory in Docker image to /etc/alertmanager (#1313)
 * [BUGFIX/CHANGE] The default group by is no labels. (#1287)
 * [FEATURE] [amtool] Filter alerts by receiver (#1402)
 * [FEATURE] Wait for mesh to settle before sending alerts (#1209)


### PR DESCRIPTION
As pointed out by @roman-vynar [here](https://github.com/prometheus/alertmanager/pull/1430#issuecomment-399429259) I was missing two change details in the CHANGELOG.md for the v0.15.0 release:

- Add entry for working dir change in Alertmanager Docker image
- Indicate cluster flag changes