### PR TITLE
notify/pagerduty: fix images

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -225,7 +225,7 @@ type PagerdutyLink struct {
 type PagerdutyImage struct {
 	Src  string `yaml:"src,omitempty" json:"src,omitempty"`
 	Alt  string `yaml:"alt,omitempty" json:"alt,omitempty"`
-	Text string `yaml:"text,omitempty" json:"text,omitempty"`
+	Href string `yaml:"href,omitempty" json:"href,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/notify/pagerduty/pagerduty.go
+++ b/notify/pagerduty/pagerduty.go
@@ -84,7 +84,7 @@ type pagerDutyLink struct {
 type pagerDutyImage struct {
 	Src  string `json:"src"`
 	Alt  string `json:"alt"`
-	Text string `json:"text"`
+	Href string `json:"href"`
 }
 
 type pagerDutyPayload struct {
@@ -187,7 +187,7 @@ func (n *Notifier) notifyV2(
 	for index, item := range n.conf.Images {
 		msg.Images[index].Src = tmpl(item.Src)
 		msg.Images[index].Alt = tmpl(item.Alt)
-		msg.Images[index].Text = tmpl(item.Text)
+		msg.Images[index].Href = tmpl(item.Href)
 	}
 
 	for index, item := range n.conf.Links {


### PR DESCRIPTION
Closes #1784

For clarity, I've chosen to rename the field `text` to `href` in the configuration though it could break people (but I suspect that it isn't widely used).

Unfortunately I don't have a way to validate it. Maybe @seanhoughton, @sbueringer, @mikebryant or @adamdecaf could help (I've looked at the Git history for people that contributed to the PagerDuty code).