### PR TITLE
Pushover: support HTML, URL title and custom sounds

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -132,8 +132,6 @@ var (
 		Title:    `{{ template "pushover.default.title" . }}`,
 		Message:  `{{ template "pushover.default.message" . }}`,
 		URL:      `{{ template "pushover.default.url" . }}`,
-		URLTitle: `{{ template "pushover.default.url_title" . }}`,
-		Sound:    `{{ template "pushover.default.sound" . }}`,
 		Priority: `{{ if eq .Status "firing" }}2{{ else }}0{{ end }}`, // emergency (firing) or normal
 		Retry:    duration(1 * time.Minute),
 		Expire:   duration(1 * time.Hour),

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -137,6 +137,7 @@ var (
 		Priority: `{{ if eq .Status "firing" }}2{{ else }}0{{ end }}`, // emergency (firing) or normal
 		Retry:    duration(1 * time.Minute),
 		Expire:   duration(1 * time.Hour),
+		HTML:     true,
 	}
 )
 
@@ -539,6 +540,7 @@ type PushoverConfig struct {
 	Priority string   `yaml:"priority,omitempty" json:"priority,omitempty"`
 	Retry    duration `yaml:"retry,omitempty" json:"retry,omitempty"`
 	Expire   duration `yaml:"expire,omitempty" json:"expire,omitempty"`
+	HTML     bool     `yaml:"html,omitempty" json:"html,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -135,7 +135,7 @@ var (
 		Priority: `{{ if eq .Status "firing" }}2{{ else }}0{{ end }}`, // emergency (firing) or normal
 		Retry:    duration(1 * time.Minute),
 		Expire:   duration(1 * time.Hour),
-		HTML:     true,
+		HTML:     false,
 	}
 )
 

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -132,6 +132,8 @@ var (
 		Title:    `{{ template "pushover.default.title" . }}`,
 		Message:  `{{ template "pushover.default.message" . }}`,
 		URL:      `{{ template "pushover.default.url" . }}`,
+		URLTitle: `{{ template "pushover.default.url_title" . }}`,
+		Sound:    `{{ template "pushover.default.sound" . }}`,
 		Priority: `{{ if eq .Status "firing" }}2{{ else }}0{{ end }}`, // emergency (firing) or normal
 		Retry:    duration(1 * time.Minute),
 		Expire:   duration(1 * time.Hour),
@@ -532,6 +534,8 @@ type PushoverConfig struct {
 	Title    string   `yaml:"title,omitempty" json:"title,omitempty"`
 	Message  string   `yaml:"message,omitempty" json:"message,omitempty"`
 	URL      string   `yaml:"url,omitempty" json:"url,omitempty"`
+	URLTitle string   `yaml:"url_title,omitempty" json:"url_title,omitempty`
+	Sound    string   `yaml:"sound,omitempty" json:"sound,omitempty"`
 	Priority string   `yaml:"priority,omitempty" json:"priority,omitempty"`
 	Retry    duration `yaml:"retry,omitempty" json:"retry,omitempty"`
 	Expire   duration `yaml:"expire,omitempty" json:"expire,omitempty"`

--- a/notify/impl.go
+++ b/notify/impl.go
@@ -1421,6 +1421,7 @@ func (n *Pushover) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		message = "(no details)"
 	}
 	parameters.Add("message", message)
+	parameters.Add("html", "1")
 
 	supplementaryURL := tmpl(n.conf.URL)
 	if len(supplementaryURL) > 512 {

--- a/notify/impl.go
+++ b/notify/impl.go
@@ -1397,7 +1397,7 @@ func (n *Pushover) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	level.Debug(n.logger).Log("msg", "Notifying Pushover", "incident", key)
 
 	var (
-		err error
+		err     error
 		message string
 	)
 	tmpl := tmplText(n.tmpl, data, &err)
@@ -1414,7 +1414,7 @@ func (n *Pushover) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	}
 	parameters.Add("title", title)
 
-	if (n.conf.HTML) {
+	if n.conf.HTML {
 		parameters.Add("html", "1")
 		message = tmplHTML(n.conf.Message)
 	} else {

--- a/notify/impl.go
+++ b/notify/impl.go
@@ -1398,6 +1398,7 @@ func (n *Pushover) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 
 	var err error
 	tmpl := tmplText(n.tmpl, data, &err)
+	tmplHTML := tmplHTML(n.tmpl, data, &err)
 
 	parameters := url.Values{}
 	parameters.Add("token", tmpl(string(n.conf.Token)))
@@ -1410,7 +1411,7 @@ func (n *Pushover) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	}
 	parameters.Add("title", title)
 
-	message := tmpl(n.conf.Message)
+	message := tmplHTML(n.conf.Message)
 	if len(message) > 1024 {
 		message = message[:1021] + "..."
 		level.Debug(n.logger).Log("msg", "Truncated message due to Pushover message limit", "truncated_message", message, "incident", key)

--- a/notify/impl.go
+++ b/notify/impl.go
@@ -1429,10 +1429,12 @@ func (n *Pushover) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		level.Debug(n.logger).Log("msg", "Truncated URL due to Pushover url limit", "truncated_url", supplementaryURL, "incident", key)
 	}
 	parameters.Add("url", supplementaryURL)
+	parameters.Add("url_title", tmpl(n.conf.URLTitle))
 
 	parameters.Add("priority", tmpl(n.conf.Priority))
 	parameters.Add("retry", fmt.Sprintf("%d", int64(time.Duration(n.conf.Retry).Seconds())))
 	parameters.Add("expire", fmt.Sprintf("%d", int64(time.Duration(n.conf.Expire).Seconds())))
+	parameters.Add("sound", tmpl(n.conf.Sound))
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Extending [Pushover](https://pushover.net) integration to allow extended customization:

- New `sound` parameter for a [custom notification sound](https://pushover.net/api#sounds).
- New `url_title` parameter, which allows setting [custom text for the supplementary URL](https://pushover.net/api#tldr).
- [HTML formatting support](https://pushover.net/api#html) within the messages.

As for the last one, I've enabled HTML support for all the messages, as I don't really see the reason why not to do so (either way, you need to use explicit HTML tags within your message to use this functionality). Anyhow, if you think otherwise, I'm good with making this configurable as well.