### PR TITLE
Sort peers before returning via API

### DIFF
--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -172,6 +172,10 @@ func (api *API) getStatusHandler(params general_ops.GetStatusParams) middleware.
 			})
 		}
 
+		sort.Slice(peers, func(i, j int) bool {
+			return *peers[i].Name < *peers[j].Name
+		})
+
 		resp.Cluster = &open_api_models.ClusterStatus{
 			Name:   api.peer.Name(),
 			Status: &status,


### PR DESCRIPTION
Before peers are returned for the status response sort them by name. This will improve the Status page, as  the order will be stable now when refreshing it several times.

The order of peers is stable like this on my cluster now, regardless of which I get routed to by the proxy in front:
![Screenshot from 2019-03-15 14-59-54](https://user-images.githubusercontent.com/872251/54436550-01c36e80-4733-11e9-9d7b-3cc23009998b.png)

/cc @mxinden 