### PR TITLE
config: forbid nil regexp matchers

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -16,6 +16,7 @@ package config
 import (
 	"encoding/json"
 	"net/url"
+	"os"
 	"reflect"
 	"regexp"
 	"strings"
@@ -773,6 +774,35 @@ func TestUnmarshalHostPort(t *testing.T) {
 			b, err = json.Marshal(&hp)
 			require.NoError(t, err)
 			require.Equal(t, tc.jsonOut, string(b))
+		})
+	}
+}
+
+func TestNilRegexp(t *testing.T) {
+	for _, tc := range []struct {
+		file   string
+		errMsg string
+	}{
+		{
+			file:   "testdata/conf.nil-match_re-route.yml",
+			errMsg: "invalid_label",
+		},
+		{
+			file:   "testdata/conf.nil-source_match_re-inhibitiion.yml",
+			errMsg: "invalid_source_label",
+		},
+		{
+			file:   "testdata/conf.nil-target_match_re-inhibitiion.yml",
+			errMsg: "invalid_target_label",
+		},
+	} {
+		t.Run(tc.file, func(t *testing.T) {
+			_, err := os.Stat(tc.file)
+			require.NoError(t, err)
+
+			_, err = LoadFile(tc.file)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.errMsg)
 		})
 	}
 }

--- a/config/testdata/conf.nil-match_re-route.yml
+++ b/config/testdata/conf.nil-match_re-route.yml
@@ -1,0 +1,10 @@
+route:
+  receiver: empty
+
+  routes:
+  - match_re:
+      invalid_label:
+    receiver: empty
+
+receivers:
+- name: empty

--- a/config/testdata/conf.nil-source_match_re-inhibitiion.yml
+++ b/config/testdata/conf.nil-source_match_re-inhibitiion.yml
@@ -1,0 +1,11 @@
+route:
+  receiver: empty
+
+receivers:
+- name: empty
+
+inhibit_rules:
+- source_match_re:
+    invalid_source_label:
+  target_match_re:
+    severity: critical

--- a/config/testdata/conf.nil-target_match_re-inhibitiion.yml
+++ b/config/testdata/conf.nil-target_match_re-inhibitiion.yml
@@ -1,0 +1,11 @@
+route:
+  receiver: empty
+
+receivers:
+- name: empty
+
+inhibit_rules:
+- source_match:
+    severity: critical
+  target_match_re:
+    invalid_target_label:


### PR DESCRIPTION
Otherwise the program could panic.

```yaml
route:
  receiver: empty

  routes:
  - match_re:
      invalid_label:
    receiver: empty

receivers:
- name: empty
```

```
level=info ts=2019-10-24T15:31:19.726Z caller=main.go:217 msg="Starting Alertmanager" version="(version=0.19.0, branch=master, revision=a75cd02786dfecd25e2469fc4df5d920e6b9c226)"
level=info ts=2019-10-24T15:31:19.726Z caller=main.go:218 build_context="(go=go1.13.1, user=simon@simon-laptop, date=20191024-15:20:11)"
level=info ts=2019-10-24T15:31:19.758Z caller=cluster.go:161 component=cluster msg="setting advertise address explicitly" addr=192.168.1.17 port=9094
level=info ts=2019-10-24T15:31:19.759Z caller=cluster.go:623 component=cluster msg="Waiting for gossip to settle..." interval=2s
level=info ts=2019-10-24T15:31:19.781Z caller=coordinator.go:119 component=configuration msg="Loading configuration file" file=config/testdata/conf.nil-match_re-route.yml
level=info ts=2019-10-24T15:31:19.781Z caller=coordinator.go:131 component=configuration msg="Completed loading of configuration file" file=config/testdata/conf.nil-match_re-route.yml
level=info ts=2019-10-24T15:31:19.783Z caller=cluster.go:632 component=cluster msg="gossip not settled but continuing anyway" polls=0 elapsed=23.742589ms
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xb32915]

goroutine 1 [running]:
regexp.(*Regexp).String(...)
        /home/simon/go/src/regexp/regexp.go:106
github.com/prometheus/alertmanager/types.NewRegexMatcher(...)
        /home/simon/workspace/src/github.com/prometheus/alertmanager/types/match.go:100
github.com/prometheus/alertmanager/dispatch.NewRoute(0xc000300510, 0xc0001b9380, 0x0)
        /home/simon/workspace/src/github.com/prometheus/alertmanager/dispatch/route.go:95 +0x3f5
github.com/prometheus/alertmanager/dispatch.NewRoutes(0xc0001282f8, 0x1, 0x1, 0xc0001b9380, 0x7fde30c3edb8, 0x1, 0x100)
        /home/simon/workspace/src/github.com/prometheus/alertmanager/dispatch/route.go:115 +0x83
github.com/prometheus/alertmanager/dispatch.NewRoute(0xc000300480, 0x0, 0xc0003ff6d0)
        /home/simon/workspace/src/github.com/prometheus/alertmanager/dispatch/route.go:106 +0x671
github.com/prometheus/alertmanager/api/v1.(*API).Update(0xc0003c6b00, 0xc0001095e0)
        /home/simon/workspace/src/github.com/prometheus/alertmanager/api/v1/api.go:140 +0x97
github.com/prometheus/alertmanager/api.(*API).Update(0xc00001df00, 0xc0001095e0, 0xc0003aa020)
        /home/simon/workspace/src/github.com/prometheus/alertmanager/api/api.go:200 +0x38
main.run.func7(0xc0001095e0, 0x8, 0x40)
        /home/simon/workspace/src/github.com/prometheus/alertmanager/cmd/alertmanager/main.go:412 +0x596
github.com/prometheus/alertmanager/config.(*Coordinator).notifySubscribers(0xc00052bb00, 0xc00001a940, 0x4)
        /home/simon/workspace/src/github.com/prometheus/alertmanager/config/coordinator.go:88 +0x72
github.com/prometheus/alertmanager/config.(*Coordinator).Reload(0xc00052bb00, 0x0, 0x0)
        /home/simon/workspace/src/github.com/prometheus/alertmanager/config/coordinator.go:136 +0x5ab
main.run(0x0)
        /home/simon/workspace/src/github.com/prometheus/alertmanager/cmd/alertmanager/main.go:440 +0x3f95
main.main()
        /home/simon/workspace/src/github.com/prometheus/alertmanager/cmd/alertmanager/main.go:173 +0x22
```