### PR TITLE
config: remove support for JSON marshaling

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -105,20 +105,6 @@ func (u URL) MarshalJSON() ([]byte, error) {
 	return nil, nil
 }
 
-// UnmarshalJSON implements the json.Marshaler interface for URL.
-func (u *URL) UnmarshalJSON(data []byte) error {
-	var s string
-	if err := json.Unmarshal(data, &s); err != nil {
-		return err
-	}
-	urlp, err := parseURL(s)
-	if err != nil {
-		return err
-	}
-	u.URL = urlp.URL
-	return nil
-}
-
 // SecretURL is a URL that must not be revealed on marshaling.
 type SecretURL URL
 
@@ -149,18 +135,6 @@ func (s *SecretURL) UnmarshalYAML(unmarshal func(interface{}) error) error {
 // MarshalJSON implements the json.Marshaler interface for SecretURL.
 func (s SecretURL) MarshalJSON() ([]byte, error) {
 	return json.Marshal(secretToken)
-}
-
-// UnmarshalJSON implements the json.Marshaler interface for SecretURL.
-func (s *SecretURL) UnmarshalJSON(data []byte) error {
-	// In order to deserialize a previously serialized configuration (eg from
-	// the Alertmanager API with amtool), `<secret>` needs to be treated
-	// specially, as it isn't a valid URL.
-	if string(data) == secretToken || string(data) == secretTokenJSON {
-		s.URL = &url.URL{}
-		return nil
-	}
-	return json.Unmarshal(data, (*URL)(s))
 }
 
 // Load parses the YAML input s into a Config.
@@ -749,29 +723,6 @@ func (re *Regexp) UnmarshalYAML(unmarshal func(interface{}) error) error {
 func (re Regexp) MarshalYAML() (interface{}, error) {
 	if re.original != "" {
 		return re.original, nil
-	}
-	return nil, nil
-}
-
-// UnmarshalJSON implements the json.Marshaler interface for Regexp
-func (re *Regexp) UnmarshalJSON(data []byte) error {
-	var s string
-	if err := json.Unmarshal(data, &s); err != nil {
-		return err
-	}
-	regex, err := regexp.Compile("^(?:" + s + ")$")
-	if err != nil {
-		return err
-	}
-	re.Regexp = regex
-	re.original = s
-	return nil
-}
-
-// MarshalJSON implements the json.Marshaler interface for Regexp.
-func (re Regexp) MarshalJSON() ([]byte, error) {
-	if re.original != "" {
-		return json.Marshal(re.original)
 	}
 	return nil, nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -366,27 +366,13 @@ func TestMarshalSecretURL(t *testing.T) {
 	}
 	u := &SecretURL{urlp}
 
-	c, err := json.Marshal(u)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// u003c -> "<"
-	// u003e -> ">"
-	require.Equal(t, "\"\\u003csecret\\u003e\"", string(c), "SecretURL not properly elided in JSON.")
-	// Check that the marshaled data can be unmarshaled again.
-	out := &SecretURL{}
-	err = json.Unmarshal(c, out)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	c, err = yaml.Marshal(u)
+	c, err := yaml.Marshal(u)
 	if err != nil {
 		t.Fatal(err)
 	}
 	require.Equal(t, "<secret>\n", string(c), "SecretURL not properly elided in YAML.")
 	// Check that the marshaled data can be unmarshaled again.
-	out = &SecretURL{}
+	out := &SecretURL{}
 	err = yaml.Unmarshal(c, &out)
 	if err != nil {
 		t.Fatal(err)
@@ -397,13 +383,7 @@ func TestUnmarshalSecretURL(t *testing.T) {
 	b := []byte(`"http://example.com/se cret"`)
 	var u SecretURL
 
-	err := json.Unmarshal(b, &u)
-	if err != nil {
-		t.Fatal(err)
-	}
-	require.Equal(t, "http://example.com/se%20cret", u.String(), "SecretURL not properly unmarshalled in JSON.")
-
-	err = yaml.Unmarshal(b, &u)
+	err := yaml.Unmarshal(b, &u)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -435,13 +415,7 @@ func TestUnmarshalURL(t *testing.T) {
 	b := []byte(`"http://example.com/a b"`)
 	var u URL
 
-	err := json.Unmarshal(b, &u)
-	if err != nil {
-		t.Fatal(err)
-	}
-	require.Equal(t, "http://example.com/a%20b", u.String(), "URL not properly unmarshalled in JSON.")
-
-	err = yaml.Unmarshal(b, &u)
+	err := yaml.Unmarshal(b, &u)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -456,12 +430,7 @@ func TestUnmarshalInvalidURL(t *testing.T) {
 	} {
 		var u URL
 
-		err := json.Unmarshal(b, &u)
-		if err == nil {
-			t.Errorf("Expected an error unmarshalling %q from JSON", string(b))
-		}
-
-		err = yaml.Unmarshal(b, &u)
+		err := yaml.Unmarshal(b, &u)
 		if err == nil {
 			t.Errorf("Expected an error unmarshalling %q from YAML", string(b))
 		}
@@ -473,26 +442,9 @@ func TestUnmarshalRelativeURL(t *testing.T) {
 	b := []byte(`"/home"`)
 	var u URL
 
-	err := json.Unmarshal(b, &u)
+	err := yaml.Unmarshal(b, &u)
 	if err == nil {
 		t.Errorf("Expected an error parsing URL")
-	}
-
-	err = yaml.Unmarshal(b, &u)
-	if err == nil {
-		t.Errorf("Expected an error parsing URL")
-	}
-}
-
-func TestJSONUnmarshal(t *testing.T) {
-	c, err := LoadFile("testdata/conf.good.yml")
-	if err != nil {
-		t.Errorf("Error parsing %s: %s", "testdata/conf.good.yml", err)
-	}
-
-	_, err = json.Marshal(c)
-	if err != nil {
-		t.Fatal("JSON Marshaling failed:", err)
 	}
 }
 

--- a/dispatch/route.go
+++ b/dispatch/route.go
@@ -14,7 +14,6 @@
 package dispatch
 
 import (
-	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -181,27 +180,4 @@ func (ro *RouteOpts) String() string {
 	}
 	return fmt.Sprintf("<RouteOpts send_to:%q group_by:%q group_by_all:%t timers:%q|%q>",
 		ro.Receiver, labels, ro.GroupByAll, ro.GroupWait, ro.GroupInterval)
-}
-
-// MarshalJSON returns a JSON representation of the routing options.
-func (ro *RouteOpts) MarshalJSON() ([]byte, error) {
-	v := struct {
-		Receiver       string           `json:"receiver"`
-		GroupBy        model.LabelNames `json:"groupBy"`
-		GroupByAll     bool             `json:"groupByAll"`
-		GroupWait      time.Duration    `json:"groupWait"`
-		GroupInterval  time.Duration    `json:"groupInterval"`
-		RepeatInterval time.Duration    `json:"repeatInterval"`
-	}{
-		Receiver:       ro.Receiver,
-		GroupByAll:     ro.GroupByAll,
-		GroupWait:      ro.GroupWait,
-		GroupInterval:  ro.GroupInterval,
-		RepeatInterval: ro.RepeatInterval,
-	}
-	for ln := range ro.GroupBy {
-		v.GroupBy = append(v.GroupBy, ln)
-	}
-
-	return json.Marshal(&v)
 }


### PR DESCRIPTION
I might be wrong but I think that JSON marshaling is a left-over from older Alertmanager versions.