### PR TITLE
Alertmanager: Add Microsoft Teams Webhook notification.

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -53,6 +53,7 @@ import (
 	"github.com/prometheus/alertmanager/notify/pagerduty"
 	"github.com/prometheus/alertmanager/notify/pushover"
 	"github.com/prometheus/alertmanager/notify/slack"
+	"github.com/prometheus/alertmanager/notify/teams"
 	"github.com/prometheus/alertmanager/notify/victorops"
 	"github.com/prometheus/alertmanager/notify/webhook"
 	"github.com/prometheus/alertmanager/notify/wechat"
@@ -151,6 +152,9 @@ func buildReceiverIntegrations(nc *config.Receiver, tmpl *template.Template, log
 	}
 	for i, c := range nc.PushoverConfigs {
 		add("pushover", i, c, func(l log.Logger) (notify.Notifier, error) { return pushover.New(c, tmpl, l) })
+	}
+	for i, c := range nc.TeamsConfigs {
+		add("teams", i, c, func(l log.Logger) (notify.Notifier, error) { return teams.New(c, tmpl, l) })
 	}
 	if errs.Len() > 0 {
 		return nil, &errs

--- a/config/config.go
+++ b/config/config.go
@@ -333,6 +333,11 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 				poc.HTTPConfig = c.Global.HTTPConfig
 			}
 		}
