### PR TITLE
Allow limiting maximum number of alerts in webhook

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -409,6 +409,10 @@ type WebhookConfig struct {
 
 	// URL to send POST request to.
 	URL *URL `yaml:"url" json:"url"`
+	// MaxAlerts is the maximum number of alerts to be sent per webhook message.
+	// Alerts exceeding this threshold will be truncated. Setting this to 0
+	// allows an unlimited number of alerts.
+	MaxAlerts int `yaml:"max_alerts" json:"max_alerts"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -412,7 +412,7 @@ type WebhookConfig struct {
 	// MaxAlerts is the maximum number of alerts to be sent per webhook message.
 	// Alerts exceeding this threshold will be truncated. Setting this to 0
 	// allows an unlimited number of alerts.
-	MaxAlerts uint32 `yaml:"max_alerts" json:"max_alerts"`
+	MaxAlerts uint64 `yaml:"max_alerts" json:"max_alerts"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -412,7 +412,7 @@ type WebhookConfig struct {
 	// MaxAlerts is the maximum number of alerts to be sent per webhook message.
 	// Alerts exceeding this threshold will be truncated. Setting this to 0
 	// allows an unlimited number of alerts.
-	MaxAlerts int `yaml:"max_alerts" json:"max_alerts"`
+	MaxAlerts uint32 `yaml:"max_alerts" json:"max_alerts"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/notify/webhook/webhook.go
+++ b/notify/webhook/webhook.go
@@ -73,8 +73,8 @@ type Message struct {
 	GroupKey string `json:"groupKey"`
 }
 
-func truncateAlerts(maxAlerts int, alerts []*types.Alert) []*types.Alert {
-	if maxAlerts > 0 && len(alerts) > maxAlerts {
+func truncateAlerts(maxAlerts uint32, alerts []*types.Alert) []*types.Alert {
+	if maxAlerts != 0 && uint32(len(alerts)) > maxAlerts {
 		return alerts[:maxAlerts]
 	}
 

--- a/notify/webhook/webhook.go
+++ b/notify/webhook/webhook.go
@@ -73,9 +73,17 @@ type Message struct {
 	GroupKey string `json:"groupKey"`
 }
 
+func truncateAlerts(maxAlerts int, alerts []*types.Alert) []*types.Alert {
+	if maxAlerts > 0 && len(alerts) > maxAlerts {
+		return alerts[:maxAlerts]
+	}
+
+	return alerts
+}
+
 // Notify implements the Notifier interface.
 func (n *Notifier) Notify(ctx context.Context, alerts ...*types.Alert) (bool, error) {
-	data := notify.GetTemplateData(ctx, n.tmpl, alerts, n.logger)
+	data := notify.GetTemplateData(ctx, n.tmpl, truncateAlerts(n.conf.MaxAlerts, alerts), n.logger)
 
 	groupKey, err := notify.ExtractGroupKey(ctx)
 	if err != nil {

--- a/notify/webhook/webhook.go
+++ b/notify/webhook/webhook.go
@@ -69,21 +69,23 @@ type Message struct {
 	*template.Data
 
 	// The protocol version.
-	Version  string `json:"version"`
-	GroupKey string `json:"groupKey"`
+	Version         string `json:"version"`
+	GroupKey        string `json:"groupKey"`
+	TruncatedAlerts uint64 `json:"truncatedAlerts`
 }
 
-func truncateAlerts(maxAlerts uint32, alerts []*types.Alert) []*types.Alert {
-	if maxAlerts != 0 && uint32(len(alerts)) > maxAlerts {
-		return alerts[:maxAlerts]
+func truncateAlerts(maxAlerts uint64, alerts []*types.Alert) ([]*types.Alert, uint64) {
+	if maxAlerts != 0 && uint64(len(alerts)) > maxAlerts {
+		return alerts[:maxAlerts], uint64(len(alerts)) - maxAlerts
 	}
 
-	return alerts
+	return alerts, 0
 }
 
 // Notify implements the Notifier interface.
 func (n *Notifier) Notify(ctx context.Context, alerts ...*types.Alert) (bool, error) {
-	data := notify.GetTemplateData(ctx, n.tmpl, truncateAlerts(n.conf.MaxAlerts, alerts), n.logger)
+	alerts, numTruncated := truncateAlerts(n.conf.MaxAlerts, alerts)
+	data := notify.GetTemplateData(ctx, n.tmpl, alerts, n.logger)
 
 	groupKey, err := notify.ExtractGroupKey(ctx)
 	if err != nil {
@@ -91,9 +93,10 @@ func (n *Notifier) Notify(ctx context.Context, alerts ...*types.Alert) (bool, er
 	}
 
 	msg := &Message{
-		Version:  "4",
-		Data:     data,
-		GroupKey: groupKey.String(),
+		Version:         "4",
+		Data:            data,
+		GroupKey:        groupKey.String(),
+		TruncatedAlerts: numTruncated,
 	}
 
 	var buf bytes.Buffer

--- a/notify/webhook/webhook.go
+++ b/notify/webhook/webhook.go
@@ -71,7 +71,7 @@ type Message struct {
 	// The protocol version.
 	Version         string `json:"version"`
 	GroupKey        string `json:"groupKey"`
-	TruncatedAlerts uint64 `json:"truncatedAlerts`
+	TruncatedAlerts uint64 `json:"truncatedAlerts"`
 }
 
 func truncateAlerts(maxAlerts uint64, alerts []*types.Alert) ([]*types.Alert, uint64) {

--- a/notify/webhook/webhook_test.go
+++ b/notify/webhook/webhook_test.go
@@ -51,7 +51,16 @@ func TestWebhookRetry(t *testing.T) {
 
 func TestWebhookTruncateAlerts(t *testing.T) {
 	alerts := make([]*types.Alert, 10)
-	require.Len(t, truncateAlerts(0, alerts), 10)
-	require.Len(t, truncateAlerts(5, alerts), 5)
-	require.Len(t, truncateAlerts(100, alerts), 10)
+
+	truncatedAlerts, numTruncated := truncateAlerts(0, alerts)
+	require.Len(t, truncatedAlerts, 10)
+	require.EqualValues(t, numTruncated, 0)
+
+	truncatedAlerts, numTruncated = truncateAlerts(4, alerts)
+	require.Len(t, truncatedAlerts, 4)
+	require.EqualValues(t, numTruncated, 6)
+
+	truncatedAlerts, numTruncated = truncateAlerts(100, alerts)
+	require.Len(t, truncatedAlerts, 10)
+	require.EqualValues(t, numTruncated, 0)
 }

--- a/notify/webhook/webhook_test.go
+++ b/notify/webhook/webhook_test.go
@@ -52,7 +52,6 @@ func TestWebhookRetry(t *testing.T) {
 func TestWebhookTruncateAlerts(t *testing.T) {
 	alerts := make([]*types.Alert, 10)
 	require.Len(t, truncateAlerts(0, alerts), 10)
-	require.Len(t, truncateAlerts(-1, alerts), 10)
 	require.Len(t, truncateAlerts(5, alerts), 5)
 	require.Len(t, truncateAlerts(100, alerts), 10)
 }

--- a/notify/webhook/webhook_test.go
+++ b/notify/webhook/webhook_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify/test"
+	"github.com/prometheus/alertmanager/types"
 )
 
 func TestWebhookRetry(t *testing.T) {
@@ -46,4 +47,12 @@ func TestWebhookRetry(t *testing.T) {
 		actual, _ := notifier.retrier.Check(statusCode, nil)
 		require.Equal(t, expected, actual, fmt.Sprintf("error on status %d", statusCode))
 	}
+}
+
+func TestWebhookTruncateAlerts(t *testing.T) {
+	alerts := make([]*types.Alert, 10)
+	require.Len(t, truncateAlerts(0, alerts), 10)
+	require.Len(t, truncateAlerts(-1, alerts), 10)
+	require.Len(t, truncateAlerts(5, alerts), 5)
+	require.Len(t, truncateAlerts(100, alerts), 10)
 }


### PR DESCRIPTION
The webhook notifier is the only notifier that does not allow templating
on the Alertmanager side. Users who encounter occasional alert storms
(10ks of alerts going off at once for the same group) have reported
webhook receiver systems not being able to cope with the load caused by
the resulting large webhook notifier messages (the alerting rules also
contained large annotations that can't be stripped away due to lack of
templating). Reducing group size also wasn't an option, but this change
proposes to allow truncating the list of alerts sent in the webhook body
to a provided maximum length. This assumes that e.g. if a group receives
20k alerts, you really are fine only receiving 10k because you wouldn't
be able to check them all anyway.

Signed-off-by: Julius Volz <julius.volz@gmail.com>