### PR TITLE
notify: improve logs on notification errors

### DIFF
--- a/notify/notify.go
+++ b/notify/notify.go
@@ -676,7 +676,11 @@ func (r RetryStage) Exec(ctx context.Context, l log.Logger, alerts ...*types.Ale
 				// integration upon context timeout.
 				iErr = err
 			} else {
-				level.Debug(l).Log("msg", "Notify success", "attempts", i)
+				lvl := level.Debug(l)
+				if i > 1 {
+					lvl = level.Info(l)
+				}
+				lvl.Log("msg", "Notify success", "attempts", i)
 				return ctx, alerts, nil
 			}
 		case <-ctx.Done():


### PR DESCRIPTION
Alertmanager can experience occasional failures when sending
notifications to an external service. If the operation succeeds after
some retry, the 'alertmanager_notifications_failed_total' metric
increases but nothing is logged (unless running with log.level=debug).
Hence an operator might receive an alert about notification failures but
wouldn't know which integration was failing.

With this change, notification failures are logged at the warning level.
To avoid log flooding, similar failures on retries aren't logged.
Additional information on the failing integration has also been added.

cc @roidelapluie for review. Based on user's feedback from https://github.com/prometheus/alertmanager/issues/2147#issuecomment-626221046.