### PR TITLE
Lookup parts in strings using regexp.MatchString

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -128,6 +128,8 @@ var DefaultFuncs = FuncMap{
 	"join": func(sep string, s []string) string {
 		return strings.Join(s, sep)
 	},
+	"containsAny": strings.ContainsAny,
+	"contains": strings.Contains,
 	"safeHtml": func(text string) tmplhtml.HTML {
 		return tmplhtml.HTML(text)
 	},

--- a/template/template.go
+++ b/template/template.go
@@ -128,8 +128,7 @@ var DefaultFuncs = FuncMap{
 	"join": func(sep string, s []string) string {
 		return strings.Join(s, sep)
 	},
-	"containsAny": strings.ContainsAny,
-	"contains": strings.Contains,
+	"match": regexp.MatchString,
 	"safeHtml": func(text string) tmplhtml.HTML {
 		return tmplhtml.HTML(text)
 	},


### PR DESCRIPTION
@stuartnelson3 For more complex templates it is sometimes required to check whether a string contains only specific parts. Therefore I added strings.Contains/strings.ContainsAny to the FuncMap