### PR TITLE
Pull DNS refresh into 0.15 branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,7 @@ ifdef DEBUG
 	bindata_flags = -debug
 endif
 
-STATICCHECK_IGNORE = \
-  github.com/prometheus/alertmanager/notify/notify.go:SA6002
-
+STATICCHECK_IGNORE =
 
 .PHONY: build-all
 # Will build both the front-end as well as the back-end

--- a/Makefile.common
+++ b/Makefile.common
@@ -16,7 +16,7 @@
 # !!! Open PRs only against the prometheus/prometheus/Makefile.common repository!
 
 # Example usage :
-# Create the main Makefile in the root project directory. 
+# Create the main Makefile in the root project directory.
 # include Makefile.common
 # customTarget:
 # 	@echo ">> Running customTarget"
@@ -28,25 +28,86 @@ unexport GOBIN
 GO           ?= go
 GOFMT        ?= $(GO)fmt
 FIRST_GOPATH := $(firstword $(subst :, ,$(shell $(GO) env GOPATH)))
+GOOPTS       ?=
+GOHOSTOS     ?= $(shell $(GO) env GOHOSTOS)
+GOHOSTARCH   ?= $(shell $(GO) env GOHOSTARCH)
+
+GO_VERSION        ?= $(shell $(GO) version)
+GO_VERSION_NUMBER ?= $(word 3, $(GO_VERSION))
+PRE_GO_111        ?= $(shell echo $(GO_VERSION_NUMBER) | grep -E 'go1\.(10|[0-9])\.')
+
+unexport GOVENDOR
+ifeq (, $(PRE_GO_111))
+	ifneq (,$(wildcard go.mod))
+		# Enforce Go modules support just in case the directory is inside GOPATH (and for Travis CI).
+		GO111MODULE := on
+
+		ifneq (,$(wildcard vendor))
+			# Always use the local vendor/ directory to satisfy the dependencies.
+			GOOPTS := $(GOOPTS) -mod=vendor
+		endif
+	endif
+else
+	ifneq (,$(wildcard go.mod))
+		ifneq (,$(wildcard vendor))
+$(warning This repository requires Go >= 1.11 because of Go modules)
+$(warning Some recipes may not work as expected as the current Go runtime is '$(GO_VERSION_NUMBER)')
+		endif
+	else
+		# This repository isn't using Go modules (yet).
+		GOVENDOR := $(FIRST_GOPATH)/bin/govendor
+	endif
+
+	unexport GO111MODULE
+endif
 PROMU        := $(FIRST_GOPATH)/bin/promu
 STATICCHECK  := $(FIRST_GOPATH)/bin/staticcheck
-GOVENDOR     := $(FIRST_GOPATH)/bin/govendor
 pkgs          = ./...
+
+ifeq (arm, $(GOHOSTARCH))
+	GOHOSTARM ?= $(shell GOARM= $(GO) env GOARM)
+	GO_BUILD_PLATFORM ?= $(GOHOSTOS)-$(GOHOSTARCH)v$(GOHOSTARM)
+else
+	GO_BUILD_PLATFORM ?= $(GOHOSTOS)-$(GOHOSTARCH)
+endif
+
+PROMU_VERSION ?= 0.2.0
+PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_VERSION)/promu-$(PROMU_VERSION).$(GO_BUILD_PLATFORM).tar.gz
+STATICCHECK_VERSION ?= 2019.1
+STATICCHECK_URL     := https://github.com/dominikh/go-tools/releases/download/$(STATICCHECK_VERSION)/staticcheck_$(GOHOSTOS)_$(GOHOSTARCH)
 
 PREFIX                  ?= $(shell pwd)
 BIN_DIR                 ?= $(shell pwd)
 DOCKER_IMAGE_TAG        ?= $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))
+DOCKER_REPO             ?= prom
+
+ifeq ($(GOHOSTARCH),amd64)
+        ifeq ($(GOHOSTOS),$(filter $(GOHOSTOS),linux freebsd darwin windows))
+                # Only supported on amd64
+                test-flags := -race
+        endif
+endif
 
 .PHONY: all
