### PR TITLE
opsgenie: Moved from deprecated, non documented teams to responders field.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 !.golangci.yml
 !/cli/testdata/*.yml
 !/cli/config/testdata/*.yml
+!/config/testdata/*.yml
 !/doc/examples/simple.yml
 !/circle.yml
 !/.travis.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next release
+
+ * [CHANGE] Opsgenie notification now uses official responders notion instead of "teams". Teams field is deprecated now and will fail the config parsing.
+
 ## 0.17.0 / 2019-05-02
 
 This release includes changes to amtool which are not fully backwards

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,7 +25,7 @@ import (
 	commoncfg "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 func TestLoadEmptyString(t *testing.T) {
@@ -633,7 +633,7 @@ func TestEmptyFieldsAndRegex(t *testing.T) {
 func TestSMTPHello(t *testing.T) {
 	c, _, err := LoadFile("testdata/conf.good.yml")
 	if err != nil {
-		t.Errorf("Error parsing %s: %s", "testdata/conf.good.yml", err)
+		t.Fatalf("Error parsing %s: %s", "testdata/conf.good.yml", err)
 	}
 
 	const refValue = "host.example.org"
@@ -646,7 +646,7 @@ func TestSMTPHello(t *testing.T) {
 func TestGroupByAll(t *testing.T) {
 	c, _, err := LoadFile("testdata/conf.group-by-all.yml")
 	if err != nil {
-		t.Errorf("Error parsing %s: %s", "testdata/conf.group-by-all.yml", err)
+		t.Fatalf("Error parsing %s: %s", "testdata/conf.group-by-all.yml", err)
 	}
 
 	if !c.Route.GroupByAll {
@@ -657,12 +657,12 @@ func TestGroupByAll(t *testing.T) {
 func TestVictorOpsDefaultAPIKey(t *testing.T) {
 	conf, _, err := LoadFile("testdata/conf.victorops-default-apikey.yml")
 	if err != nil {
-		t.Errorf("Error parsing %s: %s", "testdata/conf.victorops-default-apikey.yml", err)
+		t.Fatalf("Error parsing %s: %s", "testdata/conf.victorops-default-apikey.yml", err)
 	}
 
 	var defaultKey = conf.Global.VictorOpsAPIKey
 	if defaultKey != conf.Receivers[0].VictorOpsConfigs[0].APIKey {
-		t.Errorf("Invalid victorops key: %s\nExpected: %s", conf.Receivers[0].VictorOpsConfigs[0].APIKey, defaultKey)
+		t.Fatalf("Invalid victorops key: %s\nExpected: %s", conf.Receivers[0].VictorOpsConfigs[0].APIKey, defaultKey)
 	}
 	if defaultKey == conf.Receivers[1].VictorOpsConfigs[0].APIKey {
 		t.Errorf("Invalid victorops key: %s\nExpected: %s", conf.Receivers[0].VictorOpsConfigs[0].APIKey, "qwe456")
@@ -672,7 +672,7 @@ func TestVictorOpsDefaultAPIKey(t *testing.T) {
 func TestVictorOpsNoAPIKey(t *testing.T) {
 	_, _, err := LoadFile("testdata/conf.victorops-no-apikey.yml")
 	if err == nil {
-		t.Errorf("Expected an error parsing %s: %s", "testdata/conf.victorops-no-apikey.yml", err)
+		t.Fatalf("Expected an error parsing %s: %s", "testdata/conf.victorops-no-apikey.yml", err)
 	}
 	if err.Error() != "no global VictorOps API Key set" {
 		t.Errorf("Expected: %s\nGot: %s", "no global VictorOps API Key set", err.Error())
@@ -682,12 +682,12 @@ func TestVictorOpsNoAPIKey(t *testing.T) {
 func TestOpsGenieDefaultAPIKey(t *testing.T) {
 	conf, _, err := LoadFile("testdata/conf.opsgenie-default-apikey.yml")
 	if err != nil {
-		t.Errorf("Error parsing %s: %s", "testdata/conf.opsgenie-default-apikey.yml", err)
+		t.Fatalf("Error parsing %s: %s", "testdata/conf.opsgenie-default-apikey.yml", err)
 	}
 
 	var defaultKey = conf.Global.OpsGenieAPIKey
 	if defaultKey != conf.Receivers[0].OpsGenieConfigs[0].APIKey {
-		t.Errorf("Invalid OpsGenie key: %s\nExpected: %s", conf.Receivers[0].OpsGenieConfigs[0].APIKey, defaultKey)
+		t.Fatalf("Invalid OpsGenie key: %s\nExpected: %s", conf.Receivers[0].OpsGenieConfigs[0].APIKey, defaultKey)
 	}
 	if defaultKey == conf.Receivers[1].OpsGenieConfigs[0].APIKey {
 		t.Errorf("Invalid OpsGenie key: %s\nExpected: %s", conf.Receivers[0].OpsGenieConfigs[0].APIKey, "qwe456")
@@ -697,9 +697,22 @@ func TestOpsGenieDefaultAPIKey(t *testing.T) {
 func TestOpsGenieNoAPIKey(t *testing.T) {
 	_, _, err := LoadFile("testdata/conf.opsgenie-no-apikey.yml")
 	if err == nil {
-		t.Errorf("Expected an error parsing %s: %s", "testdata/conf.opsgenie-no-apikey.yml", err)
+		t.Fatalf("Expected an error parsing %s: %s", "testdata/conf.opsgenie-no-apikey.yml", err)
 	}
 	if err.Error() != "no global OpsGenie API Key set" {
 		t.Errorf("Expected: %s\nGot: %s", "no global OpsGenie API Key set", err.Error())
+	}
+}
+
+func TestOpsGenieDeprecatedTeamSpecified(t *testing.T) {
+	_, _, err := LoadFile("testdata/conf.opsgenie-default-apikey-old-team.yml")
+	if err == nil {
+		t.Fatalf("Expected an error parsing %s: %s", "testdata/conf.opsgenie-default-apikey-old-team.yml", err)
+	}
+
+	const expectedErr = `yaml: unmarshal errors:
+  line 18: field teams not found in type config.plain`
+	if err.Error() != expectedErr {
+		t.Errorf("Expected: %s\nGot: %s", expectedErr, err.Error())
 	}
 }

--- a/config/testdata/conf.opsgenie-default-apikey-old-team.yml
+++ b/config/testdata/conf.opsgenie-default-apikey-old-team.yml
@@ -13,14 +13,6 @@ route:
     receiver: team-X-opsgenie
 
 receivers:
-- name: 'team-X-opsgenie'
-  opsgenie_configs:
-  - responders:
-    - name: 'team-X'
-      type: 'team'
-- name: 'escalation-Y-opsgenie'
-  opsgenie_configs:
-  - responders:
-    - name: 'escalation-Y'
-      type: 'escalation'
-    api_key: qwe456
+  - name: 'team-X-opsgenie'
+    opsgenie_configs:
+      - teams: 'team-X'

--- a/config/testdata/conf.opsgenie-no-apikey.yml
+++ b/config/testdata/conf.opsgenie-no-apikey.yml
@@ -12,4 +12,6 @@ route:
 receivers:
 - name: 'team-X-opsgenie'
   opsgenie_configs:
-  - teams: 'team-X'
+  - responders:
+    - name: 'team-X'
+      type: 'team'

--- a/notify/impl_test.go
+++ b/notify/impl_test.go
@@ -461,12 +461,21 @@ func TestOpsGenie(t *testing.T) {
 		Message:     `{{ .CommonLabels.Message }}`,
 		Description: `{{ .CommonLabels.Description }}`,
 		Source:      `{{ .CommonLabels.Source }}`,
-		Teams:       `{{ .CommonLabels.Teams }}`,
-		Tags:        `{{ .CommonLabels.Tags }}`,
-		Note:        `{{ .CommonLabels.Note }}`,
-		Priority:    `{{ .CommonLabels.Priority }}`,
-		APIKey:      `{{ .ExternalURL }}`,
-		APIURL:      &config.URL{URL: u},
+		Responders: []config.OpsGenieConfigResponder{
+			{
+				Name: `{{ .CommonLabels.ResponderName1 }}`,
+				Type: `{{ .CommonLabels.ResponderType1 }}`,
+			},
+			{
+				Name: `{{ .CommonLabels.ResponderName2 }}`,
+				Type: `{{ .CommonLabels.ResponderType2 }}`,
+			},
+		},
+		Tags:     `{{ .CommonLabels.Tags }}`,
+		Note:     `{{ .CommonLabels.Note }}`,
+		Priority: `{{ .CommonLabels.Priority }}`,
+		APIKey:   `{{ .ExternalURL }}`,
+		APIURL:   &config.URL{URL: u},
 	}
 	notifier := NewOpsGenie(conf, tmpl, logger)
 
@@ -495,19 +504,22 @@ func TestOpsGenie(t *testing.T) {
 	alert2 := &types.Alert{
 		Alert: model.Alert{
 			Labels: model.LabelSet{
-				"Message":     "message",
-				"Description": "description",
-				"Source":      "http://prometheus",
-				"Teams":       "TeamA,TeamB,",
-				"Tags":        "tag1,tag2",
-				"Note":        "this is a note",
-				"Priotity":    "P1",
+				"Message":        "message",
+				"Description":    "description",
+				"Source":         "http://prometheus",
+				"ResponderName1": "TeamA",
+				"ResponderType1": "team",
+				"ResponderName2": "EscalationA",
+				"ResponderType2": "escalation",
+				"Tags":           "tag1,tag2",
+				"Note":           "this is a note",
+				"Priority":       "P1",
 			},
 			StartsAt: time.Now(),
 			EndsAt:   time.Now().Add(time.Hour),
 		},
 	}
-	expectedBody = `{"alias":"6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b","message":"message","description":"description","details":{},"source":"http://prometheus","teams":[{"name":"TeamA"},{"name":"TeamB"}],"tags":["tag1","tag2"],"note":"this is a note"}
+	expectedBody = `{"alias":"6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b","message":"message","description":"description","details":{},"source":"http://prometheus","responders":[{"name":"TeamA","type":"team"},{"name":"EscalationA","type":"escalation"}],"tags":["tag1","tag2"],"note":"this is a note","priority":"P1"}
 `
 	req, retry, err = notifier.createRequest(ctx, alert2)
 	require.NoError(t, err)


### PR DESCRIPTION
Fixes: https://github.com/prometheus/alertmanager/issues/1818
Fixes: https://github.com/prometheus/alertmanager/issues/1342

Some decisions I made:
* "Teams" config option will fail on unmarshalling the config. I marked it as deprecated. AM is 0.x version it should be fine (?)
* I allow the use case for dynamic set of responders from alert's label using templating. Seems like it fits into how others fields are treated.
* I allow for full flexibility, so you can use any type you want. There is no validation. I don't think it is worth as Opsgenie changes those things (?). Let me know if it's needed. I think if the type is wrong and create alert will fail it's fine as "validation"

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>