### PR TITLE
[gossip] Don't merge expired gossip messages

### DIFF
--- a/nflog/nflog_test.go
+++ b/nflog/nflog_test.go
@@ -269,7 +269,7 @@ func TestStateDataCoding(t *testing.T) {
 }
 
 func TestQuery(t *testing.T) {
-	nl, err := New()
+	nl, err := New(WithRetention(time.Second))
 	if err != nil {
 		require.NoError(t, err, "constructing nflog failed")
 	}

--- a/silence/silence.go
+++ b/silence/silence.go
@@ -403,7 +403,7 @@ func (s *Silences) setSilence(sil *pb.Silence) error {
 		return err
 	}
 
-	s.st.merge(msil)
+	s.st.merge(msil, s.now())
 	s.broadcast(b)
 
 	return nil
@@ -717,8 +717,10 @@ func (s *Silences) Merge(b []byte) error {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 
+	now := s.now()
+
 	for _, e := range st {
-		if merged := s.st.merge(e); merged && !cluster.OversizedMessage(b) {
+		if merged := s.st.merge(e, now); merged && !cluster.OversizedMessage(b) {
 			// If this is the first we've seen the message and it's
 			// not oversized, gossip it to other nodes. We don't
 			// propagate oversized messages because they're sent to
@@ -739,7 +741,10 @@ func (s *Silences) SetBroadcast(f func([]byte)) {
 
 type state map[string]*pb.MeshSilence
 
-func (s state) merge(e *pb.MeshSilence) bool {
+func (s state) merge(e *pb.MeshSilence, now time.Time) bool {
+	if e.ExpiresAt.Before(now) {
+		return false
+	}
 	// Comments list was moved to a single comment. Apply upgrade
 	// on silences received from peers.
 	if len(e.Silence.Comments) > 0 {


### PR DESCRIPTION
If they're expired, they should be cleaned up on
the next GC cycle, but merging them in means that
they'll probably be gossip'd continually between
the cluster members.

fixes #1624 

The issue was in the `merge` function: https://github.com/prometheus/alertmanager/blob/master/silence/silence.go#L752-L756

Expired silences would get deleted every 15 minutes (the hard-coded maintenance interval), but on each full-state sync an alertmanager would get a bunch of expired silences. Since they didn't exist in its state cache, they would be merged back in. Since the merge happens every minute, they were seemingly guaranteed to stick around. If all the alertmanagers were started at the same time they might GC all the silences before a full state sync, but if they're offset in their maintenance timing, they would keep sharing the same expired silences with each other. This explains why I saw the silences "GC'd", because I had looked within this magical window of "maintenance has run, but a full state sync hasn't yet", but then they came back.