### PR TITLE
MAINTAINERS.md: Remove Max Inden (mxinden)

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,3 +1,2 @@
 * Stuart Nelson <stuartnelson3@gmail.com>
-* Max Inden <IndenML@gmail.com>
 * Simon Pasquier <pasquier.simon@gmail.com>


### PR DESCRIPTION
I have not been very active as a maintainer of Alertmanager in the last couple of month and I don't think this will change in the near future. Thus I think it is time for me to remove myself from the maintainers list.

I will stick around within the Prometheus ecosystem and stay subscribed to all notifications of the Alertmanager repository for a bit longer.

I learned a lot, thanks everyone!



Signed-off-by: Max Inden <IndenML@gmail.com>