### PR TITLE
Fix dedup repeat time check misses peer wait consideration

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -401,7 +401,7 @@ func run() int {
 			silencer.Mutes(labels)
 		})
 
-		disp = dispatch.NewDispatcher(alerts, dispatch.NewRoute(conf.Route, nil), pipeline, marker, timeoutFunc, logger)
+		disp = dispatch.NewDispatcher(alerts, dispatch.NewRoute(conf.Route, nil), pipeline, marker, waitFunc, timeoutFunc, logger)
 
 		go disp.Run()
 		go inhibitor.Run()

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -133,7 +133,7 @@ func TestAggrGroup(t *testing.T) {
 	}
 
 	// Test regular situation where we wait for group_wait to send out alerts.
-	ag := newAggrGroup(context.Background(), lset, route, nil, log.NewNopLogger())
+	ag := newAggrGroup(context.Background(), lset, route, nil, nil, log.NewNopLogger())
 	go ag.run(ntfy)
 
 	ag.insert(a1)
@@ -187,7 +187,7 @@ func TestAggrGroup(t *testing.T) {
 	// immediate flushing.
 	// Finally, set all alerts to be resolved. After successful notify the aggregation group
 	// should empty itself.
-	ag = newAggrGroup(context.Background(), lset, route, nil, log.NewNopLogger())
+	ag = newAggrGroup(context.Background(), lset, route, nil, nil, log.NewNopLogger())
 	go ag.run(ntfy)
 
 	ag.insert(a1)
@@ -367,9 +367,10 @@ route:
 	}
 	defer alerts.Close()
 
+	wait := func() time.Duration { return time.Duration(0) }
 	timeout := func(d time.Duration) time.Duration { return time.Duration(0) }
 	recorder := &recordStage{alerts: make(map[string]map[model.Fingerprint]*types.Alert)}
-	dispatcher := NewDispatcher(alerts, route, recorder, marker, timeout, logger)
+	dispatcher := NewDispatcher(alerts, route, recorder, marker, wait, timeout, logger)
 	go dispatcher.Run()
 	defer dispatcher.Stop()
 

--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -205,7 +205,7 @@ func TestDedupStageNeedsUpdate(t *testing.T) {
 			now: func() time.Time { return now },
 			rs:  sendResolved(c.resolve),
 		}
-		res := s.needsUpdate(c.entry, c.firingAlerts, c.resolvedAlerts, c.repeat)
+		res := s.needsUpdate(c.entry, c.firingAlerts, c.resolvedAlerts, c.repeat, 0)
 		require.Equal(t, c.res, res)
 	}
 }
@@ -236,6 +236,11 @@ func TestDedupStage(t *testing.T) {
 	require.EqualError(t, err, "repeat interval missing")
 
 	ctx = WithRepeatInterval(ctx, time.Hour)
+
+	_, _, err = s.Exec(ctx, log.NewNopLogger())
+	require.EqualError(t, err, "peer wait missing")
+
+	ctx = WithPeerWait(ctx, 0)
 
 	alerts := []*types.Alert{{}, {}, {}}
 


### PR DESCRIPTION
If we don't consider peer wait, dedup repeat interval passed or not check is not accurate. Especially sometimes the repeat time is very small and smaller than the max peer wait time will cause duplicated alerts from alertmanager peer.