### PR TITLE
Fix bad syntax for struct tag value

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -543,7 +543,7 @@ type PushoverConfig struct {
 	Title    string   `yaml:"title,omitempty" json:"title,omitempty"`
 	Message  string   `yaml:"message,omitempty" json:"message,omitempty"`
 	URL      string   `yaml:"url,omitempty" json:"url,omitempty"`
-	URLTitle string   `yaml:"url_title,omitempty" json:"url_title,omitempty`
+	URLTitle string   `yaml:"url_title,omitempty" json:"url_title,omitempty"`
 	Sound    string   `yaml:"sound,omitempty" json:"sound,omitempty"`
 	Priority string   `yaml:"priority,omitempty" json:"priority,omitempty"`
 	Retry    duration `yaml:"retry,omitempty" json:"retry,omitempty"`


### PR DESCRIPTION
This fixes the following error found by go vet:

config/notifiers.go:546:2: struct field tag
`yaml:"url_title,omitempty" json:"url_title,omitempty` not compatible with
reflect.StructTag.Get: bad syntax for struct tag value (govet)
	URLTitle string   `yaml:"url_title,omitempty" json:"url_title,omitempty`
	^

Signed-off-by: Karsten Weiss <knweiss@gmail.com>