### PR TITLE
api/v2: Respond with 404 when silence ID is not found

### DIFF
--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -660,6 +660,9 @@ func (api *API) postSilencesHandler(params silence_ops.PostSilencesParams) middl
 	sid, err := api.silences.Set(sil)
 	if err != nil {
 		level.Error(api.logger).Log("msg", "failed to create silence", "err", err)
+		if err == silence.ErrNotFound {
+			return silence_ops.NewPostSilencesNotFound().WithPayload(err.Error())
+		}
 		return silence_ops.NewPostSilencesBadRequest().WithPayload(err.Error())
 	}
 

--- a/api/v2/client/silence/post_silences_responses.go
+++ b/api/v2/client/silence/post_silences_responses.go
@@ -52,6 +52,13 @@ func (o *PostSilencesReader) ReadResponse(response runtime.ClientResponse, consu
 		}
 		return nil, result
 
+	case 404:
+		result := NewPostSilencesNotFound()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
+
 	default:
 		return nil, runtime.NewAPIError("unknown error", response, response.Code())
 	}
@@ -104,6 +111,33 @@ func (o *PostSilencesBadRequest) Error() string {
 }
 
 func (o *PostSilencesBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	// response payload
+	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewPostSilencesNotFound creates a PostSilencesNotFound with default headers values
+func NewPostSilencesNotFound() *PostSilencesNotFound {
+	return &PostSilencesNotFound{}
+}
+
+/*PostSilencesNotFound handles this case with default header values.
+
+A silence with the specified ID was not found
+*/
+type PostSilencesNotFound struct {
+	Payload string
+}
+
+func (o *PostSilencesNotFound) Error() string {
+	return fmt.Sprintf("[POST /silences][%d] postSilencesNotFound  %+v", 404, o.Payload)
+}
+
+func (o *PostSilencesNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	// response payload
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {

--- a/api/v2/openapi.yaml
+++ b/api/v2/openapi.yaml
@@ -84,6 +84,10 @@ paths:
                 type: string
         '400':
           $ref: '#/responses/BadRequest'
+        '404':
+          description: A silence with the specified ID was not found
+          schema:
+            type: string
   /silence/{silenceID}:
     parameters:
       - in: path

--- a/api/v2/restapi/embedded_spec.go
+++ b/api/v2/restapi/embedded_spec.go
@@ -287,6 +287,12 @@ func init() {
           },
           "400": {
             "$ref": "#/responses/BadRequest"
+          },
+          "404": {
+            "description": "A silence with the specified ID was not found",
+            "schema": {
+              "type": "string"
+            }
           }
         }
       }
@@ -991,6 +997,12 @@ func init() {
           },
           "400": {
             "description": "Bad request",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "404": {
+            "description": "A silence with the specified ID was not found",
             "schema": {
               "type": "string"
             }

--- a/api/v2/restapi/operations/silence/post_silences_responses.go
+++ b/api/v2/restapi/operations/silence/post_silences_responses.go
@@ -111,3 +111,46 @@ func (o *PostSilencesBadRequest) WriteResponse(rw http.ResponseWriter, producer 
 	}
 
 }
+
+// PostSilencesNotFoundCode is the HTTP code returned for type PostSilencesNotFound
+const PostSilencesNotFoundCode int = 404
+
+/*PostSilencesNotFound A silence with the specified ID was not found
+
+swagger:response postSilencesNotFound
+*/
+type PostSilencesNotFound struct {
+
+	/*
+	  In: Body
+	*/
+	Payload string `json:"body,omitempty"`
+}
+
+// NewPostSilencesNotFound creates PostSilencesNotFound with default headers values
+func NewPostSilencesNotFound() *PostSilencesNotFound {
+
+	return &PostSilencesNotFound{}
+}
+
+// WithPayload adds the payload to the post silences not found response
+func (o *PostSilencesNotFound) WithPayload(payload string) *PostSilencesNotFound {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the post silences not found response
+func (o *PostSilencesNotFound) SetPayload(payload string) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *PostSilencesNotFound) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(404)
+	payload := o.Payload
+	if err := producer.Produce(rw, payload); err != nil {
+		panic(err) // let the recovery middleware deal with this
+	}
+
+}


### PR DESCRIPTION
When the client attempts to update a silence with a non-existent
ID, respond with a 404 (Not Found) instead of a 400 (Bad Request).

Signed-off-by: Paul Gier <pgier@redhat.com>