### PR TITLE
Add slack channel when logging error.

### DIFF
--- a/notify/slack/slack.go
+++ b/notify/slack/slack.go
@@ -17,6 +17,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"github.com/pkg/errors"
 	"net/http"
 
 	"github.com/go-kit/kit/log"
@@ -183,5 +185,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	// Only 5xx response codes are recoverable and 2xx codes are successful.
 	// https://api.slack.com/incoming-webhooks#handling_errors
 	// https://api.slack.com/changelog/2016-05-17-changes-to-errors-for-incoming-webhooks
-	return n.retrier.Check(resp.StatusCode, resp.Body)
+	retry, err := n.retrier.Check(resp.StatusCode, resp.Body)
+	err = errors.Wrap(err, fmt.Sprintf("channel %q", req.Channel))
+	return retry, err
 }


### PR DESCRIPTION
Add the slack channel when logging error from slack.
https://github.com/prometheus/alertmanager/issues/2176
