### PR TITLE
Add a method that returns a sorted list of a KV unique values

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -224,6 +224,21 @@ func (kv KV) Values() []string {
 	return kv.SortedPairs().Values()
 }
 
+// UniqValues returns a sorted list of unique values in the LabelSet.
+func (kv KV) UniqValues() []string {
+	vs := kv.Values()
+	vsCopy := make([]string, len(vs))
+	copy(vsCopy, vs)
+	sort.Strings(vsCopy)
+	uniqVs := vsCopy[:0]
+	for _, v := range vsCopy {
+		if len(uniqVs) == 0 || uniqVs[len(uniqVs)-1] != v {
+			uniqVs = append(uniqVs, v)
+		}
+	}
+	return uniqVs
+}
+
 // Data is the data passed to notification templates and webhook pushes.
 //
 // End-users should not be exposed to Go's type system, as this will confuse them and prevent

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -91,6 +91,34 @@ func TestKVRemove(t *testing.T) {
 	require.EqualValues(t, expected, kv.Names())
 }
 
+func TestKVUniqValues(t *testing.T) {
+	// one value is duplicated
+	kv := KV{
+		"key1": "val1",
+		"key2": "val2",
+		"key3": "val3",
+		"key4": "val3",
+	}
+
+	expected := []string{"val1", "val2", "val3"}
+	require.EqualValues(t, expected, kv.UniqValues())
+
+	// all keys have the same value
+	kv = KV{
+		"key1": "val1",
+		"key2": "val1",
+		"key3": "val1",
+	}
+
+	expected = []string{"val1"}
+	require.EqualValues(t, expected, kv.UniqValues())
+
+	kv = KV{}
+
+	expected = []string{}
+	require.EqualValues(t, expected, kv.UniqValues())
+}
+
 func TestAlertsFiring(t *testing.T) {
 	alerts := Alerts{
 		{Status: string(model.AlertFiring)},


### PR DESCRIPTION
Signed-off-by: ayoub mrini <amrini@wiremind.fr>

I don't know if one can do that using a simple combination of already-existing functions.

Made it easier to get unique values of a KV in a template, in cases where we group alerts by `job` for example and we need to get, in a template, the unique firing alerts' names, I think this question: https://stackoverflow.com/questions/59202685/alertmanager-templates-remove-duplicate-alertnames-for-grouped-notification gives more detail.

