### PR TITLE
fixes #1649 : Changed DefaultGlobalConfig to a function and added comments

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ import (
 // Secret is a string that must not be revealed on marshaling.
 type Secret string
 
-// MarshalYAML implements the yaml.Marshaler interface.
+// MarshalYAML implements the yaml.Marshaler interface for Secret.
 func (s Secret) MarshalYAML() (interface{}, error) {
 	if s != "" {
 		return "<secret>", nil
@@ -46,7 +46,7 @@ func (s *Secret) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return unmarshal((*plain)(s))
 }
 
-// MarshalJSON implements the json.Marshaler interface.
+// MarshalJSON implements the json.Marshaler interface for Secret.
 func (s Secret) MarshalJSON() ([]byte, error) {
 	return json.Marshal("<secret>")
 }
@@ -205,7 +205,7 @@ func (c Config) String() string {
 	return string(b)
 }
 
-// UnmarshalYAML implements the yaml.Unmarshaler interface.
+// UnmarshalYAML implements the yaml.Unmarshaler interface for Config.
 func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	// We want to set c to the defaults and then overwrite it with the input.
 	// To make unmarshal fill the plain data struct rather than calling UnmarshalYAML
@@ -219,7 +219,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	// We have to restore it here.
 	if c.Global == nil {
 		c.Global = &GlobalConfig{}
-		*c.Global = DefaultGlobalConfig
+		*c.Global = DefaultGlobalConfig()
 	}
 
 	names := map[string]struct{}{}
@@ -419,18 +419,20 @@ func checkReceiver(r *Route, receivers map[string]struct{}) error {
 	return nil
 }
 
-// DefaultGlobalConfig provides global default values.
-var DefaultGlobalConfig = GlobalConfig{
-	ResolveTimeout: model.Duration(5 * time.Minute),
-	HTTPConfig:     &commoncfg.HTTPClientConfig{},
+// DefaultGlobalConfig returns GlobalConfig with default values.
+func DefaultGlobalConfig() GlobalConfig {
+    return GlobalConfig{
+	  ResolveTimeout: model.Duration(5 * time.Minute),
+      HTTPConfig:     &commoncfg.HTTPClientConfig{},
 
-	SMTPHello:       "localhost",
-	SMTPRequireTLS:  true,
-	PagerdutyURL:    mustParseURL("https://events.pagerduty.com/v2/enqueue"),
-	HipchatAPIURL:   mustParseURL("https://api.hipchat.com/"),
-	OpsGenieAPIURL:  mustParseURL("https://api.opsgenie.com/"),
-	WeChatAPIURL:    mustParseURL("https://qyapi.weixin.qq.com/cgi-bin/"),
-	VictorOpsAPIURL: mustParseURL("https://alert.victorops.com/integrations/generic/20131114/alert/"),
+	  SMTPHello:       "localhost",
+	  SMTPRequireTLS:  true,
+	  PagerdutyURL:    mustParseURL("https://events.pagerduty.com/v2/enqueue"),
+	  HipchatAPIURL:   mustParseURL("https://api.hipchat.com/"),
+	  OpsGenieAPIURL:  mustParseURL("https://api.opsgenie.com/"),
+	  WeChatAPIURL:    mustParseURL("https://qyapi.weixin.qq.com/cgi-bin/"),
+	  VictorOpsAPIURL: mustParseURL("https://alert.victorops.com/integrations/generic/20131114/alert/"),
+    }
 }
 
 func mustParseURL(s string) *URL {
@@ -485,9 +487,9 @@ type GlobalConfig struct {
 	VictorOpsAPIKey  Secret     `yaml:"victorops_api_key,omitempty" json:"victorops_api_key,omitempty"`
 }
 
-// UnmarshalYAML implements the yaml.Unmarshaler interface.
+// UnmarshalYAML implements the yaml.Unmarshaler interface for GlobalConfig.
 func (c *GlobalConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	*c = DefaultGlobalConfig
+	*c = DefaultGlobalConfig()
 	type plain GlobalConfig
 	return unmarshal((*plain)(c))
 }
@@ -510,7 +512,7 @@ type Route struct {
 	RepeatInterval *model.Duration `yaml:"repeat_interval,omitempty" json:"repeat_interval,omitempty"`
 }
 
-// UnmarshalYAML implements the yaml.Unmarshaler interface.
+// UnmarshalYAML implements the yaml.Unmarshaler interface for Route.
 func (r *Route) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type plain Route
 	if err := unmarshal((*plain)(r)); err != nil {
@@ -584,7 +586,7 @@ type InhibitRule struct {
 	Equal model.LabelNames `yaml:"equal,omitempty" json:"equal,omitempty"`
 }
 
-// UnmarshalYAML implements the yaml.Unmarshaler interface.
+// UnmarshalYAML implements the yaml.Unmarshaler interface for InhibitRule.
 func (r *InhibitRule) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type plain InhibitRule
 	if err := unmarshal((*plain)(r)); err != nil {
@@ -634,7 +636,7 @@ type Receiver struct {
 	VictorOpsConfigs []*VictorOpsConfig `yaml:"victorops_configs,omitempty" json:"victorops_configs,omitempty"`
 }
 
-// UnmarshalYAML implements the yaml.Unmarshaler interface.
+// UnmarshalYAML implements the yaml.Unmarshaler interface for Receiver.
 func (c *Receiver) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type plain Receiver
 	if err := unmarshal((*plain)(c)); err != nil {
@@ -651,7 +653,7 @@ type Regexp struct {
 	*regexp.Regexp
 }
 
-// UnmarshalYAML implements the yaml.Unmarshaler interface.
+// UnmarshalYAML implements the yaml.Unmarshaler interface for Regexp.
 func (re *Regexp) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var s string
 	if err := unmarshal(&s); err != nil {
@@ -665,7 +667,7 @@ func (re *Regexp) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
-// MarshalYAML implements the yaml.Marshaler interface.
+// MarshalYAML implements the yaml.Marshaler interface for Regexp.
 func (re Regexp) MarshalYAML() (interface{}, error) {
 	if re.Regexp != nil {
 		return re.String(), nil
@@ -673,7 +675,7 @@ func (re Regexp) MarshalYAML() (interface{}, error) {
 	return nil, nil
 }
 
-// UnmarshalJSON implements the json.Marshaler interface
+// UnmarshalJSON implements the json.Marshaler interface for Regexp
 func (re *Regexp) UnmarshalJSON(data []byte) error {
 	var s string
 	if err := json.Unmarshal(data, &s); err != nil {
@@ -687,7 +689,7 @@ func (re *Regexp) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// MarshalJSON implements the json.Marshaler interface.
+// MarshalJSON implements the json.Marshaler interface for Regexp.
 func (re Regexp) MarshalJSON() ([]byte, error) {
 	if re.Regexp != nil {
 		return json.Marshal(re.String())

--- a/config/config.go
+++ b/config/config.go
@@ -421,18 +421,18 @@ func checkReceiver(r *Route, receivers map[string]struct{}) error {
 
 // DefaultGlobalConfig returns GlobalConfig with default values.
 func DefaultGlobalConfig() GlobalConfig {
-    return GlobalConfig{
-	  ResolveTimeout: model.Duration(5 * time.Minute),
-      HTTPConfig:     &commoncfg.HTTPClientConfig{},
+	return GlobalConfig{
+		ResolveTimeout: model.Duration(5 * time.Minute),
+		HTTPConfig:     &commoncfg.HTTPClientConfig{},
 
-	  SMTPHello:       "localhost",
-	  SMTPRequireTLS:  true,
-	  PagerdutyURL:    mustParseURL("https://events.pagerduty.com/v2/enqueue"),
-	  HipchatAPIURL:   mustParseURL("https://api.hipchat.com/"),
-	  OpsGenieAPIURL:  mustParseURL("https://api.opsgenie.com/"),
-	  WeChatAPIURL:    mustParseURL("https://qyapi.weixin.qq.com/cgi-bin/"),
-	  VictorOpsAPIURL: mustParseURL("https://alert.victorops.com/integrations/generic/20131114/alert/"),
-    }
+		SMTPHello:       "localhost",
+		SMTPRequireTLS:  true,
+		PagerdutyURL:    mustParseURL("https://events.pagerduty.com/v2/enqueue"),
+		HipchatAPIURL:   mustParseURL("https://api.hipchat.com/"),
+		OpsGenieAPIURL:  mustParseURL("https://api.opsgenie.com/"),
+		WeChatAPIURL:    mustParseURL("https://qyapi.weixin.qq.com/cgi-bin/"),
+		VictorOpsAPIURL: mustParseURL("https://alert.victorops.com/integrations/generic/20131114/alert/"),
+	}
 }
 
 func mustParseURL(s string) *URL {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -520,6 +520,13 @@ func TestEmptyFieldsAndRegex(t *testing.T) {
 		},
 	}
 
+	// Load a non-empty configuration to ensure that all fields are overwritten.
+	// See https://github.com/prometheus/alertmanager/issues/1649.
+	_, _, err := LoadFile("testdata/conf.good.yml")
+	if err != nil {
+		t.Errorf("Error parsing %s: %s", "testdata/conf.good.yml", err)
+	}
+
 	config, _, err := LoadFile("testdata/conf.empty-fields.yml")
 	if err != nil {
 		t.Errorf("Error parsing %s: %s", "testdata/conf.empty-fields.yml", err)

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -10,6 +10,8 @@ global:
   # Alternative host for Hipchat.
   hipchat_api_url: 'https://hipchat.foobar.org/'
   slack_api_url: "http://mysecret.example.com/"
+  http_config:
+    proxy_url:
 
 
 

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -11,7 +11,7 @@ global:
   hipchat_api_url: 'https://hipchat.foobar.org/'
   slack_api_url: "http://mysecret.example.com/"
   http_config:
-    proxy_url:
+    proxy_url: 'http://127.0.0.1:1025'
 
 
 


### PR DESCRIPTION
closes  #1649
the variable `DefaultGlobalConfig` was being used to initialize values, but it stored previous information due to which some things were persisting in the newer initialization.

In this PR, `DefaultGlobalConfig` is changed to a function so that it returns a fresh `GlobalConfig`  for initialization.

also added some comments.