### PR TITLE
Use Circle CI's org context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,6 +147,7 @@ workflows:
           tags:
             only: /.*/
     - docker_hub_master:
+        context: org-context
         requires:
         - test
         - build
@@ -154,6 +155,7 @@ workflows:
           branches:
             only: master
     - docker_hub_release_tags:
+        context: org-context
         requires:
         - test
         - build


### PR DESCRIPTION
Circle CI's [contexts](https://circleci.com/docs/2.0/configuration-reference/#context) allow to declare environment level variables at the org level instead of per project.

