### PR TITLE
docs/flags: Make it explicit that HA is enabled by default and how to disable it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ amtool config routes --alertmanager.url=http://localhost:9090
 
 ## High Availability
 
-AlertManager's high availability is in production use at many companies.
+AlertManager's high availability is in production use at many companies and is enabled by default.
 
 > Important: Both UDP and TCP are needed in alertmanager 0.15 and higher for the cluster to work.
 
@@ -335,7 +335,7 @@ To create a highly available cluster of the Alertmanager the instances need to
 be configured to communicate with each other. This is configured using the
 `--cluster.*` flags.
 
-- `--cluster.listen-address` string: cluster listen address (default "0.0.0.0:9094")
+- `--cluster.listen-address` string: cluster listen address (default "0.0.0.0:9094"; empty string disables HA mode)
 - `--cluster.advertise-address` string: cluster advertise address
 - `--cluster.peer` value: initial peers (repeat flag for each additional peer)
 - `--cluster.peer-timeout` value: peer timeout period (default "15s")
@@ -380,7 +380,6 @@ alerting:
 ### Disabling high availability
 
 If running Alertmanager in high availability mode is not desired, setting `--cluster.listen-address=` will prevent Alertmanager from listening to incoming peer requests.
-
 
 ## Contributing to the Front-End
 

--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -172,7 +172,7 @@ func run() int {
 		getConcurrency = kingpin.Flag("web.get-concurrency", "Maximum number of GET requests processed concurrently. If negative or zero, the limit is GOMAXPROC or 8, whichever is larger.").Default("0").Int()
 		httpTimeout    = kingpin.Flag("web.timeout", "Timeout for HTTP requests. If negative or zero, no timeout is set.").Default("0").Duration()
 
-		clusterBindAddr = kingpin.Flag("cluster.listen-address", "Listen address for cluster.").
+		clusterBindAddr = kingpin.Flag("cluster.listen-address", "Listen address for cluster. Set to empty string to disable HA mode.").
 				Default(defaultClusterAddr).String()
 		clusterAdvertiseAddr = kingpin.Flag("cluster.advertise-address", "Explicit address to advertise in cluster.").String()
 		peers                = kingpin.Flag("cluster.peer", "Initial peers (may be repeated).").Strings()


### PR DESCRIPTION
Fixes https://github.com/prometheus/alertmanager/issues/1814

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>