### PR TITLE
Improve documentation for group_interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ route:
   group_wait: 30s
 
   # When the first notification was sent, wait 'group_interval' to send a batch
-  # of new alerts that started firing for that group.
+  # of new alerts that started firing for that group. Alert resolution notifications
+  # follow this interval as well.
   group_interval: 5m
 
   # If an alert has successfully been sent, wait 'repeat_interval' to

--- a/doc/examples/simple.yml
+++ b/doc/examples/simple.yml
@@ -34,7 +34,8 @@ route:
   group_wait: 30s
 
   # When the first notification was sent, wait 'group_interval' to send a batch
-  # of new alerts that started firing for that group.
+  # of new alerts that started firing for that group. Alert resolution notifications
+  # follow this interval as well.
   group_interval: 5m
 
   # If an alert has successfully been sent, wait 'repeat_interval' to


### PR DESCRIPTION
After struggling for a while to understand that alert resolution notifications follow `group_interval` as well, and reading through this issue: https://github.com/prometheus/alertmanager/issues/1660 , here's a suggestion on how to improve the documentation a bit.

I'm open to different approaches on formatting or language.

Signed-off-by: Lauri Kuittinen <lauriku@gmail.com>