### PR TITLE
Fixed dispatcher metrics registration

### DIFF
--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -53,7 +53,11 @@ func NewDispatcherMetrics(r prometheus.Registerer) *DispatcherMetrics {
 			},
 		),
 	}
-	prometheus.MustRegister(m.aggrGroups, m.processingDuration)
+
+	if r != nil {
+		r.MustRegister(m.aggrGroups, m.processingDuration)
+	}
+
 	return &m
 }
 


### PR DESCRIPTION
The new dispatcher metrics are not registered on the provided registerer, but on the default one. This PR fixes it, as well as handle the case the input registerer is `nil`.