### PR TITLE
CHANGELOG.md: Add 'Next release' section with docker working dir change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next release
+
+* [CHANGE] Revert Alertmanager working directory changes in Docker image back to `/alertmanager` (#1435)
+
 ## 0.15.0 / 2018-06-22
 
 * [CHANGE] [amtool] Update silence add and update flags (#1298)


### PR DESCRIPTION
To ensure we include the breaking change notice in the next release
notes, this patch adds a 'Next release' section mentioning the breaking
change of the working directory of the Alertmanager Dockerfile.

See https://github.com/prometheus/alertmanager/pull/1435#pullrequestreview-134278203