### PR TITLE
*: remove use of golang.org/x/net/context

### DIFF
--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -14,6 +14,7 @@
 package dispatch
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"sync"
@@ -22,7 +23,6 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/common/model"
-	"golang.org/x/net/context"
 
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/provider"

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -14,6 +14,7 @@
 package dispatch
 
 import (
+	"context"
 	"reflect"
 	"sort"
 	"sync"
@@ -22,7 +23,6 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/prometheus/common/model"
-	"golang.org/x/net/context"
 
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/types"

--- a/notify/impl_test.go
+++ b/notify/impl_test.go
@@ -14,6 +14,7 @@
 package notify
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -23,7 +24,6 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/template"

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -14,6 +14,7 @@
 package notify
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"sync"
@@ -25,7 +26,6 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
-	"golang.org/x/net/context"
 
 	"github.com/prometheus/alertmanager/cluster"
 	"github.com/prometheus/alertmanager/config"

--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -13,6 +13,7 @@
 package notify
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -23,7 +24,6 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 
 	"github.com/prometheus/alertmanager/nflog"
 	"github.com/prometheus/alertmanager/nflog/nflogpb"
@@ -617,7 +617,7 @@ func TestSilenceStage(t *testing.T) {
 	// the WasSilenced flag set to true afterwards.
 	marker.SetSilenced(inAlerts[1].Fingerprint(), "123")
 
-	_, alerts, err := silencer.Exec(nil, log.NewNopLogger(), inAlerts...)
+	_, alerts, err := silencer.Exec(context.Background(), log.NewNopLogger(), inAlerts...)
 	if err != nil {
 		t.Fatalf("Exec failed: %s", err)
 	}
@@ -665,7 +665,7 @@ func TestInhibitStage(t *testing.T) {
 		})
 	}
 
-	_, alerts, err := inhibitor.Exec(nil, log.NewNopLogger(), inAlerts...)
+	_, alerts, err := inhibitor.Exec(context.Background(), log.NewNopLogger(), inAlerts...)
 	if err != nil {
 		t.Fatalf("Exec failed: %s", err)
 	}

--- a/test/with_api_v1/acceptance.go
+++ b/test/with_api_v1/acceptance.go
@@ -15,6 +15,7 @@ package test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -30,7 +31,6 @@ import (
 
 	"github.com/prometheus/client_golang/api"
 	"github.com/prometheus/common/model"
-	"golang.org/x/net/context"
 
 	"github.com/prometheus/alertmanager/client"
 )

--- a/test/with_api_v2/acceptance.go
+++ b/test/with_api_v2/acceptance.go
@@ -15,6 +15,7 @@ package test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -35,7 +36,6 @@ import (
 
 	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
-	"golang.org/x/net/context"
 )
 
 // AcceptanceTest provides declarative definition of given inputs and expected

--- a/test/with_api_v2/api_v2_client/client/alert/get_alerts_parameters.go
+++ b/test/with_api_v2/api_v2_client/client/alert/get_alerts_parameters.go
@@ -6,10 +6,9 @@ package alert
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"net/http"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"

--- a/test/with_api_v2/api_v2_client/client/alert/post_alerts_parameters.go
+++ b/test/with_api_v2/api_v2_client/client/alert/post_alerts_parameters.go
@@ -6,10 +6,9 @@ package alert
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"net/http"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"

--- a/test/with_api_v2/api_v2_client/client/general/get_receivers_parameters.go
+++ b/test/with_api_v2/api_v2_client/client/general/get_receivers_parameters.go
@@ -6,10 +6,9 @@ package general
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"net/http"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"

--- a/test/with_api_v2/api_v2_client/client/general/get_status_parameters.go
+++ b/test/with_api_v2/api_v2_client/client/general/get_status_parameters.go
@@ -6,10 +6,9 @@ package general
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"net/http"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"

--- a/test/with_api_v2/api_v2_client/client/receiver/get_receivers_parameters.go
+++ b/test/with_api_v2/api_v2_client/client/receiver/get_receivers_parameters.go
@@ -6,10 +6,9 @@ package receiver
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"net/http"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"

--- a/test/with_api_v2/api_v2_client/client/silence/delete_silence_parameters.go
+++ b/test/with_api_v2/api_v2_client/client/silence/delete_silence_parameters.go
@@ -6,10 +6,9 @@ package silence
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"net/http"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"

--- a/test/with_api_v2/api_v2_client/client/silence/get_silence_parameters.go
+++ b/test/with_api_v2/api_v2_client/client/silence/get_silence_parameters.go
@@ -6,10 +6,9 @@ package silence
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"net/http"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"

--- a/test/with_api_v2/api_v2_client/client/silence/get_silences_parameters.go
+++ b/test/with_api_v2/api_v2_client/client/silence/get_silences_parameters.go
@@ -6,10 +6,9 @@ package silence
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"net/http"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"

--- a/test/with_api_v2/api_v2_client/client/silence/post_silences_parameters.go
+++ b/test/with_api_v2/api_v2_client/client/silence/post_silences_parameters.go
@@ -6,10 +6,9 @@ package silence
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"net/http"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"


### PR DESCRIPTION
Some dependencies still depend on it but at the AlertManager's code is clean.