### PR TITLE
Allow sending of unauthenticated SMTP requests when smtp_auth_username is not supplied

### DIFF
--- a/notify/impl.go
+++ b/notify/impl.go
@@ -225,7 +225,7 @@ func (n *Email) auth(mechs string) (smtp.Auth, error) {
 	// If no username is set, keep going without authentication.
 	if n.conf.AuthUsername == "" {
 		level.Debug(n.logger).Log("msg", "smtp_auth_username is not configured. Attempting to send email without authenticating")
-		return NoAuth(), nil
+		return nil, nil
 	}
 
 	err := &types.MultiError{}
@@ -1570,21 +1570,6 @@ func (a *loginAuth) Next(fromServer []byte, more bool) ([]byte, error) {
 			return nil, errors.New("unexpected server challenge")
 		}
 	}
-	return nil, nil
-}
-
-type noAuth struct{}
-
-func NoAuth() smtp.Auth {
-	return &noAuth{}
-}
-
-func (a *noAuth) Start(server *smtp.ServerInfo) (string, []byte, error) {
-	// return proto == "" to indicate that the authentication should be skipped.
-	return "", []byte{}, nil
-}
-
-func (a *noAuth) Next(fromServer []byte, more bool) ([]byte, error) {
 	return nil, nil
 }
 

