### PR TITLE
Modify the self-inhibition prevention semantics

### DIFF
--- a/inhibit/inhibit.go
+++ b/inhibit/inhibit.go
@@ -29,8 +29,9 @@ import (
 	"github.com/prometheus/alertmanager/types"
 )
 
-// An Inhibitor determines whether a given label set is muted
-// based on the currently active alerts and a set of inhibition rules.
+// An Inhibitor determines whether a given label set is muted based on the
+// currently active alerts and a set of inhibition rules. It implements the
+// Muter interface.
 type Inhibitor struct {
 	alerts provider.Alerts
 	rules  []*InhibitRule
@@ -121,7 +122,8 @@ func (ih *Inhibitor) Stop() {
 	}
 }
 
-// Mutes returns true iff the given label set is muted.
+// Mutes returns true iff the given label set is muted. It implements the Muter
+// interface.
 func (ih *Inhibitor) Mutes(lset model.LabelSet) bool {
 	fp := lset.Fingerprint()
 
@@ -197,8 +199,9 @@ func NewInhibitRule(cr *config.InhibitRule) *InhibitRule {
 }
 
 // hasEqual checks whether the source cache contains alerts matching the equal
-// labels for the given label set. If excludeTwoSidedMatch is true, alerts that
-// match both the source and the target side of the rule are disregarded.
+// labels for the given label set. If so, the fingerprint of one of those alerts
+// is returned. If excludeTwoSidedMatch is true, alerts that match both the
+// source and the target side of the rule are disregarded.
 func (r *InhibitRule) hasEqual(lset model.LabelSet, excludeTwoSidedMatch bool) (model.Fingerprint, bool) {
 Outer:
 	for a := range r.scache.List() {

--- a/inhibit/inhibit.go
+++ b/inhibit/inhibit.go
@@ -126,8 +126,13 @@ func (ih *Inhibitor) Mutes(lset model.LabelSet) bool {
 	fp := lset.Fingerprint()
 
 	for _, r := range ih.rules {
-		// Only inhibit if target matchers match but source matchers don't.
-		if inhibitedByFP, eq := r.hasEqual(lset); !r.SourceMatchers.Match(lset) && r.TargetMatchers.Match(lset) && eq {
+		if !r.TargetMatchers.Match(lset) {
+			// If target side of rule doesn't match, we don't need to look any further.
+			continue
+		}
+		// If we are here, the target side matches. If the source side matches, too, we
+		// need to exclude inhibiting alerts for which the same is true.
+		if inhibitedByFP, eq := r.hasEqual(lset, r.SourceMatchers.Match(lset)); eq {
 			ih.marker.SetInhibited(fp, inhibitedByFP.String())
 			return true
 		}
@@ -191,9 +196,10 @@ func NewInhibitRule(cr *config.InhibitRule) *InhibitRule {
 	}
 }
 
-// hasEqual checks whether the source cache contains alerts matching
-// the equal labels for the given label set.
-func (r *InhibitRule) hasEqual(lset model.LabelSet) (model.Fingerprint, bool) {
+// hasEqual checks whether the source cache contains alerts matching the equal
+// labels for the given label set. If excludeTwoSidedMatch is true, alerts that
+// match both the source and the target side of the rule are disregarded.
+func (r *InhibitRule) hasEqual(lset model.LabelSet, excludeTwoSidedMatch bool) (model.Fingerprint, bool) {
 Outer:
 	for a := range r.scache.List() {
 		// The cache might be stale and contain resolved alerts.
@@ -204,6 +210,9 @@ Outer:
 			if a.Labels[n] != lset[n] {
 				continue Outer
 			}
+		}
+		if excludeTwoSidedMatch && r.TargetMatchers.Match(a.Labels) {
+			continue Outer
 		}
 		return a.Fingerprint(), true
 	}

--- a/inhibit/inhibit_test.go
+++ b/inhibit/inhibit_test.go
@@ -131,7 +131,7 @@ func TestInhibitRuleHasEqual(t *testing.T) {
 			r.scache.Set(v)
 		}
 
-		if _, have := r.hasEqual(c.input); have != c.result {
+		if _, have := r.hasEqual(c.input, false); have != c.result {
 			t.Errorf("Unexpected result %t, expected %t", have, c.result)
 		}
 	}
@@ -140,55 +140,87 @@ func TestInhibitRuleHasEqual(t *testing.T) {
 func TestInhibitRuleMatches(t *testing.T) {
 	t.Parallel()
 
-	// Simple inhibut rule
-	cr := config.InhibitRule{
-		SourceMatch: map[string]string{"s": "1"},
-		TargetMatch: map[string]string{"t": "1"},
+	rule1 := config.InhibitRule{
+		SourceMatch: map[string]string{"s1": "1"},
+		TargetMatch: map[string]string{"t1": "1"},
+		Equal:       model.LabelNames{"e"},
+	}
+	rule2 := config.InhibitRule{
+		SourceMatch: map[string]string{"s2": "1"},
+		TargetMatch: map[string]string{"t2": "1"},
 		Equal:       model.LabelNames{"e"},
 	}
 	m := types.NewMarker(prometheus.NewRegistry())
-	ih := NewInhibitor(nil, []*config.InhibitRule{&cr}, m, nopLogger)
-	ir := ih.rules[0]
+	ih := NewInhibitor(nil, []*config.InhibitRule{&rule1, &rule2}, m, nopLogger)
 	now := time.Now()
-	// Active alert that matches the source filter
-	sourceAlert := &types.Alert{
+	// Active alert that matches the source filter of rule1.
+	sourceAlert1 := &types.Alert{
 		Alert: model.Alert{
-			Labels:   model.LabelSet{"s": "1", "e": "1"},
+			Labels:   model.LabelSet{"s1": "1", "t1": "2", "e": "1"},
+			StartsAt: now.Add(-time.Minute),
+			EndsAt:   now.Add(time.Hour),
+		},
+	}
+	// Active alert that matches the source filter _and_ the target filter of rule2.
+	sourceAlert2 := &types.Alert{
+		Alert: model.Alert{
+			Labels:   model.LabelSet{"s2": "1", "t2": "1", "e": "1"},
 			StartsAt: now.Add(-time.Minute),
 			EndsAt:   now.Add(time.Hour),
 		},
 	}
 
-	ir.scache = store.NewAlerts(5 * time.Minute)
-	ir.scache.Set(sourceAlert)
+	ih.rules[0].scache = store.NewAlerts(5 * time.Minute)
+	ih.rules[0].scache.Set(sourceAlert1)
+	ih.rules[1].scache = store.NewAlerts(5 * time.Minute)
+	ih.rules[1].scache.Set(sourceAlert2)
 
 	cases := []struct {
 		target   model.LabelSet
 		expected bool
 	}{
 		{
-			// Matches target filter, inhibited
-			target:   model.LabelSet{"t": "1", "e": "1"},
+			// Matches target filter of rule1, inhibited.
+			target:   model.LabelSet{"t1": "1", "e": "1"},
 			expected: true,
 		},
 		{
-			// Matches target filter (plus noise), inhibited
-			target:   model.LabelSet{"t": "1", "t2": "1", "e": "1"},
+			// Matches target filter of rule2, inhibited.
+			target:   model.LabelSet{"t2": "1", "e": "1"},
 			expected: true,
 		},
 		{
-			// Doesn't match target filter, not inhibited
-			target:   model.LabelSet{"t": "0", "e": "1"},
+			// Matches target filter of rule1 (plus noise), inhibited.
+			target:   model.LabelSet{"t1": "1", "t3": "1", "e": "1"},
+			expected: true,
+		},
+		{
+			// Matches target filter of rule1 plus rule2, inhibited.
+			target:   model.LabelSet{"t1": "1", "t2": "1", "e": "1"},
+			expected: true,
+		},
+		{
+			// Doesn't match target filter, not inhibited.
+			target:   model.LabelSet{"t1": "0", "e": "1"},
 			expected: false,
 		},
 		{
-			// Matches both source and target filters, not inhibited
-			target:   model.LabelSet{"s": "1", "t": "1", "e": "1"},
+			// Matches both source and target filters of rule1,
+			// inhibited because sourceAlert1 matches only the
+			// source filter of rule1.
+			target:   model.LabelSet{"s1": "1", "t1": "1", "e": "1"},
+			expected: true,
+		},
+		{
+			// Matches both source and target filters of rule2,
+			// inhibited because sourceAlert2 matches also both the
+			// source and target filterof rule1.
+			target:   model.LabelSet{"s2": "1", "t2": "1", "e": "1"},
 			expected: false,
 		},
 		{
 			// Matches target filter, equal label doesn't match, not inhibited
-			target:   model.LabelSet{"t": "1", "e": "0"},
+			target:   model.LabelSet{"t1": "1", "e": "0"},
 			expected: false,
 		},
 	}

--- a/inhibit/inhibit_test.go
+++ b/inhibit/inhibit_test.go
@@ -213,8 +213,8 @@ func TestInhibitRuleMatches(t *testing.T) {
 		},
 		{
 			// Matches both source and target filters of rule2,
-			// inhibited because sourceAlert2 matches also both the
-			// source and target filterof rule1.
+			// not inhibited because sourceAlert2 matches also both the
+			// source and target filter of rule1.
 			target:   model.LabelSet{"s2": "1", "t2": "1", "e": "1"},
 			expected: false,
 		},

--- a/inhibit/inhibit_test.go
+++ b/inhibit/inhibit_test.go
@@ -214,7 +214,7 @@ func TestInhibitRuleMatches(t *testing.T) {
 		{
 			// Matches both source and target filters of rule2,
 			// not inhibited because sourceAlert2 matches also both the
-			// source and target filter of rule1.
+			// source and target filter of rule2.
 			target:   model.LabelSet{"s2": "1", "t2": "1", "e": "1"},
 			expected: false,
 		},


### PR DESCRIPTION
This has been discussed in #666 (issue of hell...).

As concluded there, the cleanest semantics is most likely the
following: "An alert that matches both target and source side cannot
inhibit alerts for which the same is true." The two open questions
were:
1. How difficult is the implementation?
2. Is it needed?

This relatively simple commit proves that the answer to (1) is: Not
very difficult. (This also includes a performance-improving
simplification, which would have been possible without a change of
semantics.)

The answer to (2) is twofold:

For one, the original use case in #666 wasn't solved by our interim
solution. What we solved is the case where the self-inhibition is
triggered by a wide target match, i.e. I have a specific alert that
should inhibit a whole group of target alerts without inhibiting
itself. What we did _not_ solve is the inverted case: Self-inhibition
by a wide source match, i.e. an alert that should only fire if none of
a whole group of source alert fires. I mean, we "fixed" it as in, the
target alert will _never_ be inhibited, but @lmb in #666 wanted the
alert to be inhibited _sometimes_ (just not _always_).

The other part is that I think that the asymmetry in our interim
solution will at some point haunt us. Thus, I really would like to get
this change in before we do a 1.0 release.

In practice, I expect this to be only relevant in very rare cases. But
those cases will be most difficult to reason with, and I claim that
the solution in this commit is matching what humans intuitively
expect.

Signed-off-by: beorn7 <beorn@soundcloud.com>