### PR TITLE
Add redirect on / to routePrefix

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -470,6 +470,9 @@ func run() int {
 
 	router := route.New().WithInstrumentation(instrumentHandler)
 	if *routePrefix != "/" {
+		router.Get("/", func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, *routePrefix, http.StatusFound)
+		})
 		router = router.WithPrefix(*routePrefix)
 	}
 


### PR DESCRIPTION
When `routePrefix` is set alertmanager doesn't redirect traffic from `/` to target `routePrefix`
Prometheus implemented it with an http redirect to targeted `routePrefix`,  [here](https://github.com/prometheus/prometheus/blob/cd12f0873c3eb2031f7ba9b2e169449aa1012e3f/web/web.go#L328-L330)

Add the same code, to have the same comportement