### PR TITLE
Throw error if no auth mechanism is match

### DIFF
--- a/notify/impl.go
+++ b/notify/impl.go
@@ -251,7 +251,7 @@ func (n *Email) auth(mechs string) (smtp.Auth, error) {
 			return LoginAuth(username, password), nil
 		}
 	}
-	return nil, nil
+	return nil, errors.New("Unknown auth mechanism: " + mechs)
 }
 
 // Notify implements the Notifier interface.

--- a/notify/impl.go
+++ b/notify/impl.go
@@ -226,7 +226,7 @@ func (n *Email) auth(mechs string) (smtp.Auth, error) {
 		case "CRAM-MD5":
 			secret := string(n.conf.AuthSecret)
 			if secret == "" {
-				err.Add(errors.New("Missing secret for CRAM-MD5 auth mechanism"))
+				err.Add(errors.New("missing secret for CRAM-MD5 auth mechanism"))
 				continue
 			}
 			return smtp.CRAMMD5Auth(username, secret), nil
@@ -234,7 +234,7 @@ func (n *Email) auth(mechs string) (smtp.Auth, error) {
 		case "PLAIN":
 			password := string(n.conf.AuthPassword)
 			if password == "" {
-				err.Add(errors.New("Missing password for PLAIN auth mechanism"))
+				err.Add(errors.New("missing password for PLAIN auth mechanism"))
 				continue
 			}
 			identity := n.conf.AuthIdentity
@@ -248,14 +248,14 @@ func (n *Email) auth(mechs string) (smtp.Auth, error) {
 		case "LOGIN":
 			password := string(n.conf.AuthPassword)
 			if password == "" {
-				err.Add(errors.New("Missing password for LOGIN auth mechanism"))
+				err.Add(errors.New("missing password for LOGIN auth mechanism"))
 				continue
 			}
 			return LoginAuth(username, password), nil
 		}
 	}
 	if err.Len() == 0 {
-		err.Add(errors.New("Unknown auth mechanism: " + mechs))
+		err.Add(errors.New("unknown auth mechanism: " + mechs))
 	}
 	return nil, err
 }

--- a/notify/impl_test.go
+++ b/notify/impl_test.go
@@ -298,7 +298,7 @@ func TestEmailConfigNoAuthMechs(t *testing.T) {
 	}
 	_, err := email.auth("")
 	require.Error(t, err)
-	require.Equal(t, err.Error(), "Unknown auth mechanism: ")
+	require.Equal(t, err.Error(), "unknown auth mechanism: ")
 }
 
 func TestEmailConfigMissingAuthParam(t *testing.T) {
@@ -308,17 +308,17 @@ func TestEmailConfigMissingAuthParam(t *testing.T) {
 	}
 	_, err := email.auth("CRAM-MD5")
 	require.Error(t, err)
-	require.Equal(t, err.Error(), "Missing secret for CRAM-MD5 auth mechanism")
+	require.Equal(t, err.Error(), "missing secret for CRAM-MD5 auth mechanism")
 
 	_, err = email.auth("PLAIN")
 	require.Error(t, err)
-	require.Equal(t, err.Error(), "Missing password for PLAIN auth mechanism")
+	require.Equal(t, err.Error(), "missing password for PLAIN auth mechanism")
 
 	_, err = email.auth("LOGIN")
 	require.Error(t, err)
-	require.Equal(t, err.Error(), "Missing password for LOGIN auth mechanism")
+	require.Equal(t, err.Error(), "missing password for LOGIN auth mechanism")
 
 	_, err = email.auth("PLAIN LOGIN")
 	require.Error(t, err)
-	require.Equal(t, err.Error(), "Missing password for PLAIN auth mechanism; Missing password for LOGIN auth mechanism")
+	require.Equal(t, err.Error(), "missing password for PLAIN auth mechanism; missing password for LOGIN auth mechanism")
 }

--- a/notify/impl_test.go
+++ b/notify/impl_test.go
@@ -290,3 +290,35 @@ func TestOpsGenie(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, err.Error(), "templating error: template: :1: function \"kaput\" not defined")
 }
+
+func TestEmailConfigNoAuthMechs(t *testing.T) {
+
+	email := &Email{
+		conf: &config.EmailConfig{}, tmpl: &template.Template{}, logger: log.NewNopLogger(),
+	}
+	_, err := email.auth("")
+	require.Error(t, err)
+	require.Equal(t, err.Error(), "Unknown auth mechanism: ")
+}
+
+func TestEmailConfigMissingAuthParam(t *testing.T) {
+
+	email := &Email{
+		conf: &config.EmailConfig{}, tmpl: &template.Template{}, logger: log.NewNopLogger(),
+	}
+	_, err := email.auth("CRAM-MD5")
+	require.Error(t, err)
+	require.Equal(t, err.Error(), "Missing secret for CRAM-MD5 auth mechanism")
+
+	_, err = email.auth("PLAIN")
+	require.Error(t, err)
+	require.Equal(t, err.Error(), "Missing password for PLAIN auth mechanism")
+
+	_, err = email.auth("LOGIN")
+	require.Error(t, err)
+	require.Equal(t, err.Error(), "Missing password for LOGIN auth mechanism")
+
+	_, err = email.auth("PLAIN LOGIN")
+	require.Error(t, err)
+	require.Equal(t, err.Error(), "Missing password for PLAIN auth mechanism; Missing password for LOGIN auth mechanism")
+}


### PR DESCRIPTION
This pull request aims to close #1555 by returning an error if no auth mechanism is found.


Signed-off-by: glefloch <glfloch@gmail.com>