### PR TITLE
Add some missing PagerDuty fields to docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -406,6 +406,15 @@ images:
 links:
   [ <link_config> ... ]
 
+# The part or component of the affected system that is broken.
+[ component: <tmpl_string> ]
+
+# A cluster or grouping of sources.
+[ group: <tmpl_string> ]
+
+# The class/type of the event.
+[ class: <tmpl_string> ]
+
 # The HTTP client's configuration.
 [ http_config: <http_config> | default = global.http_config ]
 ```


### PR DESCRIPTION
These fields are all available on the PagerdutyConfig type:
https://github.com/prometheus/alertmanager/blob/59a96579cc9d117ae72cfb6ad45033ee746c6ba8/config/notifiers.go#L201..L203

I took the descriptions from the PagerDuty events-api-v2 docs:
https://developer.pagerduty.com/docs/events-api-v2/overview/