### PR TITLE
template: add the method RemoveKeys to KV

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -195,6 +195,11 @@ func (kv KV) SortedPairs() Pairs {
 	return pairs
 }
 
+// RemoveKeys returns a copy of the key/value set without the given keys.
+func (kv KV) RemoveKeys(key ...string) KV {
+	return kv.Remove(key)
+}
+
 // Remove returns a copy of the key/value set without the given keys.
 func (kv KV) Remove(keys []string) KV {
 	keySet := make(map[string]struct{}, len(keys))

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -77,6 +77,20 @@ func TestKVSortedPairs(t *testing.T) {
 	}
 }
 
+func TestKVRemoveKeys(t *testing.T) {
+	kv := KV{
+		"key1": "val1",
+		"key2": "val2",
+		"key3": "val3",
+		"key4": "val4",
+	}
+
+	kv = kv.RemoveKeys("key2", "key4")
+
+	expected := []string{"key1", "key3"}
+	require.EqualValues(t, expected, kv.Names())
+}
+
 func TestKVRemove(t *testing.T) {
 	kv := KV{
 		"key1": "val1",
@@ -356,6 +370,19 @@ func TestTemplateExpansion(t *testing.T) {
 			title: "Template using reReplaceAll",
 			in:    `{{ reReplaceAll "ab" "AB" "abcdabcda"}}`,
 			exp:   "ABcdABcda",
+		},
+		{
+			title: "Template which calls RemoveKeys",
+			in:    `{{ with .GroupLabels }}{{ with .RemoveKeys "key1" "key3" }}{{ .SortedPairs.Values }}{{ end }}{{ end }}`,
+			data: Data{
+				GroupLabels: KV{
+					"key1": "key1",
+					"key2": "key2",
+					"key3": "key3",
+					"key4": "key4",
+				},
+			},
+			exp: "[key2 key4]",
 		},
 	} {
 		tc := tc


### PR DESCRIPTION
KV.Remove is not callable inside a template because it needs a slice of string which can't be created in a template.
Introduce the KV.RemoveKeys method which takes a vararg of strings and then calls KV.Remove.

I came across this problem because I was trying to do this in my Slack template:
```
{{ define "__subject" }}{{ if .GroupLabels.type }}{{ .GroupLabels.type }} {{ end }} {{with .GroupLabels}}{{.Remove "type"}}{{ .SortedPairs.Values | join " / " }}{{end}}{{end}}
```

except this doesn't work because of this error:
```
template: default.tmpl:6:223: executing \"__subject\" at <\"type\">: can't handle \"type\" for arg of type []string
```
As far as I can tell there's no way to create a slice/array in a Go template so right now `Remove` is completely unusable inside a template.

This PR adds a method `RemoveKeys` which takes a vararg string and simply calls Remove itself.