### PR TITLE
notify/pagerduty: check that PagerDuty keys aren't empty

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -217,7 +217,7 @@ type PagerdutyConfig struct {
 
 // PagerdutyLink is a link
 type PagerdutyLink struct {
-	HRef string `yaml:"href,omitempty" json:"href,omitempty"`
+	Href string `yaml:"href,omitempty" json:"href,omitempty"`
 	Text string `yaml:"text,omitempty" json:"text,omitempty"`
 }
 


### PR DESCRIPTION
Relates to #2082 

When loading the configuration, we check that`routing_key` and `service_key` aren't empty but we didn't do the same after expanding the template.