### PR TITLE
notify: Improve error handling

### DIFF
--- a/notify/impl_test.go
+++ b/notify/impl_test.go
@@ -232,7 +232,7 @@ func TestOpsGenie(t *testing.T) {
 	ctx := context.Background()
 	ctx = WithGroupKey(ctx, "1")
 
-	expectedUrl, _ := url.Parse("https://opsgenie/apiv2/alerts")
+	expectedURL, _ := url.Parse("https://opsgenie/apiv2/alerts")
 
 	// Empty alert.
 	alert1 := &types.Alert{
@@ -246,7 +246,7 @@ func TestOpsGenie(t *testing.T) {
 	req, retry, err := notifier.createRequest(ctx, alert1)
 	require.NoError(t, err)
 	require.Equal(t, true, retry)
-	require.Equal(t, expectedUrl, req.URL)
+	require.Equal(t, expectedURL, req.URL)
 	require.Equal(t, "GenieKey s3cr3t", req.Header.Get("Authorization"))
 	require.Equal(t, expectedBody, readBody(t, req))
 


### PR DESCRIPTION
- `tmplText` and `tmplHTML` are using a monad-style error handling [1].
This reduces the verbosity of the error logic, but introduces the risk
of forgetting the final error check. This patch does not remove this
coding-style, but ensures proper error checking in the Email and
PagerDuty notifier.

- Ensure to handle errors returned by `multipartWriter.Close()` and
`wc.Write(buffer.Bytes())` in `Email.Notify()`.

[1] https://www.innoq.com/en/blog/golang-errors-monads/

Follow up to https://github.com/prometheus/alertmanager/pull/1436#issuecomment-402711826