### PR TITLE
circleci: switch to 2.1 config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 ---
-version: 2
+version: 2.1
 
 jobs:
   test:


### PR DESCRIPTION
See https://github.com/prometheus/prometheus/pull/4713 for the rationale.