### PR TITLE
Ensure nil registry not registered

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -122,8 +122,12 @@ func (m *memMarker) registerMetrics(r prometheus.Registerer) {
 	alertsActive := newAlertMetricByState(AlertStateActive)
 	alertsSuppressed := newAlertMetricByState(AlertStateSuppressed)
 
-	r.MustRegister(alertsActive)
-	r.MustRegister(alertsSuppressed)
+	if r != nil {
+		r.MustRegister(
+			alertsActive,
+			alertsSuppressed,
+		)
+	}
 }
 
 // Count implements Marker.


### PR DESCRIPTION
The types package does not follow the common pattern of avoiding metrics registration when a nil registry parameter is passed. This copies the pattern used in the silences/nflog/etc package.

Signed-off-by: Jacob Lisi <jacob.t.lisi@gmail.com>