### PR TITLE
Fix race condition in dispatcher

### DIFF
--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -258,7 +258,7 @@ func (d *Dispatcher) Stop() {
 		return
 	}
 	d.mtx.Lock()
-	if d == nil || d.cancel == nil {
+	if d.cancel == nil {
 		return
 	}
 	d.cancel()

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -111,9 +111,8 @@ func (d *Dispatcher) Run() {
 	d.mtx.Lock()
 	d.aggrGroups = map[*Route]map[model.Fingerprint]*aggrGroup{}
 	d.metrics.aggrGroups.Set(0)
-	d.mtx.Unlock()
-
 	d.ctx, d.cancel = context.WithCancel(context.Background())
+	d.mtx.Unlock()
 
 	d.run(d.alerts.Subscribe())
 	close(d.done)
@@ -255,11 +254,13 @@ func (d *Dispatcher) Groups(routeFilter func(*Route) bool, alertFilter func(*typ
 
 // Stop the dispatcher.
 func (d *Dispatcher) Stop() {
+	d.mtx.Lock()
 	if d == nil || d.cancel == nil {
 		return
 	}
 	d.cancel()
 	d.cancel = nil
+	d.mtx.Unlock()
 
 	<-d.done
 }

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -254,6 +254,9 @@ func (d *Dispatcher) Groups(routeFilter func(*Route) bool, alertFilter func(*typ
 
 // Stop the dispatcher.
 func (d *Dispatcher) Stop() {
+	if d == nil {
+		return
+	}
 	d.mtx.Lock()
 	if d == nil || d.cancel == nil {
 		return

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -522,3 +522,18 @@ func newAlert(labels model.LabelSet) *types.Alert {
 		Timeout:   false,
 	}
 }
+
+func TestDispatcherRace(t *testing.T) {
+	logger := log.NewNopLogger()
+	marker := types.NewMarker(prometheus.NewRegistry())
+	alerts, err := mem.NewAlerts(context.Background(), marker, time.Hour, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer alerts.Close()
+
+	timeout := func(d time.Duration) time.Duration { return time.Duration(0) }
+	dispatcher := NewDispatcher(alerts, nil, nil, marker, timeout, logger, NewDispatcherMetrics(prometheus.NewRegistry()))
+	go dispatcher.Run()
+	dispatcher.Stop()
+}


### PR DESCRIPTION
Fixes: #2182 

By ensuring operations on the `cancel` and `ctx` field are wrapped with a mutex this removes the race condition from the dispatcher.