### PR TITLE
Fixed typo in license statement URL

### DIFF
--- a/provider/mem/mem.go
+++ b/provider/mem/mem.go
@@ -3,7 +3,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/lic:wenses/LICENSE-2.0
+// http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/provider/mem/mem_test.go
+++ b/provider/mem/mem_test.go
@@ -3,7 +3,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/lic:wenses/LICENSE-2.0
+// http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
@mxinden - Just a minor fix to a typo in the license statements in /provider/mem/

Signed-off-by: Steve Winslow <swinslow@gmail.com>