### PR TITLE
test: Enable testing against cluster of Alertmanagers

### DIFF
--- a/test/with_api_v2/acceptance.go
+++ b/test/with_api_v2/acceptance.go
@@ -30,6 +30,7 @@ import (
 
 	apiclient "github.com/prometheus/alertmanager/test/with_api_v2/api_v2_client/client"
 	"github.com/prometheus/alertmanager/test/with_api_v2/api_v2_client/client/alert"
+	"github.com/prometheus/alertmanager/test/with_api_v2/api_v2_client/client/general"
 	"github.com/prometheus/alertmanager/test/with_api_v2/api_v2_client/models"
 
 	httptransport "github.com/go-openapi/runtime/client"
@@ -44,7 +45,7 @@ type AcceptanceTest struct {
 
 	opts *AcceptanceOpts
 
-	ams        []*Alertmanager
+	amc        *AlertmanagerCluster
 	collectors []*Collector
 
 	actions map[float64][]func()
@@ -83,6 +84,9 @@ func NewAcceptanceTest(t *testing.T, opts *AcceptanceOpts) *AcceptanceTest {
 		opts:    opts,
 		actions: map[float64][]func(){},
 	}
+	// TODO: Should this really be set during creation time? Why not do this
+	// during Run() time, maybe there is something else long happening between
+	// creation and running.
 	opts.baseTime = time.Now()
 
 	return test
@@ -110,38 +114,42 @@ func (t *AcceptanceTest) Do(at float64, f func()) {
 	t.actions[at] = append(t.actions[at], f)
 }
 
-// Alertmanager returns a new structure that allows starting an instance
-// of Alertmanager on a random port.
-func (t *AcceptanceTest) Alertmanager(conf string) *Alertmanager {
-	am := &Alertmanager{
-		t:    t,
-		opts: t.opts,
+// AlertmanagerCluster returns a new AlertmanagerCluster that allows starting a
+// cluster of Alertmanager instances on random ports.
+func (t *AcceptanceTest) AlertmanagerCluster(conf string, size int) *AlertmanagerCluster {
+	amc := AlertmanagerCluster{}
+
+	for i := 0; i < size; i++ {
+		am := &Alertmanager{
+			t:    t,
+			opts: t.opts,
+		}
+
+		dir, err := ioutil.TempDir("", "am_test")
+		if err != nil {
+			t.Fatal(err)
+		}
+		am.dir = dir
+
+		cf, err := os.Create(filepath.Join(dir, "config.yml"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		am.confFile = cf
+		am.UpdateConfig(conf)
+
+		am.apiAddr = freeAddress()
+		am.clusterAddr = freeAddress()
+
+		transport := httptransport.New(am.apiAddr, "/api/v2/", nil)
+		am.clientV2 = apiclient.New(transport, strfmt.Default)
+
+		amc.ams = append(amc.ams, am)
 	}
 
-	dir, err := ioutil.TempDir("", "am_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	am.dir = dir
+	t.amc = &amc
 
-	cf, err := os.Create(filepath.Join(dir, "config.yml"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	am.confFile = cf
-	am.UpdateConfig(conf)
-
-	am.apiAddr = freeAddress()
-	am.clusterAddr = freeAddress()
-
-	t.Logf("AM on %s", am.apiAddr)
-
-	transport := httptransport.New(am.apiAddr, "/api/v2/", nil)
-	am.clientV2 = apiclient.New(transport, strfmt.Default)
-
-	t.ams = append(t.ams, am)
-
-	return am
+	return &amc
 }
 
 // Collector returns a new collector bound to the test instance.
@@ -163,16 +171,19 @@ func (t *AcceptanceTest) Collector(name string) *Collector {
 func (t *AcceptanceTest) Run() {
 	errc := make(chan error)
 
-	for _, am := range t.ams {
+	for _, am := range t.amc.ams {
 		am.errc = errc
-
-		am.Start()
 		defer func(am *Alertmanager) {
 			am.Terminate()
 			am.cleanup()
 			t.Logf("stdout:\n%v", am.cmd.Stdout)
 			t.Logf("stderr:\n%v", am.cmd.Stderr)
 		}(am)
+	}
+
+	err := t.amc.Start()
+	if err != nil {
+		t.T.Fatal(err)
 	}
 
 	go t.runActions()
@@ -191,11 +202,6 @@ func (t *AcceptanceTest) Run() {
 		// continue
 	case err := <-errc:
 		t.Error(err)
-	}
-
-	for _, coll := range t.collectors {
-		report := coll.check()
-		t.Log(report)
 	}
 }
 
@@ -252,16 +258,49 @@ type Alertmanager struct {
 	errc chan<- error
 }
 
+// AlertmanagerCluster represents a group of Alertmanager instances
+// acting as a cluster.
+type AlertmanagerCluster struct {
+	ams []*Alertmanager
+}
+
+// Start the Alertmanager cluster and wait until it is ready to receive.
+func (amc *AlertmanagerCluster) Start() error {
+	var peerFlags []string
+	for _, am := range amc.ams {
+		peerFlags = append(peerFlags, "--cluster.peer="+am.clusterAddr)
+	}
+
+	for _, am := range amc.ams {
+		err := am.Start(peerFlags)
+		if err != nil {
+			return fmt.Errorf("starting alertmanager cluster: %v", err.Error())
+		}
+	}
+
+	for _, am := range amc.ams {
+		err := am.WaitForCluster(len(amc.ams))
+		if err != nil {
+			return fmt.Errorf("starting alertmanager cluster: %v", err.Error())
+		}
+	}
+
+	return nil
+}
+
 // Start the alertmanager and wait until it is ready to receive.
-func (am *Alertmanager) Start() {
-	cmd := exec.Command("../../../alertmanager",
+func (am *Alertmanager) Start(additionalArg []string) error {
+	args := []string{
 		"--config.file", am.confFile.Name(),
 		"--log.level", "debug",
 		"--web.listen-address", am.apiAddr,
 		"--storage.path", am.dir,
 		"--cluster.listen-address", am.clusterAddr,
 		"--cluster.settle-timeout", "0s",
-	)
+	}
+	args = append(args, additionalArg...)
+
+	cmd := exec.Command("../../../alertmanager", args...)
 
 	if am.cmd == nil {
 		var outb, errb buffer
@@ -274,7 +313,7 @@ func (am *Alertmanager) Start() {
 	am.cmd = cmd
 
 	if err := am.cmd.Start(); err != nil {
-		am.t.Fatalf("Starting alertmanager failed: %s", err)
+		return fmt.Errorf("starting alertmanager failed: %s", err)
 	}
 
 	go func() {
@@ -289,14 +328,50 @@ func (am *Alertmanager) Start() {
 		if err == nil {
 			_, err := ioutil.ReadAll(resp.Body)
 			if err != nil {
-				am.t.Fatalf("Starting alertmanager failed: %s", err)
+				return fmt.Errorf("starting alertmanager failed: %s", err)
 			}
 			resp.Body.Close()
-			return
+			return nil
 		}
 		time.Sleep(500 * time.Millisecond)
 	}
-	am.t.Fatalf("Starting alertmanager failed: timeout")
+	return fmt.Errorf("starting alertmanager failed: timeout")
+}
+
+// WaitForCluster waits for the Alertmanager instance to join a cluster with the
+// given size.
+func (am *Alertmanager) WaitForCluster(size int) error {
+	params := general.NewGetStatusParams()
+	params.WithContext(context.Background())
+	var status general.GetStatusOK
+
+	// Poll for 2s
+	for i := 0; i < 20; i++ {
+		status, err := am.clientV2.General.GetStatus(params)
+		if err != nil {
+			return err
+		}
+
+		if len(status.Payload.Peers) == size {
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	return fmt.Errorf(
+		"failed to wait for Alertmanager instance %q to join cluster: expected %v peers, but got %v",
+		am.clusterAddr,
+		size,
+		len(status.Payload.Peers),
+	)
+}
+
+// Terminate kills the underlying Alertmanager cluster processes and removes intermediate
+// data.
+func (amc *AlertmanagerCluster) Terminate() {
+	for _, am := range amc.ams {
+		am.Terminate()
+	}
 }
 
 // Terminate kills the underlying Alertmanager process and remove intermediate
@@ -307,6 +382,13 @@ func (am *Alertmanager) Terminate() {
 	}
 }
 
+// Reload sends the reloading signal to the Alertmanager instances.
+func (amc *AlertmanagerCluster) Reload() {
+	for _, am := range amc.ams {
+		am.Reload()
+	}
+}
+
 // Reload sends the reloading signal to the Alertmanager process.
 func (am *Alertmanager) Reload() {
 	if err := syscall.Kill(am.cmd.Process.Pid, syscall.SIGHUP); err != nil {
@@ -314,9 +396,23 @@ func (am *Alertmanager) Reload() {
 	}
 }
 
+func (amc *AlertmanagerCluster) cleanup() {
+	for _, am := range amc.ams {
+		am.cleanup()
+	}
+}
+
 func (am *Alertmanager) cleanup() {
 	if err := os.RemoveAll(am.confFile.Name()); err != nil {
 		am.t.Errorf("Error removing test config file %q: %v", am.confFile.Name(), err)
+	}
+}
+
+// Push declares alerts that are to be pushed to the Alertmanager
+// servers at a relative point in time.
+func (amc *AlertmanagerCluster) Push(at float64, alerts ...*TestAlert) {
+	for _, am := range amc.ams {
+		am.Push(at, alerts...)
 	}
 }
 
@@ -344,6 +440,13 @@ func (am *Alertmanager) Push(at float64, alerts ...*TestAlert) {
 			am.t.Errorf("Error pushing %v: %s", cas, err)
 		}
 	})
+}
+
+// SetSilence updates or creates the given Silence.
+func (amc *AlertmanagerCluster) SetSilence(at float64, sil *TestSilence) {
+	for _, am := range amc.ams {
+		am.SetSilence(at, sil)
+	}
 }
 
 // SetSilence updates or creates the given Silence.
@@ -382,6 +485,13 @@ func (am *Alertmanager) SetSilence(at float64, sil *TestSilence) {
 }
 
 // DelSilence deletes the silence with the sid at the given time.
+func (amc *AlertmanagerCluster) DelSilence(at float64, sil *TestSilence) {
+	for _, am := range amc.ams {
+		am.DelSilence(at, sil)
+	}
+}
+
+// DelSilence deletes the silence with the sid at the given time.
 func (am *Alertmanager) DelSilence(at float64, sil *TestSilence) {
 	am.t.Do(at, func() {
 		req, err := http.NewRequest("DELETE", fmt.Sprintf("http://%s/api/v1/silence/%s", am.apiAddr, sil.ID()), nil)
@@ -398,6 +508,14 @@ func (am *Alertmanager) DelSilence(at float64, sil *TestSilence) {
 	})
 }
 
+// UpdateConfig rewrites the configuration file for the Alertmanager cluster. It
+// does not initiate config reloading.
+func (amc *AlertmanagerCluster) UpdateConfig(conf string) {
+	for _, am := range amc.ams {
+		am.UpdateConfig(conf)
+	}
+}
+
 // UpdateConfig rewrites the configuration file for the Alertmanager. It does not
 // initiate config reloading.
 func (am *Alertmanager) UpdateConfig(conf string) {
@@ -408,6 +526,14 @@ func (am *Alertmanager) UpdateConfig(conf string) {
 	if err := am.confFile.Sync(); err != nil {
 		am.t.Fatal(err)
 		return
+	}
+}
+
+// GenericAPIV2Call takes a time slot and a function to run against the API v2
+// TODO: Can this be removed?
+func (amc *AlertmanagerCluster) GenericAPIV2Call(at float64, f func()) {
+	for _, am := range amc.ams {
+		am.GenericAPIV2Call(at, f)
 	}
 }
 

--- a/test/with_api_v2/acceptance/cluster_test.go
+++ b/test/with_api_v2/acceptance/cluster_test.go
@@ -1,0 +1,125 @@
+// Copyright 2018 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	a "github.com/prometheus/alertmanager/test/with_api_v2"
+)
+
+// TestClusterDeduplication tests, that in an Alertmanager cluster of 3
+// instances, only one should send a notification for a given alert.
+func TestClusterDeduplication(t *testing.T) {
+	t.Parallel()
+
+	conf := `
+route:
+  receiver: "default"
+  group_by: []
+  group_wait:      1s
+  group_interval:  1s
+  repeat_interval: 1h
+
+receivers:
+- name: "default"
+  webhook_configs:
+  - url: 'http://%s'
+`
+
+	at := a.NewAcceptanceTest(t, &a.AcceptanceOpts{
+		Tolerance: 1 * time.Second,
+	})
+	co := at.Collector("webhook")
+	wh := a.NewWebhook(co)
+
+	amc := at.AlertmanagerCluster(fmt.Sprintf(conf, wh.Address()), 3)
+
+	amc.Push(a.At(1), a.Alert("alertname", "test1"))
+
+	co.Want(a.Between(2, 3), a.Alert("alertname", "test1").Active(1))
+
+	at.Run()
+
+	t.Log(co.Check())
+}
+
+// TestClusterVSInstance compares notifications sent by Alertmanager cluster to
+// notifications sent by single instance.
+func TestClusterVSInstance(t *testing.T) {
+	t.Parallel()
+
+	conf := `
+route:
+  receiver: "default"
+  group_by: [ "alertname" ]
+  group_wait:      1s
+  group_interval:  1s
+  repeat_interval: 1h
+
+receivers:
+- name: "default"
+  webhook_configs:
+  - url: 'http://%s'
+`
+
+	acceptanceOpts := &a.AcceptanceOpts{
+		Tolerance: 2 * time.Second,
+	}
+
+	clusterSizes := []int{1, 3}
+
+	tests := []*a.AcceptanceTest{
+		a.NewAcceptanceTest(t, acceptanceOpts),
+		a.NewAcceptanceTest(t, acceptanceOpts),
+	}
+
+	collectors := []*a.Collector{}
+	amClusters := []*a.AlertmanagerCluster{}
+	wg := sync.WaitGroup{}
+
+	for i, t := range tests {
+		collectors = append(collectors, t.Collector("webhook"))
+		webhook := a.NewWebhook(collectors[i])
+
+		amClusters = append(amClusters, t.AlertmanagerCluster(fmt.Sprintf(conf, webhook.Address()), clusterSizes[i]))
+
+		wg.Add(1)
+	}
+
+	for _, time := range []float64{0, 2, 4, 6, 8} {
+		for i, amc := range amClusters {
+			alert := a.Alert("alertname", fmt.Sprintf("test1-%v", time))
+			amc.Push(a.At(time), alert)
+			collectors[i].Want(a.Between(time, time+5), alert.Active(time))
+		}
+	}
+
+	for _, t := range tests {
+		go func(t *a.AcceptanceTest) {
+			t.Run()
+			wg.Done()
+		}(t)
+	}
+
+	wg.Wait()
+
+	_, err := a.CompareCollectors(collectors[0], collectors[1], acceptanceOpts)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/test/with_api_v2/mock.go
+++ b/test/with_api_v2/mock.go
@@ -243,6 +243,9 @@ type MockWebhook struct {
 	collector *Collector
 	listener  net.Listener
 
+	// Func is called early on when retrieving a notification by an
+	// Alertmanager. If Func returns true, the given notification is dropped.
+	// See sample usage in `send_test.go/TestRetry()`.
 	Func func(timestamp float64) bool
 }
 


### PR DESCRIPTION
Instead of only testing single instance Alertmanagers, this patch
enables individual tests to spin up Alertmanager clusters.

In addition it adds two tests:

1. A test firing alerts against a cluster, expecting to only receive a a
notification by one of the Alertmanager instances in the cluster.

2. A test firing alerts both against a single instance as well as a
cluster, making sure the output equals.

Signed-off-by: Max Leonard Inden <IndenML@gmail.com>