### PR TITLE
dispatch: don't garbage-collect alerts from store

### DIFF
--- a/inhibit/inhibit.go
+++ b/inhibit/inhibit.go
@@ -94,7 +94,7 @@ func (ih *Inhibitor) Run() {
 	runCtx, runCancel := context.WithCancel(ctx)
 
 	for _, rule := range ih.rules {
-		rule.scache.Run(runCtx)
+		rule.scache.Run(runCtx, 15*time.Minute)
 	}
 
 	g.Add(func() error {
@@ -194,7 +194,7 @@ func NewInhibitRule(cr *config.InhibitRule) *InhibitRule {
 		SourceMatchers: sourcem,
 		TargetMatchers: targetm,
 		Equal:          equal,
-		scache:         store.NewAlerts(15 * time.Minute),
+		scache:         store.NewAlerts(),
 	}
 }
 

--- a/inhibit/inhibit_test.go
+++ b/inhibit/inhibit_test.go
@@ -122,7 +122,7 @@ func TestInhibitRuleHasEqual(t *testing.T) {
 	for _, c := range cases {
 		r := &InhibitRule{
 			Equal:  map[model.LabelName]struct{}{},
-			scache: store.NewAlerts(5 * time.Minute),
+			scache: store.NewAlerts(),
 		}
 		for _, ln := range c.equal {
 			r.Equal[ln] = struct{}{}
@@ -170,9 +170,9 @@ func TestInhibitRuleMatches(t *testing.T) {
 		},
 	}
 
-	ih.rules[0].scache = store.NewAlerts(5 * time.Minute)
+	ih.rules[0].scache = store.NewAlerts()
 	ih.rules[0].scache.Set(sourceAlert1)
-	ih.rules[1].scache = store.NewAlerts(5 * time.Minute)
+	ih.rules[1].scache = store.NewAlerts()
 	ih.rules[1].scache.Set(sourceAlert2)
 
 	cases := []struct {

--- a/provider/mem/mem.go
+++ b/provider/mem/mem.go
@@ -50,7 +50,7 @@ type listeningAlerts struct {
 func NewAlerts(ctx context.Context, m types.Marker, intervalGC time.Duration, l log.Logger) (*Alerts, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	a := &Alerts{
-		alerts:    store.NewAlerts(intervalGC),
+		alerts:    store.NewAlerts(),
 		cancel:    cancel,
 		listeners: map[int]listeningAlerts{},
 		next:      0,
@@ -76,7 +76,7 @@ func NewAlerts(ctx context.Context, m types.Marker, intervalGC time.Duration, l 
 		}
 		a.mtx.Unlock()
 	})
-	a.alerts.Run(ctx)
+	a.alerts.Run(ctx, intervalGC)
 
 	return a, nil
 }


### PR DESCRIPTION
Ref https://github.com/coreos/kube-prometheus/issues/205

The aggregation group is already responsible for removing the resolved alerts. Running the garbage collection in parallel introduces a race and eventually resolved notifications may be dropped.

I couldn't find a way to add a test since the first GC happened after 15min. I have a script to reproduce the issue and I've verified that the issue is gone after this change. The script goes like:

* send firing alert repeatedly for about 14min.
* send resolved alert at 14min45s (just before the GC which itself happens before the next group interval).

```
route:
  group_by: [job]
  group_wait: 10s
  group_interval: 30s
  repeat_interval: 10h
```