### PR TITLE
Enrich templating functions

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -134,6 +134,9 @@ var DefaultFuncs = FuncMap{
 	"join": func(sep string, s []string) string {
 		return strings.Join(s, sep)
 	},
+	"split": func(sep string, s string) []string {
+		return strings.Split(s, sep)
+	},
 	"match": regexp.MatchString,
 	"safeHtml": func(text string) tmplhtml.HTML {
 		return tmplhtml.HTML(text)

--- a/template/template.go
+++ b/template/template.go
@@ -141,6 +141,9 @@ var DefaultFuncs = FuncMap{
 	"safeHtml": func(text string) tmplhtml.HTML {
 		return tmplhtml.HTML(text)
 	},
+	"urlEncode": func(text string) string {
+		return url.QueryEscape(text)
+	},
 	"reReplaceAll": func(pattern, repl, text string) string {
 		re := regexp.MustCompile(pattern)
 		return re.ReplaceAllString(text, repl)

--- a/template/template.go
+++ b/template/template.go
@@ -212,6 +212,22 @@ func (kv KV) Remove(keys []string) KV {
 	return res
 }
 
+// Select returns a copy of the key/value set with the given keys.
+func (kv KV) Select(keys []string) KV {
+	keySet := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		keySet[k] = struct{}{}
+	}
+
+	res := KV{}
+	for k, v := range kv {
+		if _, ok := keySet[k]; ok {
+			res[k] = v
+		}
+	}
+	return res
+}
+
 // Names returns the names of the label names in the LabelSet.
 func (kv KV) Names() []string {
 	return kv.SortedPairs().Names()


### PR DESCRIPTION
This PR does two things.

First it adds two new functions usable in templates:

 - `split(separator, string) []string`: convert a string to an array of strings
 - `urlEncode(string) string`: convert a string to another usable in URL query parameters

Then it adds a `Select([]string) KV` method on the KV struct.

The goal of all of this is to improve the templates of pagerduty, i.e., selecting only useful labels in the alert description:

```
        pagerduty_configs:
        - routing_key: xxxxxxxxxxxxxxxxxxxxxxxxxx
          details:
            firing: |
              {{ range .Alerts.Firing }}Labels:
              {{ range .Labels.SortedPairs -}}
              - {{ .Name }} = {{ .Value }}
              {{ end }}
              Annotations:
              {{ range .Annotations.SortedPairs -}}
              - {{ .Name }} = {{ .Value }}
              {{ end }}
              Source: {{ .GeneratorURL }}

              {{ end }}
          description: |
            [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .GroupLabels.SortedPairs.Values | join " " }}{{ " " }}
            {{- if gt (len .CommonLabels) (len .GroupLabels) -}}
              (
              {{- if .CommonAnnotations.alert_title_labels -}}
                {{- $allowed_labels := split "," .CommonAnnotations.alert_title_labels -}}
                {{- with .CommonLabels.Remove .GroupLabels.Names -}}
                  {{- with .Select $allowed_labels -}}
                    {{- .Values | join " " -}}
                  {{- end -}}
                {{- end -}}
              {{- else -}}
                {{- with .CommonLabels.Remove .GroupLabels.Names -}}
                  {{- .Values | join " " -}}
                {{- end -}}
              {{- end -}}
              )
            {{- end -}}
```

If you decide to surprise me for once and merge this I'll make a PR for the documentation.