### PR TITLE
api/v2: sort silences similarly to v1 api

### DIFF
--- a/api/v2/api_test.go
+++ b/api/v2/api_test.go
@@ -14,9 +14,13 @@
 package v2
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
+	"github.com/go-openapi/strfmt"
+
+	open_api_models "github.com/prometheus/alertmanager/api/v2/models"
 	general_ops "github.com/prometheus/alertmanager/api/v2/restapi/operations/general"
 	"github.com/prometheus/alertmanager/config"
 )
@@ -46,5 +50,75 @@ func TestGetStatusHandlerWithNilPeer(t *testing.T) {
 
 	if c.Name != "" {
 		t.Fatal("expected cluster name to be empty, violating the openapi specification")
+	}
+}
+
+func assertEqualStrings(t *testing.T, expected string, actual string) {
+	if expected != actual {
+		t.Fatal("expected: ", expected, ", actual: ", actual)
+	}
+}
+
+var (
+	testComment = "comment"
+	createdBy   = "test"
+)
+
+func gettableSilence(id string, state string,
+	updatedAt string, start string, end string,
+) *open_api_models.GettableSilence {
+
+	updAt, err := strfmt.ParseDateTime(updatedAt)
+	if err != nil {
+		panic(err)
+	}
+	strAt, err := strfmt.ParseDateTime(start)
+	if err != nil {
+		panic(err)
+	}
+	endAt, err := strfmt.ParseDateTime(end)
+	if err != nil {
+		panic(err)
+	}
+	return &open_api_models.GettableSilence{
+		Silence: open_api_models.Silence{
+			StartsAt:  &strAt,
+			EndsAt:    &endAt,
+			Comment:   &testComment,
+			CreatedBy: &createdBy,
+		},
+		ID:        &id,
+		UpdatedAt: &updAt,
+		Status: &open_api_models.SilenceStatus{
+			State: &state,
+		},
+	}
+}
+
+func TestGetSilencesHandler(t *testing.T) {
+
+	updateTime := "2019-01-01T12:00:00+00:00"
+	silences := []*open_api_models.GettableSilence{
+		gettableSilence("silence-6-expired", "expired", updateTime,
+			"2019-01-01T12:00:00+00:00", "2019-01-01T11:00:00+00:00"),
+		gettableSilence("silence-1-active", "active", updateTime,
+			"2019-01-01T12:00:00+00:00", "2019-01-01T13:00:00+00:00"),
+		gettableSilence("silence-7-expired", "expired", updateTime,
+			"2019-01-01T12:00:00+00:00", "2019-01-01T10:00:00+00:00"),
+		gettableSilence("silence-5-expired", "expired", updateTime,
+			"2019-01-01T12:00:00+00:00", "2019-01-01T12:00:00+00:00"),
+		gettableSilence("silence-0-active", "active", updateTime,
+			"2019-01-01T12:00:00+00:00", "2019-01-01T12:00:00+00:00"),
+		gettableSilence("silence-4-pending", "pending", updateTime,
+			"2019-01-01T13:00:00+00:00", "2019-01-01T12:00:00+00:00"),
+		gettableSilence("silence-3-pending", "pending", updateTime,
+			"2019-01-01T12:00:00+00:00", "2019-01-01T12:00:00+00:00"),
+		gettableSilence("silence-2-active", "active", updateTime,
+			"2019-01-01T12:00:00+00:00", "2019-01-01T14:00:00+00:00"),
+	}
+	sortSilences(open_api_models.GettableSilences(silences))
+
+	for i, sil := range silences {
+		assertEqualStrings(t, "silence-"+strconv.Itoa(i)+"-"+*sil.Status.State, *sil.ID)
 	}
 }


### PR DESCRIPTION
Sort the queried silences to match behaviour in the v1 api.
Fixes #1781 