### PR TITLE
Revert "slack: retry 429 errors (#2112)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
 * [BUGFIX] Don't garbage-collect alerts from the store. #2040
 * [BUGFIX] [ui] Disable the grammarly plugin on all textareas. #2061
 * [BUGFIX] [config] Forbid nil regexp matchers. #2083
-* [BUGFIX] [slack] Retry 429 errors. #2112
 * [BUGFIX] [ui] Fix Silences UI when several filters are applied. #2075
 
 Contributors:

--- a/notify/slack/slack.go
+++ b/notify/slack/slack.go
@@ -49,7 +49,7 @@ func New(c *config.SlackConfig, t *template.Template, l log.Logger) (*Notifier, 
 		tmpl:    t,
 		logger:  l,
 		client:  client,
-		retrier: &notify.Retrier{RetryCodes: []int{http.StatusTooManyRequests}},
+		retrier: &notify.Retrier{},
 	}, nil
 }
 

--- a/notify/slack/slack_test.go
+++ b/notify/slack/slack_test.go
@@ -15,7 +15,6 @@ package slack
 
 import (
 	"fmt"
-	"net/http"
 	"testing"
 
 	"github.com/go-kit/kit/log"
@@ -36,8 +35,7 @@ func TestSlackRetry(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	retryCodes := append(test.DefaultRetryCodes(), http.StatusTooManyRequests)
-	for statusCode, expected := range test.RetryTests(retryCodes) {
+	for statusCode, expected := range test.RetryTests(test.DefaultRetryCodes()) {
 		actual, _ := notifier.retrier.Check(statusCode, nil)
 		require.Equal(t, expected, actual, fmt.Sprintf("error on status %d", statusCode))
 	}


### PR DESCRIPTION
This reverts commit 26cc96a787b8b3b597a14fb7ced986194ae2c062.

As discussed in https://github.com/prometheus/alertmanager/issues/2121, when an API endpoint applies rate-limits, retrying immediately might cause more harm than waiting a bit.

From the Slack [documentation](https://api.slack.com/docs/rate-limits):

> Continuing to send messages after exceeding a rate limit runs the risk of your app being permanently disabled.

For now, I think that retrying the notification on the next `group_interval` as it was before is the safest option.

cc @roidelapluie @gavk34 @stuartnelson3 @mxinden 