### PR TITLE
FIX "PLAIN" auth during notification via smtp-over-tls on port 465

### DIFF
--- a/notify/impl.go
+++ b/notify/impl.go
@@ -276,7 +276,7 @@ func (n *Email) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 		if err != nil {
 			return true, err
 		}
-		c, err = smtp.NewClient(conn, n.conf.Smarthost)
+		c, err = smtp.NewClient(conn, host)
 		if err != nil {
 			return true, err
 		}


### PR DESCRIPTION
When creating a `NewClient`, pass only the hostname
as value for the `host` parameter, instead of `n.conf.Smarthost`,
which is hostname port.

This is the same as `smtp.Dial` does, which is called in
the else-branch.

The value passed as `host` argument to `NewClient` is
later compared against the `plainAuth.host` value:
`net/smtp.(*Client).Auth` and `net/smtp.(*plainAuth).Start`
(plainAuth is created created here: <https://github.com/prometheus/alertmanager/blob/master/notify/impl.go#L245>)

In my tests, this fixed the problems described in #980 

Note: after this change, the strings which are compared in
https://golang.org/src/net/smtp/auth.go at (`if server.Name != a.host`)
are derived from the same config value. I think that is correct, but as it
might affect security, it should be reviewed carefully.