### PR TITLE
Add objectives to Summaries

### DIFF
--- a/nflog/nflog.go
+++ b/nflog/nflog.go
@@ -104,12 +104,14 @@ func newMetrics(r prometheus.Registerer) *metrics {
 	m := &metrics{}
 
 	m.gcDuration = prometheus.NewSummary(prometheus.SummaryOpts{
-		Name: "alertmanager_nflog_gc_duration_seconds",
-		Help: "Duration of the last notification log garbage collection cycle.",
+		Name:       "alertmanager_nflog_gc_duration_seconds",
+		Help:       "Duration of the last notification log garbage collection cycle.",
+		Objectives: map[float64]float64{},
 	})
 	m.snapshotDuration = prometheus.NewSummary(prometheus.SummaryOpts{
-		Name: "alertmanager_nflog_snapshot_duration_seconds",
-		Help: "Duration of the last notification log snapshot.",
+		Name:       "alertmanager_nflog_snapshot_duration_seconds",
+		Help:       "Duration of the last notification log snapshot.",
+		Objectives: map[float64]float64{},
 	})
 	m.snapshotSize = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "alertmanager_nflog_snapshot_size_bytes",

--- a/silence/silence.go
+++ b/silence/silence.go
@@ -36,7 +36,7 @@ import (
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 // ErrNotFound is returned if a silence was not found.
@@ -225,12 +225,14 @@ func newMetrics(r prometheus.Registerer, s *Silences) *metrics {
 	m := &metrics{}
 
 	m.gcDuration = prometheus.NewSummary(prometheus.SummaryOpts{
-		Name: "alertmanager_silences_gc_duration_seconds",
-		Help: "Duration of the last silence garbage collection cycle.",
+		Name:       "alertmanager_silences_gc_duration_seconds",
+		Help:       "Duration of the last silence garbage collection cycle.",
+		Objectives: map[float64]float64{},
 	})
 	m.snapshotDuration = prometheus.NewSummary(prometheus.SummaryOpts{
-		Name: "alertmanager_silences_snapshot_duration_seconds",
-		Help: "Duration of the last silence snapshot.",
+		Name:       "alertmanager_silences_snapshot_duration_seconds",
+		Help:       "Duration of the last silence snapshot.",
+		Objectives: map[float64]float64{},
 	})
 	m.snapshotSize = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "alertmanager_silences_snapshot_size_bytes",


### PR DESCRIPTION
With the next release of client_golang, Summaries will not have
objectives by default. To not lose the objectives we have right now,
explicitly state the current default objectives.

Signed-off-by: beorn7 <beorn@grafana.com>