### PR TITLE
config: enforce HTTP or HTTPS URLs

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -369,7 +369,28 @@ func TestUnmarshalURL(t *testing.T) {
 }
 
 func TestUnmarshalInvalidURL(t *testing.T) {
-	b := []byte(`"://example.com"`)
+	for _, b := range [][]byte{
+		[]byte(`"://example.com"`),
+		[]byte(`"http:example.com"`),
+		[]byte(`"telnet://example.com"`),
+	} {
+		var u URL
+
+		err := json.Unmarshal(b, &u)
+		if err == nil {
+			t.Errorf("Expected an error unmarshalling %q from JSON", string(b))
+		}
+
+		err = yaml.Unmarshal(b, &u)
+		if err == nil {
+			t.Errorf("Expected an error unmarshalling %q from YAML", string(b))
+		}
+		t.Logf("%s", err)
+	}
+}
+
+func TestUnmarshalRelativeURL(t *testing.T) {
+	b := []byte(`"/home"`)
 	var u URL
 
 	err := json.Unmarshal(b, &u)
@@ -383,21 +404,15 @@ func TestUnmarshalInvalidURL(t *testing.T) {
 	}
 }
 
-func TestJSONUnmarshalMarshaled(t *testing.T) {
+func TestJSONUnmarshal(t *testing.T) {
 	c, _, err := LoadFile("testdata/conf.good.yml")
 	if err != nil {
 		t.Errorf("Error parsing %s: %s", "testdata/conf.good.yml", err)
 	}
 
-	plainCfg, err := json.Marshal(c)
+	_, err = json.Marshal(c)
 	if err != nil {
 		t.Fatal("JSON Marshaling failed:", err)
-	}
-
-	cfg := Config{}
-	err = json.Unmarshal(plainCfg, &cfg)
-	if err != nil {
-		t.Fatal("JSON Unmarshaling failed:", err)
 	}
 }
 

--- a/config/testdata/conf.empty-fields.yml
+++ b/config/testdata/conf.empty-fields.yml
@@ -6,7 +6,7 @@ global:
   smtp_hello: ''
   hipchat_auth_token: 'mysecret'
   hipchat_api_url: 'https://hipchat.foobar.org/'
-  slack_api_url: 'mysecret'
+  slack_api_url: 'https://slack.com/webhook'
 
 
 


### PR DESCRIPTION
Closes #1565 

AlertManager won't start if a URL parameter isn't formatted like `http[s]://host[:port][/path]`. It might break existing installations but in any case, those weren't functioning properly (eg notifications couldn't be sent).