### PR TITLE
pagerduty: allow custom url for v1 api

### DIFF
--- a/notify/impl.go
+++ b/notify/impl.go
@@ -477,7 +477,7 @@ func (n *PagerDuty) notifyV1(
 		Details:     details,
 	}
 
-	if n.conf.URL.String() == "https://events.pagerduty.com/v2/enqueue" {
+	if n.conf.URL == config.DefaultGlobalConfig.PagerdutyURL {
 		apiURL, err := url.Parse("https://events.pagerduty.com/generic/2010-04-15/create_event.json")
 		if err != nil {
 			return false, err

--- a/notify/impl.go
+++ b/notify/impl.go
@@ -477,11 +477,13 @@ func (n *PagerDuty) notifyV1(
 		Details:     details,
 	}
 
-	apiURL, err := url.Parse("https://events.pagerduty.com/generic/2010-04-15/create_event.json")
-	if err != nil {
-		return false, err
+	if n.conf.URL.String() == "https://events.pagerduty.com/v2/enqueue" {
+		apiURL, err := url.Parse("https://events.pagerduty.com/generic/2010-04-15/create_event.json")
+		if err != nil {
+			return false, err
+		}
+		n.conf.URL = &config.URL{apiURL}
 	}
-	n.conf.URL = &config.URL{apiURL}
 
 	if eventType == pagerDutyEventTrigger {
 		msg.Client = tmpl(n.conf.Client)


### PR DESCRIPTION
On the pagerduty v1 api codepath, the target url is always forced
to the default pagerduty url. This commit changes the logic so the
switch to the default v1 pagerduty url only happens if the url
hasn't already been overridden in configuration.

@stuartnelson3 please let me know if there are any adjustments you'd like me to make and I will do my best. We really enjoy using alertmanager at salesforce, and this change allows us to use our own internal endpoint that is compatible with pagerduty v1 api. Thanks for taking a look!