### PR TITLE
add group_by_all support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,10 @@ route:
   # multiple alerts coming in for cluster=A and alertname=LatencyHigh would
   # be batched into a single group.
   group_by: ['alertname', 'cluster']
-
+  
+  # if true all labels of alert will be used for grouping. If true then group_by should be empty.
+  group_by_all: false
+  
   # When a new group of alerts is created by an incoming alert, wait at
   # least 'group_wait' to send the initial notification.
   # This way ensures that you get multiple alerts for the same group that start

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ route:
   # a very low alert volume or your upstream notification system performs 
   # its own grouping. Example: group_by: [...]
   group_by: ['alertname', 'cluster']
-  
+
   # When a new group of alerts is created by an incoming alert, wait at
   # least 'group_wait' to send the initial notification.
   # This way ensures that you get multiple alerts for the same group that start

--- a/README.md
+++ b/README.md
@@ -71,10 +71,11 @@ route:
   # multiple alerts coming in for cluster=A and alertname=LatencyHigh would
   # be batched into a single group.
   #
-  # To aggregate by all labels use '...' instead of label names. 
-  # The wildcard label should be used only alone.
-  # For example: group_by: [...]
-  # WARNING! This will create a separate alert for each unique label set, so use it wisely
+  # To aggregate by all possible labels use '...' as the sole label name. 
+  # This effectively disables aggregation entirely, passing through all 
+  # alerts as-is. This is unlikely to be what you want, unless you have 
+  # a very low alert volume or your upstream notification system performs 
+  # its own grouping. Example: group_by: [...]
   group_by: ['alertname', 'cluster']
   
   # When a new group of alerts is created by an incoming alert, wait at

--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ route:
   # The labels by which incoming alerts are grouped together. For example,
   # multiple alerts coming in for cluster=A and alertname=LatencyHigh would
   # be batched into a single group.
+  # To aggregate by all labels use '...' instead of label names. 
+  # The wildcard label should be used only alone.
+  # For example: group_by: [...]
   group_by: ['alertname', 'cluster']
-  
-  # if true all labels of alert will be used for grouping. If true then group_by should be empty.
-  group_by_all: false
   
   # When a new group of alerts is created by an incoming alert, wait at
   # least 'group_wait' to send the initial notification.

--- a/README.md
+++ b/README.md
@@ -70,9 +70,11 @@ route:
   # The labels by which incoming alerts are grouped together. For example,
   # multiple alerts coming in for cluster=A and alertname=LatencyHigh would
   # be batched into a single group.
+  #
   # To aggregate by all labels use '...' instead of label names. 
   # The wildcard label should be used only alone.
   # For example: group_by: [...]
+  # WARNING! This will create a separate alert for each unique label set, so use it wisely
   group_by: ['alertname', 'cluster']
   
   # When a new group of alerts is created by an incoming alert, wait at

