### PR TITLE
Allow retry for 429 on webhook receiver

### DIFF
--- a/notify/webhook/webhook.go
+++ b/notify/webhook/webhook.go
@@ -60,6 +60,7 @@ func New(conf *config.WebhookConfig, t *template.Template, l log.Logger) (*Notif
 			CustomDetailsFunc: func(int, io.Reader) string {
 				return conf.URL.String()
 			},
+			RetryCodes: []int{http.StatusTooManyRequests},
 		},
 	}, nil
 }

--- a/notify/webhook/webhook_test.go
+++ b/notify/webhook/webhook_test.go
@@ -15,6 +15,7 @@ package webhook
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"testing"
 
@@ -42,7 +43,8 @@ func TestWebhookRetry(t *testing.T) {
 	if err != nil {
 		require.NoError(t, err)
 	}
-	for statusCode, expected := range test.RetryTests(test.DefaultRetryCodes()) {
+	retryCodes := append(test.DefaultRetryCodes(), http.StatusTooManyRequests)
+	for statusCode, expected := range test.RetryTests(retryCodes) {
 		actual, _ := notifier.retrier.Check(statusCode, nil)
 		require.Equal(t, expected, actual, fmt.Sprintf("error on status %d", statusCode))
 	}


### PR DESCRIPTION
To address #2121 - proposing patch which adds 429 response to the retry codes for webhooks only.