### PR TITLE
.circleci/config.yml: bump Prometheus orb version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 version: 2.1
 
 orbs:
-  prometheus: prometheus/prometheus@0.6.0
+  prometheus: prometheus/prometheus@0.8.0
   go: circleci/go@0.2.0
 
 jobs:


### PR DESCRIPTION
Version `0..6.0` of the orb was buggy and led to container images not being pushed to the registries.

cc @juliusv 