### PR TITLE
config/notifiers.go: fix opsgenieValidTypesRe

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -467,7 +467,7 @@ type OpsGenieConfig struct {
 	Priority    string                    `yaml:"priority,omitempty" json:"priority,omitempty"`
 }
 
-const opsgenieValidTypesRe = `^team|user|escalation|schedule$`
+const opsgenieValidTypesRe = `^(team|user|escalation|schedule)$`
 
 var opsgenieTypeMatcher = regexp.MustCompile(opsgenieValidTypesRe)
 

--- a/config/notifiers_test.go
+++ b/config/notifiers_test.go
@@ -527,6 +527,21 @@ actions:
 	}
 }
 
+func TestOpsgenieTypeMatcher(t *testing.T) {
+	good := []string{"team", "user", "escalation", "schedule"}
+	for _, g := range good {
+		if !opsgenieTypeMatcher.MatchString(g) {
+			t.Fatalf("failed to match with %s", g)
+		}
+	}
+	bad := []string{"0user", "team1", "2escalation3", "sche4dule", "User", "TEAM"}
+	for _, b := range bad {
+		if opsgenieTypeMatcher.MatchString(b) {
+			t.Errorf("mistakenly match with %s", b)
+		}
+	}
+}
+
 func newBoolPointer(b bool) *bool {
 	return &b
 }


### PR DESCRIPTION
`^apple|banana|cherry$` finds matches to either of `^apple`, `banana`, or `cherry$`, so strings like `apple0`, `1banana2`, `3cherry` are accepted; I believe this wasn't intentional.