### PR TITLE
nflog: use errors.New instead of fmt.Errorf for no custom error msg.

### DIFF
--- a/nflog/nflog.go
+++ b/nflog/nflog.go
@@ -39,7 +39,7 @@ import (
 var ErrNotFound = errors.New("not found")
 
 // ErrInvalidState is returned if the state isn't valid.
-var ErrInvalidState = fmt.Errorf("invalid state")
+var ErrInvalidState = errors.New("invalid state")
 
 // query currently allows filtering by and/or receiver group key.
 // It is configured via QueryParameter functions.
@@ -193,7 +193,7 @@ func WithMetrics(r prometheus.Registerer) Option {
 func WithMaintenance(d time.Duration, stopc chan struct{}, done func()) Option {
 	return func(l *Log) error {
 		if d == 0 {
-			return fmt.Errorf("maintenance interval must not be 0")
+			return errors.New("maintenance interval must not be 0")
 		}
 		l.runInterval = d
 		l.stopc = stopc


### PR DESCRIPTION
use errors.New instead of fmt.Errorf for no custom error msg.