### PR TITLE
api/v2: return empty array of peers when disabled

### DIFF
--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -166,6 +166,7 @@ func (api *API) getStatusHandler(params general_ops.GetStatusParams) middleware.
 		},
 		Cluster: &open_api_models.ClusterStatus{
 			Status: &status,
+			Peers:  []*open_api_models.PeerStatus{},
 		},
 	}
 

--- a/api/v2/api_test.go
+++ b/api/v2/api_test.go
@@ -47,8 +47,11 @@ func TestGetStatusHandlerWithNilPeer(t *testing.T) {
 		t.Fatal("expected cluster status not to be nil, violating the openapi specification")
 	}
 
-	if c.Peers != nil {
-		t.Fatal("expected cluster peers to be nil when api.peer is nil, violating the openapi specification")
+	if c.Peers == nil {
+		t.Fatal("expected cluster peers to be not nil when api.peer is nil, violating the openapi specification")
+	}
+	if len(c.Peers) != 0 {
+		t.Fatal("expected cluster peers to be empty when api.peer is nil, violating the openapi specification")
 	}
 
 	if c.Name != "" {

--- a/api/v2/models/cluster_status.go
+++ b/api/v2/models/cluster_status.go
@@ -38,7 +38,6 @@ type ClusterStatus struct {
 	Name string `json:"name,omitempty"`
 
 	// peers
-	// Minimum: 0
 	Peers []*PeerStatus `json:"peers"`
 
 	// status

--- a/api/v2/openapi.yaml
+++ b/api/v2/openapi.yaml
@@ -279,7 +279,6 @@ definitions:
         enum: ["ready", "settling", "disabled"]
       peers:
         type: array
-        minimum: 0
         items:
           $ref: '#/definitions/peerStatus'
     required:

--- a/api/v2/restapi/embedded_spec.go
+++ b/api/v2/restapi/embedded_spec.go
@@ -1306,7 +1306,6 @@ func init() {
         },
         "peers": {
           "type": "array",
-          "minimum": 0,
           "items": {
             "$ref": "#/definitions/peerStatus"
           }


### PR DESCRIPTION
Before this change, the API returns a `null` value for `peers`:

```
$ curl -s localhost:9093/api/v2/status | jq '.cluster'
{           
  "peers": null,           
  "status": "disabled"  
}  
```

After

```
{           
  "peers": [],           
  "status": "disabled"  
}
```