### PR TITLE
store: fix potential flaky test

### DIFF
--- a/inhibit/inhibit.go
+++ b/inhibit/inhibit.go
@@ -94,7 +94,7 @@ func (ih *Inhibitor) Run() {
 	runCtx, runCancel := context.WithCancel(ctx)
 
 	for _, rule := range ih.rules {
-		rule.scache.Run(runCtx, 15*time.Minute)
+		go rule.scache.Run(runCtx, 15*time.Minute)
 	}
 
 	g.Add(func() error {

--- a/provider/mem/mem.go
+++ b/provider/mem/mem.go
@@ -76,7 +76,7 @@ func NewAlerts(ctx context.Context, m types.Marker, intervalGC time.Duration, l 
 		}
 		a.mtx.Unlock()
 	})
-	a.alerts.Run(ctx, intervalGC)
+	go a.alerts.Run(ctx, intervalGC)
 
 	return a, nil
 }

--- a/store/store.go
+++ b/store/store.go
@@ -58,16 +58,16 @@ func (a *Alerts) SetGCCallback(cb func([]*types.Alert)) {
 
 // Run starts the GC loop. The interval must be greater than zero; if not, the function will panic.
 func (a *Alerts) Run(ctx context.Context, interval time.Duration) {
-	go func(t *time.Ticker) {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-t.C:
-				a.gc()
-			}
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			a.gc()
 		}
-	}(time.NewTicker(interval))
+	}
 }
 
 func (a *Alerts) gc() {


### PR DESCRIPTION
I've spotted a date race in a CI run. It's very unlikely to happen but still better to fix it.

```
==================                                                                             
WARNING: DATA RACE                                                                             
Write at 0x00c000016c10 by goroutine 15:                                                       
  github.com/prometheus/alertmanager/store.TestGC.func2()             
      /home/simon/workspace/src/github.com/prometheus/alertmanager/store/store_test.go:91 +0x6e 
  github.com/prometheus/alertmanager/store.(*Alerts).gc()
      /home/simon/workspace/src/github.com/prometheus/alertmanager/store/store.go:84 +0x346
  github.com/prometheus/alertmanager/store.(*Alerts).Run.func1()
      /home/simon/workspace/src/github.com/prometheus/alertmanager/store/store.go:67 +0x52

Previous read at 0x00c000016c10 by goroutine 14:
  github.com/prometheus/alertmanager/store.TestGC()
      /home/simon/workspace/src/github.com/prometheus/alertmanager/store/store_test.go:119 +0x862
  testing.tRunner()
      /home/simon/go/src/testing/testing.go:909 +0x199

Goroutine 15 (running) created at:
  github.com/prometheus/alertmanager/store.(*Alerts).Run()
      /home/simon/workspace/src/github.com/prometheus/alertmanager/store/store.go:61 +0x78
  github.com/prometheus/alertmanager/store.TestGC()
      /home/simon/workspace/src/github.com/prometheus/alertmanager/store/store_test.go:100 +0x517
  testing.tRunner()
      /home/simon/go/src/testing/testing.go:909 +0x199

Goroutine 14 (finished) created at:
  testing.(*T).Run()
      /home/simon/go/src/testing/testing.go:960 +0x651
  testing.runTests.func1()
      /home/simon/go/src/testing/testing.go:1202 +0xa6
  testing.tRunner()
      /home/simon/go/src/testing/testing.go:909 +0x199
  testing.runTests()
      /home/simon/go/src/testing/testing.go:1200 +0x521
  testing.(*M).Run()
      /home/simon/go/src/testing/testing.go:1117 +0x2ff
  main.main()
      _testmain.go:48 +0x223
==================
panic: close of closed channel


goroutine 14 [running]:
github.com/prometheus/alertmanager/store.TestGC.func2(0x0, 0x0, 0x0)
        /home/simon/workspace/src/github.com/prometheus/alertmanager/store/store_test.go:93 +0xbf
github.com/prometheus/alertmanager/store.(*Alerts).gc(0xc00000f600)
        /home/simon/workspace/src/github.com/prometheus/alertmanager/store/store.go:84 +0x347
github.com/prometheus/alertmanager/store.(*Alerts).Run.func1(0xb63c80, 0xc000030f40, 0xc00000f600, 0xc0000b8820)
        /home/simon/workspace/src/github.com/prometheus/alertmanager/store/store.go:67 +0x53
created by github.com/prometheus/alertmanager/store.(*Alerts).Run
        /home/simon/workspace/src/github.com/prometheus/alertmanager/store/store.go:61 +0x79
```