### PR TITLE
Move alert endpoints filter parsing to single function

### DIFF
--- a/test/with_api_v2/acceptance/api_test.go
+++ b/test/with_api_v2/acceptance/api_test.go
@@ -165,3 +165,69 @@ receivers:
 		}
 	}
 }
+
+func TestFilterAlertRequest(t *testing.T) {
+	t.Parallel()
+
+	conf := `
+route:
+  receiver: "default"
+  group_by: []
+  group_wait:      1s
+  group_interval:  10m
+  repeat_interval: 1h
+
+inhibit_rules:
+  - source_match:
+      severity: 'critical'
+    target_match:
+      severity: 'warning'
+    equal: ['alertname']
+
+receivers:
+- name: "default"
+  webhook_configs:
+  - url: 'http://%s'
+`
+
+	at := a.NewAcceptanceTest(t, &a.AcceptanceOpts{
+		Tolerance: 1 * time.Second,
+	})
+	co := at.Collector("webhook")
+	wh := a.NewWebhook(co)
+
+	amc := at.AlertmanagerCluster(fmt.Sprintf(conf, wh.Address()), 1)
+	require.NoError(t, amc.Start())
+	defer amc.Terminate()
+
+	am := amc.Members()[0]
+
+	now := time.Now()
+	startsAt := strfmt.DateTime(now)
+	endsAt := strfmt.DateTime(now.Add(5 * time.Minute))
+
+	labels := models.LabelSet(map[string]string{"alertname": "test1", "severity": "warning"})
+	pa1 := &models.PostableAlert{
+		StartsAt: startsAt,
+		EndsAt:   endsAt,
+		Alert:    models.Alert{Labels: labels},
+	}
+	labels = models.LabelSet(map[string]string{"system": "foo", "severity": "critical"})
+	pa2 := &models.PostableAlert{
+		StartsAt: startsAt,
+		EndsAt:   endsAt,
+		Alert:    models.Alert{Labels: labels},
+	}
+	alertParams := alert.NewPostAlertsParams()
+	alertParams.Alerts = models.PostableAlerts{pa1, pa2}
+	_, err := am.Client().Alert.PostAlerts(alertParams)
+	require.NoError(t, err)
+
+	filter := []string{"alertname=test1", "severity=warning"}
+	resp, err := am.Client().Alert.GetAlerts(alert.NewGetAlertsParams().WithFilter(filter))
+	require.NoError(t, err)
+	require.Equal(t, 1, len(resp.Payload))
+	for _, alert := range resp.Payload {
+		require.Equal(t, models.AlertStatusStateActive, *alert.Status.State)
+	}
+}


### PR DESCRIPTION
They are exactly the same, no reason to duplicate.