### PR TITLE
*: use persistent HTTP clients

### DIFF
--- a/scripts/errcheck_excludes.txt
+++ b/scripts/errcheck_excludes.txt
@@ -1,2 +1,4 @@
+// Don't flag lines such as "io.Copy(ioutil.Discard, resp.Body)".
+io.Copy
 // Never check for logger errors.
 (github.com/go-kit/kit/log.Logger).Log


### PR DESCRIPTION
Currently every time an HTTP-based integration notifies something, it creates a new HTTP client and the connection is only closed after 5 minutes (idle connection time-out). Although usually there aren't thousands of notification requests during such interval, it consumes unnecessary resources.

[`config.NewClientFromConfig()`](https://godoc.org/github.com/prometheus/common/config#NewClientFromConfig) from `github.com/prometheus/common` detects whenever the configuration on disk (eg certificates, tokens) has changed so re-using the same client instead of creating one per request should be transparent. It also means that an invalid configuration (eg non-existing certificate) will be detected during the loading of the configuration instead of during the first notification.