### PR TITLE
Limit the number of tests executed in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,8 +46,11 @@ jobs:
     - run:
         command: make
         environment:
-          # Run garbage collection more aggresively to avoid getting OOMed.
-          GOGC: "20"
+          # By default Go uses GOMAXPROCS but a Circle CI executor has many
+          # cores (> 30) while the CPU and RAM resources are throttled. If we
+          # don't limit this to the number of allocated cores, the job is
+          # likely to get OOMed and killed.
+          GOOPTS: "-p 2"
     - run:
        command: |
          curl -s -L https://github.com/protocolbuffers/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip > /tmp/protoc.zip


### PR DESCRIPTION
By default Go uses GOMAXPROCS but a Circle CI executor has many cores (> 30) while the CPU and RAM resources are throttled (a medium instance has 2 vCPUs and 4GB of RAM). If we don't limit this to the number of allocated cores, the job is likely to get OOMed and killed.