### PR TITLE
registering /favicon.ico prior to setting a prefix in the router

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -457,6 +457,9 @@ func run() int {
 		return 1
 	}
 
+	router := route.New().WithInstrumentation(instrumentHandler)
+	ui.RegisterFavIcon(router)
+
 	// Make routePrefix default to externalURL path if empty string.
 	if *routePrefix == "" {
 		*routePrefix = amURL.Path
@@ -464,7 +467,6 @@ func run() int {
 	*routePrefix = "/" + strings.Trim(*routePrefix, "/")
 	level.Debug(logger).Log("routePrefix", *routePrefix)
 
-	router := route.New().WithInstrumentation(instrumentHandler)
 	if *routePrefix != "/" {
 		router.Get("/", func(w http.ResponseWriter, r *http.Request) {
 			http.Redirect(w, r, *routePrefix, http.StatusFound)

--- a/ui/web.go
+++ b/ui/web.go
@@ -26,6 +26,17 @@ import (
 	"github.com/prometheus/alertmanager/asset"
 )
 
+// RegisterFavIcon Favicon are always requested at /favicon.ico
+func RegisterFavIcon(r *route.Router) {
+	r.Get("/favicon.ico", func(w http.ResponseWriter, req *http.Request) {
+		disableCaching(w)
+
+		req.URL.Path = "/static/favicon.ico"
+		fs := http.FileServer(asset.Assets)
+		fs.ServeHTTP(w, req)
+	})
+}
+
 // Register registers handlers to serve files for the web interface.
 func Register(r *route.Router, reloadCh chan<- chan error, logger log.Logger) {
 	r.Get("/metrics", promhttp.Handler().ServeHTTP)
@@ -42,14 +53,6 @@ func Register(r *route.Router, reloadCh chan<- chan error, logger log.Logger) {
 		disableCaching(w)
 
 		req.URL.Path = "/static/script.js"
-		fs := http.FileServer(asset.Assets)
-		fs.ServeHTTP(w, req)
-	})
-
-	r.Get("/favicon.ico", func(w http.ResponseWriter, req *http.Request) {
-		disableCaching(w)
-
-		req.URL.Path = "/static/favicon.ico"
 		fs := http.FileServer(asset.Assets)
 		fs.ServeHTTP(w, req)
 	})


### PR DESCRIPTION
The favico.ico is always requested at /favico.ico by the browser. You may need to disable browser caching to see this working.