### PR TITLE
Switch to Go 1.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ executors:
   # should also be updated.
   golang:
     docker:
-    - image: circleci/golang:1.11
+    - image: circleci/golang:1.12
     # errcheck requires to be executed from GOPATH for now.
     working_directory: /go/src/github.com/prometheus/alertmanager
 

--- a/.promu.yml
+++ b/.promu.yml
@@ -1,7 +1,7 @@
 go:
     # Whenever the Go version is updated here, .travis.yml and
     # .circle/config.yml should also be updated.
-    version: 1.11
+    version: 1.12
 repository:
     path: github.com/prometheus/alertmanager
 build:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 # Whenever the Go version is updated here, .circleci/config.yml and .promu.yml
 # should also be updated.
 go:
-- 1.11.x
+- 1.12.x
 
 script:
 # test front-end

--- a/Makefile
+++ b/Makefile
@@ -63,11 +63,4 @@ test: common-test $(ERRCHECK_BINARY)
 	$(ERRCHECK_BINARY) -verbose -exclude scripts/errcheck_excludes.txt -ignoretests ./...
 
 $(ERRCHECK_BINARY):
-# Get errcheck from a temporary directory to avoid modifying the local go.{mod,sum}.
-# See https://github.com/golang/go/issues/27643.
-	tmpModule=$$(mktemp -d 2>&1) && \
-	mkdir -p $${tmpModule}/staticcheck && \
-	cd "$${tmpModule}"/staticcheck && \
-	GO111MODULE=on $(GO) mod init example.com/staticcheck && \
-	GO111MODULE=on GOOS= GOARCH= $(GO) get github.com/kisielk/errcheck && \
-	rm -rf $${tmpModule};
+	(cd .. && GO111MODULE=on GOOS= GOARCH= $(GO) get github.com/kisielk/errcheck@v1.2.0)


### PR DESCRIPTION
It also pins errcheck to the latest stable release and simplifies how it gets installed.