### PR TITLE
notify/webhook: add timeout config for hints. #1997

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -20,8 +20,8 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-
 	commoncfg "github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
 )
 
 var (
@@ -409,6 +409,9 @@ type WebhookConfig struct {
 
 	// URL to send POST request to.
 	URL *URL `yaml:"url" json:"url"`
+
+	// Timeout to tell server cancel response after timeout
+	Timeout model.Duration `yaml:"timeout" json:"timeout"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/notify/webhook/webhook_test.go
+++ b/notify/webhook/webhook_test.go
@@ -14,16 +14,22 @@
 package webhook
 
 import (
+	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/go-kit/kit/log"
 	commoncfg "github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify/test"
+	"github.com/prometheus/alertmanager/types"
 )
 
 func TestWebhookRetry(t *testing.T) {
@@ -42,8 +48,59 @@ func TestWebhookRetry(t *testing.T) {
 	if err != nil {
 		require.NoError(t, err)
 	}
-	for statusCode, expected := range test.RetryTests(test.DefaultRetryCodes()) {
+
+	retryCodes := append(test.DefaultRetryCodes(), http.StatusRequestTimeout)
+	for statusCode, expected := range test.RetryTests(retryCodes) {
 		actual, _ := notifier.retrier.Check(statusCode, nil)
 		require.Equal(t, expected, actual, fmt.Sprintf("error on status %d", statusCode))
 	}
+}
+
+func TestTimeout(t *testing.T) {
+	const (
+		configTimeout   = model.Duration(1500 * time.Millisecond)
+		expectedTimeout = "1.500000"
+	)
+
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			timeout := r.Header.Get("X-Alertmanager-Notify-Timeout-Seconds")
+			if timeout != expectedTimeout {
+				t.Errorf("Expected scrape timeout header %q, got %q", expectedTimeout, timeout)
+			}
+			w.WriteHeader(http.StatusRequestTimeout)
+		}),
+	)
+	defer server.Close()
+
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		require.NoError(t, err)
+	}
+	notifier, err := New(
+		&config.WebhookConfig{
+			URL:        &config.URL{URL: u},
+			HTTPConfig: &commoncfg.HTTPClientConfig{},
+			Timeout:    configTimeout,
+		},
+		test.CreateTmpl(t),
+		log.NewNopLogger(),
+	)
+	if err != nil {
+		require.NoError(t, err)
+	}
+
+	alert := &types.Alert{
+		Alert: model.Alert{
+			Labels: model.LabelSet{
+				"job":       "j1",
+				"instance":  "i1",
+				"alertname": "an1",
+			},
+		},
+	}
+
+	retry, err := notifier.Notify(context.Background(), alert)
+	require.Error(t, err)
+	require.Equal(t, true, retry)
 }


### PR DESCRIPTION
Only the timeout option is added for webhook.

If modify 'HTTPClientConfig', some notifier may not support `X-Prometheus-Scrape-Timeout-Seconds`  in http headers.

https://github.com/prometheus/common/blob/b5fe7d854c42dc7842e48d1ca58f60feae09d77b/config/http_config.go#L75-L86