### PR TITLE
provider/mem: Add `Put` `Subscribe` starvation test

### DIFF
--- a/provider/mem/mem.go
+++ b/provider/mem/mem.go
@@ -22,6 +22,8 @@ import (
 	"github.com/prometheus/common/model"
 )
 
+const alertChannelLength = 200
+
 // Alerts gives access to a set of alerts. All methods are goroutine-safe.
 type Alerts struct {
 	mtx        sync.RWMutex
@@ -88,7 +90,7 @@ func (a *Alerts) Close() error {
 // They are not guaranteed to be in chronological order.
 func (a *Alerts) Subscribe() provider.AlertIterator {
 	var (
-		ch   = make(chan *types.Alert, 200)
+		ch   = make(chan *types.Alert, alertChannelLength)
 		done = make(chan struct{})
 	)
 	alerts, err := a.getPending()
@@ -125,7 +127,7 @@ func (a *Alerts) Subscribe() provider.AlertIterator {
 // pending notifications.
 func (a *Alerts) GetPending() provider.AlertIterator {
 	var (
-		ch   = make(chan *types.Alert, 200)
+		ch   = make(chan *types.Alert, alertChannelLength)
 		done = make(chan struct{})
 	)
 

--- a/provider/mem/mem_test.go
+++ b/provider/mem/mem_test.go
@@ -16,6 +16,7 @@ package mem
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"testing"
 	"time"
 
@@ -70,6 +71,63 @@ var (
 
 func init() {
 	pretty.CompareConfig.IncludeUnexported = true
+}
+
+// TestAlertsSubscribePutStarvation tests starvation of `iterator.Close` and
+// `alerts.Put`. Both `Subscribe` and `Put` use the Alerts.mtx lock. `Subscribe`
+// needs it to subscribe and more importantly unsubscribe `Alerts.listeners`. `Put`
+// uses the lock to add additional alerts and iterate the `Alerts.listeners` map.
+// If the channel of a listener is at its limit, `alerts.Lock` is blocked, whereby
+// a listener can not unsubscribe as the lock is hold by `alerts.Lock`.
+func TestAlertsSubscribePutStarvation(t *testing.T) {
+	marker := types.NewMarker()
+	alerts, err := NewAlerts(marker, 30*time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	iterator := alerts.Subscribe()
+
+	alertsToInsert := []*types.Alert{}
+	// Exhaust alert channel
+	for i := 0; i < alertChannelLength+1; i++ {
+		alertsToInsert = append(alertsToInsert, &types.Alert{
+			Alert: model.Alert{
+				// Make sure the fingerprints differ
+				Labels:       model.LabelSet{"iteration": model.LabelValue(strconv.Itoa(i))},
+				Annotations:  model.LabelSet{"foo": "bar"},
+				StartsAt:     t0,
+				EndsAt:       t1,
+				GeneratorURL: "http://example.com/prometheus",
+			},
+			UpdatedAt: t0,
+			Timeout:   false,
+		})
+	}
+
+	putIsDone := make(chan struct{})
+	putsErr := make(chan error, 1)
+	go func() {
+		if err := alerts.Put(alertsToInsert...); err != nil {
+			putsErr <- err
+			return
+		}
+
+		putIsDone <- struct{}{}
+	}()
+
+	// Increase probability that `iterator.Close` is called after `alerts.Put`.
+	time.Sleep(100 * time.Millisecond)
+	iterator.Close()
+
+	select {
+	case <-putsErr:
+		t.Fatal(err)
+	case <-putIsDone:
+		// continue
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected `alerts.Put` and `iterator.Close` not to starve each other")
+	}
 }
 
 func TestAlertsPut(t *testing.T) {


### PR DESCRIPTION
TestAlertsSubscribePutStarvation tests starvation of `iterator.Close` and
`alerts.Put`. Both `Subscribe` and `Put` use the Alerts.mtx lock. `Subscribe`
needs it to subscribe and more importantly unsubscribe `Alerts.listeners`.
`Put` uses the lock to add additional alerts and iterate the `Alerts.listeners`
map.  If the channel of a listener is at its limit, `alerts.Lock` is blocked,
whereby a listener can not unsubscribe as the lock is hold by `alerts.Lock`.

This test will succeed once https://github.com/prometheus/alertmanager/pull/1482 is merged.


//CC @waterdrink @s-urbaniak @simonpasquier @stuartnelson3