### PR TITLE
test: don't run TestResolved() in parallel

### DIFF
--- a/test/with_api_v1/acceptance/send_test.go
+++ b/test/with_api_v1/acceptance/send_test.go
@@ -271,7 +271,7 @@ receivers:
 func TestResolved(t *testing.T) {
 	t.Parallel()
 
-	ch := make(chan struct{}, 2)
+	ch := make(chan struct{}, 1)
 	for i := 0; i < 10; i++ {
 		ch <- struct{}{}
 		go func() {

--- a/test/with_api_v1/acceptance/send_test.go
+++ b/test/with_api_v1/acceptance/send_test.go
@@ -271,12 +271,8 @@ receivers:
 func TestResolved(t *testing.T) {
 	t.Parallel()
 
-	ch := make(chan struct{}, 1)
-	for i := 0; i < 10; i++ {
-		ch <- struct{}{}
-		go func() {
-			defer func() { <-ch }()
-			conf := `
+	for i := 0; i < 2; i++ {
+		conf := `
 global:
   resolve_timeout: 10s
 
@@ -292,38 +288,33 @@ receivers:
   - url: 'http://%s'
 `
 
-			at := NewAcceptanceTest(t, &AcceptanceOpts{
-				Tolerance: 150 * time.Millisecond,
-			})
+		at := NewAcceptanceTest(t, &AcceptanceOpts{
+			Tolerance: 150 * time.Millisecond,
+		})
 
-			co := at.Collector("webhook")
-			wh := NewWebhook(co)
+		co := at.Collector("webhook")
+		wh := NewWebhook(co)
 
-			am := at.Alertmanager(fmt.Sprintf(conf, wh.Address()))
+		am := at.Alertmanager(fmt.Sprintf(conf, wh.Address()))
 
-			am.Push(At(1),
-				Alert("alertname", "test", "lbl", "v1"),
-				Alert("alertname", "test", "lbl", "v2"),
-				Alert("alertname", "test", "lbl", "v3"),
-			)
+		am.Push(At(1),
+			Alert("alertname", "test", "lbl", "v1"),
+			Alert("alertname", "test", "lbl", "v2"),
+			Alert("alertname", "test", "lbl", "v3"),
+		)
 
-			co.Want(Between(2, 2.5),
-				Alert("alertname", "test", "lbl", "v1").Active(1),
-				Alert("alertname", "test", "lbl", "v2").Active(1),
-				Alert("alertname", "test", "lbl", "v3").Active(1),
-			)
-			co.Want(Between(12, 13),
-				Alert("alertname", "test", "lbl", "v1").Active(1, 11),
-				Alert("alertname", "test", "lbl", "v2").Active(1, 11),
-				Alert("alertname", "test", "lbl", "v3").Active(1, 11),
-			)
+		co.Want(Between(2, 2.5),
+			Alert("alertname", "test", "lbl", "v1").Active(1),
+			Alert("alertname", "test", "lbl", "v2").Active(1),
+			Alert("alertname", "test", "lbl", "v3").Active(1),
+		)
+		co.Want(Between(12, 13),
+			Alert("alertname", "test", "lbl", "v1").Active(1, 11),
+			Alert("alertname", "test", "lbl", "v2").Active(1, 11),
+			Alert("alertname", "test", "lbl", "v3").Active(1, 11),
+		)
 
-			at.Run()
-		}()
-	}
-
-	for i := 0; i < cap(ch); i++ {
-		ch <- struct{}{}
+		at.Run()
 	}
 }
 

--- a/test/with_api_v1/acceptance/send_test.go
+++ b/test/with_api_v1/acceptance/send_test.go
@@ -269,9 +269,9 @@ receivers:
 }
 
 func TestResolved(t *testing.T) {
-	//TODO: run this test in parallel with other tests. For now it causes test failures on Travis CI.
-	ch := make(chan struct{}, 2)
+	t.Parallel()
 
+	ch := make(chan struct{}, 2)
 	for i := 0; i < 10; i++ {
 		ch <- struct{}{}
 		go func() {

--- a/test/with_api_v1/acceptance/send_test.go
+++ b/test/with_api_v1/acceptance/send_test.go
@@ -270,7 +270,7 @@ receivers:
 }
 
 func TestResolved(t *testing.T) {
-	t.Parallel()
+	//TODO: run this test in parallel with other tests. For now it causes test failures on Travis CI.
 
 	var wg sync.WaitGroup
 	wg.Add(10)

--- a/test/with_api_v2/acceptance/send_test.go
+++ b/test/with_api_v2/acceptance/send_test.go
@@ -271,7 +271,7 @@ receivers:
 func TestResolved(t *testing.T) {
 	t.Parallel()
 
-	ch := make(chan struct{}, 2)
+	ch := make(chan struct{}, 1)
 	for i := 0; i < 10; i++ {
 		ch <- struct{}{}
 		go func() {

--- a/test/with_api_v2/acceptance/send_test.go
+++ b/test/with_api_v2/acceptance/send_test.go
@@ -271,12 +271,8 @@ receivers:
 func TestResolved(t *testing.T) {
 	t.Parallel()
 
-	ch := make(chan struct{}, 1)
-	for i := 0; i < 10; i++ {
-		ch <- struct{}{}
-		go func() {
-			defer func() { <-ch }()
-			conf := `
+	for i := 0; i < 2; i++ {
+		conf := `
 global:
   resolve_timeout: 10s
 
@@ -292,38 +288,33 @@ receivers:
   - url: 'http://%s'
 `
 
-			at := NewAcceptanceTest(t, &AcceptanceOpts{
-				Tolerance: 150 * time.Millisecond,
-			})
+		at := NewAcceptanceTest(t, &AcceptanceOpts{
+			Tolerance: 150 * time.Millisecond,
+		})
 
-			co := at.Collector("webhook")
-			wh := NewWebhook(co)
+		co := at.Collector("webhook")
+		wh := NewWebhook(co)
 
-			am := at.Alertmanager(fmt.Sprintf(conf, wh.Address()))
+		am := at.Alertmanager(fmt.Sprintf(conf, wh.Address()))
 
-			am.Push(At(1),
-				Alert("alertname", "test", "lbl", "v1"),
-				Alert("alertname", "test", "lbl", "v2"),
-				Alert("alertname", "test", "lbl", "v3"),
-			)
+		am.Push(At(1),
+			Alert("alertname", "test", "lbl", "v1"),
+			Alert("alertname", "test", "lbl", "v2"),
+			Alert("alertname", "test", "lbl", "v3"),
+		)
 
-			co.Want(Between(2, 2.5),
-				Alert("alertname", "test", "lbl", "v1").Active(1),
-				Alert("alertname", "test", "lbl", "v2").Active(1),
-				Alert("alertname", "test", "lbl", "v3").Active(1),
-			)
-			co.Want(Between(12, 13),
-				Alert("alertname", "test", "lbl", "v1").Active(1, 11),
-				Alert("alertname", "test", "lbl", "v2").Active(1, 11),
-				Alert("alertname", "test", "lbl", "v3").Active(1, 11),
-			)
+		co.Want(Between(2, 2.5),
+			Alert("alertname", "test", "lbl", "v1").Active(1),
+			Alert("alertname", "test", "lbl", "v2").Active(1),
+			Alert("alertname", "test", "lbl", "v3").Active(1),
+		)
+		co.Want(Between(12, 13),
+			Alert("alertname", "test", "lbl", "v1").Active(1, 11),
+			Alert("alertname", "test", "lbl", "v2").Active(1, 11),
+			Alert("alertname", "test", "lbl", "v3").Active(1, 11),
+		)
 
-			at.Run()
-		}()
-	}
-
-	for i := 0; i < cap(ch); i++ {
-		ch <- struct{}{}
+		at.Run()
 	}
 }
 

--- a/test/with_api_v2/acceptance/send_test.go
+++ b/test/with_api_v2/acceptance/send_test.go
@@ -269,9 +269,9 @@ receivers:
 }
 
 func TestResolved(t *testing.T) {
-	//TODO: run this test in parallel with other tests. For now it causes test failures on Travis CI.
-	ch := make(chan struct{}, 2)
+	t.Parallel()
 
+	ch := make(chan struct{}, 2)
 	for i := 0; i < 10; i++ {
 		ch <- struct{}{}
 		go func() {

--- a/test/with_api_v2/acceptance/send_test.go
+++ b/test/with_api_v2/acceptance/send_test.go
@@ -270,7 +270,7 @@ receivers:
 }
 
 func TestResolved(t *testing.T) {
-	t.Parallel()
+	//TODO: run this test in parallel with other tests. For now it causes test failures on Travis CI.
 
 	var wg sync.WaitGroup
 	wg.Add(10)


### PR DESCRIPTION
Recently Travis CI started failing tests quite often (#1532 and #1543 for instance). In particular `TestResolved()` fails because the notifications aren't received in the expected timeframe (tolerance is 150ms).