### PR TITLE
Fix build problems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ PRECHECK_OPTIONS_bzr = version
 build-all: assets apiv2 build
 
 assets: ui/app/script.js ui/app/index.html ui/app/lib template/default.tmpl
-	cd $(PREFIX)/asset && $(GO) generate
+	GO111MODULE=$(GO111MODULE) $(GO) generate ./asset
 	@$(GOFMT) -w ./asset
 
 ui/app/script.js: $(shell find ui/app/src -iname *.elm) api/v2/openapi.yaml

--- a/scripts/errcheck_excludes.txt
+++ b/scripts/errcheck_excludes.txt
@@ -3,8 +3,8 @@
 fmt.Fprintf
 fmt.Fprintln
 
+// Exclude both vendored and un-vendored to cover both vendor mode and module mode. 
 (github.com/prometheus/alertmanager/vendor/github.com/go-kit/kit/log.Logger).Log
-// Allowed log levels are enforced via kingpin
-(*github.com/prometheus/alertmanager/vendor/github.com/prometheus/common/promlog.AllowedLevel).Set
+(github.com/go-kit/kit/log.Logger).Log
 // Generated via go-swagger
 (*github.com/prometheus/alertmanager/api/v2/restapi.Server).Shutdown


### PR DESCRIPTION
This will fix the errcheck problems, and it might have an impact on the `go generate` part.

It indeed looks like Circle somehow keeps `GOPATH` in the environment for external commands (via `go generate` or the `errcheck` command), while Travis somehow removes it or builds outside of it or whatever. More investigation needed, but this removes a few parts of the equation at least.