### PR TITLE
Add cache control headers to the API responses to avoid IE caching th…

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -68,7 +68,7 @@ var corsHeaders = map[string]string{
 	"Access-Control-Allow-Methods":  "GET, DELETE, OPTIONS",
 	"Access-Control-Allow-Origin":   "*",
 	"Access-Control-Expose-Headers": "Date",
-	"Cache-Control": "no-cache, no-store, must-revalidate",
+	"Cache-Control":                 "no-cache, no-store, must-revalidate",
 }
 
 // Enables cross-site script calls.

--- a/api/api.go
+++ b/api/api.go
@@ -68,6 +68,7 @@ var corsHeaders = map[string]string{
 	"Access-Control-Allow-Methods":  "GET, DELETE, OPTIONS",
 	"Access-Control-Allow-Origin":   "*",
 	"Access-Control-Expose-Headers": "Date",
+	"Cache-Control": "no-cache, no-store, must-revalidate",
 }
 
 // Enables cross-site script calls.


### PR DESCRIPTION
Add cache-control headers to the API response so that IE won't cache the response. 

I've tested the change in IE and Chrome and checked that amtool continues to work after the change. 

Closes #1499 

First time PR. Be gentle! :)

@stuartnelson3 