### PR TITLE
.dockerignore: add more exceptions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,5 @@
 .tarballs/
 
 !.build/linux-amd64/
+!.build/linux-armv7/
+!.build/linux-arm64/


### PR DESCRIPTION
This should fix the build issues for container images.