### PR TITLE
[amtool] Add timeout support to amtool commands

### DIFF
--- a/cli/alert_query.go
+++ b/cli/alert_query.go
@@ -72,10 +72,10 @@ func configureQueryAlertsCmd(cc *kingpin.CmdClause) {
 	queryCmd.Flag("unprocessed", "Show unprocessed alerts").Short('u').BoolVar(&a.unprocessed)
 	queryCmd.Flag("receiver", "Show alerts matching receiver (Supports regex syntax)").Short('r').StringVar(&a.receiver)
 	queryCmd.Arg("matcher-groups", "Query filter").StringsVar(&a.matcherGroups)
-	queryCmd.Action(a.queryAlerts)
+	queryCmd.Action(execWithTimeout(a.queryAlerts))
 }
 
-func (a *alertQueryCmd) queryAlerts(ctx *kingpin.ParseContext) error {
+func (a *alertQueryCmd) queryAlerts(ctx context.Context, _ *kingpin.ParseContext) error {
 	var filterString = ""
 	if len(a.matcherGroups) == 1 {
 		// If the parser fails then we likely don't have a (=|=~|!=|!~) so lets
@@ -100,7 +100,7 @@ func (a *alertQueryCmd) queryAlerts(ctx *kingpin.ParseContext) error {
 	if !a.silenced && !a.inhibited && !a.active && !a.unprocessed {
 		a.active = true
 	}
-	fetchedAlerts, err := alertAPI.List(context.Background(), filterString, a.receiver, a.silenced, a.inhibited, a.active, a.unprocessed)
+	fetchedAlerts, err := alertAPI.List(ctx, filterString, a.receiver, a.silenced, a.inhibited, a.active, a.unprocessed)
 	if err != nil {
 		return err
 	}

--- a/cli/config.go
+++ b/cli/config.go
@@ -34,17 +34,17 @@ The amount of output is controlled by the output selection flag:
 
 // configCmd represents the config command
 func configureConfigCmd(app *kingpin.Application) {
-	app.Command("config", configHelp).Action(queryConfig).PreAction(requireAlertManagerURL)
+	app.Command("config", configHelp).Action(execWithTimeout(queryConfig)).PreAction(requireAlertManagerURL)
 
 }
 
-func queryConfig(ctx *kingpin.ParseContext) error {
+func queryConfig(ctx context.Context, _ *kingpin.ParseContext) error {
 	c, err := api.NewClient(api.Config{Address: alertmanagerURL.String()})
 	if err != nil {
 		return err
 	}
 	statusAPI := client.NewStatusAPI(c)
-	status, err := statusAPI.Get(context.Background())
+	status, err := statusAPI.Get(ctx)
 	if err != nil {
 		return err
 	}

--- a/cli/root.go
+++ b/cli/root.go
@@ -16,6 +16,7 @@ package cli
 import (
 	"net/url"
 	"os"
+	"time"
 
 	"github.com/prometheus/common/version"
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -28,6 +29,7 @@ var (
 	verbose         bool
 	alertmanagerURL *url.URL
 	output          string
+	timeout         time.Duration
 
 	configFiles = []string{os.ExpandEnv("$HOME/.config/amtool/config.yml"), "/etc/amtool/config.yml"}
 	legacyFlags = map[string]string{"comment_required": "require-comment"}
@@ -61,6 +63,8 @@ func Execute() {
 	app.Flag("verbose", "Verbose running information").Short('v').BoolVar(&verbose)
 	app.Flag("alertmanager.url", "Alertmanager to talk to").URLVar(&alertmanagerURL)
 	app.Flag("output", "Output formatter (simple, extended, json)").Short('o').Default("simple").EnumVar(&output, "simple", "extended", "json")
+	app.Flag("timeout", "Timeout for the executed command").Default("30s").DurationVar(&timeout)
+
 	app.Version(version.Print("amtool"))
 	app.GetFlag("help").Short('h')
 	app.UsageTemplate(kingpin.CompactUsageTemplate)

--- a/cli/silence.go
+++ b/cli/silence.go
@@ -13,7 +13,9 @@
 
 package cli
 
-import "gopkg.in/alecthomas/kingpin.v2"
+import (
+	"gopkg.in/alecthomas/kingpin.v2"
+)
 
 // silenceCmd represents the silence command
 func configureSilenceCmd(app *kingpin.Application) {

--- a/cli/silence_add.go
+++ b/cli/silence_add.go
@@ -82,11 +82,11 @@ func configureSilenceAddCmd(cc *kingpin.CmdClause) {
 	addCmd.Flag("end", "Set when the silence should end (overwrites duration). RFC3339 format 2006-01-02T15:04:05Z07:00").StringVar(&c.end)
 	addCmd.Flag("comment", "A comment to help describe the silence").Short('c').StringVar(&c.comment)
 	addCmd.Arg("matcher-groups", "Query filter").StringsVar(&c.matchers)
-	addCmd.Action(c.add)
+	addCmd.Action(execWithTimeout(c.add))
 
 }
 
-func (c *silenceAddCmd) add(ctx *kingpin.ParseContext) error {
+func (c *silenceAddCmd) add(ctx context.Context, _ *kingpin.ParseContext) error {
 	var err error
 
 	matchers, err := parseMatchers(c.matchers)
@@ -152,7 +152,7 @@ func (c *silenceAddCmd) add(ctx *kingpin.ParseContext) error {
 		return err
 	}
 	silenceAPI := client.NewSilenceAPI(apiClient)
-	silenceID, err := silenceAPI.Set(context.Background(), silence)
+	silenceID, err := silenceAPI.Set(ctx, silence)
 	if err != nil {
 		return err
 	}

--- a/cli/silence_expire.go
+++ b/cli/silence_expire.go
@@ -33,10 +33,10 @@ func configureSilenceExpireCmd(cc *kingpin.CmdClause) {
 		expireCmd = cc.Command("expire", "expire an alertmanager silence")
 	)
 	expireCmd.Arg("silence-ids", "Ids of silences to expire").StringsVar(&c.ids)
-	expireCmd.Action(c.expire)
+	expireCmd.Action(execWithTimeout(c.expire))
 }
 
-func (c *silenceExpireCmd) expire(ctx *kingpin.ParseContext) error {
+func (c *silenceExpireCmd) expire(ctx context.Context, _ *kingpin.ParseContext) error {
 	if len(c.ids) < 1 {
 		return errors.New("no silence IDs specified")
 	}
@@ -48,7 +48,7 @@ func (c *silenceExpireCmd) expire(ctx *kingpin.ParseContext) error {
 	silenceAPI := client.NewSilenceAPI(apiClient)
 
 	for _, id := range c.ids {
-		err := silenceAPI.Expire(context.Background(), id)
+		err := silenceAPI.Expire(ctx, id)
 		if err != nil {
 			return err
 		}

--- a/cli/silence_query.go
+++ b/cli/silence_query.go
@@ -88,10 +88,10 @@ func configureSilenceQueryCmd(cc *kingpin.CmdClause) {
 	queryCmd.Flag("quiet", "Only show silence ids").Short('q').BoolVar(&c.quiet)
 	queryCmd.Arg("matcher-groups", "Query filter").StringsVar(&c.matchers)
 	queryCmd.Flag("within", "Show silences that will expire or have expired within a duration").DurationVar(&c.within)
-	queryCmd.Action(c.query)
+	queryCmd.Action(execWithTimeout(c.query))
 }
 
-func (c *silenceQueryCmd) query(ctx *kingpin.ParseContext) error {
+func (c *silenceQueryCmd) query(ctx context.Context, _ *kingpin.ParseContext) error {
 	var filterString = ""
 	if len(c.matchers) == 1 {
 		// If the parser fails then we likely don't have a (=|=~|!=|!~) so lets
@@ -112,7 +112,7 @@ func (c *silenceQueryCmd) query(ctx *kingpin.ParseContext) error {
 		return err
 	}
 	silenceAPI := client.NewSilenceAPI(apiClient)
-	fetchedSilences, err := silenceAPI.List(context.Background(), filterString)
+	fetchedSilences, err := silenceAPI.List(ctx, filterString)
 	if err != nil {
 		return err
 	}

--- a/cli/silence_update.go
+++ b/cli/silence_update.go
@@ -49,10 +49,10 @@ func configureSilenceUpdateCmd(cc *kingpin.CmdClause) {
 	updateCmd.Flag("comment", "A comment to help describe the silence").Short('c').StringVar(&c.comment)
 	updateCmd.Arg("update-ids", "Silence IDs to update").StringsVar(&c.ids)
 
-	updateCmd.Action(c.update)
+	updateCmd.Action(execWithTimeout(c.update))
 }
 
-func (c *silenceUpdateCmd) update(ctx *kingpin.ParseContext) error {
+func (c *silenceUpdateCmd) update(ctx context.Context, _ *kingpin.ParseContext) error {
 	if len(c.ids) < 1 {
 		return fmt.Errorf("no silence IDs specified")
 	}
@@ -65,7 +65,7 @@ func (c *silenceUpdateCmd) update(ctx *kingpin.ParseContext) error {
 
 	var updatedSilences []types.Silence
 	for _, silenceID := range c.ids {
-		silence, err := silenceAPI.Get(context.Background(), silenceID)
+		silence, err := silenceAPI.Get(ctx, silenceID)
 		if err != nil {
 			return err
 		}
@@ -100,7 +100,7 @@ func (c *silenceUpdateCmd) update(ctx *kingpin.ParseContext) error {
 			silence.Comment = c.comment
 		}
 
-		newID, err := silenceAPI.Set(context.Background(), *silence)
+		newID, err := silenceAPI.Set(ctx, *silence)
 		if err != nil {
 			return err
 		}

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -14,12 +14,15 @@
 package cli
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/url"
 	"path"
 
 	"github.com/prometheus/alertmanager/client"
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+
 	"github.com/prometheus/alertmanager/pkg/parse"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
@@ -113,4 +116,13 @@ func TypeMatcher(matcher labels.Matcher) (types.Matcher, error) {
 		return types.Matcher{}, fmt.Errorf("invalid match type for creation operation: %s", matcher.Type)
 	}
 	return *typeMatcher, nil
+}
+
+// Helper function for adding the ctx with timeout into an action.
+func execWithTimeout(fn func(context.Context, *kingpin.ParseContext) error) func(*kingpin.ParseContext) error {
+	return func(x *kingpin.ParseContext) error {
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		return fn(ctx, x)
+	}
 }


### PR DESCRIPTION
implements https://github.com/prometheus/alertmanager/issues/1464

the whole global `timeout` and `execWithTimeout` are because I don't know how to parse a global variable and then access it from or pass it in to the different subcommand actions. I'm not too upset about having a global timeout variable since it will only affect one command per execution, but I would prefer to pass it in explicitly instead of doing this lame closure thing in `execWithTimeout`.

so, if you're more familiar with kingpin's api and know how to do this, I'm all ears :)