### PR TITLE
Pagerduty: implement append_common_annotations and append_common_labels

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -213,6 +213,9 @@ type PagerdutyConfig struct {
 	Class       string            `yaml:"class,omitempty" json:"class,omitempty"`
 	Component   string            `yaml:"component,omitempty" json:"component,omitempty"`
 	Group       string            `yaml:"group,omitempty" json:"group,omitempty"`
+
+	AppendCommonAnnotations bool `yaml:"append_common_annotations,omitempty" json:"append_common_annotations,omitempty"`
+	AppendCommonLabels      bool `yaml:"append_common_labels,omitempty" json:"append_common_labels,omitempty"`
 }
 
 // PagerdutyLink is a link

--- a/notify/pagerduty/pagerduty.go
+++ b/notify/pagerduty/pagerduty.go
@@ -250,6 +250,19 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		details[k] = detail
 	}
 
+	if n.conf.AppendCommonAnnotations {
+		for k, v := range data.CommonAnnotations {
+			level.Info(n.logger).Log(k, v)
+			details[k] = v
+		}
+	}
+
+	if n.conf.AppendCommonLabels {
+		for k, v := range data.CommonLabels {
+			details[k] = v
+		}
+	}
+
 	if n.apiV1 != "" {
 		return n.notifyV1(ctx, eventType, key, data, details, as...)
 	}


### PR DESCRIPTION
We have found a need to dynamically add KV pairs to the [`details` field in `pagerduty_config`](https://prometheus.io/docs/alerting/configuration/#pagerduty_config). I have found similar requests in the Prometheus users Google group - one for [pagerduty itself](https://groups.google.com/forum/#!searchin/prometheus-users/pagerduty$20details%7Csort:date/prometheus-users/TD00BnzbG2M/8ClEg7q3BQAJ) and one for [opsgenie](https://groups.google.com/forum/#!searchin/prometheus-users/pagerduty$20details%7Csort:date/prometheus-users/TD00BnzbG2M/8ClEg7q3BQAJ) and I can't find any follow-up or consensus on whether or not this is something desirable by the project. Apologies if I've missed some discussion somewhere.

This PR adds 2 boolean options to `pagerduty_config`, `append_common_annotations` and `append_common_labels` which simply appends the relevant KV pairs to `details`.