### PR TITLE
notify: optimize length check.

### DIFF
--- a/notify/notify.go
+++ b/notify/notify.go
@@ -576,18 +576,19 @@ func (n *DedupStage) Exec(ctx context.Context, l log.Logger, alerts ...*types.Al
 	ctx = WithResolvedAlerts(ctx, resolved)
 
 	entries, err := n.nflog.Query(nflog.QGroupKey(gkey), nflog.QReceiver(n.recv))
-
 	if err != nil && err != nflog.ErrNotFound {
 		return ctx, nil, err
 	}
+
 	var entry *nflogpb.Entry
 	switch len(entries) {
 	case 0:
 	case 1:
 		entry = entries[0]
-	case 2:
+	default:
 		return ctx, nil, fmt.Errorf("unexpected entry result size %d", len(entries))
 	}
+
 	if n.needsUpdate(entry, firingSet, resolvedSet, repeatInterval) {
 		return ctx, alerts, nil
 	}


### PR DESCRIPTION
https://github.com/prometheus/alertmanager/blob/311650658ada0ad906b6a6a77c985b7536a09f14/nflog/nflog.go#L454-L481

It is difficult to return a value from a function call that is not of length 0 or 1, and the length 2 check has two drawbacks
1. If the query function returns a length of 3 in the future, the check is skipped (probably not desired) and default is probably better
2. Checks of length 2 should be expiration codes



Signed-off-by: johncming <johncming@yahoo.com>