### PR TITLE
Add POST as an allowed CORS request method

### DIFF
--- a/api/v1/api.go
+++ b/api/v1/api.go
@@ -43,7 +43,7 @@ import (
 
 var corsHeaders = map[string]string{
 	"Access-Control-Allow-Headers":  "Accept, Authorization, Content-Type, Origin",
-	"Access-Control-Allow-Methods":  "GET, DELETE, OPTIONS",
+	"Access-Control-Allow-Methods":  "GET, POST, DELETE, OPTIONS",
 	"Access-Control-Allow-Origin":   "*",
 	"Access-Control-Expose-Headers": "Date",
 	"Cache-Control":                 "no-cache, no-store, must-revalidate",


### PR DESCRIPTION
As discussed in #1793 this breaks external clients when the requests are cross domain