### PR TITLE
Add image_url to example of good config

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -326,7 +326,7 @@ func TestHideConfigSecrets(t *testing.T) {
 
 	// String method must not reveal authentication credentials.
 	s := c.String()
-	if strings.Count(s, "<secret>") != 14 || strings.Contains(s, "mysecret") {
+	if strings.Count(s, "<secret>") != 15 || strings.Contains(s, "mysecret") {
 		t.Fatal("config's String method reveals authentication credentials.")
 	}
 }

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -140,3 +140,7 @@ receivers:
   pushover_configs:
     - token: mysecret
       user_key: key
+- name: slack-receiver
+  slack_configs:
+    - channel: '#my-channel'
+      image_url: 'http://some.img.com/img.png'


### PR DESCRIPTION
There was a report that this isn't working.
Updating the config and ensuring the parsing works
correctly indicates that the image_url is being
read into a string.

check is in response to #1551