### PR TITLE
notify: add markdown support for wechat

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -424,7 +424,7 @@ func (c *WechatConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 
 	if !wechatTypeMatcher.MatchString(c.MessageType) {
-		return errors.Errorf("WeChat responder `MessageType` type does not match valid options %s", wechatValidTypesRe)
+		return errors.Errorf("WeChat message type %q does not match valid options %s", c.MessageType, wechatValidTypesRe)
 	}
 
 	return nil

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -396,14 +396,15 @@ type WechatConfig struct {
 
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
-	APISecret Secret `yaml:"api_secret,omitempty" json:"api_secret,omitempty"`
-	CorpID    string `yaml:"corp_id,omitempty" json:"corp_id,omitempty"`
-	Message   string `yaml:"message,omitempty" json:"message,omitempty"`
-	APIURL    *URL   `yaml:"api_url,omitempty" json:"api_url,omitempty"`
-	ToUser    string `yaml:"to_user,omitempty" json:"to_user,omitempty"`
-	ToParty   string `yaml:"to_party,omitempty" json:"to_party,omitempty"`
-	ToTag     string `yaml:"to_tag,omitempty" json:"to_tag,omitempty"`
-	AgentID   string `yaml:"agent_id,omitempty" json:"agent_id,omitempty"`
+	APISecret   Secret `yaml:"api_secret,omitempty" json:"api_secret,omitempty"`
+	CorpID      string `yaml:"corp_id,omitempty" json:"corp_id,omitempty"`
+	Message     string `yaml:"message,omitempty" json:"message,omitempty"`
+	APIURL      *URL   `yaml:"api_url,omitempty" json:"api_url,omitempty"`
+	ToUser      string `yaml:"to_user,omitempty" json:"to_user,omitempty"`
+	ToParty     string `yaml:"to_party,omitempty" json:"to_party,omitempty"`
+	ToTag       string `yaml:"to_tag,omitempty" json:"to_tag,omitempty"`
+	AgentID     string `yaml:"agent_id,omitempty" json:"agent_id,omitempty"`
+	MessageType string `yaml:"message_type,omitempty" json:"message_type,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/config/notifiers_test.go
+++ b/config/notifiers_test.go
@@ -590,6 +590,21 @@ func TestOpsgenieTypeMatcher(t *testing.T) {
 	}
 }
 
+func TestWeChatTypeMatcher(t *testing.T) {
+	good := []string{"text", "markdown"}
+	for _, g := range good {
+		if !wechatTypeMatcher.MatchString(g) {
+			t.Fatalf("failed to match with %s", g)
+		}
+	}
+	bad := []string{"TEXT", "MarkDOwn"}
+	for _, b := range bad {
+		if wechatTypeMatcher.MatchString(b) {
+			t.Errorf("mistakenly match with %s", b)
+		}
+	}
+}
+
 func newBoolPointer(b bool) *bool {
 	return &b
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -711,7 +711,7 @@ API](http://admin.wechat.com/wiki/index.php?title=Customer_Service_Messages).
 
 # API request data as defined by the WeChat API.
 [ message: <tmpl_string> | default = '{{ template "wechat.default.message" . }}' ]
-# The message type only support for `text` and `markdown`.
+# Type of the message type, supported values are `text` and `markdown`.
 [ message_type: <string> | default = 'text' ]
 [ agent_id: <string> | default = '{{ template "wechat.default.agent_id" . }}' ]
 [ to_user: <string> | default = '{{ template "wechat.default.to_user" . }}' ]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -711,6 +711,8 @@ API](http://admin.wechat.com/wiki/index.php?title=Customer_Service_Messages).
 
 # API request data as defined by the WeChat API.
 [ message: <tmpl_string> | default = '{{ template "wechat.default.message" . }}' ]
+# The message type only support for `text` and `markdown`.
+[ message_type: <string> | default = 'text' ]
 [ agent_id: <string> | default = '{{ template "wechat.default.agent_id" . }}' ]
 [ to_user: <string> | default = '{{ template "wechat.default.to_user" . }}' ]
 [ to_party: <string> | default = '{{ template "wechat.default.to_party" . }}' ]

--- a/notify/wechat/wechat.go
+++ b/notify/wechat/wechat.go
@@ -141,6 +141,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		Totag:   tmpl(n.conf.ToTag),
 		AgentID: tmpl(n.conf.AgentID),
 		Type:    n.conf.MessageType,
+		Safe:    "0",
 	}
 
 	if msg.Type == "markdown" {
@@ -151,7 +152,6 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		msg.Text = weChatMessageContent{
 			Content: tmpl(n.conf.Message),
 		}
-		msg.Safe = "0"
 	}
 	if err != nil {
 		return false, fmt.Errorf("templating error: %s", err)

--- a/notify/wechat/wechat.go
+++ b/notify/wechat/wechat.go
@@ -135,7 +135,6 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		n.accessTokenAt = time.Now()
 	}
 
-	// Define base message params
 	msg := &weChatMessage{
 		ToUser:  tmpl(n.conf.ToUser),
 		ToParty: tmpl(n.conf.ToParty),
@@ -143,7 +142,6 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		AgentID: tmpl(n.conf.AgentID),
 	}
 
-	// Determine message type
 	switch n.conf.MessageType {
 	case "markdown":
 		msg.Markdown = weChatMessageContent{

--- a/notify/wechat/wechat.go
+++ b/notify/wechat/wechat.go
@@ -51,13 +51,14 @@ type token struct {
 }
 
 type weChatMessage struct {
-	Text    weChatMessageContent `yaml:"text,omitempty" json:"text,omitempty"`
-	ToUser  string               `yaml:"touser,omitempty" json:"touser,omitempty"`
-	ToParty string               `yaml:"toparty,omitempty" json:"toparty,omitempty"`
-	Totag   string               `yaml:"totag,omitempty" json:"totag,omitempty"`
-	AgentID string               `yaml:"agentid,omitempty" json:"agentid,omitempty"`
-	Safe    string               `yaml:"safe,omitempty" json:"safe,omitempty"`
-	Type    string               `yaml:"msgtype,omitempty" json:"msgtype,omitempty"`
+	Text     weChatMessageContent `yaml:"text,omitempty" json:"text,omitempty"`
+	ToUser   string               `yaml:"touser,omitempty" json:"touser,omitempty"`
+	ToParty  string               `yaml:"toparty,omitempty" json:"toparty,omitempty"`
+	Totag    string               `yaml:"totag,omitempty" json:"totag,omitempty"`
+	AgentID  string               `yaml:"agentid,omitempty" json:"agentid,omitempty"`
+	Safe     string               `yaml:"safe,omitempty" json:"safe,omitempty"`
+	Type     string               `yaml:"msgtype,omitempty" json:"msgtype,omitempty"`
+	Markdown weChatMessageContent `yaml:"markdown,omitempty" json:"markdown,omitempty"`
 }
 
 type weChatMessageContent struct {
@@ -134,16 +135,29 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		n.accessTokenAt = time.Now()
 	}
 
+	// Define base message params
 	msg := &weChatMessage{
-		Text: weChatMessageContent{
-			Content: tmpl(n.conf.Message),
-		},
 		ToUser:  tmpl(n.conf.ToUser),
 		ToParty: tmpl(n.conf.ToParty),
 		Totag:   tmpl(n.conf.ToTag),
 		AgentID: tmpl(n.conf.AgentID),
-		Type:    "text",
-		Safe:    "0",
+	}
+
+	// Determine message type
+	switch n.conf.MessageType {
+	case "markdown":
+		msg.Markdown = weChatMessageContent{
+			Content: tmpl(n.conf.Message),
+		}
+		msg.Type = "markdown"
+	case "text":
+		fallthrough
+	default:
+		msg.Text = weChatMessageContent{
+			Content: tmpl(n.conf.Message),
+		}
+		msg.Type = "text"
+		msg.Safe = "0"
 	}
 	if err != nil {
 		return false, fmt.Errorf("templating error: %s", err)

--- a/notify/wechat/wechat.go
+++ b/notify/wechat/wechat.go
@@ -140,21 +140,17 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		ToParty: tmpl(n.conf.ToParty),
 		Totag:   tmpl(n.conf.ToTag),
 		AgentID: tmpl(n.conf.AgentID),
+		Type:    n.conf.MessageType,
 	}
 
-	switch n.conf.MessageType {
-	case "markdown":
+	if msg.Type == "markdown" {
 		msg.Markdown = weChatMessageContent{
 			Content: tmpl(n.conf.Message),
 		}
-		msg.Type = "markdown"
-	case "text":
-		fallthrough
-	default:
+	} else {
 		msg.Text = weChatMessageContent{
 			Content: tmpl(n.conf.Message),
 		}
-		msg.Type = "text"
 		msg.Safe = "0"
 	}
 	if err != nil {

--- a/notify/wechat/wechat_test.go
+++ b/notify/wechat/wechat_test.go
@@ -67,3 +67,26 @@ func TestWechatRedactedURLOnNotify(t *testing.T) {
 
 	test.AssertNotifyLeaksNoSecret(t, ctx, notifier, secret, token)
 }
+
+func TestWechatMessageTypeSelector(t *testing.T) {
+	secret, token := "secret", "token"
+	ctx, u, fn := test.GetContextWithCancelingURL(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{"access_token":"%s"}`, token)
+	})
+	defer fn()
+
+	notifier, err := New(
+		&config.WechatConfig{
+			APIURL:      &config.URL{URL: u},
+			HTTPConfig:  &commoncfg.HTTPClientConfig{},
+			CorpID:      "corpid",
+			APISecret:   config.Secret(secret),
+			MessageType: "markdown",
+		},
+		test.CreateTmpl(t),
+		log.NewNopLogger(),
+	)
+	require.NoError(t, err)
+
+	test.AssertNotifyLeaksNoSecret(t, ctx, notifier, secret, token)
+}


### PR DESCRIPTION
According to the WeChat work official API document, adding markdown type message support.

https://translate.google.com/translate?hl=en&sl=zh-CN&tl=en&u=https%3A%2F%2Fwork.weixin.qq.com%2Fapi%2Fdoc%2F90000%2F90135%2F90236%23markdown%25E6%25B6%2588%25E6%2581%25AF&prev=search