--- a/notify/impl.go
+++ b/notify/impl.go
@@ -221,6 +221,13 @@ func NewEmail(c *config.EmailConfig, t *template.Template, l log.Logger) *Email 
 // auth resolves a string of authentication mechanisms.
 func (n *Email) auth(mechs string) (smtp.Auth, error) {
 	username := n.conf.AuthUsername
+
+	// If no username is set, keep going without authentication
+	if n.conf.AuthUsername == "" {
+        level.Debug(n.logger).Log("msg", "smtp_auth_username is not configured. Attempting to send email without authenticating")
+		return NoAuth(), nil
+    }
+
 	err := &types.MultiError{}
 	for _, mech := range strings.Split(mechs, " ") {
 		switch mech {
@@ -326,6 +333,8 @@ func (n *Email) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 			return true, fmt.Errorf("starttls failed: %s", err)
 		}
 	}
+
+	// If SMTP authentication is configured, check it
 
 	if ok, mech := c.Extension("AUTH"); ok {
 		auth, err := n.auth(mech)
@@ -1549,6 +1558,21 @@ func LoginAuth(username, password string) smtp.Auth {
 
 func (a *loginAuth) Start(server *smtp.ServerInfo) (string, []byte, error) {
 	return "LOGIN", []byte{}, nil
+}
+
+type noAuth struct {}
+
+func NoAuth() smtp.Auth {
+	return &noAuth{}
+}
+
+func (a *noAuth) Start(server *smtp.ServerInfo) (string, []byte, error) {
+	// return proto == "" to indicate that the authentication should be skipped."
+	return "", []byte{}, nil
+}
+
+func (a *noAuth) Next(fromServer []byte, more bool) ([]byte, error) {
+	return nil, nil
 }
 
 // Used for AUTH LOGIN. (Maybe password should be encrypted)

--- a/notify/impl.go
+++ b/notify/impl.go
@@ -1558,21 +1558,6 @@ func (a *loginAuth) Start(server *smtp.ServerInfo) (string, []byte, error) {
 	return "LOGIN", []byte{}, nil
 }
 
-type noAuth struct{}
-
-func NoAuth() smtp.Auth {
-	return &noAuth{}
-}
-
-func (a *noAuth) Start(server *smtp.ServerInfo) (string, []byte, error) {
-	// return proto == "" to indicate that the authentication should be skipped.
-	return "", []byte{}, nil
-}
-
-func (a *noAuth) Next(fromServer []byte, more bool) ([]byte, error) {
-	return nil, nil
-}
-
 // Used for AUTH LOGIN. (Maybe password should be encrypted)
 func (a *loginAuth) Next(fromServer []byte, more bool) ([]byte, error) {
 	if more {
@@ -1585,6 +1570,21 @@ func (a *loginAuth) Next(fromServer []byte, more bool) ([]byte, error) {
 			return nil, errors.New("unexpected server challenge")
 		}
 	}
+	return nil, nil
+}
+
+type noAuth struct{}
+
+func NoAuth() smtp.Auth {
+	return &noAuth{}
+}
+
+func (a *noAuth) Start(server *smtp.ServerInfo) (string, []byte, error) {
+	// return proto == "" to indicate that the authentication should be skipped.
+	return "", []byte{}, nil
+}
+
+func (a *noAuth) Next(fromServer []byte, more bool) ([]byte, error) {
 	return nil, nil
 }
 

--- a/notify/impl.go
+++ b/notify/impl.go
@@ -222,11 +222,11 @@ func NewEmail(c *config.EmailConfig, t *template.Template, l log.Logger) *Email 
 func (n *Email) auth(mechs string) (smtp.Auth, error) {
 	username := n.conf.AuthUsername
 
-	// If no username is set, keep going without authentication
+	// If no username is set, keep going without authentication.
 	if n.conf.AuthUsername == "" {
-        level.Debug(n.logger).Log("msg", "smtp_auth_username is not configured. Attempting to send email without authenticating")
+		level.Debug(n.logger).Log("msg", "smtp_auth_username is not configured. Attempting to send email without authenticating")
 		return NoAuth(), nil
-    }
+	}
 
 	err := &types.MultiError{}
 	for _, mech := range strings.Split(mechs, " ") {
@@ -333,8 +333,6 @@ func (n *Email) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 			return true, fmt.Errorf("starttls failed: %s", err)
 		}
 	}
-
-	// If SMTP authentication is configured, check it
 
 	if ok, mech := c.Extension("AUTH"); ok {
 		auth, err := n.auth(mech)
@@ -1560,14 +1558,14 @@ func (a *loginAuth) Start(server *smtp.ServerInfo) (string, []byte, error) {
 	return "LOGIN", []byte{}, nil
 }
 
-type noAuth struct {}
+type noAuth struct{}
 
 func NoAuth() smtp.Auth {
 	return &noAuth{}
 }
 
 func (a *noAuth) Start(server *smtp.ServerInfo) (string, []byte, error) {
-	// return proto == "" to indicate that the authentication should be skipped."
+	// return proto == "" to indicate that the authentication should be skipped.
 	return "", []byte{}, nil
 }
 

--- a/notify/impl_test.go
+++ b/notify/impl_test.go
@@ -295,7 +295,7 @@ func TestOpsGenie(t *testing.T) {
 func TestEmailConfigNoAuthMechs(t *testing.T) {
 
 	email := &Email{
-		conf: &config.EmailConfig{}, tmpl: &template.Template{}, logger: log.NewNopLogger(),
+		conf: &config.EmailConfig{AuthUsername: "test"}, tmpl: &template.Template{}, logger: log.NewNopLogger(),
 	}
 	_, err := email.auth("")
 	require.Error(t, err)
@@ -304,8 +304,9 @@ func TestEmailConfigNoAuthMechs(t *testing.T) {
 
 func TestEmailConfigMissingAuthParam(t *testing.T) {
 
+	conf := &config.EmailConfig{AuthUsername: "test"}
 	email := &Email{
-		conf: &config.EmailConfig{}, tmpl: &template.Template{}, logger: log.NewNopLogger(),
+		conf: conf, tmpl: &template.Template{}, logger: log.NewNopLogger(),
 	}
 	_, err := email.auth("CRAM-MD5")
 	require.Error(t, err)
@@ -329,7 +330,7 @@ func TestEmailNoUsernameStillOk(t *testing.T) {
 		conf: &config.EmailConfig{}, tmpl: &template.Template{}, logger: log.NewNopLogger(),
 	}
 	_, err := email.auth("CRAM-MD5")
-	require.Error(t, err)
+	require.NoError(t, err)
 }
 
 func TestVictorOpsCustomFields(t *testing.T) {

--- a/notify/impl_test.go
+++ b/notify/impl_test.go
@@ -329,8 +329,9 @@ func TestEmailNoUsernameStillOk(t *testing.T) {
 	email := &Email{
 		conf: &config.EmailConfig{}, tmpl: &template.Template{}, logger: log.NewNopLogger(),
 	}
-	_, err := email.auth("CRAM-MD5")
+	a, err := email.auth("CRAM-MD5")
 	require.NoError(t, err)
+	require.Nil(t, a)
 }
 
 func TestVictorOpsCustomFields(t *testing.T) {

--- a/notify/impl_test.go
+++ b/notify/impl_test.go
@@ -324,6 +324,14 @@ func TestEmailConfigMissingAuthParam(t *testing.T) {
 	require.Equal(t, err.Error(), "missing password for PLAIN auth mechanism; missing password for LOGIN auth mechanism")
 }
 
+func TestEmailNoUsernameStillOk(t *testing.T) {
+	email := &Email{
+		conf: &config.EmailConfig{}, tmpl: &template.Template{}, logger: log.NewNopLogger(),
+	}
+	_, err := email.auth("CRAM-MD5")
+	require.Error(t, err)
+}
+
 func TestVictorOpsCustomFields(t *testing.T) {
 	logger := log.NewNopLogger()
 	tmpl := createTmpl(t)


### PR DESCRIPTION
This PR is intended to replace #1713 which I got into a mess trying to retrospectively sign commits using git rebase.

It adds a noAuth SMTP authentication mechanism which is returned when no `smtp_auth_username` is supplied, allowing this option where a server advertises AUTH but does not require it

CC @simonpasquier - sorry for the extra effort here. 

Closes #1721

