### PR TITLE
support for assuming first label is alertname in silence add and query

### DIFF
--- a/cli/silence_add.go
+++ b/cli/silence_add.go
@@ -89,6 +89,16 @@ func configureSilenceAddCmd(cc *kingpin.CmdClause) {
 func (c *silenceAddCmd) add(ctx context.Context, _ *kingpin.ParseContext) error {
 	var err error
 
+	if len(c.matchers) > 0 {
+		// If the parser fails then we likely don't have a (=|=~|!=|!~) so lets
+		// assume that the user wants alertname=<arg> and prepend `alertname=`
+		// to the front.
+		_, err := parseMatchers([]string{c.matchers[0]})
+		if err != nil {
+			c.matchers[0] = fmt.Sprintf("alertname=%s", c.matchers[0])
+		}
+	}
+
 	matchers, err := parseMatchers(c.matchers)
 	if err != nil {
 		return err

--- a/cli/silence_query.go
+++ b/cli/silence_query.go
@@ -93,17 +93,14 @@ func configureSilenceQueryCmd(cc *kingpin.CmdClause) {
 
 func (c *silenceQueryCmd) query(ctx context.Context, _ *kingpin.ParseContext) error {
 	var filterString = ""
-	if len(c.matchers) == 1 {
+	if len(c.matchers) > 0 {
 		// If the parser fails then we likely don't have a (=|=~|!=|!~) so lets
 		// assume that the user wants alertname=<arg> and prepend `alertname=`
 		// to the front.
 		_, err := parse.Matcher(c.matchers[0])
 		if err != nil {
-			filterString = fmt.Sprintf("{alertname=%s}", c.matchers[0])
-		} else {
-			filterString = fmt.Sprintf("{%s}", strings.Join(c.matchers, ","))
+			c.matchers[0] = fmt.Sprintf("alertname=%s", c.matchers[0])
 		}
-	} else if len(c.matchers) > 1 {
 		filterString = fmt.Sprintf("{%s}", strings.Join(c.matchers, ","))
 	}
 


### PR DESCRIPTION
ref #1575
This PR adds support for assuming the first label is `alertname` in silence add and query. It was already existing on silence query, did some cleanup.

Will create another PR for #1682