-all: style staticcheck unused build test
+all: precheck style staticcheck unused build test
 
-.PHONY: style
-style:
+# This rule is used to forward a target like "build" to "common-build".  This
+# allows a new "build" target to be defined in a Makefile which includes this
+# one and override "common-build" without override warnings.
+%: common-% ;
+
+.PHONY: common-style
+common-style:
 	@echo ">> checking code style"
-	! $(GOFMT) -d $$(find . -path ./vendor -prune -o -name '*.go' -print) | grep '^'
+	@fmtRes=$$($(GOFMT) -d $$(find . -path ./vendor -prune -o -name '*.go' -print)); \
+	if [ -n "$${fmtRes}" ]; then \
+		echo "gofmt checking failed!"; echo "$${fmtRes}"; echo; \
+		echo "Please ensure you are using $$($(GO) version) for formatting code."; \
+		exit 1; \
+	fi
 
-.PHONY: check_license
-check_license:
+.PHONY: common-check_license
+common-check_license:
 	@echo ">> checking license header"
 	@licRes=$$(for file in $$(find . -type f -iname '*.go' ! -path './vendor/*') ; do \
                awk 'NR<=3' $$file | grep -Eq "(Copyright|generated|GENERATED)" || echo $$file; \
@@ -56,58 +117,117 @@ check_license:
                exit 1; \
        fi
 
-.PHONY: test-short
-test-short:
+.PHONY: common-test-short
+common-test-short:
 	@echo ">> running short tests"
-	$(GO) test -short $(pkgs)
+	GO111MODULE=$(GO111MODULE) $(GO) test -short $(GOOPTS) $(pkgs)
 
-.PHONY: test
-test:
+.PHONY: common-test
+common-test:
 	@echo ">> running all tests"
-	$(GO) test -race $(pkgs)
+	GO111MODULE=$(GO111MODULE) $(GO) test $(test-flags) $(GOOPTS) $(pkgs)
 
-.PHONY: format
-format:
+.PHONY: common-format
+common-format:
 	@echo ">> formatting code"
-	$(GO) fmt $(pkgs)
+	GO111MODULE=$(GO111MODULE) $(GO) fmt $(pkgs)
 
-.PHONY: vet
-vet:
+.PHONY: common-vet
+common-vet:
 	@echo ">> vetting code"
-	$(GO) vet $(pkgs)
+	GO111MODULE=$(GO111MODULE) $(GO) vet $(GOOPTS) $(pkgs)
 
-.PHONY: staticcheck
-staticcheck: $(STATICCHECK)
+.PHONY: common-staticcheck
+common-staticcheck: $(STATICCHECK)
 	@echo ">> running staticcheck"
+	chmod +x $(STATICCHECK)
+ifdef GO111MODULE
+# 'go list' needs to be executed before staticcheck to prepopulate the modules cache.
+# Otherwise staticcheck might fail randomly for some reason not yet explained.
+	GO111MODULE=$(GO111MODULE) $(GO) list -e -compiled -test=true -export=false -deps=true -find=false -tags= -- ./... > /dev/null
+	GO111MODULE=$(GO111MODULE) $(STATICCHECK) -ignore "$(STATICCHECK_IGNORE)" $(pkgs)
+else
 	$(STATICCHECK) -ignore "$(STATICCHECK_IGNORE)" $(pkgs)
+endif
 
-.PHONY: unused
-unused: $(GOVENDOR)
+.PHONY: common-unused
+common-unused: $(GOVENDOR)
+ifdef GOVENDOR
 	@echo ">> running check for unused packages"
 	@$(GOVENDOR) list +unused | grep . && exit 1 || echo 'No unused packages'
+else
+ifdef GO111MODULE
+	@echo ">> running check for unused/missing packages in go.mod"
+	GO111MODULE=$(GO111MODULE) $(GO) mod tidy
+ifeq (,$(wildcard vendor))
+	@git diff --exit-code -- go.sum go.mod
+else
+	@echo ">> running check for unused packages in vendor/"
+	GO111MODULE=$(GO111MODULE) $(GO) mod vendor
+	@git diff --exit-code -- go.sum go.mod vendor/
+endif
+endif
+endif
 
-.PHONY: build
-build: promu
+.PHONY: common-build
+common-build: promu
 	@echo ">> building binaries"
-	$(PROMU) build --prefix $(PREFIX)
+	GO111MODULE=$(GO111MODULE) $(PROMU) build --prefix $(PREFIX)
 
-.PHONY: tarball
-tarball: promu
+.PHONY: common-tarball
+common-tarball: promu
 	@echo ">> building release tarball"
 	$(PROMU) tarball --prefix $(PREFIX) $(BIN_DIR)
 
-.PHONY: docker
-docker:
-	docker build -t "$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" .
+.PHONY: common-docker
+common-docker:
+	docker build -t "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" .
+
+.PHONY: common-docker-publish
+common-docker-publish:
+	docker push "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)"
+
+.PHONY: common-docker-tag-latest
+common-docker-tag-latest:
+	docker tag "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):latest"
 
 .PHONY: promu
-promu:
-	GOOS= GOARCH= $(GO) get -u github.com/prometheus/promu
+promu: $(PROMU)
 
-.PHONY: $(STATICCHECK)
+$(PROMU):
+	$(eval PROMU_TMP := $(shell mktemp -d))
+	curl -s -L $(PROMU_URL) | tar -xvzf - -C $(PROMU_TMP)
+	mkdir -p $(FIRST_GOPATH)/bin
+	cp $(PROMU_TMP)/promu-$(PROMU_VERSION).$(GO_BUILD_PLATFORM)/promu $(FIRST_GOPATH)/bin/promu
+	rm -r $(PROMU_TMP)
+
+.PHONY: proto
+proto:
+	@echo ">> generating code from proto files"
+	@./scripts/genproto.sh
+
 $(STATICCHECK):
-	GOOS= GOARCH= $(GO) get -u honnef.co/go/tools/cmd/staticcheck
+	mkdir -p $(FIRST_GOPATH)/bin
+	curl -s -L $(STATICCHECK_URL) > $(STATICCHECK)
 
+ifdef GOVENDOR
 .PHONY: $(GOVENDOR)
 $(GOVENDOR):
 	GOOS= GOARCH= $(GO) get -u github.com/kardianos/govendor
+endif
+
+.PHONY: precheck
+precheck::
+
+define PRECHECK_COMMAND_template =
+precheck:: $(1)_precheck
+
+
+PRECHECK_COMMAND_$(1) ?= $(1) $$(strip $$(PRECHECK_OPTIONS_$(1)))
+.PHONY: $(1)_precheck
+$(1)_precheck:
+	@if ! $$(PRECHECK_COMMAND_$(1)) 1>/dev/null 2>&1; then \
+		echo "Execution of '$$(PRECHECK_COMMAND_$(1))' command failed. Is $(1) installed?"; \
+		exit 1; \
+	fi
+endef

--- a/api/api.go
+++ b/api/api.go
@@ -161,7 +161,6 @@ func (api *API) Update(cfg *config.Config, resolveTimeout time.Duration) error {
 type errorType string
 
 const (
-	errorNone     errorType = ""
 	errorInternal errorType = "server_error"
 	errorBadData  errorType = "bad_data"
 )

--- a/client/client.go
+++ b/client/client.go
@@ -31,11 +31,10 @@ import (
 const (
 	apiPrefix = "/api/v1"
 
-	epStatus      = apiPrefix + "/status"
-	epSilence     = apiPrefix + "/silence/:id"
-	epSilences    = apiPrefix + "/silences"
-	epAlerts      = apiPrefix + "/alerts"
-	epAlertGroups = apiPrefix + "/alerts/groups"
+	epStatus   = apiPrefix + "/status"
+	epSilence  = apiPrefix + "/silence/:id"
+	epSilences = apiPrefix + "/silences"
+	epAlerts   = apiPrefix + "/alerts"
 
 	statusSuccess = "success"
 	statusError   = "error"

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -319,7 +319,7 @@ func TestAPI(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if bytes.Compare(want, got) != 0 {
+			if !bytes.Equal(want, got) {
 				t.Errorf("unexpected result: want: %s, got: %s", string(want), string(got))
 			}
 		})

--- a/nflog/nflogpb/set_test.go
+++ b/nflog/nflogpb/set_test.go
@@ -84,7 +84,7 @@ func newSubset(elements ...uint64) map[uint64]struct{} {
 
 func elements(m map[uint64]struct{}) []uint64 {
 	els := make([]uint64, 0, len(m))
-	for k, _ := range m {
+	for k := range m {
 		els = append(els, k)
 	}
 

--- a/notify/impl.go
+++ b/notify/impl.go
@@ -807,7 +807,7 @@ func (n *Hipchat) Notify(ctx context.Context, as ...*types.Alert) (bool, error) 
 	)
 	apiURL.Path += fmt.Sprintf("v2/room/%s/notification", roomid)
 	q := apiURL.Query()
-	q.Set("auth_token", fmt.Sprintf("%s", n.conf.AuthToken))
+	q.Set("auth_token", string(n.conf.AuthToken))
 	apiURL.RawQuery = q.Encode()
 
 	if n.conf.MessageFormat == "html" {
@@ -919,7 +919,7 @@ func (n *Wechat) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 	}
 
 	// Refresh AccessToken over 2 hours
-	if n.accessToken == "" || time.Now().Sub(n.accessTokenAt) > 2*time.Hour {
+	if n.accessToken == "" || time.Since(n.accessTokenAt) > 2*time.Hour {
 		parameters := url.Values{}
 		parameters.Add("corpsecret", tmpl(string(n.conf.APISecret)))
 		parameters.Add("corpid", tmpl(string(n.conf.CorpID)))

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -489,6 +489,7 @@ func getHashBuffer() []byte {
 
 func putHashBuffer(b []byte) {
 	b = b[:0]
+	//lint:ignore SA6002 relax staticcheck verification.
 	hashBuffers.Put(b)
 }
 

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -33,12 +33,8 @@ var (
 
 func Matchers(s string) ([]*labels.Matcher, error) {
 	matchers := []*labels.Matcher{}
-	if strings.HasPrefix(s, "{") {
-		s = s[1:]
-	}
-	if strings.HasSuffix(s, "}") {
-		s = s[:len(s)-1]
-	}
+	s = strings.TrimPrefix(s, "{")
+	s = strings.TrimSuffix(s, "}")
 
 	var insideQuotes bool
 	var token string

--- a/test/acceptance.go
+++ b/test/acceptance.go
@@ -186,7 +186,7 @@ func (t *AcceptanceTest) Run() {
 	deadline := t.opts.expandTime(latest)
 
 	select {
-	case <-time.After(deadline.Sub(time.Now())):
+	case <-time.After(time.Until(deadline)):
 		// continue
 	case err := <-errc:
 		t.Error(err)
@@ -208,7 +208,7 @@ func (t *AcceptanceTest) runActions() {
 
 		for _, f := range fs {
 			go func(f func()) {
-				time.Sleep(ts.Sub(time.Now()))
+				time.Sleep(time.Until(ts))
 				f()
 				wg.Done()
 			}(f)

--- a/types/types.go
+++ b/types/types.go
@@ -373,10 +373,6 @@ type Silence struct {
 	CreatedBy string `json:"createdBy"`
 	Comment   string `json:"comment,omitempty"`
 
-	// timeFunc provides the time against which to evaluate
-	// the silence. Used for test injection.
-	now func() time.Time
-
 	Status SilenceStatus `json:"status"`
 }
 


### PR DESCRIPTION
This change cherry picks the PR that added DNS refresh logic to master (https://github.com/prometheus/alertmanager/pull/1428) into the 0.15 release branch.

The issue that this change resolved (https://github.com/prometheus/alertmanager/issues/1449) is quite a problem for folks trying to use AlertManager clustering within Kubernetes.  Partitions within the AlertManager cluster can easily occur otherwise (more details in the parent PR).

The above change is presently available only in 0.16.0.  That release is marked alpha, so it's unlikely users will want to pick that up in production.  By adding this change to the 0.15 branch, hopefully a new 0.15 release can be cut with this, so that users of AlertManager on Kubernetes won't have to wait to make use of clustering.