### PR TITLE
fix amtool: Fixed config path check in amtool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [CHANGE] Revert Alertmanager working directory changes in Docker image back to `/alertmanager` (#1435)
 * [CHANGE] Remove `api/v1/alerts/groups` GET endpoint (#1508)
 * [FEATURE] [amtool] Added `config routes` tools for vizualization and testing routes (#1511)
+* [BUGFIX] [amtool] Fixed issue with loading path of a default configs (#1529)
 
 ## 0.15.2 / 2018-08-14
 

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -34,6 +34,9 @@ type Resolver struct {
 func NewResolver(files []string, legacyFlags map[string]string) (*Resolver, error) {
 	flags := map[string]string{}
 	for _, f := range files {
+		if _, err := os.Stat(f); err != nil {
+			continue
+		}
 		b, err := ioutil.ReadFile(f)
 		if err != nil {
 			if os.IsNotExist(err) {


### PR DESCRIPTION
Fixes https://github.com/prometheus/alertmanager/issues/1529

If `~/.config/amtool` path is file amtool fails on any command. This adds `os.Stat` check before loading the file as sugested by @simonpasquier .

