### PR TITLE
template: add the default template function stringSlice

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -141,6 +141,9 @@ var DefaultFuncs = FuncMap{
 		re := regexp.MustCompile(pattern)
 		return re.ReplaceAllString(text, repl)
 	},
+	"stringSlice": func(s ...string) []string {
+		return s
+	},
 }
 
 // Pair is a key/value string pair.

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -357,6 +357,19 @@ func TestTemplateExpansion(t *testing.T) {
 			in:    `{{ reReplaceAll "ab" "AB" "abcdabcda"}}`,
 			exp:   "ABcdABcda",
 		},
+		{
+			title: "Template using stringSlice",
+			in:    `{{ with .GroupLabels }}{{ with .Remove (stringSlice "key1" "key3") }}{{ .SortedPairs.Values }}{{ end }}{{ end }}`,
+			data: Data{
+				GroupLabels: KV{
+					"key1": "key1",
+					"key2": "key2",
+					"key3": "key3",
+					"key4": "key4",
+				},
+			},
+			exp: "[key2 key4]",
+		},
 	} {
 		tc := tc
 		t.Run(tc.title, func(t *testing.T) {


### PR DESCRIPTION
Since it's impossible to create a string slice in a Go template by
default, add a function to work around this problem.

The use case is to make it easy to call KV.Remove with an arbitrary
slice inside a template.

This is a follow up to https://github.com/prometheus/alertmanager/pull/2094