### PR TITLE
fix: reverted change of dockerfile entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ COPY examples/ha/alertmanager.yml /etc/alertmanager/alertmanager.yml
 
 EXPOSE     9093
 VOLUME     [ "/alertmanager" ]
-WORKDIR    /etc/alertmanager
+WORKDIR    /alertmanager
 ENTRYPOINT [ "/bin/alertmanager" ]
-CMD        [ "--storage.path=/alertmanager" ]
+CMD        [ "--config.file=/etc/alertmanager/alertmanager.yml", \
+             "--storage.path=/alertmanager" ]


### PR DESCRIPTION
Fixes #1433 

This PR fixes breaking change in chande in dockerfile WORKDIR.

Since `0.15.0` if user overridden the `cmd` and did not specify the `storage.path` data were stored by default to `/etc/alertmanager/data`

