### PR TITLE
Add alert status for extended and simple output

### DIFF
--- a/cli/format/format_extended.go
+++ b/cli/format/format_extended.go
@@ -61,16 +61,17 @@ func (formatter *ExtendedFormatter) FormatSilences(silences []models.GettableSil
 func (formatter *ExtendedFormatter) FormatAlerts(alerts []*models.GettableAlert) error {
 	w := tabwriter.NewWriter(formatter.writer, 0, 0, 2, ' ', 0)
 	sort.Sort(ByStartsAt(alerts))
-	fmt.Fprintln(w, "Labels\tAnnotations\tStarts At\tEnds At\tGenerator URL\t")
+	fmt.Fprintln(w, "Labels\tAnnotations\tStarts At\tEnds At\tGenerator URL\tState\t")
 	for _, alert := range alerts {
 		fmt.Fprintf(
 			w,
-			"%s\t%s\t%s\t%s\t%s\t\n",
+			"%s\t%s\t%s\t%s\t%s\t%s\t\n",
 			extendedFormatLabels(alert.Labels),
 			extendedFormatAnnotations(alert.Annotations),
 			FormatDate(*alert.StartsAt),
 			FormatDate(*alert.EndsAt),
 			alert.GeneratorURL,
+			*alert.Status.State,
 		)
 	}
 	return w.Flush()

--- a/cli/format/format_simple.go
+++ b/cli/format/format_simple.go
@@ -57,14 +57,15 @@ func (formatter *SimpleFormatter) FormatSilences(silences []models.GettableSilen
 func (formatter *SimpleFormatter) FormatAlerts(alerts []*models.GettableAlert) error {
 	w := tabwriter.NewWriter(formatter.writer, 0, 0, 2, ' ', 0)
 	sort.Sort(ByStartsAt(alerts))
-	fmt.Fprintln(w, "Alertname\tStarts At\tSummary\t")
+	fmt.Fprintln(w, "Alertname\tStarts At\tSummary\tState\t")
 	for _, alert := range alerts {
 		fmt.Fprintf(
 			w,
-			"%s\t%s\t%s\t\n",
+			"%s\t%s\t%s\t%s\t\n",
 			alert.Labels["alertname"],
 			FormatDate(*alert.StartsAt),
 			alert.Annotations["summary"],
+			*alert.Status.State,
 		)
 	}
 	return w.Flush()


### PR DESCRIPTION
Closes #2204 
Signed-off-by: Fahri Yardımcı

Added state field into both simple and extended output. 

sometimes extended output can be a bit long and can be hard to read sometimes therefore finding the alert state in simple output can things much easier.

Extended output
```
$ ./amtool --alertmanager.url http://alertmanager:9093 alert query -o extended -s -a  'alertname="Watchdog"'
Labels                                                            Annotations  Starts At  Ends At  Generator URL  State
alertname="Watchdog" prometheus="test" severity="none"  message="This is an alert meant to ensure that the entire alerting pipeline is functional.
"                                                                 2020-07-10 11:00:00 UTC  2020-07-16 16:00:00 UTC  http://prom:9090/graph?g0.expr=vector%281%29&g0.tab=1  active
````


Simple output

```
$ ./amtool --alertmanager.url http://alertmanager:9093 alert query  -s -a  'alertname="Watchdog"'
Alertname  Starts At                Summary  State
Watchdog   2020-07-10 11:00:00 UTC           active
```


Not sure about the state field order in extended output ? 