### PR TITLE
Email is green if no firing alerts

### DIFF
--- a/template/email.html
+++ b/template/email.html
@@ -323,7 +323,11 @@ a {
       <div class="content">
         <table class="main" width="100%" cellpadding="0" cellspacing="0">
           <tr>
+            {{ if gt (len .Alerts.Firing) 0 }}
             <td class="alert alert-warning">
+            {{ else }}
+            <td class="alert alert-good">
+            {{ end }}
               {{ .Alerts | len }} alert{{ if gt (len .Alerts) 1 }}s{{ end }} for {{ range .GroupLabels.SortedPairs }}
                 {{ .Name }}={{ .Value }} 
               {{ end }}


### PR DESCRIPTION
@stuartnelson3 

Emails that contain no firing alerts should not be red. This makes them green.

#859 was a past (never merged) attempt to do something similar, but this is simpler