### PR TITLE
Correctly encode query strings in notifiers

### DIFF
--- a/notify/impl.go
+++ b/notify/impl.go
@@ -805,7 +805,10 @@ func (n *Hipchat) Notify(ctx context.Context, as ...*types.Alert) (bool, error) 
 		roomid   = tmplText(n.conf.RoomID)
 		apiURL   = n.conf.APIURL.Copy()
 	)
-	apiURL.Path += fmt.Sprintf("v2/room/%s/notification?auth_token=%s", roomid, n.conf.AuthToken)
+	apiURL.Path += fmt.Sprintf("v2/room/%s/notification", roomid)
+	q := apiURL.Query()
+	q.Set("auth_token", fmt.Sprintf("%s", n.conf.AuthToken))
+	apiURL.RawQuery = q.Encode()
 
 	if n.conf.MessageFormat == "html" {
 		msg = tmplHTML(n.conf.Message)
@@ -976,7 +979,10 @@ func (n *Wechat) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 	}
 
 	postMessageURL := n.conf.APIURL.Copy()
-	postMessageURL.Path += "message/send?access_token=" + n.accessToken
+	postMessageURL.Path += "message/send"
+	q := postMessageURL.Query()
+	q.Set("access_token", n.accessToken)
+	postMessageURL.RawQuery = q.Encode()
 
 	req, err := http.NewRequest(http.MethodPost, postMessageURL.String(), &buf)
 	if err != nil {
@@ -1106,7 +1112,10 @@ func (n *OpsGenie) createRequest(ctx context.Context, as ...*types.Alert) (*http
 	)
 	switch alerts.Status() {
 	case model.AlertResolved:
-		apiURL.Path += fmt.Sprintf("v2/alerts/%s/close?identifierType=alias", alias)
+		apiURL.Path += fmt.Sprintf("v2/alerts/%s/close", alias)
+		q := apiURL.Query()
+		q.Set("identifierType", "alias")
+		apiURL.RawQuery = q.Encode()
 		msg = &opsGenieCloseMessage{Source: tmpl(n.conf.Source)}
 	default:
 		message := tmpl(n.conf.Message)


### PR DESCRIPTION
In moving from a plain string to url.URL, we
incorrectly were setting the query string via the
path. The `?` signaling the start of the query
string would then be escaped when the URL was
turned into a string.

@mxinden @simonpasquier I would classify this as extremely important, we should get a release out as soon as this is merged IMO. I'm guessing hipchat, wechat, and opsgenie are all broken?

Fixes #1515 