### PR TITLE
Enforce 512KB event size limit for Pagerduty events

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -57,10 +57,9 @@ var (
 		NotifierConfig: NotifierConfig{
 			VSendResolved: true,
 		},
-		Description:  `{{ template "pagerduty.default.description" .}}`,
-		Client:       `{{ template "pagerduty.default.client" . }}`,
-		ClientURL:    `{{ template "pagerduty.default.clientURL" . }}`,
-		MaxEventSize: 512000,
+		Description: `{{ template "pagerduty.default.description" .}}`,
+		Client:      `{{ template "pagerduty.default.client" . }}`,
+		ClientURL:   `{{ template "pagerduty.default.clientURL" . }}`,
 	}
 
 	// DefaultSlackConfig defines default values for Slack configurations.
@@ -201,20 +200,19 @@ type PagerdutyConfig struct {
 
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
-	ServiceKey   Secret            `yaml:"service_key,omitempty" json:"service_key,omitempty"`
-	RoutingKey   Secret            `yaml:"routing_key,omitempty" json:"routing_key,omitempty"`
-	URL          *URL              `yaml:"url,omitempty" json:"url,omitempty"`
-	Client       string            `yaml:"client,omitempty" json:"client,omitempty"`
-	ClientURL    string            `yaml:"client_url,omitempty" json:"client_url,omitempty"`
-	Description  string            `yaml:"description,omitempty" json:"description,omitempty"`
-	Details      map[string]string `yaml:"details,omitempty" json:"details,omitempty"`
-	Images       []PagerdutyImage  `yaml:"images,omitempty" json:"images,omitempty"`
-	Links        []PagerdutyLink   `yaml:"links,omitempty" json:"links,omitempty"`
-	Severity     string            `yaml:"severity,omitempty" json:"severity,omitempty"`
-	Class        string            `yaml:"class,omitempty" json:"class,omitempty"`
-	Component    string            `yaml:"component,omitempty" json:"component,omitempty"`
-	Group        string            `yaml:"group,omitempty" json:"group,omitempty"`
-	MaxEventSize int               `yaml:"max_event_size,omitempty" json:"max_event_size"` // in KB
+	ServiceKey  Secret            `yaml:"service_key,omitempty" json:"service_key,omitempty"`
+	RoutingKey  Secret            `yaml:"routing_key,omitempty" json:"routing_key,omitempty"`
+	URL         *URL              `yaml:"url,omitempty" json:"url,omitempty"`
+	Client      string            `yaml:"client,omitempty" json:"client,omitempty"`
+	ClientURL   string            `yaml:"client_url,omitempty" json:"client_url,omitempty"`
+	Description string            `yaml:"description,omitempty" json:"description,omitempty"`
+	Details     map[string]string `yaml:"details,omitempty" json:"details,omitempty"`
+	Images      []PagerdutyImage  `yaml:"images,omitempty" json:"images,omitempty"`
+	Links       []PagerdutyLink   `yaml:"links,omitempty" json:"links,omitempty"`
+	Severity    string            `yaml:"severity,omitempty" json:"severity,omitempty"`
+	Class       string            `yaml:"class,omitempty" json:"class,omitempty"`
+	Component   string            `yaml:"component,omitempty" json:"component,omitempty"`
+	Group       string            `yaml:"group,omitempty" json:"group,omitempty"`
 }
 
 // PagerdutyLink is a link

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -57,9 +57,10 @@ var (
 		NotifierConfig: NotifierConfig{
 			VSendResolved: true,
 		},
-		Description: `{{ template "pagerduty.default.description" .}}`,
-		Client:      `{{ template "pagerduty.default.client" . }}`,
-		ClientURL:   `{{ template "pagerduty.default.clientURL" . }}`,
+		Description:  `{{ template "pagerduty.default.description" .}}`,
+		Client:       `{{ template "pagerduty.default.client" . }}`,
+		ClientURL:    `{{ template "pagerduty.default.clientURL" . }}`,
+		MaxEventSize: 512000,
 	}
 
 	// DefaultSlackConfig defines default values for Slack configurations.
