### PR TITLE
Improve remark on UDP/TCP for high availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ Alertmanager's high availability is in production use at many companies and is e
 
 > Important: Both UDP and TCP are needed in alertmanager 0.15 and higher for the cluster to work.
 >  - If you are using a firewall, make sure to whitelist the clustering port for both protocols.
->  - If you are using docker, make sure to expose the clustering port for both protocols (i.e. `-p 9094:9094/tcp -p 9094:9094/udp`)
+>  - If you are using docker, make sure to expose the clustering port for both protocols (i.e. `-p 9094:9094/tcp -p 9094:9094/udp`).
 
 To create a highly available cluster of the Alertmanager the instances need to
 be configured to communicate with each other. This is configured using the

--- a/README.md
+++ b/README.md
@@ -331,6 +331,8 @@ $ amtool config routes test --config.file=doc/examples/simple.yml --tree --verif
 Alertmanager's high availability is in production use at many companies and is enabled by default.
 
 > Important: Both UDP and TCP are needed in alertmanager 0.15 and higher for the cluster to work.
+>  - If you are using a firewall, make sure to whitelist the clustering port for both protocols.
+>  - If you are using docker, make sure to expose the clustering port for both protocols (i.e. `-p 9094:9094/tcp -p 9094:9094/udp`)
 
 To create a highly available cluster of the Alertmanager the instances need to
 be configured to communicate with each other. This is configured using the

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ Alertmanager's high availability is in production use at many companies and is e
 
 > Important: Both UDP and TCP are needed in alertmanager 0.15 and higher for the cluster to work.
 >  - If you are using a firewall, make sure to whitelist the clustering port for both protocols.
->  - If you are using docker, make sure to expose the clustering port for both protocols (i.e. `-p 9094:9094/tcp -p 9094:9094/udp`).
+>  - If you are running in a container, make sure to expose the clustering port for both protocols.
 
 To create a highly available cluster of the Alertmanager the instances need to
 be configured to communicate with each other. This is configured using the


### PR DESCRIPTION
A lot of people (including myself) seem to struggle with setting up high availability. I think it makes sense to improve the remarks on UDP/TCP for high availability.