### PR TITLE
enable templating of hipchat room_id

### DIFF
--- a/notify/impl.go
+++ b/notify/impl.go
@@ -759,7 +759,8 @@ func (n *Hipchat) Notify(ctx context.Context, as ...*types.Alert) (bool, error) 
 		data     = n.tmpl.Data(receiverName(ctx, n.logger), groupLabels(ctx, n.logger), as...)
 		tmplText = tmplText(n.tmpl, data, &err)
 		tmplHTML = tmplHTML(n.tmpl, data, &err)
-		url      = fmt.Sprintf("%sv2/room/%s/notification?auth_token=%s", n.conf.APIURL, n.conf.RoomID, n.conf.AuthToken)
+		roomid   = tmplText(n.conf.RoomID)
+		url      = fmt.Sprintf("%sv2/room/%s/notification?auth_token=%s", n.conf.APIURL, roomid, n.conf.AuthToken)
 	)
 
 	if n.conf.MessageFormat == "html" {


### PR DESCRIPTION
I noticed that I was unable to template the room_id field of hipchat_config, upon reviewing the code I found that tmplText was never being called on room_id despite it being declared as a tmpl_string in the documentation at https://prometheus.io/docs/alerting/configuration/#%3Chipchat_config%3E

This PR simply calls tmplText on RoomID before passing it into the url Sprintf