@@ -200,19 +201,20 @@ type PagerdutyConfig struct {
 
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
-	ServiceKey  Secret            `yaml:"service_key,omitempty" json:"service_key,omitempty"`
-	RoutingKey  Secret            `yaml:"routing_key,omitempty" json:"routing_key,omitempty"`
-	URL         *URL              `yaml:"url,omitempty" json:"url,omitempty"`
-	Client      string            `yaml:"client,omitempty" json:"client,omitempty"`
-	ClientURL   string            `yaml:"client_url,omitempty" json:"client_url,omitempty"`
-	Description string            `yaml:"description,omitempty" json:"description,omitempty"`
-	Details     map[string]string `yaml:"details,omitempty" json:"details,omitempty"`
-	Images      []PagerdutyImage  `yaml:"images,omitempty" json:"images,omitempty"`
-	Links       []PagerdutyLink   `yaml:"links,omitempty" json:"links,omitempty"`
-	Severity    string            `yaml:"severity,omitempty" json:"severity,omitempty"`
-	Class       string            `yaml:"class,omitempty" json:"class,omitempty"`
-	Component   string            `yaml:"component,omitempty" json:"component,omitempty"`
-	Group       string            `yaml:"group,omitempty" json:"group,omitempty"`
+	ServiceKey   Secret            `yaml:"service_key,omitempty" json:"service_key,omitempty"`
+	RoutingKey   Secret            `yaml:"routing_key,omitempty" json:"routing_key,omitempty"`
+	URL          *URL              `yaml:"url,omitempty" json:"url,omitempty"`
+	Client       string            `yaml:"client,omitempty" json:"client,omitempty"`
+	ClientURL    string            `yaml:"client_url,omitempty" json:"client_url,omitempty"`
+	Description  string            `yaml:"description,omitempty" json:"description,omitempty"`
+	Details      map[string]string `yaml:"details,omitempty" json:"details,omitempty"`
+	Images       []PagerdutyImage  `yaml:"images,omitempty" json:"images,omitempty"`
+	Links        []PagerdutyLink   `yaml:"links,omitempty" json:"links,omitempty"`
+	Severity     string            `yaml:"severity,omitempty" json:"severity,omitempty"`
+	Class        string            `yaml:"class,omitempty" json:"class,omitempty"`
+	Component    string            `yaml:"component,omitempty" json:"component,omitempty"`
+	Group        string            `yaml:"group,omitempty" json:"group,omitempty"`
+	MaxEventSize int               `yaml:"max_event_size,omitempty" json:"max_event_size"`
 }
 
 // PagerdutyLink is a link

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -214,7 +214,7 @@ type PagerdutyConfig struct {
 	Class        string            `yaml:"class,omitempty" json:"class,omitempty"`
 	Component    string            `yaml:"component,omitempty" json:"component,omitempty"`
 	Group        string            `yaml:"group,omitempty" json:"group,omitempty"`
-	MaxEventSize int               `yaml:"max_event_size,omitempty" json:"max_event_size"`
+	MaxEventSize int               `yaml:"max_event_size,omitempty" json:"max_event_size"` // in KB
 }
 
 // PagerdutyLink is a link

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/prometheus/alertmanager
 
 require (
+	github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4
 	github.com/cenkalti/backoff v0.0.0-20181003080854-62661b46c409
 	github.com/cespare/xxhash v1.1.0
 	github.com/go-kit/kit v0.9.0

--- a/notify/pagerduty/pagerduty.go
+++ b/notify/pagerduty/pagerduty.go
@@ -37,6 +37,8 @@ import (
 
 const MaxEventSize int = 512000
 
+var truncatedCustomDetailsMsg = fmt.Sprintf("Custom details have been removed because the original event exceeds the maximum size of %s", units.MetricBytes(MaxEventSize).String())
+
 // Notifier implements a Notifier for PagerDuty notifications.
 type Notifier struct {
 	conf    *config.PagerdutyConfig
@@ -117,23 +119,21 @@ func (n *Notifier) encodeMessage(msg *pagerDutyMessage) (bytes.Buffer, error) {
 	}
 
 	if buf.Len() >= MaxEventSize {
-		truncatedMsg := fmt.Sprintf("Custom details have been removed because the original event exceeds the maximum size of %s", units.MetricBytes(MaxEventSize).String())
-
 		if n.apiV1 != "" {
 			errorMsg, ok := msg.Details["error"]
-			if ok && errorMsg == truncatedMsg {
+			if ok && errorMsg == truncatedCustomDetailsMsg {
 				return buf, errors.New("PagerDuty event is too big")
 			}
 
-			msg.Details = map[string]string{"error": truncatedMsg}
+			msg.Details = map[string]string{"error": truncatedCustomDetailsMsg}
 			return n.encodeMessage(msg)
 		} else {
 			errorMsg, ok := msg.Payload.CustomDetails["error"]
-			if ok && errorMsg == truncatedMsg {
+			if ok && errorMsg == truncatedCustomDetailsMsg {
 				return buf, errors.New("PagerDuty event is too big")
 			}
 
-			msg.Payload.CustomDetails = map[string]string{"error": truncatedMsg}
+			msg.Payload.CustomDetails = map[string]string{"error": truncatedCustomDetailsMsg}
 			return n.encodeMessage(msg)
 		}
 	}

--- a/notify/pagerduty/pagerduty.go
+++ b/notify/pagerduty/pagerduty.go
@@ -114,7 +114,7 @@ func (n *Notifier) encodeMessage(msg *pagerDutyMessage) (bytes.Buffer, error) {
 	}
 
 	if buf.Len() >= n.conf.MaxEventSize {
-		truncated_msg := "Custom details have been removed because the original event was too big"
+		truncated_msg := fmt.Sprintf("Custom details have been removed because the original event exceeds the maximum size of %dKB", n.conf.MaxEventSize/1000)
 
 		if n.apiV1 != "" {
 			error_msg, ok := msg.Details["error"]

--- a/notify/pagerduty/pagerduty.go
+++ b/notify/pagerduty/pagerduty.go
@@ -35,7 +35,7 @@ import (
 	"github.com/prometheus/alertmanager/types"
 )
 
-const MaxEventSize int = 512000
+const maxEventSize int = 512000
 
 // Notifier implements a Notifier for PagerDuty notifications.
 type Notifier struct {
@@ -116,8 +116,8 @@ func (n *Notifier) encodeMessage(msg *pagerDutyMessage) (bytes.Buffer, error) {
 		return buf, errors.Wrap(err, "failed to encode PagerDuty message")
 	}
 
-	if buf.Len() >= MaxEventSize {
-		truncatedMsg := fmt.Sprintf("Custom details have been removed because the original event exceeds the maximum size of %s", units.MetricBytes(MaxEventSize).String())
+	if buf.Len() > maxEventSize {
+		truncatedMsg := fmt.Sprintf("Custom details have been removed because the original event exceeds the maximum size of %s", units.MetricBytes(maxEventSize).String())
 
 		if n.apiV1 != "" {
 			msg.Details = map[string]string{"error": truncatedMsg}
@@ -125,7 +125,7 @@ func (n *Notifier) encodeMessage(msg *pagerDutyMessage) (bytes.Buffer, error) {
 			msg.Payload.CustomDetails = map[string]string{"error": truncatedMsg}
 		}
 
-		warningMsg := fmt.Sprintf("Truncated Details because message of size %s exceeds limit %s", units.MetricBytes(buf.Len()).String(), units.MetricBytes(MaxEventSize).String())
+		warningMsg := fmt.Sprintf("Truncated Details because message of size %s exceeds limit %s", units.MetricBytes(buf.Len()).String(), units.MetricBytes(maxEventSize).String())
 		level.Warn(n.logger).Log("msg", warningMsg)
 
 		buf.Reset()

--- a/notify/pagerduty/pagerduty_test.go
+++ b/notify/pagerduty/pagerduty_test.go
@@ -198,20 +198,6 @@ func TestPagerDutyTemplating(t *testing.T) {
 			},
 			errMsg: "service key cannot be empty",
 		},
-		{
-			title: "Event is too big",
-			cfg: &config.PagerdutyConfig{
-				RoutingKey: config.Secret("01234567890123456789012345678901"),
-				Group:      strings.Repeat("a", 513000),
-				Details: map[string]string{
-					"firing":       `{{ template "pagerduty.default.instances" .Alerts.Firing }}`,
-					"resolved":     `{{ template "pagerduty.default.instances" .Alerts.Resolved }}`,
-					"num_firing":   `{{ .Alerts.Firing | len }}`,
-					"num_resolved": `{{ .Alerts.Resolved | len }}`,
-				},
-			},
-			errMsg: "PagerDuty event is too big",
-		},
 	} {
 		t.Run(tc.title, func(t *testing.T) {
 			tc.cfg.URL = &config.URL{URL: u}

--- a/notify/pagerduty/pagerduty_test.go
+++ b/notify/pagerduty/pagerduty_test.go
@@ -299,7 +299,7 @@ func TestErrDetails(t *testing.T) {
 
 func TestEventSizeEnforcement(t *testing.T) {
 	bigDetails := map[string]string{
-		"firing": strings.Repeat("a", 1000),
+		"firing": strings.Repeat("a", 1100),
 	}
 
 	// V1 Messages
@@ -313,7 +313,7 @@ func TestEventSizeEnforcement(t *testing.T) {
 		&config.PagerdutyConfig{
 			ServiceKey:   config.Secret("01234567890123456789012345678901"),
 			HTTPConfig:   &commoncfg.HTTPClientConfig{},
-			MaxEventSize: 800,
+			MaxEventSize: 1000,
 		},
 		test.CreateTmpl(t),
 		log.NewNopLogger(),
@@ -322,7 +322,7 @@ func TestEventSizeEnforcement(t *testing.T) {
 
 	encodedV1, err := notifierV1.encodeMessage(msgV1)
 	require.NoError(t, err)
-	require.Contains(t, encodedV1.String(), `"details":{"error":"Custom details have been removed because the original event was too big"}`)
+	require.Contains(t, encodedV1.String(), `"details":{"error":"Custom details have been removed because the original event exceeds the maximum size of 1KB"}`)
 
 	// V2 Messages
 	msgV2 := &pagerDutyMessage{
@@ -337,7 +337,7 @@ func TestEventSizeEnforcement(t *testing.T) {
 		&config.PagerdutyConfig{
 			RoutingKey:   config.Secret("01234567890123456789012345678901"),
 			HTTPConfig:   &commoncfg.HTTPClientConfig{},
-			MaxEventSize: 800,
+			MaxEventSize: 1000,
 		},
 		test.CreateTmpl(t),
 		log.NewNopLogger(),
@@ -346,5 +346,5 @@ func TestEventSizeEnforcement(t *testing.T) {
 
 	encodedV2, err := notifierV2.encodeMessage(msgV2)
 	require.NoError(t, err)
-	require.Contains(t, encodedV2.String(), `"custom_details":{"error":"Custom details have been removed because the original event was too big"}`)
+	require.Contains(t, encodedV2.String(), `"custom_details":{"error":"Custom details have been removed because the original event exceeds the maximum size of 1KB"}`)
 }


### PR DESCRIPTION
PagerDuty will soon start enforcing a size limit of 512KB on all events. To prevent sending events that are larger than that, this PR implements the proposal that was decided in this issue https://github.com/prometheus/alertmanager/issues/2178

The size of events are checked after they are encoded into json. If the size is above 512KB, the custom details (or details for v1 events) are replaced with an error message.

This was my first time writing Go so the code may not be the best :) 