### PR TITLE
dispatch: route group labels should contain group common label.

### DIFF
--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -38,8 +38,11 @@ func TestAggrGroup(t *testing.T) {
 		"b": "v2",
 	}
 	opts := &RouteOpts{
-		Receiver:       "n1",
-		GroupBy:        map[model.LabelName]struct{}{},
+		Receiver: "n1",
+		GroupBy: map[model.LabelName]struct{}{
+			"a": struct{}{},
+			"b": struct{}{},
+		},
 		GroupWait:      1 * time.Second,
 		GroupInterval:  300 * time.Millisecond,
 		RepeatInterval: 1 * time.Hour,


### PR DESCRIPTION
`GroupBy` is empty in the test case which is not matched with production code.

https://github.com/prometheus/alertmanager/blob/ab537b5b2f9dc55cc4a1faed5df5618c7648c088/dispatch/dispatch_test.go#L42

In production code,  `GroupBy` is not empty unless `GroupByAll` enabled. when `GroupBy` no empty, it contains all the keys of responding labels.

https://github.com/prometheus/alertmanager/blob/4535311c34f13ddcc492e3c1e769eec85c18dde2/dispatch/dispatch.go#L253

https://github.com/prometheus/alertmanager/blob/4535311c34f13ddcc492e3c1e769eec85c18dde2/dispatch/dispatch.go#L237