### PR TITLE
Support filtering cli alert queries by receiver

### DIFF
--- a/cli/alert_query.go
+++ b/cli/alert_query.go
@@ -96,6 +96,7 @@ func (a *alertQueryCmd) queryAlerts(ctx context.Context, _ *kingpin.ParseContext
 		WithInhibited(&a.inhibited).
 		WithSilenced(&a.silenced).
 		WithUnprocessed(&a.unprocessed).
+		WithReceiver(&a.receiver).
 		WithFilter(a.matcherGroups)
 
 	amclient := NewAlertmanagerClient(alertmanagerURL)


### PR DESCRIPTION
This was dropped accidentally in
https://github.com/prometheus/alertmanager/pull/1798

fixes #1906 