### PR TITLE
Make OpsGenie API Key a templated string

### DIFF
--- a/notify/impl.go
+++ b/notify/impl.go
@@ -1193,6 +1193,9 @@ func (n *OpsGenie) createRequest(ctx context.Context, as ...*types.Alert) (*http
 			Priority:    tmpl(n.conf.Priority),
 		}
 	}
+
+	apiKey := tmpl(string(n.conf.APIKey))
+
 	if err != nil {
 		return nil, false, fmt.Errorf("templating error: %s", err)
 	}
@@ -1207,7 +1210,7 @@ func (n *OpsGenie) createRequest(ctx context.Context, as ...*types.Alert) (*http
 		return nil, true, err
 	}
 	req.Header.Set("Content-Type", contentTypeJSON)
-	req.Header.Set("Authorization", fmt.Sprintf("GenieKey %s", n.conf.APIKey))
+	req.Header.Set("Authorization", fmt.Sprintf("GenieKey %s", apiKey))
 	return req, true, nil
 }
 

--- a/notify/impl_test.go
+++ b/notify/impl_test.go
@@ -235,7 +235,7 @@ func TestOpsGenie(t *testing.T) {
 		Tags:        `{{ .CommonLabels.Tags }}`,
 		Note:        `{{ .CommonLabels.Note }}`,
 		Priority:    `{{ .CommonLabels.Priority }}`,
-		APIKey:      `s3cr3t`,
+		APIKey:      `{{ .ExternalURL }}`,
 		APIURL:      &config.URL{u},
 	}
 	notifier := NewOpsGenie(conf, tmpl, logger)
@@ -258,7 +258,7 @@ func TestOpsGenie(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, true, retry)
 	require.Equal(t, expectedURL, req.URL)
-	require.Equal(t, "GenieKey s3cr3t", req.Header.Get("Authorization"))
+	require.Equal(t, "GenieKey http://am", req.Header.Get("Authorization"))
 	require.Equal(t, expectedBody, readBody(t, req))
 
 	// Fully defined alert.
@@ -283,4 +283,10 @@ func TestOpsGenie(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, true, retry)
 	require.Equal(t, expectedBody, readBody(t, req))
+
+	// Broken API Key Template.
+	conf.APIKey = "{{ kaput "
+	_, _, err = notifier.createRequest(ctx, alert2)
+	require.Error(t, err)
+	require.Equal(t, err.Error(), "templating error: template: :1: function \"kaput\" not defined")
 }


### PR DESCRIPTION
This is analogous of what is done for PagerDuty secrets.

Probably needs a doc update as well.

/cc @stuartnelson3