### PR TITLE
Make filter labels consistent with Prometheus

### DIFF
--- a/api/v1/api.go
+++ b/api/v1/api.go
@@ -662,7 +662,7 @@ func matchFilterLabels(matchers []*labels.Matcher, sms map[string]string) bool {
 			if string(m.Value) == "" && !prs {
 				continue
 			}
-			if !prs || !m.Matches(string(v)) {
+			if !m.Matches(string(v)) {
 				return false
 			}
 		}

--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -551,7 +551,7 @@ func matchFilterLabels(matchers []*labels.Matcher, sms map[string]string) bool {
 			if m.Value == "" && !prs {
 				continue
 			}
-			if !prs || !m.Matches(v) {
+			if !m.Matches(v) {
 				return false
 			}
 		}


### PR DESCRIPTION
Filtering the alert out when the label is missing precludes a
possible match for an empty value. This change allows the
match to be evaluated.

Closes #2342

Signed-off-by: Victor Araujo <vear91@gmail.com>