### PR TITLE
Travis: specify go_import_path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: go
+go_import_path: github.com/prometheus/alertmanager
 
 services:
 - docker


### PR DESCRIPTION
This allows to use travis on your github fork.

Otherwise the code is imported inside `$GOPATH/src/github.com/user/repo` and make fails.