### PR TITLE
docs: Add warning that inhibition occurs on missing `equal`

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ inhibit_rules:
   target_match:
     severity: 'warning'
   # Apply inhibition if the alertname is the same.
+  # CAUTION: 
+  #   If all label names listed in `equal` are missing 
+  #   from both the source and target alerts,
+  #   the inhibition rule will apply!
   equal: ['alertname']
 
 

--- a/doc/examples/simple.yml
+++ b/doc/examples/simple.yml
@@ -97,6 +97,10 @@ inhibit_rules:
   target_match:
     severity: 'warning'
   # Apply inhibition if the alertname is the same.
+  # CAUTION: 
+  #   If all label names listed in `equal` are missing 
+  #   from both the source and target alerts,
+  #   the inhibition rule will apply!
   equal: ['alertname', 'cluster', 'service']
 
 


### PR DESCRIPTION
I would say mentioning this wherever possible would help that others get to know this as early as possible. The [`simple.yml` is also referenced from the documentation](https://github.com/prometheus/docs/blob/master/content/docs/alerting/configuration.md#L52-L53). Means it's part of the documentation itself, isn't it?

We've learned it the harder way: All services monitored with the `ServiceMonitor` from the [`Prometheus Operator`](https://github.com/coreos/prometheus-operator) get a `service` label. Therefore we've set `equal: ['service']`. Except alerts based on the [`kube-state-metrics` service](https://github.com/kubernetes/kube-state-metrics) which needed an extra `equal: ['container']` instead. We didn't know this while configuring this (relates to https://github.com/prometheus/alertmanager/issues/2201).
 
[Other users experienced the "default inhibition"](https://groups.google.com/forum/#!msg/prometheus-users/8EVrpGReoMY/F0lXEn4mBAAJ) with other examples, too. 


BTW: You already considered to link to the example config from the `Readme.md` instead of doubling it there? It's out of sync anyway (looking at the `equal` values).