### PR TITLE
Create a `Muter` implementation for silences

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -186,7 +186,7 @@ func (api *API) Register(r *route.Router, routePrefix string) *http.ServeMux {
 
 // Update config and resolve timeout of each API. APIv2 also needs
 // setAlertStatus to be updated.
-func (api *API) Update(cfg *config.Config, setAlertStatus func(model.LabelSet) error) {
+func (api *API) Update(cfg *config.Config, setAlertStatus func(model.LabelSet)) {
 	api.v1.Update(cfg)
 	api.v2.Update(cfg, setAlertStatus)
 }

--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -70,7 +70,7 @@ type API struct {
 }
 
 type getAlertStatusFn func(prometheus_model.Fingerprint) types.AlertStatus
-type setAlertStatusFn func(prometheus_model.LabelSet) error
+type setAlertStatusFn func(prometheus_model.LabelSet)
 
 // NewAPI returns a new Alertmanager API v2
 func NewAPI(
@@ -260,9 +260,8 @@ func (api *API) getAlertsHandler(params alert_ops.GetAlertsParams) middleware.Re
 		}
 
 		// Set alert's current status based on its label set.
-		if err := api.setAlertStatus(a.Labels); err != nil {
-			level.Error(api.logger).Log("msg", "set alert status failed", "err", err)
-		}
+		api.setAlertStatus(a.Labels)
+
 		// Get alert's current status after seeing if it is suppressed.
 		status := api.getAlertStatus(a.Fingerprint())
 


### PR DESCRIPTION
This encapsulates the logic of querying and marking silenced
alerts. It removes the code duplication flagged earlier.

I removed the error returned by the setAlertStatus function as we were
only logging it, and that's already done anyway when the error is
received from the `silence.Query` call (now in the `Mutes` method).

Signed-off-by: beorn7 <beorn@soundcloud.com>