### PR TITLE
Update PagerDuty doc links

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -412,7 +412,7 @@ links:
 
 ### `<image_config>`
 
-The fields are documented in the [PagerDuty API documentation](https://v2.developer.pagerduty.com/v2/docs/send-an-event-events-api-v2#section-the-images-property).
+The fields are documented in the [PagerDuty API documentation](https://developer.pagerduty.com/docs/events-api-v2/trigger-events/#the-images-property).
 
 ```yaml
 href: <tmpl_string>
@@ -422,7 +422,7 @@ alt: <tmpl_string>
 
 ### `<link_config>`
 
-The fields are documented in the [PagerDuty API documentation](https://v2.developer.pagerduty.com/v2/docs/send-an-event-events-api-v2#section-the-links-property).
+The fields are documented in the [PagerDuty API documentation](https://developer.pagerduty.com/docs/events-api-v2/trigger-events/#the-links-property).
 
 ```yaml
 href: <tmpl_string>


### PR DESCRIPTION
PagerDuty has restructured their documentation, making links stale