### PR TITLE
Fix dedup repeat time check misses cluster wait

### DIFF
--- a/nflog/nflog_test.go
+++ b/nflog/nflog_test.go
@@ -269,7 +269,7 @@ func TestStateDataCoding(t *testing.T) {
 }
 
 func TestQuery(t *testing.T) {
-	nl, err := New(WithRetention(time.Second))
+	nl, err := New(WithRetention(time.Second), WithClusterWait(func() time.Duration { return time.Duration(0) }))
 	if err != nil {
 		require.NoError(t, err, "constructing nflog failed")
 	}


### PR DESCRIPTION
If we do not check cluster wait, dedup repeat interval passed check is inaccurate.
Especially sometimes the repeat time is too small and smaller than the cluster peer wait time will cause duplicated alerts from alertmanager peer.

Signed-off-by: xiancli <xiancli@ebay.com>