### PR TITLE
config: use the origin field instead of local var

### DIFF
--- a/cli/check_config.go
+++ b/cli/check_config.go
@@ -63,7 +63,7 @@ func CheckConfig(args []string) error {
 
 	for _, arg := range args {
 		fmt.Printf("Checking '%s'", arg)
-		cfg, _, err := config.LoadFile(arg)
+		cfg, err := config.LoadFile(arg)
 		if err != nil {
 			fmt.Printf("  FAILED: %s\n", err)
 			failed++

--- a/cli/test_routing_test.go
+++ b/cli/test_routing_test.go
@@ -50,7 +50,7 @@ func TestRoutingTest(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		cfg, _, err := config.LoadFile(test.configFile)
+		cfg, err := config.LoadFile(test.configFile)
 		if err != nil {
 			t.Fatalf("failed to load test configuration: %v", err)
 		}

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -97,7 +97,7 @@ func checkRoutingConfigInputFlags(alertmanagerURL *url.URL, configFile string) {
 func loadAlertmanagerConfig(ctx context.Context, alertmanagerURL *url.URL, configFile string) (*config.Config, error) {
 	checkRoutingConfigInputFlags(alertmanagerURL, configFile)
 	if configFile != "" {
-		cfg, _, err := config.LoadFile(configFile)
+		cfg, err := config.LoadFile(configFile)
 		if err != nil {
 			return nil, err
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -186,18 +186,18 @@ func Load(s string) (*Config, error) {
 }
 
 // LoadFile parses the given YAML file into a Config.
-func LoadFile(filename string) (*Config, []byte, error) {
+func LoadFile(filename string) (*Config, error) {
 	content, err := ioutil.ReadFile(filename)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	cfg, err := Load(string(content))
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	resolveFilepaths(filepath.Dir(filename), cfg)
-	return cfg, content, nil
+	return cfg, nil
 }
 
 // resolveFilepaths joins all relative paths in a configuration

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -319,7 +319,7 @@ receivers:
 }
 
 func TestHideConfigSecrets(t *testing.T) {
-	c, _, err := LoadFile("testdata/conf.good.yml")
+	c, err := LoadFile("testdata/conf.good.yml")
 	if err != nil {
 		t.Fatalf("Error parsing %s: %s", "testdata/conf.good.yml", err)
 	}
@@ -332,7 +332,7 @@ func TestHideConfigSecrets(t *testing.T) {
 }
 
 func TestJSONMarshal(t *testing.T) {
-	c, _, err := LoadFile("testdata/conf.good.yml")
+	c, err := LoadFile("testdata/conf.good.yml")
 	if err != nil {
 		t.Errorf("Error parsing %s: %s", "testdata/conf.good.yml", err)
 	}
@@ -486,7 +486,7 @@ func TestUnmarshalRelativeURL(t *testing.T) {
 }
 
 func TestJSONUnmarshal(t *testing.T) {
-	c, _, err := LoadFile("testdata/conf.good.yml")
+	c, err := LoadFile("testdata/conf.good.yml")
 	if err != nil {
 		t.Errorf("Error parsing %s: %s", "testdata/conf.good.yml", err)
 	}
@@ -498,7 +498,7 @@ func TestJSONUnmarshal(t *testing.T) {
 }
 
 func TestMarshalIdempotency(t *testing.T) {
-	c, _, err := LoadFile("testdata/conf.good.yml")
+	c, err := LoadFile("testdata/conf.good.yml")
 	if err != nil {
 		t.Errorf("Error parsing %s: %s", "testdata/conf.good.yml", err)
 	}
@@ -605,12 +605,12 @@ func TestEmptyFieldsAndRegex(t *testing.T) {
 
 	// Load a non-empty configuration to ensure that all fields are overwritten.
 	// See https://github.com/prometheus/alertmanager/issues/1649.
-	_, _, err := LoadFile("testdata/conf.good.yml")
+	_, err := LoadFile("testdata/conf.good.yml")
 	if err != nil {
 		t.Errorf("Error parsing %s: %s", "testdata/conf.good.yml", err)
 	}
 
-	config, _, err := LoadFile("testdata/conf.empty-fields.yml")
+	config, err := LoadFile("testdata/conf.empty-fields.yml")
 	if err != nil {
 		t.Errorf("Error parsing %s: %s", "testdata/conf.empty-fields.yml", err)
 	}
@@ -631,7 +631,7 @@ func TestEmptyFieldsAndRegex(t *testing.T) {
 }
 
 func TestSMTPHello(t *testing.T) {
-	c, _, err := LoadFile("testdata/conf.good.yml")
+	c, err := LoadFile("testdata/conf.good.yml")
 	if err != nil {
 		t.Fatalf("Error parsing %s: %s", "testdata/conf.good.yml", err)
 	}
@@ -644,7 +644,7 @@ func TestSMTPHello(t *testing.T) {
 }
 
 func TestGroupByAll(t *testing.T) {
-	c, _, err := LoadFile("testdata/conf.group-by-all.yml")
+	c, err := LoadFile("testdata/conf.group-by-all.yml")
 	if err != nil {
 		t.Fatalf("Error parsing %s: %s", "testdata/conf.group-by-all.yml", err)
 	}
@@ -655,7 +655,7 @@ func TestGroupByAll(t *testing.T) {
 }
 
 func TestVictorOpsDefaultAPIKey(t *testing.T) {
-	conf, _, err := LoadFile("testdata/conf.victorops-default-apikey.yml")
+	conf, err := LoadFile("testdata/conf.victorops-default-apikey.yml")
 	if err != nil {
 		t.Fatalf("Error parsing %s: %s", "testdata/conf.victorops-default-apikey.yml", err)
 	}
@@ -670,7 +670,7 @@ func TestVictorOpsDefaultAPIKey(t *testing.T) {
 }
 
 func TestVictorOpsNoAPIKey(t *testing.T) {
-	_, _, err := LoadFile("testdata/conf.victorops-no-apikey.yml")
+	_, err := LoadFile("testdata/conf.victorops-no-apikey.yml")
 	if err == nil {
 		t.Fatalf("Expected an error parsing %s: %s", "testdata/conf.victorops-no-apikey.yml", err)
 	}
@@ -680,7 +680,7 @@ func TestVictorOpsNoAPIKey(t *testing.T) {
 }
 
 func TestOpsGenieDefaultAPIKey(t *testing.T) {
-	conf, _, err := LoadFile("testdata/conf.opsgenie-default-apikey.yml")
+	conf, err := LoadFile("testdata/conf.opsgenie-default-apikey.yml")
 	if err != nil {
 		t.Fatalf("Error parsing %s: %s", "testdata/conf.opsgenie-default-apikey.yml", err)
 	}
@@ -695,7 +695,7 @@ func TestOpsGenieDefaultAPIKey(t *testing.T) {
 }
 
 func TestOpsGenieNoAPIKey(t *testing.T) {
-	_, _, err := LoadFile("testdata/conf.opsgenie-no-apikey.yml")
+	_, err := LoadFile("testdata/conf.opsgenie-no-apikey.yml")
 	if err == nil {
 		t.Fatalf("Expected an error parsing %s: %s", "testdata/conf.opsgenie-no-apikey.yml", err)
 	}
@@ -705,7 +705,7 @@ func TestOpsGenieNoAPIKey(t *testing.T) {
 }
 
 func TestOpsGenieDeprecatedTeamSpecified(t *testing.T) {
-	_, _, err := LoadFile("testdata/conf.opsgenie-default-apikey-old-team.yml")
+	_, err := LoadFile("testdata/conf.opsgenie-default-apikey-old-team.yml")
 	if err == nil {
 		t.Fatalf("Expected an error parsing %s: %s", "testdata/conf.opsgenie-default-apikey-old-team.yml", err)
 	}

--- a/config/coordinator.go
+++ b/config/coordinator.go
@@ -95,7 +95,7 @@ func (c *Coordinator) notifySubscribers() error {
 
 // loadFromFile triggers a configuration load, discarding the old configuration.
 func (c *Coordinator) loadFromFile() error {
-	conf, plainConfig, err := LoadFile(c.configFilePath)
+	conf, err := LoadFile(c.configFilePath)
 	if err != nil {
 		c.configSuccessMetric.Set(0)
 		return err
@@ -104,7 +104,7 @@ func (c *Coordinator) loadFromFile() error {
 	c.config = conf
 	c.configSuccessMetric.Set(1)
 	c.configSuccessTimeMetric.Set(float64(time.Now().Unix()))
-	hash := md5HashAsMetricValue(plainConfig)
+	hash := md5HashAsMetricValue([]byte(c.config.original))
 	c.configHashMetric.Set(hash)
 
 	return nil


### PR DESCRIPTION
The origin field of config is not currently in use. It can be used to replace local variables

Signed-off-by: johncming <johncming@yahoo.com>