### PR TITLE
notify retry optimize

### DIFF
--- a/notify/notify.go
+++ b/notify/notify.go
@@ -661,7 +661,7 @@ func (r RetryStage) Exec(ctx context.Context, l log.Logger, alerts ...*types.Ale
 
 		select {
 		case t := <-tick.C:
-			// return if timer stop
+			// return when timer stop
 			if t.IsZero() {
 				return ctx, alerts, iErr
 			}


### PR DESCRIPTION
1.  always retry during a flush
2. return if timer stopped(by accident or what)

as discussed in issue #2286 