### PR TITLE
docs: Fix dead link to visual route editor (#2298)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,8 +12,8 @@ While the command-line flags configure immutable system parameters, the
 configuration file defines inhibition rules, notification routing and
 notification receivers.
 
-The [visual editor](/webtools/alerting/routing-tree-editor) can assist in
-building routing trees.
+The [visual editor](https://www.prometheus.io/webtools/alerting/routing-tree-editor)
+can assist in building routing trees.
 
 To view all available command-line flags, run `alertmanager -h`.
 


### PR DESCRIPTION
Relative links are rendered relatively to the source repository, so this
link points to GitHub at the moment.

This commit changes the link to an absolute URL, bringing readers to the
Routing tree editor.

Signed-off-by: Manuel Hutter <manuel@hutter.io>