### PR TITLE
api/v2: Disable serving swagger spec and redoc UI

### DIFF
--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -91,6 +91,12 @@ func NewAPI(alerts provider.Alerts, sf getAlertStatusFn, silences *silence.Silen
 	// create new service API
 	openAPI := operations.NewAlertmanagerAPI(swaggerSpec)
 
+	// Skip swagger spec and redoc middleware, only serving the API itself via
+	// RoutesHandler. See: https://github.com/go-swagger/go-swagger/issues/1779
+	openAPI.Middleware = func(b middleware.Builder) http.Handler {
+		return middleware.Spec("", nil, openAPI.Context().RoutesHandler(b))
+	}
+
 	openAPI.AlertGetAlertsHandler = alert_ops.GetAlertsHandlerFunc(api.getAlertsHandler)
 	openAPI.AlertPostAlertsHandler = alert_ops.PostAlertsHandlerFunc(api.postAlertsHandler)
 	openAPI.GeneralGetStatusHandler = general_ops.GetStatusHandlerFunc(api.getStatusHandler)


### PR DESCRIPTION
By default go-swagger serves the swagger spec and the redoc UI. This
patch disables both.

This does not need to be permanent, but for now I would prefer to reduce the attach-surface. What are your thoughts?

//CC @metalmatze (Thanks for the catch!)