### PR TITLE
[amtool] support assuming first label is alertname in alert query with matchers

### DIFF
--- a/cli/alert_query.go
+++ b/cli/alert_query.go
@@ -77,17 +77,16 @@ func configureQueryAlertsCmd(cc *kingpin.CmdClause) {
 
 func (a *alertQueryCmd) queryAlerts(ctx context.Context, _ *kingpin.ParseContext) error {
 	var filterString = ""
-	if len(a.matcherGroups) == 1 {
-		// If the parser fails then we likely don't have a (=|=~|!=|!~) so lets
-		// assume that the user wants alertname=<arg> and prepend `alertname=`
-		// to the front.
-		_, err := parse.Matcher(a.matcherGroups[0])
+	if len(a.matcherGroups) > 0 {
+		// Attempt to parse the first argument. If the parser fails
+		// then we likely don't have a (=|=~|!=|!~) so lets assume that
+		// the user wants alertname=<arg> and prepend `alertname=` to
+		// the front.
+		m := a.matcherGroups[0]
+		_, err := parse.Matcher(m)
 		if err != nil {
-			filterString = fmt.Sprintf("{alertname=%s}", a.matcherGroups[0])
-		} else {
-			filterString = fmt.Sprintf("{%s}", strings.Join(a.matcherGroups, ","))
+			a.matcherGroups[0] = fmt.Sprintf("alertname=%s", m)
 		}
-	} else if len(a.matcherGroups) > 1 {
 		filterString = fmt.Sprintf("{%s}", strings.Join(a.matcherGroups, ","))
 	}
 


### PR DESCRIPTION
The documentation stated that the `alertname=`
part of a matcher could be dropped and it would be
assumed that the first value was the alertname.
This behavior was only honored if there was a
single matcher, but failed if there were multiple.

Any time we have one or more matchers, check to
see if the first matcher fails parsing. If so,
assume it's intended to be used as the alertname,
and append that value to the matcher.