### PR TITLE
cluster: change lock from Read lock to Write Lock since function modi…

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -260,8 +260,8 @@ func (p *Peer) setInitialFailed(peers []string, myAddr string) {
 		return
 	}
 
-	p.peerLock.RLock()
-	defer p.peerLock.RUnlock()
+	p.peerLock.Lock()
+	defer p.peerLock.Unlock()
 
 	now := time.Now()
 	for _, peerAddr := range peers {


### PR DESCRIPTION
 function setInitialFailed()  modifies the struct with RLock ,it will not cause any bug becase the function is only called onece during initialization, but it's not right and really make people confused :P