### PR TITLE
fix concurrent read and write group error

### DIFF
--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -271,7 +271,9 @@ func (d *Dispatcher) processAlert(alert *types.Alert, route *Route) {
 	ag, ok := group[fp]
 	if !ok {
 		ag = newAggrGroup(d.ctx, groupLabels, route, d.timeout, d.logger)
+		d.mtx.Lock()
 		group[fp] = ag
+		d.mtx.Unlock()
 
 		go ag.run(func(ctx context.Context, alerts ...*types.Alert) bool {
 			_, _, err := d.stage.Exec(ctx, d.logger, alerts...)


### PR DESCRIPTION
There is no lock when adding aggrGroup to group map. If another goroutine call Dispatcher.Groups or Dispatcher.run clear up aggrGroups, alertmanager will be panic.