### PR TITLE
Fix route prefix for the API v2

### DIFF
--- a/test/with_api_v1/acceptance/web_test.go
+++ b/test/with_api_v1/acceptance/web_test.go
@@ -1,0 +1,42 @@
+// Copyright 2018 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"testing"
+
+	a "github.com/prometheus/alertmanager/test/with_api_v1"
+)
+
+func TestWebWithPrefix(t *testing.T) {
+	t.Parallel()
+
+	conf := `
+route:
+  receiver: "default"
+  group_by: []
+  group_wait:      1s
+  group_interval:  1s
+  repeat_interval: 1h
+
+receivers:
+- name: "default"
+`
+
+	// The test framework polls the API with the given prefix during
+	// Alertmanager startup and thereby ensures proper configuration.
+	at := a.NewAcceptanceTest(t, &a.AcceptanceOpts{RoutePrefix: "/foo"})
+	at.Alertmanager(conf)
+	at.Run()
+}

--- a/test/with_api_v2/acceptance.go
+++ b/test/with_api_v2/acceptance.go
@@ -53,8 +53,9 @@ type AcceptanceTest struct {
 
 // AcceptanceOpts defines configuration paramters for an acceptance test.
 type AcceptanceOpts struct {
-	Tolerance time.Duration
-	baseTime  time.Time
+	RoutePrefix string
+	Tolerance   time.Duration
+	baseTime    time.Time
 }
 
 func (opts *AcceptanceOpts) alertString(a *models.Alert) string {
@@ -141,7 +142,7 @@ func (t *AcceptanceTest) AlertmanagerCluster(conf string, size int) *Alertmanage
 		am.apiAddr = freeAddress()
 		am.clusterAddr = freeAddress()
 
-		transport := httptransport.New(am.apiAddr, "/api/v2/", nil)
+		transport := httptransport.New(am.apiAddr, t.opts.RoutePrefix+"/api/v2/", nil)
 		am.clientV2 = apiclient.New(transport, strfmt.Default)
 
 		amc.ams = append(amc.ams, am)
@@ -290,6 +291,7 @@ func (amc *AlertmanagerCluster) Start() error {
 
 // Start the alertmanager and wait until it is ready to receive.
 func (am *Alertmanager) Start(additionalArg []string) error {
+	am.t.Helper()
 	args := []string{
 		"--config.file", am.confFile.Name(),
 		"--log.level", "debug",
@@ -297,6 +299,9 @@ func (am *Alertmanager) Start(additionalArg []string) error {
 		"--storage.path", am.dir,
 		"--cluster.listen-address", am.clusterAddr,
 		"--cluster.settle-timeout", "0s",
+	}
+	if am.opts.RoutePrefix != "" {
+		args = append(args, "--web.route-prefix", am.opts.RoutePrefix)
 	}
 	args = append(args, additionalArg...)
 
@@ -324,16 +329,20 @@ func (am *Alertmanager) Start(additionalArg []string) error {
 
 	time.Sleep(50 * time.Millisecond)
 	for i := 0; i < 10; i++ {
-		resp, err := http.Get(fmt.Sprintf("http://%s/status", am.apiAddr))
-		if err == nil {
-			_, err := ioutil.ReadAll(resp.Body)
-			if err != nil {
-				return fmt.Errorf("starting alertmanager failed: %s", err)
-			}
-			resp.Body.Close()
-			return nil
+		resp, err := http.Get(am.getURL("/"))
+		if err != nil {
+			time.Sleep(500 * time.Millisecond)
+			continue
 		}
-		time.Sleep(500 * time.Millisecond)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("starting alertmanager failed: expected HTTP status '200', got '%d'", resp.StatusCode)
+		}
+		_, err = ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("starting alertmanager failed: %s", err)
+		}
+		return nil
 	}
 	return fmt.Errorf("starting alertmanager failed: timeout")
 }
@@ -377,6 +386,7 @@ func (amc *AlertmanagerCluster) Terminate() {
 // Terminate kills the underlying Alertmanager process and remove intermediate
 // data.
 func (am *Alertmanager) Terminate() {
+	am.t.Helper()
 	if err := syscall.Kill(am.cmd.Process.Pid, syscall.SIGTERM); err != nil {
 		am.t.Fatalf("Error sending SIGTERM to Alertmanager process: %v", err)
 	}
@@ -391,18 +401,14 @@ func (amc *AlertmanagerCluster) Reload() {
 
 // Reload sends the reloading signal to the Alertmanager process.
 func (am *Alertmanager) Reload() {
+	am.t.Helper()
 	if err := syscall.Kill(am.cmd.Process.Pid, syscall.SIGHUP); err != nil {
 		am.t.Fatalf("Error sending SIGHUP to Alertmanager process: %v", err)
 	}
 }
 
-func (amc *AlertmanagerCluster) cleanup() {
-	for _, am := range amc.ams {
-		am.cleanup()
-	}
-}
-
 func (am *Alertmanager) cleanup() {
+	am.t.Helper()
 	if err := os.RemoveAll(am.confFile.Name()); err != nil {
 		am.t.Errorf("Error removing test config file %q: %v", am.confFile.Name(), err)
 	}
@@ -458,7 +464,7 @@ func (am *Alertmanager) SetSilence(at float64, sil *TestSilence) {
 			return
 		}
 
-		resp, err := http.Post(fmt.Sprintf("http://%s/api/v1/silences", am.apiAddr), "application/json", &buf)
+		resp, err := http.Post(am.getURL("/api/v1/silences"), "application/json", &buf)
 		if err != nil {
 			am.t.Errorf("Error setting silence %v: %s", sil, err)
 			return
@@ -494,7 +500,7 @@ func (amc *AlertmanagerCluster) DelSilence(at float64, sil *TestSilence) {
 // DelSilence deletes the silence with the sid at the given time.
 func (am *Alertmanager) DelSilence(at float64, sil *TestSilence) {
 	am.t.Do(at, func() {
-		req, err := http.NewRequest("DELETE", fmt.Sprintf("http://%s/api/v1/silence/%s", am.apiAddr, sil.ID()), nil)
+		req, err := http.NewRequest("DELETE", am.getURL(fmt.Sprintf("/api/v1/silence/%s", sil.ID())), nil)
 		if err != nil {
 			am.t.Errorf("Error deleting silence %v: %s", sil, err)
 			return
@@ -540,4 +546,8 @@ func (amc *AlertmanagerCluster) GenericAPIV2Call(at float64, f func()) {
 // GenericAPIV2Call takes a time slot and a function to run against the API v2
 func (am *Alertmanager) GenericAPIV2Call(at float64, f func()) {
 	am.t.Do(at, f)
+}
+
+func (am *Alertmanager) getURL(path string) string {
+	return fmt.Sprintf("http://%s%s%s", am.apiAddr, am.opts.RoutePrefix, path)
 }

--- a/test/with_api_v2/acceptance/web_test.go
+++ b/test/with_api_v2/acceptance/web_test.go
@@ -1,0 +1,42 @@
+// Copyright 2018 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"testing"
+
+	a "github.com/prometheus/alertmanager/test/with_api_v2"
+)
+
+func TestWebWithPrefix(t *testing.T) {
+	t.Parallel()
+
+	conf := `
+route:
+  receiver: "default"
+  group_by: []
+  group_wait:      1s
+  group_interval:  1s
+  repeat_interval: 1h
+
+receivers:
+- name: "default"
+`
+
+	// The test framework polls the API with the given prefix during
+	// Alertmanager startup and thereby ensures proper configuration.
+	at := a.NewAcceptanceTest(t, &a.AcceptanceOpts{RoutePrefix: "/foo"})
+	at.AlertmanagerCluster(conf, 1)
+	at.Run()
+}


### PR DESCRIPTION
Closes #1627 

While I was looking at the code, it occurred to me that we use [`os.Exit`](https://godoc.org/os#Exit) improperly as it doesn't run deferred functions. I refactored that part in this PR but it can go in another PR if someone prefers.

Finally, there's still a problem with the UI: the Status tab doesn't render properly but I'm not familiar enough with the front-end code to know how to fix it. @stuartnelson3 and @mxinden, you probably know better.