--- a/config/config.go
+++ b/config/config.go
@@ -494,7 +494,7 @@ func (c *GlobalConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // A Route is a node that contains definitions of how to handle alerts.
 type Route struct {
-	Receiver   string `yaml:"receiver,omitempty" json:"receiver,omitempty"`
+	Receiver string `yaml:"receiver,omitempty" json:"receiver,omitempty"`
 
 	GroupByStr []string `yaml:"group_by,omitempty" json:"group_by,omitempty"`
 	GroupBy    []model.LabelName

--- a/config/config.go
+++ b/config/config.go
@@ -541,7 +541,7 @@ func (r *Route) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 
 	if len(r.GroupBy) > 0 && r.GroupByAll {
-		return fmt.Errorf("cannot have wildcard group_by and other other labels at same time")
+		return fmt.Errorf("cannot have wildcard group_by and other other labels at the same time")
 	}
 
 	groupBy := map[model.LabelName]struct{}{}

--- a/config/config.go
+++ b/config/config.go
@@ -494,9 +494,10 @@ func (c *GlobalConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // A Route is a node that contains definitions of how to handle alerts.
 type Route struct {
-	Receiver   string            `yaml:"receiver,omitempty" json:"receiver,omitempty"`
-	GroupBy    []model.LabelName `yaml:"group_by,omitempty" json:"group_by,omitempty"`
-	GroupByAll bool              `yaml:"group_by_all,omitempty" json:"group_by_all,omitempty"`
+	Receiver   string `yaml:"receiver,omitempty" json:"receiver,omitempty"`
+	GroupBy    []model.LabelName
+	GroupByStr []string `yaml:"group_by,omitempty" json:"group_by,omitempty"`
+	GroupByAll bool
 
 	Match    map[string]string `yaml:"match,omitempty" json:"match,omitempty"`
 	MatchRE  map[string]Regexp `yaml:"match_re,omitempty" json:"match_re,omitempty"`
@@ -526,9 +527,20 @@ func (r *Route) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			return fmt.Errorf("invalid label name %q", k)
 		}
 	}
+	for _, l := range r.GroupByStr {
+		if l == "..." {
+			r.GroupByAll = true
+		} else {
+			labelName := model.LabelName(l)
+			if !labelName.IsValid() {
+				return fmt.Errorf("invalid label name %q in group_by list", l)
+			}
+			r.GroupBy = append(r.GroupBy, labelName)
+		}
+	}
 
 	if len(r.GroupBy) > 0 && r.GroupByAll {
-		return fmt.Errorf("cannot have group_by_all is true and non-empty group_by")
+		return fmt.Errorf("cannot have wildcard group_by and other other labels at same time")
 	}
 
 	groupBy := map[model.LabelName]struct{}{}

--- a/config/config.go
+++ b/config/config.go
@@ -541,7 +541,7 @@ func (r *Route) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 
 	if len(r.GroupBy) > 0 && r.GroupByAll {
-		return fmt.Errorf("cannot have wildcard group_by and other other labels at the same time")
+		return fmt.Errorf("cannot have wildcard group_by (`...`) and other other labels at the same time")
 	}
 
 	groupBy := map[model.LabelName]struct{}{}

--- a/config/config.go
+++ b/config/config.go
@@ -496,6 +496,7 @@ func (c *GlobalConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 type Route struct {
 	Receiver string            `yaml:"receiver,omitempty" json:"receiver,omitempty"`
 	GroupBy  []model.LabelName `yaml:"group_by,omitempty" json:"group_by,omitempty"`
+	GroupByAll bool `yaml:"group_by_all,omitempty" json:"group_by_all,omitempty"`
 
 	Match    map[string]string `yaml:"match,omitempty" json:"match,omitempty"`
 	MatchRE  map[string]Regexp `yaml:"match_re,omitempty" json:"match_re,omitempty"`
@@ -524,6 +525,10 @@ func (r *Route) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		if !model.LabelNameRE.MatchString(k) {
 			return fmt.Errorf("invalid label name %q", k)
 		}
+	}
+
+	if len(r.GroupBy) > 0 && r.GroupByAll {
+		return fmt.Errorf("cannot have group_by_all is true and non-empty group_by")
 	}
 
 	groupBy := map[model.LabelName]struct{}{}

--- a/config/config.go
+++ b/config/config.go
@@ -494,9 +494,9 @@ func (c *GlobalConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // A Route is a node that contains definitions of how to handle alerts.
 type Route struct {
-	Receiver string            `yaml:"receiver,omitempty" json:"receiver,omitempty"`
-	GroupBy  []model.LabelName `yaml:"group_by,omitempty" json:"group_by,omitempty"`
-	GroupByAll bool `yaml:"group_by_all,omitempty" json:"group_by_all,omitempty"`
+	Receiver   string            `yaml:"receiver,omitempty" json:"receiver,omitempty"`
+	GroupBy    []model.LabelName `yaml:"group_by,omitempty" json:"group_by,omitempty"`
+	GroupByAll bool              `yaml:"group_by_all,omitempty" json:"group_by_all,omitempty"`
 
 	Match    map[string]string `yaml:"match,omitempty" json:"match,omitempty"`
 	MatchRE  map[string]Regexp `yaml:"match_re,omitempty" json:"match_re,omitempty"`

--- a/config/config.go
+++ b/config/config.go
@@ -495,8 +495,9 @@ func (c *GlobalConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 // A Route is a node that contains definitions of how to handle alerts.
 type Route struct {
 	Receiver   string `yaml:"receiver,omitempty" json:"receiver,omitempty"`
-	GroupBy    []model.LabelName
+
 	GroupByStr []string `yaml:"group_by,omitempty" json:"group_by,omitempty"`
+	GroupBy    []model.LabelName
 	GroupByAll bool
 
 	Match    map[string]string `yaml:"match,omitempty" json:"match,omitempty"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -154,7 +154,7 @@ receivers:
 `
 	_, err := Load(in)
 
-	expected := "cannot have wildcard group_by and other other labels at same time"
+	expected := "cannot have wildcard group_by and other other labels at the same time"
 
 	if err == nil {
 		t.Fatalf("no error returned, expected:\n%q", expected)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -144,6 +144,27 @@ receivers:
 
 }
 
+func TestNonEmptyGroupByAndGroupByAl(t *testing.T) {
+	in := `
+route:
+  group_by: ['alertname', 'cluster']
+  group_by_all: true	
+
+receivers:
+- name: 'team-X-mails'
+`
+	_, err := Load(in)
+
+	expected := "cannot have group_by_all is true and non-empty group_by"
+
+	if err == nil {
+		t.Fatalf("no error returned, expected:\n%q", expected)
+	}
+	if err.Error() != expected {
+		t.Errorf("\nexpected:\n%q\ngot:\n%q", expected, err.Error())
+	}
+}
+
 func TestRootRouteExists(t *testing.T) {
 	in := `
 receivers:
@@ -448,6 +469,7 @@ func TestEmptyFieldsAndRegex(t *testing.T) {
 				"cluster",
 				"service",
 			},
+			GroupByAll: false,
 			Routes: []*Route{
 				{
 					Receiver: "team-X-mails",
@@ -503,6 +525,17 @@ func TestSMTPHello(t *testing.T) {
 	var hostName = c.Global.SMTPHello
 	if hostName != refValue {
 		t.Errorf("Invalid SMTP Hello hostname: %s\nExpected: %s", hostName, refValue)
+	}
+}
+
+func TestGroupByAll(t *testing.T) {
+	c, _, err := LoadFile("testdata/conf.group-by-all.yml")
+	if err != nil {
+		t.Errorf("Error parsing %s: %s", "testdata/conf.group-by-all.yml", err)
+	}
+
+	if !c.Route.GroupByAll {
+		t.Errorf("Invalid group by all param: expected to by true")
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -154,7 +154,7 @@ receivers:
 `
 	_, err := Load(in)
 
-	expected := "cannot have wildcard group_by and other other labels at the same time"
+	expected := "cannot have wildcard group_by (`...`) and other other labels at the same time"
 
 	if err == nil {
 		t.Fatalf("no error returned, expected:\n%q", expected)

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -22,10 +22,11 @@ route:
   # The labels by which incoming alerts are grouped together. For example,
   # multiple alerts coming in for cluster=A and alertname=LatencyHigh would
   # be batched into a single group.
+  # To aggregate by all labels use '...' instead of label names.
+  # The wildcard label should be used only alone.
+  # For example: group_by: [...]
   group_by: ['alertname', 'cluster', 'service']
 
-  # If true, each unique set of labels will constitute new group.
-  group_by_all: false
 
   # When a new group of alerts is created by an incoming alert, wait at
   # least 'group_wait' to send the initial notification.

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -24,7 +24,6 @@ route:
   # be batched into a single group.
   group_by: ['alertname', 'cluster', 'service']
 
-
   # When a new group of alerts is created by an incoming alert, wait at
   # least 'group_wait' to send the initial notification.
   # This way ensures that you get multiple alerts for the same group that start

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -24,6 +24,9 @@ route:
   # be batched into a single group.
   group_by: ['alertname', 'cluster', 'service']
 
+  # If true, each unique set of labels will constitute new group.
+  group_by_all: false
+
   # When a new group of alerts is created by an incoming alert, wait at
   # least 'group_wait' to send the initial notification.
   # This way ensures that you get multiple alerts for the same group that start

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -22,9 +22,6 @@ route:
   # The labels by which incoming alerts are grouped together. For example,
   # multiple alerts coming in for cluster=A and alertname=LatencyHigh would
   # be batched into a single group.
-  # To aggregate by all labels use '...' instead of label names.
-  # The wildcard label should be used only alone.
-  # For example: group_by: [...]
   group_by: ['alertname', 'cluster', 'service']
 
 

--- a/config/testdata/conf.group-by-all.yml
+++ b/config/testdata/conf.group-by-all.yml
@@ -1,0 +1,9 @@
+route:
+  group_by_all: true
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 3h
+  receiver: team-X
+
+receivers:
+- name: 'team-X'

--- a/config/testdata/conf.group-by-all.yml
+++ b/config/testdata/conf.group-by-all.yml
@@ -1,5 +1,5 @@
 route:
-  group_by_all: true
+  group_by: [...]
   group_wait: 30s
   group_interval: 5m
   repeat_interval: 3h
@@ -7,4 +7,4 @@ route:
 
 receivers:
 - name: 'team-X'
-  
+

--- a/config/testdata/conf.group-by-all.yml
+++ b/config/testdata/conf.group-by-all.yml
@@ -7,3 +7,4 @@ route:
 
 receivers:
 - name: 'team-X'
+  

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -152,13 +152,7 @@ type notifyFunc func(context.Context, ...*types.Alert) bool
 // processAlert determines in which aggregation group the alert falls
 // and inserts it.
 func (d *Dispatcher) processAlert(alert *types.Alert, route *Route) {
-	groupLabels := model.LabelSet{}
-
-	for ln, lv := range alert.Labels {
-		if _, ok := route.RouteOpts.GroupBy[ln]; ok {
-			groupLabels[ln] = lv
-		}
-	}
+	groupLabels := getGroupLabels(alert, route)
 
 	fp := groupLabels.Fingerprint()
 
@@ -187,6 +181,17 @@ func (d *Dispatcher) processAlert(alert *types.Alert, route *Route) {
 	}
 
 	ag.insert(alert)
+}
+
+func getGroupLabels(alert *types.Alert, route *Route) model.LabelSet {
+	groupLabels := model.LabelSet{}
+	for ln, lv := range alert.Labels {
+		if _, ok := route.RouteOpts.GroupBy[ln]; ok || route.RouteOpts.GroupByAll {
+			groupLabels[ln] = lv
+		}
+	}
+
+	return groupLabels
 }
 
 // aggrGroup aggregates alert fingerprints into groups to which a

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -240,3 +240,67 @@ func TestAggrGroup(t *testing.T) {
 
 	ag.stop()
 }
+
+func TestGroupLabels(t *testing.T) {
+	var a = &types.Alert{
+		Alert: model.Alert{
+			Labels: model.LabelSet{
+				"a": "v1",
+				"b": "v2",
+				"c": "v3",
+			},
+		},
+	}
+
+	route := &Route{
+		RouteOpts: RouteOpts{
+			GroupBy:        map[model.LabelName]struct{}{
+				"a": struct{}{},
+				"b": struct{}{},
+			},
+			GroupByAll: 	false,
+		},
+	}
+
+	expLs := model.LabelSet{
+		"a": "v1",
+		"b": "v2",
+	}
+
+	ls := getGroupLabels(a, route)
+
+	if !reflect.DeepEqual(ls, expLs) {
+		t.Fatalf("expected labels are %v, but got %v", expLs, ls)
+	}
+}
+
+func TestGroupByAllLabels(t *testing.T) {
+	var a = &types.Alert{
+		Alert: model.Alert{
+			Labels: model.LabelSet{
+				"a": "v1",
+				"b": "v2",
+				"c": "v3",
+			},
+		},
+	}
+
+	route := &Route{
+		RouteOpts: RouteOpts{
+			GroupBy:        map[model.LabelName]struct{}{},
+			GroupByAll: 	true,
+		},
+	}
+
+	expLs := model.LabelSet{
+		"a": "v1",
+		"b": "v2",
+		"c": "v3",
+	}
+
+	ls := getGroupLabels(a, route)
+
+	if !reflect.DeepEqual(ls, expLs) {
+		t.Fatalf("expected labels are %v, but got %v", expLs, ls)
+	}
+}

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -254,11 +254,11 @@ func TestGroupLabels(t *testing.T) {
 
 	route := &Route{
 		RouteOpts: RouteOpts{
-			GroupBy:        map[model.LabelName]struct{}{
+			GroupBy: map[model.LabelName]struct{}{
 				"a": struct{}{},
 				"b": struct{}{},
 			},
-			GroupByAll: 	false,
+			GroupByAll: false,
 		},
 	}
 
@@ -287,8 +287,8 @@ func TestGroupByAllLabels(t *testing.T) {
 
 	route := &Route{
 		RouteOpts: RouteOpts{
-			GroupBy:        map[model.LabelName]struct{}{},
-			GroupByAll: 	true,
+			GroupBy:    map[model.LabelName]struct{}{},
+			GroupByAll: true,
 		},
 	}
 

--- a/dispatch/route.go
+++ b/dispatch/route.go
@@ -32,6 +32,7 @@ var DefaultRouteOpts = RouteOpts{
 	GroupInterval:  5 * time.Minute,
 	RepeatInterval: 4 * time.Hour,
 	GroupBy:        map[model.LabelName]struct{}{},
+	GroupByAll:		false,
 }
 
 // A Route is a node that contains definitions of how to handle alerts.
@@ -69,6 +70,9 @@ func NewRoute(cr *config.Route, parent *Route) *Route {
 			opts.GroupBy[ln] = struct{}{}
 		}
 	}
+
+	opts.GroupByAll = cr.GroupByAll
+
 	if cr.GroupWait != nil {
 		opts.GroupWait = time.Duration(*cr.GroupWait)
 	}
@@ -158,6 +162,9 @@ type RouteOpts struct {
 	// What labels to group alerts by for notifications.
 	GroupBy map[model.LabelName]struct{}
 
+	// Use all alert's labels to group
+	GroupByAll bool
+
 	// How long to wait to group matching alerts before sending
 	// a notification.
 	GroupWait      time.Duration
@@ -170,7 +177,8 @@ func (ro *RouteOpts) String() string {
 	for ln := range ro.GroupBy {
 		labels = append(labels, ln)
 	}
-	return fmt.Sprintf("<RouteOpts send_to:%q group_by:%q timers:%q|%q>", ro.Receiver, labels, ro.GroupWait, ro.GroupInterval)
+	return fmt.Sprintf("<RouteOpts send_to:%q group_by:%q group_by_all:%t timers:%q|%q>",
+		ro.Receiver, labels, ro.GroupByAll, ro.GroupWait, ro.GroupInterval)
 }
 
 // MarshalJSON returns a JSON representation of the routing options.
@@ -178,11 +186,13 @@ func (ro *RouteOpts) MarshalJSON() ([]byte, error) {
 	v := struct {
 		Receiver       string           `json:"receiver"`
 		GroupBy        model.LabelNames `json:"groupBy"`
+		GroupByAll	   bool 			`json:"groupByAll"`
 		GroupWait      time.Duration    `json:"groupWait"`
 		GroupInterval  time.Duration    `json:"groupInterval"`
 		RepeatInterval time.Duration    `json:"repeatInterval"`
 	}{
 		Receiver:       ro.Receiver,
+		GroupByAll:		ro.GroupByAll,
 		GroupWait:      ro.GroupWait,
 		GroupInterval:  ro.GroupInterval,
 		RepeatInterval: ro.RepeatInterval,

--- a/dispatch/route.go
+++ b/dispatch/route.go
@@ -32,7 +32,7 @@ var DefaultRouteOpts = RouteOpts{
 	GroupInterval:  5 * time.Minute,
 	RepeatInterval: 4 * time.Hour,
 	GroupBy:        map[model.LabelName]struct{}{},
-	GroupByAll:		false,
+	GroupByAll:     false,
 }
 
 // A Route is a node that contains definitions of how to handle alerts.
@@ -186,13 +186,13 @@ func (ro *RouteOpts) MarshalJSON() ([]byte, error) {
 	v := struct {
 		Receiver       string           `json:"receiver"`
 		GroupBy        model.LabelNames `json:"groupBy"`
-		GroupByAll	   bool 			`json:"groupByAll"`
+		GroupByAll     bool             `json:"groupByAll"`
 		GroupWait      time.Duration    `json:"groupWait"`
 		GroupInterval  time.Duration    `json:"groupInterval"`
 		RepeatInterval time.Duration    `json:"repeatInterval"`
 	}{
 		Receiver:       ro.Receiver,
-		GroupByAll:		ro.GroupByAll,
+		GroupByAll:     ro.GroupByAll,
 		GroupWait:      ro.GroupWait,
 		GroupInterval:  ro.GroupInterval,
 		RepeatInterval: ro.RepeatInterval,

--- a/dispatch/route.go
+++ b/dispatch/route.go
@@ -162,7 +162,7 @@ type RouteOpts struct {
 	// What labels to group alerts by for notifications.
 	GroupBy map[model.LabelName]struct{}
 
-	// Use all alert's labels to group
+	// Use all alert labels to group.
 	GroupByAll bool
 
 	// How long to wait to group matching alerts before sending

--- a/dispatch/route_test.go
+++ b/dispatch/route_test.go
@@ -111,7 +111,7 @@ routes:
 				{
 					Receiver:       "notify-A",
 					GroupBy:        def.GroupBy,
-					GroupByAll: 	false,
+					GroupByAll:     false,
 					GroupWait:      def.GroupWait,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
@@ -128,7 +128,7 @@ routes:
 				{
 					Receiver:       "notify-A",
 					GroupBy:        def.GroupBy,
-					GroupByAll:		false,
+					GroupByAll:     false,
 					GroupWait:      def.GroupWait,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
@@ -144,7 +144,7 @@ routes:
 				{
 					Receiver:       "notify-BC",
 					GroupBy:        lset("foo", "bar"),
-					GroupByAll:		false,
+					GroupByAll:     false,
 					GroupWait:      2 * time.Minute,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
@@ -161,7 +161,7 @@ routes:
 				{
 					Receiver:       "notify-testing",
 					GroupBy:        lset(),
-					GroupByAll: 	true,
+					GroupByAll:     true,
 					GroupWait:      def.GroupWait,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
@@ -178,7 +178,7 @@ routes:
 				{
 					Receiver:       "notify-productionA",
 					GroupBy:        def.GroupBy,
-					GroupByAll:		false,
+					GroupByAll:     false,
 					GroupWait:      1 * time.Minute,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
@@ -186,7 +186,7 @@ routes:
 				{
 					Receiver:       "notify-productionB",
 					GroupBy:        lset("job"),
-					GroupByAll:		false,
+					GroupByAll:     false,
 					GroupWait:      30 * time.Second,
 					GroupInterval:  5 * time.Minute,
 					RepeatInterval: 1 * time.Hour,
@@ -205,7 +205,7 @@ routes:
 				{
 					Receiver:       "notify-def",
 					GroupBy:        lset("role"),
-					GroupByAll:		false,
+					GroupByAll:     false,
 					GroupWait:      def.GroupWait,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
@@ -222,7 +222,7 @@ routes:
 				{
 					Receiver:       "notify-testing",
 					GroupBy:        lset("role"),
-					GroupByAll:		false,
+					GroupByAll:     false,
 					GroupWait:      def.GroupWait,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
@@ -240,7 +240,7 @@ routes:
 				{
 					Receiver:       "notify-testing",
 					GroupBy:        lset("role"),
-					GroupByAll:		false,
+					GroupByAll:     false,
 					GroupWait:      2 * time.Minute,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,

--- a/dispatch/route_test.go
+++ b/dispatch/route_test.go
@@ -40,6 +40,7 @@ routes:
 
     receiver: 'notify-testing'
     group_by: []
+    group_by_all: true
 
   - match:
       env: "production"
@@ -110,6 +111,7 @@ routes:
 				{
 					Receiver:       "notify-A",
 					GroupBy:        def.GroupBy,
+					GroupByAll: 	false,
 					GroupWait:      def.GroupWait,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
@@ -126,6 +128,7 @@ routes:
 				{
 					Receiver:       "notify-A",
 					GroupBy:        def.GroupBy,
+					GroupByAll:		false,
 					GroupWait:      def.GroupWait,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
@@ -141,6 +144,7 @@ routes:
 				{
 					Receiver:       "notify-BC",
 					GroupBy:        lset("foo", "bar"),
+					GroupByAll:		false,
 					GroupWait:      2 * time.Minute,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
@@ -157,6 +161,7 @@ routes:
 				{
 					Receiver:       "notify-testing",
 					GroupBy:        lset(),
+					GroupByAll: 	true,
 					GroupWait:      def.GroupWait,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
@@ -173,6 +178,7 @@ routes:
 				{
 					Receiver:       "notify-productionA",
 					GroupBy:        def.GroupBy,
+					GroupByAll:		false,
 					GroupWait:      1 * time.Minute,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
@@ -180,6 +186,7 @@ routes:
 				{
 					Receiver:       "notify-productionB",
 					GroupBy:        lset("job"),
+					GroupByAll:		false,
 					GroupWait:      30 * time.Second,
 					GroupInterval:  5 * time.Minute,
 					RepeatInterval: 1 * time.Hour,
@@ -198,6 +205,7 @@ routes:
 				{
 					Receiver:       "notify-def",
 					GroupBy:        lset("role"),
+					GroupByAll:		false,
 					GroupWait:      def.GroupWait,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
@@ -214,6 +222,7 @@ routes:
 				{
 					Receiver:       "notify-testing",
 					GroupBy:        lset("role"),
+					GroupByAll:		false,
 					GroupWait:      def.GroupWait,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
@@ -231,6 +240,7 @@ routes:
 				{
 					Receiver:       "notify-testing",
 					GroupBy:        lset("role"),
+					GroupByAll:		false,
 					GroupWait:      2 * time.Minute,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,

--- a/dispatch/route_test.go
+++ b/dispatch/route_test.go
@@ -39,8 +39,7 @@ routes:
       env: 'testing'
 
     receiver: 'notify-testing'
-    group_by: []
-    group_by_all: true
+    group_by: [...]
 
   - match:
       env: "production"

--- a/doc/examples/simple.yml
+++ b/doc/examples/simple.yml
@@ -19,10 +19,11 @@ route:
   # multiple alerts coming in for cluster=A and alertname=LatencyHigh would
   # be batched into a single group.
   #
-  # To aggregate by all labels use '...' instead of label names.
-  # The wildcard label should be used only alone.
-  # For example: group_by: [...]
-  # WARNING! This will create a separate alert for each unique label set, so use it wisely
+  # To aggregate by all possible labels use '...' as the sole label name.
+  # This effectively disables aggregation entirely, passing through all
+  # alerts as-is. This is unlikely to be what you want, unless you have
+  # a very low alert volume or your upstream notification system performs
+  # its own grouping. Example: group_by: [...]
   group_by: ['alertname', 'cluster', 'service']
 
   # When a new group of alerts is created by an incoming alert, wait at

--- a/doc/examples/simple.yml
+++ b/doc/examples/simple.yml
@@ -20,6 +20,9 @@ route:
   # be batched into a single group.
   group_by: ['alertname', 'cluster', 'service']
 
+  # if true all labels of alert will be used for grouping. If true then group_by should be empty.
+  group_by_all: false
+
   # When a new group of alerts is created by an incoming alert, wait at
   # least 'group_wait' to send the initial notification.
   # This way ensures that you get multiple alerts for the same group that start

--- a/doc/examples/simple.yml
+++ b/doc/examples/simple.yml
@@ -18,10 +18,10 @@ route:
   # The labels by which incoming alerts are grouped together. For example,
   # multiple alerts coming in for cluster=A and alertname=LatencyHigh would
   # be batched into a single group.
+  # To aggregate by all labels use '...' instead of label names.
+  # The wildcard label should be used only alone.
+  # For example: group_by: [...]
   group_by: ['alertname', 'cluster', 'service']
-
-  # if true all labels of alert will be used for grouping. If true then group_by should be empty.
-  group_by_all: false
 
   # When a new group of alerts is created by an incoming alert, wait at
   # least 'group_wait' to send the initial notification.

--- a/doc/examples/simple.yml
+++ b/doc/examples/simple.yml
@@ -18,9 +18,11 @@ route:
   # The labels by which incoming alerts are grouped together. For example,
   # multiple alerts coming in for cluster=A and alertname=LatencyHigh would
   # be batched into a single group.
+  #
   # To aggregate by all labels use '...' instead of label names.
   # The wildcard label should be used only alone.
   # For example: group_by: [...]
+  # WARNING! This will create a separate alert for each unique label set, so use it wisely
   group_by: ['alertname', 'cluster', 'service']
 
   # When a new group of alerts is created by an incoming alert, wait at


### PR DESCRIPTION
This PR adds support for group_by_all parameter.

If it is true, all alert's labels will be used for grouping. 
If each alert has unique set of labels, this setting will effectively disable aggregation of different alerts. 

