### PR TITLE
main.go: Move marker metric registering into types/types.go

### DIFF
--- a/inhibit/inhibit_test.go
+++ b/inhibit/inhibit_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 
 	"github.com/prometheus/alertmanager/config"
@@ -145,7 +146,7 @@ func TestInhibitRuleMatches(t *testing.T) {
 		TargetMatch: map[string]string{"t": "1"},
 		Equal:       model.LabelNames{"e"},
 	}
-	m := types.NewMarker()
+	m := types.NewMarker(prometheus.NewRegistry())
 	ih := NewInhibitor(nil, []*config.InhibitRule{&cr}, m, nopLogger)
 	ir := ih.rules[0]
 	now := time.Now()
@@ -320,7 +321,7 @@ func TestInhibit(t *testing.T) {
 		},
 	} {
 		ap := newFakeAlerts(tc.alerts)
-		mk := types.NewMarker()
+		mk := types.NewMarker(prometheus.NewRegistry())
 		inhibitor := NewInhibitor(ap, []*config.InhibitRule{inhibitRule()}, mk, nopLogger)
 
 		go func() {

--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
@@ -586,7 +587,7 @@ func TestSilenceStage(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	marker := types.NewMarker()
+	marker := types.NewMarker(prometheus.NewRegistry())
 	silencer := NewSilenceStage(silences, marker)
 
 	in := []model.LabelSet{

--- a/provider/mem/mem_test.go
+++ b/provider/mem/mem_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/kylelemons/godebug/pretty"
 	"github.com/prometheus/alertmanager/store"
 	"github.com/prometheus/alertmanager/types"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 )
@@ -83,7 +84,7 @@ func init() {
 // If the channel of a listener is at its limit, `alerts.Lock` is blocked, whereby
 // a listener can not unsubscribe as the lock is hold by `alerts.Lock`.
 func TestAlertsSubscribePutStarvation(t *testing.T) {
-	marker := types.NewMarker()
+	marker := types.NewMarker(prometheus.NewRegistry())
 	alerts, err := NewAlerts(context.Background(), marker, 30*time.Minute, log.NewNopLogger())
 	if err != nil {
 		t.Fatal(err)
@@ -134,7 +135,7 @@ func TestAlertsSubscribePutStarvation(t *testing.T) {
 }
 
 func TestAlertsPut(t *testing.T) {
-	marker := types.NewMarker()
+	marker := types.NewMarker(prometheus.NewRegistry())
 	alerts, err := NewAlerts(context.Background(), marker, 30*time.Minute, log.NewNopLogger())
 	if err != nil {
 		t.Fatal(err)
@@ -159,7 +160,7 @@ func TestAlertsPut(t *testing.T) {
 }
 
 func TestAlertsSubscribe(t *testing.T) {
-	marker := types.NewMarker()
+	marker := types.NewMarker(prometheus.NewRegistry())
 	alerts, err := NewAlerts(context.Background(), marker, 30*time.Minute, log.NewNopLogger())
 	if err != nil {
 		t.Fatal(err)
@@ -248,7 +249,7 @@ func TestAlertsSubscribe(t *testing.T) {
 }
 
 func TestAlertsGetPending(t *testing.T) {
-	marker := types.NewMarker()
+	marker := types.NewMarker(prometheus.NewRegistry())
 	alerts, err := NewAlerts(context.Background(), marker, 30*time.Minute, log.NewNopLogger())
 	if err != nil {
 		t.Fatal(err)
@@ -291,7 +292,7 @@ func TestAlertsGetPending(t *testing.T) {
 }
 
 func TestAlertsGC(t *testing.T) {
-	marker := types.NewMarker()
+	marker := types.NewMarker(prometheus.NewRegistry())
 	alerts, err := NewAlerts(context.Background(), marker, 200*time.Millisecond, log.NewNopLogger())
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Instead of registering marker metrics inside of
cmd/alertmanager/main.go, register them in types/types.go, encapsulating
marker specific logic in its module, not in main.go. In addition it
paves the path for removing the usage of the global metric registry in
the future, by taking a local metric registerer.

Signed-off-by: Max Leonard Inden <IndenML@gmail.com>