### PR TITLE
config: fix Wechat global parameters

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -444,16 +444,7 @@ type WechatConfig struct {
 func (c *WechatConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	*c = DefaultWechatConfig
 	type plain WechatConfig
-	if err := unmarshal((*plain)(c)); err != nil {
-		return err
-	}
-	if c.APISecret == "" {
-		return fmt.Errorf("missing Wechat APISecret in Wechat config")
-	}
-	if c.CorpID == "" {
-		return fmt.Errorf("missing Wechat CorpID in Wechat config")
-	}
-	return nil
+	return unmarshal((*plain)(c))
 }
 
 // OpsGenieConfig configures notifications via OpsGenie.

--- a/config/notifiers_test.go
+++ b/config/notifiers_test.go
@@ -236,40 +236,6 @@ http_config:
 	}
 }
 
-func TestWechatAPIKeyIsPresent(t *testing.T) {
-	in := `
-api_secret: ''
-`
-	var cfg WechatConfig
-	err := yaml.UnmarshalStrict([]byte(in), &cfg)
-
-	expected := "missing Wechat APISecret in Wechat config"
-
-	if err == nil {
-		t.Fatalf("no error returned, expected:\n%v", expected)
-	}
-	if err.Error() != expected {
-		t.Errorf("\nexpected:\n%v\ngot:\n%v", expected, err.Error())
-	}
-}
-func TestWechatCorpIDIsPresent(t *testing.T) {
-	in := `
-api_secret: 'api_secret'
-corp_id: ''
-`
-	var cfg WechatConfig
-	err := yaml.UnmarshalStrict([]byte(in), &cfg)
-
-	expected := "missing Wechat CorpID in Wechat config"
-
-	if err == nil {
-		t.Fatalf("no error returned, expected:\n%v", expected)
-	}
-	if err.Error() != expected {
-		t.Errorf("\nexpected:\n%v\ngot:\n%v", expected, err.Error())
-	}
-}
-
 func TestVictorOpsRoutingKeyIsPresent(t *testing.T) {
 	in := `
 routing_key: ''


### PR DESCRIPTION
Closes #1808 

`APISecret` and `CorpID` are validated after un-marshaling the full configuration.

https://github.com/prometheus/alertmanager/blob/a94088406ab7212acadaa01f4e86467ee1eac8f6/config/config.go#L378-L390