### PR TITLE
Change HA exemple defaults to be more reasonable

### DIFF
--- a/examples/ha/alertmanager.yml
+++ b/examples/ha/alertmanager.yml
@@ -3,8 +3,8 @@ global:
 
 route:
   group_by: ['alertname']
-  group_wait: 10s
-  group_interval: 10s
+  group_wait: 30s
+  group_interval: 5m
   repeat_interval: 1h
   receiver: 'web.hook'
 receivers:


### PR DESCRIPTION
10s+10s does not really change.

Give 30s for group wait and 5m for group interval seems better.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>