### PR TITLE
Add support for images and links in the PagerDuty notification config

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -203,10 +203,25 @@ type PagerdutyConfig struct {
 	ClientURL   string            `yaml:"client_url,omitempty" json:"client_url,omitempty"`
 	Description string            `yaml:"description,omitempty" json:"description,omitempty"`
 	Details     map[string]string `yaml:"details,omitempty" json:"details,omitempty"`
+	Images      []PagerdutyImage  `yaml:"images,omitempty" json:"images,omitempty"`
+	Links       []PagerdutyLink   `yaml:"links,omitempty" json:"links,omitempty"`
 	Severity    string            `yaml:"severity,omitempty" json:"severity,omitempty"`
 	Class       string            `yaml:"class,omitempty" json:"class,omitempty"`
 	Component   string            `yaml:"component,omitempty" json:"component,omitempty"`
 	Group       string            `yaml:"group,omitempty" json:"group,omitempty"`
+}
+
+// PagerdutyLink is a link
+type PagerdutyLink struct {
+	HRef string `json:"href"`
+	Text string `json:"text"`
+}
+
+// PagerdutyImage is an image
+type PagerdutyImage struct {
+	Src  string `json:"src"`
+	Alt  string `json:"alt"`
+	Text string `json:"text"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -213,15 +213,15 @@ type PagerdutyConfig struct {
 
 // PagerdutyLink is a link
 type PagerdutyLink struct {
-	HRef string `json:"href"`
-	Text string `json:"text"`
+	HRef string `yaml:"href,omitempty" json:"href,omitempty"`
+	Text string `yaml:"text,omitempty" json:"text,omitempty"`
 }
 
 // PagerdutyImage is an image
 type PagerdutyImage struct {
-	Src  string `json:"src"`
-	Alt  string `json:"alt"`
-	Text string `json:"text"`
+	Src  string `yaml:"src,omitempty" json:"src,omitempty"`
+	Alt  string `yaml:"alt,omitempty" json:"alt,omitempty"`
+	Text string `yaml:"text,omitempty" json:"text,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/notify/impl.go
+++ b/notify/impl.go
@@ -554,50 +554,14 @@ func (n *PagerDuty) notifyV2(
 		n.conf.Severity = "error"
 	}
 
-	images := make([]pagerDutyImage, len(n.conf.Images))
-	for index, item := range n.conf.Images {
-		text, err := n.tmpl.ExecuteTextString(item.Text, data)
-		if err != nil {
-			return false, fmt.Errorf("failed to template %q: %v", item.Text, err)
-		}
-		images[index].Text = text
-
-		alt, err := n.tmpl.ExecuteTextString(item.Alt, data)
-		if err != nil {
-			return false, fmt.Errorf("failed to template %q: %v", item.Alt, err)
-		}
-		images[index].Alt = alt
-
-		src, err := n.tmpl.ExecuteTextString(item.Src, data)
-		if err != nil {
-			return false, fmt.Errorf("failed to template %q: %v", item.Src, err)
-		}
-		images[index].Src = src
-	}
-
-	links := make([]pagerDutyLink, len(n.conf.Links))
-	for index, item := range n.conf.Links {
-		text, err := n.tmpl.ExecuteTextString(item.Text, data)
-		if err != nil {
-			return false, fmt.Errorf("failed to template %q: %v", item.Text, err)
-		}
-		links[index].Text = text
-
-		href, err := n.tmpl.ExecuteTextString(item.HRef, data)
-		if err != nil {
-			return false, fmt.Errorf("failed to template %q: %v", item.HRef, err)
-		}
-		links[index].HRef = href
-	}
-
 	msg := &pagerDutyMessage{
 		Client:      tmpl(n.conf.Client),
 		ClientURL:   tmpl(n.conf.ClientURL),
 		RoutingKey:  tmpl(string(n.conf.RoutingKey)),
 		EventAction: eventType,
 		DedupKey:    hashKey(key),
-		Images:      images,
-		Links:       links,
+		Images:      make([]pagerDutyImage, len(n.conf.Images)),
+		Links:       make([]pagerDutyLink, len(n.conf.Links)),
 		Payload: &pagerDutyPayload{
 			Summary:       tmpl(n.conf.Description),
 			Source:        tmpl(n.conf.Client),
@@ -607,6 +571,17 @@ func (n *PagerDuty) notifyV2(
 			Component:     tmpl(n.conf.Component),
 			Group:         tmpl(n.conf.Group),
 		},
+	}
+
+	for index, item := range n.conf.Images {
+		msg.Images[index].Src = tmpl(item.Src)
+		msg.Images[index].Alt = tmpl(item.Alt)
+		msg.Images[index].Text = tmpl(item.Text)
+	}
+
+	for index, item := range n.conf.Links {
+		msg.Links[index].HRef = tmpl(item.HRef)
+		msg.Links[index].Text = tmpl(item.Text)
 	}
 
 	if tmplErr != nil {

--- a/notify/impl.go
+++ b/notify/impl.go
@@ -545,8 +545,6 @@ func (n *PagerDuty) notifyV2(
 	eventType, key string,
 	data *template.Data,
 	details map[string]string,
-	images []pagerDutyImage,
-	links []pagerDutyLink,
 	as ...*types.Alert,
 ) (bool, error) {
 	var tmplErr error
@@ -554,6 +552,42 @@ func (n *PagerDuty) notifyV2(
 
 	if n.conf.Severity == "" {
 		n.conf.Severity = "error"
+	}
+
+	images := make([]pagerDutyImage, len(n.conf.Images))
+	for index, item := range n.conf.Images {
+		text, err := n.tmpl.ExecuteTextString(item.Text, data)
+		if err != nil {
+			return false, fmt.Errorf("failed to template %q: %v", item.Text, err)
+		}
+		images[index].Text = text
+
+		alt, err := n.tmpl.ExecuteTextString(item.Alt, data)
+		if err != nil {
+			return false, fmt.Errorf("failed to template %q: %v", item.Alt, err)
+		}
+		images[index].Alt = alt
+
+		src, err := n.tmpl.ExecuteTextString(item.Src, data)
+		if err != nil {
+			return false, fmt.Errorf("failed to template %q: %v", item.Src, err)
+		}
+		images[index].Src = src
+	}
+
+	links := make([]pagerDutyLink, len(n.conf.Links))
+	for index, item := range n.conf.Links {
+		text, err := n.tmpl.ExecuteTextString(item.Text, data)
+		if err != nil {
+			return false, fmt.Errorf("failed to template %q: %v", item.Text, err)
+		}
+		links[index].Text = text
+
+		href, err := n.tmpl.ExecuteTextString(item.HRef, data)
+		if err != nil {
+			return false, fmt.Errorf("failed to template %q: %v", item.HRef, err)
+		}
+		links[index].HRef = href
 	}
 
 	msg := &pagerDutyMessage{
@@ -623,42 +657,6 @@ func (n *PagerDuty) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 		details[k] = detail
 	}
 
-	images := make([]pagerDutyImage, len(n.conf.Images))
-	for index, item := range n.conf.Images {
-		text, err := n.tmpl.ExecuteTextString(item.Text, data)
-		if err != nil {
-			return false, fmt.Errorf("failed to template %q: %v", item.Text, err)
-		}
-		images[index].Text = text
-
-		alt, err := n.tmpl.ExecuteTextString(item.Alt, data)
-		if err != nil {
-			return false, fmt.Errorf("failed to template %q: %v", item.Alt, err)
-		}
-		images[index].Alt = alt
-
-		src, err := n.tmpl.ExecuteTextString(item.Src, data)
-		if err != nil {
-			return false, fmt.Errorf("failed to template %q: %v", item.Src, err)
-		}
-		images[index].Src = src
-	}
-
-	links := make([]pagerDutyLink, len(n.conf.Links))
-	for index, item := range n.conf.Links {
-		text, err := n.tmpl.ExecuteTextString(item.Text, data)
-		if err != nil {
-			return false, fmt.Errorf("failed to template %q: %v", item.Text, err)
-		}
-		links[index].Text = text
-
-		href, err := n.tmpl.ExecuteTextString(item.HRef, data)
-		if err != nil {
-			return false, fmt.Errorf("failed to template %q: %v", item.HRef, err)
-		}
-		links[index].HRef = href
-	}
-
 	if err != nil {
 		return false, err
 	}
@@ -671,7 +669,7 @@ func (n *PagerDuty) Notify(ctx context.Context, as ...*types.Alert) (bool, error
 	if n.conf.ServiceKey != "" {
 		return n.notifyV1(ctx, c, eventType, key, data, details, as...)
 	}
-	return n.notifyV2(ctx, c, eventType, key, data, details, images, links, as...)
+	return n.notifyV2(ctx, c, eventType, key, data, details, as...)
 }
 
 func (n *PagerDuty) retryV1(resp *http.Response) (bool, error) {


### PR DESCRIPTION
This pull request adds two additional fields (images and links) to the data sent to PagerDuty. Users can either provide a static value in the config or provide template strings which allows values to come from the alert definitions and labels themselves.

Note that this only works when using the v2 API. It could be implemented in the v1 api but it has been deprecated so it's probably not worth it.

I've tested it with both static and template values using my PagerDuty instance.