### PR TITLE
api/v2: serve OpenAPI specification

### DIFF
--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -91,10 +91,11 @@ func NewAPI(alerts provider.Alerts, sf getAlertStatusFn, silences *silence.Silen
 	// create new service API
 	openAPI := operations.NewAlertmanagerAPI(swaggerSpec)
 
-	// Skip swagger spec and redoc middleware, only serving the API itself via
-	// RoutesHandler. See: https://github.com/go-swagger/go-swagger/issues/1779
+	// Skip the  redoc middleware, only serving the OpenAPI specification and
+	// the API itself via RoutesHandler. See:
+	// https://github.com/go-swagger/go-swagger/issues/1779
 	openAPI.Middleware = func(b middleware.Builder) http.Handler {
-		return middleware.Spec("", nil, openAPI.Context().RoutesHandler(b))
+		return middleware.Spec("", swaggerSpec.Raw(), openAPI.Context().RoutesHandler(b))
 	}
 
 	openAPI.AlertGetAlertsHandler = alert_ops.GetAlertsHandlerFunc(api.getAlertsHandler)


### PR DESCRIPTION
Follow up of #1711. It seems to me that exposing the OpenAPI specification at `/api/v2/swagger.json` isn't too risky and might be useful for some users ([ref](https://groups.google.com/d/msg/prometheus-users/pzTnCvQ-A0Q/EVFmjMYtDwAJ)). 