### PR TITLE
Improve doc comments for Marker and friends

### DIFF
--- a/inhibit/inhibit.go
+++ b/inhibit/inhibit.go
@@ -29,8 +29,9 @@ import (
 	"github.com/prometheus/alertmanager/types"
 )
 
-// An Inhibitor determines whether a given label set is muted
-// based on the currently active alerts and a set of inhibition rules.
+// An Inhibitor determines whether a given label set is muted based on the
+// currently active alerts and a set of inhibition rules. It implements the
+// Muter interface.
 type Inhibitor struct {
 	alerts provider.Alerts
 	rules  []*InhibitRule
@@ -121,7 +122,8 @@ func (ih *Inhibitor) Stop() {
 	}
 }
 
-// Mutes returns true iff the given label set is muted.
+// Mutes returns true iff the given label set is muted. It implements the Muter
+// interface.
 func (ih *Inhibitor) Mutes(lset model.LabelSet) bool {
 	fp := lset.Fingerprint()
 
@@ -197,8 +199,9 @@ func NewInhibitRule(cr *config.InhibitRule) *InhibitRule {
 }
 
 // hasEqual checks whether the source cache contains alerts matching the equal
-// labels for the given label set. If excludeTwoSidedMatch is true, alerts that
-// match both the source and the target side of the rule are disregarded.
+// labels for the given label set. If so, the fingerprint of one of those alerts
+// is returned. If excludeTwoSidedMatch is true, alerts that match both the
+// source and the target side of the rule are disregarded.
 func (r *InhibitRule) hasEqual(lset model.LabelSet, excludeTwoSidedMatch bool) (model.Fingerprint, bool) {
 Outer:
 	for a := range r.scache.List() {


### PR DESCRIPTION
This clarifies a bunch of things I have run into during code reading
in preparation for some performance improvements around muting.

It also moves doc comments from places where they don't show up in
godoc to visible places.

It also fixes golint warnings.

Signed-off-by: beorn7 <beorn@soundcloud.com>