### PR TITLE
Consolidate invalid address log

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -121,11 +121,11 @@ func Create(
 ) (*Peer, error) {
 	bindHost, bindPortStr, err := net.SplitHostPort(bindAddr)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "invalid listen address")
 	}
 	bindPort, err := strconv.Atoi(bindPortStr)
 	if err != nil {
-		return nil, errors.Wrap(err, "invalid listen address")
+		return nil, errors.Wrapf(err, "address %s: invalid port", bindAddr)
 	}
 
 	var advertiseHost string
@@ -138,7 +138,7 @@ func Create(
 		}
 		advertisePort, err = strconv.Atoi(advertisePortStr)
 		if err != nil {
-			return nil, errors.Wrap(err, "invalid advertise address, wrong port")
+			return nil, errors.Wrapf(err, "address %s: invalid port", advertiseAddr)
 		}
 	}
 


### PR DESCRIPTION
The Invalid listen address errors should be as same as Invalid advertise address.

Signed-off-by: Kien Nguyen <kiennt2609@gmail.com>