### PR TITLE
api/v1: return error more clear and common.

### DIFF
--- a/api/v1/api.go
+++ b/api/v1/api.go
@@ -791,6 +791,7 @@ func (api *API) receive(r *http.Request, v interface{}) error {
 	err := dec.Decode(v)
 	if err != nil {
 		level.Debug(api.logger).Log("msg", "Decoding request failed", "err", err)
+		return err
 	}
-	return err
+	return nil
 }


### PR DESCRIPTION
relatively rare  typo:

https://github.com/prometheus/alertmanager/blob/e4437ab54f26dbcd66b90eaf4d5701fee98a1da6/api/v1/api.go#L791-L796

return error more common.