### PR TITLE
Unused function 'QTimeRange' and empty slice declaration via literal 

### DIFF
--- a/silence/silence.go
+++ b/silence/silence.go
@@ -511,22 +511,11 @@ type query struct {
 // should be dropped from a result set for a given time.
 type silenceFilter func(*pb.Silence, *Silences, time.Time) (bool, error)
 
-var errNotSupported = errors.New("query parameter not supported")
-
 // QIDs configures a query to select the given silence IDs.
 func QIDs(ids ...string) QueryParam {
 	return func(q *query) error {
 		q.ids = append(q.ids, ids...)
 		return nil
-	}
-}
-
-// QTimeRange configures a query to search for silences that are active
-// in the given time range.
-// TODO(fabxc): not supported yet.
-func QTimeRange(start, end time.Time) QueryParam {
-	return func(q *query) error {
-		return errNotSupported
 	}
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -68,7 +68,7 @@ func (a *Alerts) gc() {
 	a.Lock()
 	defer a.Unlock()
 
-	resolved := []*types.Alert{}
+	var resolved []*types.Alert
 	for fp, alert := range a.c {
 		if alert.Resolved() {
 			delete(a.c, fp)


### PR DESCRIPTION
1.There is an unused function 'QTimeRange', clean it.
2. Slice declaration with empty literal initializer instead of nil.