### PR TITLE
Remove resolve timeout from the config shipped by default

### DIFF
--- a/examples/ha/alertmanager.yml
+++ b/examples/ha/alertmanager.yml
@@ -1,6 +1,3 @@
-global:
-  resolve_timeout: 5m
-
 route:
   group_by: ['alertname']
   group_wait: 30s


### PR DESCRIPTION
It is not needed with Prometheus and can confuse users.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>