### PR TITLE
test/with_api_v2: remove calls to the v1 API

### DIFF
--- a/test/with_api_v2/mock.go
+++ b/test/with_api_v2/mock.go
@@ -105,13 +105,15 @@ func (s *TestSilence) ID() string {
 func (s *TestSilence) nativeSilence(opts *AcceptanceOpts) *models.Silence {
 	nsil := &models.Silence{}
 
+	t := false
 	for i := 0; i < len(s.match); i += 2 {
 		nsil.Matchers = append(nsil.Matchers, &models.Matcher{
-			Name:  &s.match[i],
-			Value: &s.match[i+1],
+			Name:    &s.match[i],
+			Value:   &s.match[i+1],
+			IsRegex: &t,
 		})
 	}
-	t := true
+	t = true
 	for i := 0; i < len(s.matchRE); i += 2 {
 		nsil.Matchers = append(nsil.Matchers, &models.Matcher{
 			Name:    &s.matchRE[i],


### PR DESCRIPTION
I've discovered this while reviewing #1830. I coudln't find any reason why we were using the v1 API for the v2 tests.