### PR TITLE
README.md: Add consistency for amtool examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,10 +316,10 @@ and it prints out all receivers the alert would match ordered and separated by `
 Example of usage:
 ```
 # View routing tree of remote Alertmanager
-amtool config routes --alertmanager.url=http://localhost:9090
+$ amtool config routes --alertmanager.url=http://localhost:9090
 
 # Test if alert matches expected receiver
-./amtool config routes test --config.file=doc/examples/simple.yml --tree --verify.receivers=team-X-pager service=database owner=team-X
+$ amtool config routes test --config.file=doc/examples/simple.yml --tree --verify.receivers=team-X-pager service=database owner=team-X
 ```
 
 ## High Availability


### PR DESCRIPTION
All the examples are written with `$ amtool` except for two of them.
This change will add `$ amtool` for all of them.