### PR TITLE
Performance improvement checking the silenced state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,5 +69,5 @@ $(ERRCHECK_BINARY):
 	mkdir -p $${tmpModule}/staticcheck && \
 	cd "$${tmpModule}"/staticcheck && \
 	GO111MODULE=on $(GO) mod init example.com/staticcheck && \
-	GO111MODULE=on GOOS= GOARCH= $(GO) get -u github.com/kisielk/errcheck && \
+	GO111MODULE=on GOOS= GOARCH= $(GO) get github.com/kisielk/errcheck && \
 	rm -rf $${tmpModule};

--- a/api/v1/api.go
+++ b/api/v1/api.go
@@ -556,7 +556,7 @@ func (api *API) setSilence(w http.ResponseWriter, r *http.Request) {
 func (api *API) getSilence(w http.ResponseWriter, r *http.Request) {
 	sid := route.Param(r.Context(), "sid")
 
-	sils, err := api.silences.Query(silence.QIDs(sid))
+	sils, _, err := api.silences.Query(silence.QIDs(sid))
 	if err != nil || len(sils) == 0 {
 		http.Error(w, fmt.Sprint("Error getting silence: ", err), http.StatusNotFound)
 		return
@@ -587,7 +587,7 @@ func (api *API) delSilence(w http.ResponseWriter, r *http.Request) {
 }
 
 func (api *API) listSilences(w http.ResponseWriter, r *http.Request) {
-	psils, err := api.silences.Query()
+	psils, _, err := api.silences.Query()
 	if err != nil {
 		api.respondError(w, apiError{
 			typ: errorInternal,

--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -489,7 +489,7 @@ func (api *API) getSilencesHandler(params silence_ops.GetSilencesParams) middlew
 		}
 	}
 
-	psils, err := api.silences.Query()
+	psils, _, err := api.silences.Query()
 	if err != nil {
 		level.Error(api.logger).Log("msg", "failed to get silences", "err", err)
 		return silence_ops.NewGetSilencesInternalServerError().WithPayload(err.Error())
@@ -521,7 +521,7 @@ func gettableSilenceMatchesFilterLabels(s open_api_models.GettableSilence, match
 }
 
 func (api *API) getSilenceHandler(params silence_ops.GetSilenceParams) middleware.Responder {
-	sils, err := api.silences.Query(silence.QIDs(params.SilenceID.String()))
+	sils, _, err := api.silences.Query(silence.QIDs(params.SilenceID.String()))
 	if err != nil {
 		level.Error(api.logger).Log("msg", "failed to get silence by id", "err", err)
 		return silence_ops.NewGetSilenceInternalServerError().WithPayload(err.Error())

--- a/silence/silence_test.go
+++ b/silence/silence_test.go
@@ -573,7 +573,7 @@ func TestSilencesQuery(t *testing.T) {
 
 	for _, c := range cases {
 		// Run default query of retrieving all silences.
-		res, err := s.query(c.q, time.Time{})
+		res, _, err := s.query(c.q, time.Time{})
 		require.NoError(t, err, "unexpected error on querying")
 
 		// Currently there are no sorting guarantees in the querying API.
@@ -1130,7 +1130,7 @@ func benchmarkSilencesQuery(b *testing.B, numSilences int) {
 	}
 
 	// Run things once to populate the matcherCache.
-	sils, err := s.Query(
+	sils, _, err := s.Query(
 		QState(types.SilenceStateActive),
 		QMatches(lset),
 	)
@@ -1139,7 +1139,7 @@ func benchmarkSilencesQuery(b *testing.B, numSilences int) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		sils, err := s.Query(
+		sils, _, err := s.Query(
 			QState(types.SilenceStateActive),
 			QMatches(lset),
 		)

--- a/silence/silence_test.go
+++ b/silence/silence_test.go
@@ -199,7 +199,7 @@ func TestSilencesSetSilence(t *testing.T) {
 	// setSilence() is always called with s.mtx locked()
 	go func() {
 		s.mtx.Lock()
-		require.NoError(t, s.setSilence(sil))
+		require.NoError(t, s.setSilence(sil, now))
 		s.mtx.Unlock()
 	}()
 
@@ -864,8 +864,8 @@ func TestSilenceExpireWithZeroRetention(t *testing.T) {
 	require.Contains(t, err.Error(), "already expired")
 
 	_, err = s.QueryOne(QIDs("pending"))
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "silence not found") // It is expired from the storage, too.
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
 
 	count, err = s.CountState(types.SilenceStatePending)
 	require.NoError(t, err)
@@ -873,7 +873,7 @@ func TestSilenceExpireWithZeroRetention(t *testing.T) {
 
 	count, err = s.CountState(types.SilenceStateExpired)
 	require.NoError(t, err)
-	require.Equal(t, 1, count) // As the two explicitly expired silences have immediately expired.
+	require.Equal(t, 3, count)
 }
 
 func TestValidateMatcher(t *testing.T) {


### PR DESCRIPTION
I have also found a bug with zero retention time while doing so. See individual commits.

The first commit just adds a benchmark, which showed me that we need this optimization for high-alert scenarios.