### PR TITLE
config/test: Count `<secret>` occurrences via golang strings

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -257,9 +257,7 @@ func TestHideConfigSecrets(t *testing.T) {
 
 	// String method must not reveal authentication credentials.
 	s := c.String()
-	secretRe := regexp.MustCompile("<secret>")
-	matches := secretRe.FindAllStringIndex(s, -1)
-	if len(matches) != 14 || strings.Contains(s, "mysecret") {
+	if strings.Count(s, "<secret>") != 14 || strings.Contains(s, "mysecret") {
 		t.Fatal("config's String method reveals authentication credentials.")
 	}
 }


### PR DESCRIPTION
`honnef.co/go/tools/cmd/staticcheck` complains with
`config/config_test.go:260:32: regular expression does not contain any
meta characters (SA6004)`. Instead of using a RegEx this patch simply
switches to using Golangs `strings.Count` function.

This patch fixes our current CI failures, e.g. seen in https://github.com/prometheus/alertmanager/pull/1482.