+		for _, poc := range rcv.TeamsConfigs {
+			if poc.HTTPConfig == nil {
+				poc.HTTPConfig = c.Global.HTTPConfig
+			}
+		}
 		for _, pdc := range rcv.PagerdutyConfigs {
 			if pdc.HTTPConfig == nil {
 				pdc.HTTPConfig = c.Global.HTTPConfig
@@ -710,6 +715,7 @@ type Receiver struct {
 	WechatConfigs    []*WechatConfig    `yaml:"wechat_configs,omitempty" json:"wechat_configs,omitempty"`
 	PushoverConfigs  []*PushoverConfig  `yaml:"pushover_configs,omitempty" json:"pushover_configs,omitempty"`
 	VictorOpsConfigs []*VictorOpsConfig `yaml:"victorops_configs,omitempty" json:"victorops_configs,omitempty"`
+	TeamsConfigs     []*TeamsConfig     `yaml:"teams_configs,omitempty" json:"teams_configs,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for Receiver.

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -139,6 +139,16 @@ var (
 		Expire:   duration(1 * time.Hour),
 		HTML:     false,
 	}
+
+	// DefaultTeamsConfig defines default values for Teams configurations.
+	DefaultTeamsConfig = TeamsConfig{
+		NotifierConfig: NotifierConfig{
+			VSendResolved: true,
+		},
+		Title:   `{{ template "teams.default.title" . }}`,
+		Summary: `{{ template "teams.default.summary" . }}`,
+		Link:    `{{ template "teams.default.link" . }}`,
+	}
 )
 
 // NotifierConfig contains base options common across all notifier configurations.
@@ -586,6 +596,29 @@ func (c *PushoverConfig) UnmarshalYAML(unmarshal func(interface{}) error) error 
 	}
 	if c.Token == "" {
 		return fmt.Errorf("missing token in Pushover config")
+	}
+	return nil
+}
+
+// TeamsConfig configures notifications via Teams.
+type TeamsConfig struct {
+	NotifierConfig `yaml:",inline" json:",inline"`
+
+	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
+
+	WEBHOOKURL *SecretURL `yaml:"webhook_url,omitempty" json:"webhook_url,omitempty"`
+
+	Title   string `yaml:"title,omitempty" json:"title,omitempty"`
+	Summary string `yaml:"summary,omitempty" json:"summary,omitempty"`
+	Link    string `yaml:"link,omitempty" json:"link,omitempty"`
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (c *TeamsConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	*c = DefaultTeamsConfig
+	type plain TeamsConfig
+	if err := unmarshal((*plain)(c)); err != nil {
+		return err
 	}
 	return nil
 }

--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -144,3 +144,6 @@ receivers:
   slack_configs:
     - channel: '#my-channel'
       image_url: 'http://some.img.com/img.png'
+- name: teams-receiver
+  teams_configs:
+    - webhook_url: mysecret

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -238,6 +238,7 @@ func newMetrics(r prometheus.Registerer) *metrics {
 		"wechat",
 		"pushover",
 		"slack",
+		"teams",
 		"opsgenie",
 		"webhook",
 		"victorops",

--- a/notify/teams/teams.go
+++ b/notify/teams/teams.go
@@ -1,0 +1,129 @@
+// Copyright 2019 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package teams
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-kit/kit/log"
+	commoncfg "github.com/prometheus/common/config"
+
+	"github.com/prometheus/alertmanager/config"
+	"github.com/prometheus/alertmanager/notify"
+	"github.com/prometheus/alertmanager/template"
+	"github.com/prometheus/alertmanager/types"
+)
+
+// Notifier implements a Notifier for Teams notifications.
+type Notifier struct {
+	conf    *config.TeamsConfig
+	tmpl    *template.Template
+	logger  log.Logger
+	client  *http.Client
+	retrier *notify.Retrier
+}
+
+// New returns a new Teams notification handler.
+func New(c *config.TeamsConfig, t *template.Template, l log.Logger) (*Notifier, error) {
+	client, err := commoncfg.NewClientFromConfig(*c.HTTPConfig, "teams", false)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Notifier{
+		conf:    c,
+		tmpl:    t,
+		logger:  l,
+		client:  client,
+		retrier: &notify.Retrier{},
+	}, nil
+}
+
+type card struct {
+	Context    string    `json:"@context,omitempty"`
+	Type       string    `json:"@type,omitempty"`
+	Title      string    `json:"title,omitempty"`
+	Summary    string    `json:"summary,omitempty"`
+	ThemeColor string    `json:"themeColor,omitempty"`
+	Sections   []section `json:"sections"`
+	Actions    []action  `json:"potentialAction"`
+}
+
+type section struct {
+	ActivityTitle    string `json:"activityTitle,omitempty"`
+	ActivitySubtitle string `json:"activitySubtitle,omitempty"`
+	ActivityImage    string `json:"activityImage,omitempty"`
+	Text             string `json:"text,omitempty"`
+}
+
+type action struct {
+	Type    string   `json:"@type,omitempty"`
+	Name    string   `json:"name,omitempty"`
+	Targets []target `json:"targets"`
+}
+
+type target struct {
+	Os  string `json:"os,omitempty"`
+	Uri string `json:"uri,omitempty"`
+}
+
+// Notify implements the Notifier interface.
+func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
+	var err error
+	var (
+		data     = notify.GetTemplateData(ctx, n.tmpl, as, n.logger)
+		tmplText = notify.TmplText(n.tmpl, data, &err)
+	)
+
+	t := &target{
+		Os:  "default",
+		Uri: tmplText(n.conf.Link),
+	}
+	a := &action{
+		Type:    "OpenUri",
+		Name:    "View in AlertManager",
+		Targets: []target{*t},
+	}
+	req := &card{
+		Context:    "http://schema.org/extensions",
+		Type:       "MessageCard",
+		ThemeColor: "0078D7",
+		Title:      tmplText(n.conf.Title),
+		Summary:    tmplText(n.conf.Summary),
+		Actions:    []action{*a},
+	}
+	if err != nil {
+		return false, err
+	}
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(req); err != nil {
+		return false, err
+	}
+
+	u := n.conf.WEBHOOKURL.String()
+	resp, err := notify.PostJSON(ctx, n.client, u, &buf)
+	if err != nil {
+		return true, notify.RedactURL(err)
+	}
+	defer notify.Drain(resp)
+
+	// Only 5xx response codes are recoverable and 2xx codes are successful.
+	// https://api.slack.com/incoming-webhooks#handling_errors
+	// https://api.slack.com/changelog/2016-05-17-changes-to-errors-for-incoming-webhooks
+	return n.retrier.Check(resp.StatusCode, resp.Body)
+}

--- a/notify/teams/teams_test.go
+++ b/notify/teams/teams_test.go
@@ -1,0 +1,59 @@
+// Copyright 2019 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package teams
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	commoncfg "github.com/prometheus/common/config"
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/alertmanager/config"
+	"github.com/prometheus/alertmanager/notify/test"
+)
+
+func TestTeamsRetry(t *testing.T) {
+	notifier, err := New(
+		&config.TeamsConfig{
+			HTTPConfig: &commoncfg.HTTPClientConfig{},
+		},
+		test.CreateTmpl(t),
+		log.NewNopLogger(),
+	)
+	require.NoError(t, err)
+
+	for statusCode, expected := range test.RetryTests(test.DefaultRetryCodes()) {
+		actual, _ := notifier.retrier.Check(statusCode, nil)
+		require.Equal(t, expected, actual, fmt.Sprintf("error on status %d", statusCode))
+	}
+}
+
+func TestTeamsRedactedURL(t *testing.T) {
+	ctx, u, fn := test.GetContextWithCancelingURL()
+	defer fn()
+
+	notifier, err := New(
+		&config.TeamsConfig{
+			WEBHOOKURL: &config.SecretURL{URL: u},
+			HTTPConfig: &commoncfg.HTTPClientConfig{},
+		},
+		test.CreateTmpl(t),
+		log.NewNopLogger(),
+	)
+	require.NoError(t, err)
+
+	test.AssertNotifyLeaksNoSecret(t, ctx, notifier, u.String())
+}

--- a/template/default.tmpl
+++ b/template/default.tmpl
@@ -221,3 +221,7 @@ Alerts Resolved:
 {{ end }}
 {{ end }}
 {{ define "pushover.default.url" }}{{ template "__alertmanagerURL" . }}{{ end }}
+
+{{ define "teams.default.title" }}{{ template "__subject" . }}{{ end }}
+{{ define "teams.default.summary" }}{{ template "__subject" . }}{{ end }}
+{{ define "teams.default.link" }}{{ template "__alertmanagerURL" . }}{{ end }}


### PR DESCRIPTION
This adds notifications to Microsoft Teams. It is using the Webhook connector. Let me know what you think.

It should be simple as this
```
receivers:
- name: teams-receiver
  teams_configs:
    - webhook_url: https://outlook.office.com/webhook/[REDACTED]
```