### PR TITLE
dispatch: add metrics

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -371,6 +371,7 @@ func run() int {
 		tmpl      *template.Template
 	)
 
+	dispMetrics := dispatch.NewDispatcherMetrics(prometheus.DefaultRegisterer)
 	pipelineBuilder := notify.NewPipelineBuilder(prometheus.DefaultRegisterer)
 	configCoordinator := config.NewCoordinator(
 		*configFile,
@@ -415,7 +416,7 @@ func run() int {
 		})
 
 		routes := dispatch.NewRoute(conf.Route, nil)
-		disp = dispatch.NewDispatcher(alerts, routes, pipeline, marker, timeoutFunc, logger)
+		disp = dispatch.NewDispatcher(alerts, routes, pipeline, marker, timeoutFunc, logger, dispMetrics)
 		walkRoute(routes, func(r *dispatch.Route) {
 			if r.RouteOpts.RepeatInterval > *retention {
 				level.Warn(log.With(logger, "component", "configuration")).Log(

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -372,7 +372,7 @@ route:
 
 	timeout := func(d time.Duration) time.Duration { return time.Duration(0) }
 	recorder := &recordStage{alerts: make(map[string]map[model.Fingerprint]*types.Alert)}
-	dispatcher := NewDispatcher(alerts, route, recorder, marker, timeout, logger)
+	dispatcher := NewDispatcher(alerts, route, recorder, marker, timeout, logger, NewDispatcherMetrics(prometheus.NewRegistry()))
 	go dispatcher.Run()
 	defer dispatcher.Stop()
 


### PR DESCRIPTION
This change adds 2 metrics:
* `alertmanager_dispatcher_aggregation_groups`, number of active aggregation groups.
* `rate(alertmanager_dispatcher_alert_processing_duration_seconds`, quantile-less summary for the processing of alerts by the dispatcher.