### PR TITLE
Use FQDNs for hardcoded commercial API endpoints

### DIFF
--- a/notify/pagerduty/pagerduty.go
+++ b/notify/pagerduty/pagerduty.go
@@ -55,7 +55,7 @@ func New(c *config.PagerdutyConfig, t *template.Template, l log.Logger) (*Notifi
 	}
 	n := &Notifier{conf: c, tmpl: t, logger: l, client: client}
 	if c.ServiceKey != "" {
-		n.apiV1 = "https://events.pagerduty.com/generic/2010-04-15/create_event.json"
+		n.apiV1 = "https://events.pagerduty.com./generic/2010-04-15/create_event.json"
 		// Retrying can solve the issue on 403 (rate limiting) and 5xx response codes.
 		// https://v2.developer.pagerduty.com/docs/trigger-events
 		n.retrier = &notify.Retrier{RetryCodes: []int{http.StatusForbidden}, CustomDetailsFunc: errDetails}

--- a/notify/pushover/pushover.go
+++ b/notify/pushover/pushover.go
@@ -53,7 +53,7 @@ func New(c *config.PushoverConfig, t *template.Template, l log.Logger) (*Notifie
 		logger:  l,
 		client:  client,
 		retrier: &notify.Retrier{},
-		apiURL:  "https://api.pushover.net/1/messages.json",
+		apiURL:  "https://api.pushover.net./1/messages.json",
 	}, nil
 }
 


### PR DESCRIPTION
Uses fully-qualified domain names (including trailing periods) for the
API endpoints for commercial notification providers, where they are
already hard-coded. This prevents Kubernetes-hosted Alertmanagers from
first trying to resolve the endpoints on the internal Kubernetes DNS,
i.e. it forces `https://events.pagerduty.com` to resolve to
`https://events.pagerduty.com.` and not throw NXDOMAIN errors when it
tries to resolve
`https://events.pagerduty.com.namespace.svc.cluster.local`.