### PR TITLE
store: delete repeated deletion.

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -77,7 +77,6 @@ func (a *Alerts) gc() {
 	var resolved []*types.Alert
 	for fp, alert := range a.c {
 		if alert.Resolved() {
-			delete(a.c, fp)
 			resolved = append(resolved, alert)
 		}
 	}


### PR DESCRIPTION
The delete resolved alarm has been set here

https://github.com/prometheus/alertmanager/blob/25b32434a661610be63931e2ce259faeac35fda2/provider/mem/mem.go#L59-L65

The GC can only collect resolved alerts. Assign the GC operation (such as delete) to the specific callback

https://github.com/prometheus/alertmanager/blob/25b32434a661610be63931e2ce259faeac35fda2/store/store.go#L80


Signed-off-by: johncming <johncming@yahoo.com>