### PR TITLE
Add amtool command for rendering templates.

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -35,6 +35,7 @@ func configureConfigCmd(app *kingpin.Application) {
 	configCmd := app.Command("config", configHelp)
 	configCmd.Command("show", configHelp).Default().Action(execWithTimeout(queryConfig)).PreAction(requireAlertManagerURL)
 	configureRoutingCmd(configCmd)
+	configureTemplatingCmd(configCmd)
 }
 
 func queryConfig(ctx context.Context, _ *kingpin.ParseContext) error {

--- a/cli/templating.go
+++ b/cli/templating.go
@@ -1,0 +1,129 @@
+// Copyright 2018 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"github.com/prometheus/alertmanager/config"
+	"github.com/prometheus/alertmanager/integrationbuilder"
+	"github.com/prometheus/alertmanager/notify"
+	"github.com/prometheus/alertmanager/template"
+	"github.com/prometheus/alertmanager/types"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/common/promlog"
+	"gopkg.in/yaml.v2"
+	"net/url"
+	"time"
+
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+)
+
+type templatesRenderData struct {
+	configFile   string
+	receiverName string
+	receiverId   int
+	receiverType string
+
+	alertLabels       string
+	alertAnnotations  string
+	alertGeneratorURL string
+}
+
+const (
+	templatingHelp = `` // TODO add docs
+)
+
+func configureTemplatingCmd(app *kingpin.CmdClause) {
+	var (
+		c                  = &templatesRenderData{}
+		templatesCmd       = app.Command("templates", templatingHelp)
+		templatesRenderCmd = templatesCmd.Command("render", templatingHelp).Default()
+	)
+	templatesCmd.Flag("config.file", "Config file to be used.").Required().ExistingFileVar(&c.configFile)
+	templatesCmd.Flag("receiver.name", "Name of receiver to be used for templating.").StringVar(&c.receiverName)
+	templatesCmd.Flag("receiver.type", "Type of receiver to be used for templating.").StringVar(&c.receiverType)
+	templatesCmd.Flag("receiver.id", "Id of receiver to be used for templating.").Default("-1").IntVar(&c.receiverId)
+
+	templatesCmd.Flag("additional.labels", "Labels of the alert used for rendering of the templates.").Default("label-name=label-value").StringVar(&c.alertLabels)
+	templatesCmd.Flag("additional.annotations", "Annotations of the alert used for rendering of the templates.").Default("annotation-name=annotation-value").StringVar(&c.alertAnnotations)
+
+	templatesCmd.Flag("alert.count", "Number of alerts to be passed to the rendering.").Default("annotation-name=annotation-value").StringVar(&c.alertAnnotations)
+
+	templatesRenderCmd.Action(execWithTimeout(c.renderReceiverNotification))
+}
+
+func (c *templatesRenderData) renderReceiverNotification(ctx context.Context, _ *kingpin.ParseContext) error {
+	cfg, err := config.LoadFile(c.configFile)
+	if err != nil {
+		kingpin.Fatalf("%s", err)
+		return err
+	}
+	tmpl, err := template.FromGlobs(cfg.Templates...)
+	if err != nil {
+		return err
+	}
+	tmpl.ExternalURL, _ = url.Parse("http://external.url/")
+	ctx = notify.WithNow(ctx, time.Time{})
+	ctx = notify.WithGroupKey(ctx, "<group-key>")
+	ctx = notify.WithGroupLabels(ctx, model.LabelSet{})
+	ctx = notify.WithReceiverName(ctx, c.receiverName)
+	ctx = notify.WithRepeatInterval(ctx, time.Hour)
+
+	var integrationsToRender []*notify.Integration
+	for _, r := range cfg.Receivers {
+		if c.receiverName != "" && r.Name != c.receiverName {
+			continue
+		}
+		receiverIntegrations, err := integrationbuilder.BuildReceiverIntegrations(r, tmpl, promlog.New(&promlog.Config{}))
+		if err != nil {
+			return err
+		}
+		for _, i := range receiverIntegrations {
+			if c.receiverType != "" && i.Name() != c.receiverType {
+				continue
+			}
+			if c.receiverId != -1 && i.Index() != c.receiverId {
+				continue
+			}
+			integrationsToRender = append(integrationsToRender, &i)
+		}
+	}
+
+	results := make([]string, len(integrationsToRender))
+	for i, integration := range integrationsToRender {
+		fmt.Printf("--- # receiver: %s type: %s index: %d\n\n", "", integration.Name(), integration.Index())
+		renderedConfig, err := integration.RenderConfiguration(ctx, &types.Alert{
+			Alert: model.Alert{
+				Labels:       map[model.LabelName]model.LabelValue{"foo": "bar"},
+				Annotations:  map[model.LabelName]model.LabelValue{"foo": "bar"},
+				StartsAt:     time.Time{},
+				EndsAt:       time.Time{},
+				GeneratorURL: "http://foo.bar",
+			},
+			UpdatedAt: time.Time{},
+			Timeout:   false,
+		})
+		if err != nil {
+			return err
+		}
+		configData, err := yaml.Marshal(renderedConfig)
+		if err != nil {
+			return err
+		}
+		results[i] = string(configData)
+		fmt.Println(string(configData))
+	}
+	return nil
+}

--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -16,6 +16,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/prometheus/alertmanager/integrationbuilder"
 	"net"
 	"net/http"
 	"net/url"
@@ -47,14 +48,6 @@ import (
 	"github.com/prometheus/alertmanager/inhibit"
 	"github.com/prometheus/alertmanager/nflog"
 	"github.com/prometheus/alertmanager/notify"
-	"github.com/prometheus/alertmanager/notify/email"
-	"github.com/prometheus/alertmanager/notify/opsgenie"
-	"github.com/prometheus/alertmanager/notify/pagerduty"
-	"github.com/prometheus/alertmanager/notify/pushover"
-	"github.com/prometheus/alertmanager/notify/slack"
-	"github.com/prometheus/alertmanager/notify/victorops"
-	"github.com/prometheus/alertmanager/notify/webhook"
-	"github.com/prometheus/alertmanager/notify/wechat"
 	"github.com/prometheus/alertmanager/provider/mem"
 	"github.com/prometheus/alertmanager/silence"
 	"github.com/prometheus/alertmanager/template"
@@ -122,52 +115,6 @@ func instrumentHandler(handlerName string, handler http.HandlerFunc) http.Handle
 
 const defaultClusterAddr = "0.0.0.0:9094"
 
-// buildReceiverIntegrations builds a list of integration notifiers off of a
-// receiver config.
-func buildReceiverIntegrations(nc *config.Receiver, tmpl *template.Template, logger log.Logger) ([]notify.Integration, error) {
-	var (
-		errs         types.MultiError
-		integrations []notify.Integration
-		add          = func(name string, i int, rs notify.ResolvedSender, f func(l log.Logger) (notify.Notifier, error)) {
-			n, err := f(log.With(logger, "integration", name))
-			if err != nil {
-				errs.Add(err)
-				return
-			}
-			integrations = append(integrations, notify.NewIntegration(n, rs, name, i))
-		}
-	)
-
-	for i, c := range nc.WebhookConfigs {
-		add("webhook", i, c, func(l log.Logger) (notify.Notifier, error) { return webhook.New(c, tmpl, l) })
-	}
-	for i, c := range nc.EmailConfigs {
-		add("email", i, c, func(l log.Logger) (notify.Notifier, error) { return email.New(c, tmpl, l), nil })
-	}
-	for i, c := range nc.PagerdutyConfigs {
-		add("pagerduty", i, c, func(l log.Logger) (notify.Notifier, error) { return pagerduty.New(c, tmpl, l) })
-	}
-	for i, c := range nc.OpsGenieConfigs {
-		add("opsgenie", i, c, func(l log.Logger) (notify.Notifier, error) { return opsgenie.New(c, tmpl, l) })
-	}
-	for i, c := range nc.WechatConfigs {
-		add("wechat", i, c, func(l log.Logger) (notify.Notifier, error) { return wechat.New(c, tmpl, l) })
-	}
-	for i, c := range nc.SlackConfigs {
-		add("slack", i, c, func(l log.Logger) (notify.Notifier, error) { return slack.New(c, tmpl, l) })
-	}
-	for i, c := range nc.VictorOpsConfigs {
-		add("victorops", i, c, func(l log.Logger) (notify.Notifier, error) { return victorops.New(c, tmpl, l) })
-	}
-	for i, c := range nc.PushoverConfigs {
-		add("pushover", i, c, func(l log.Logger) (notify.Notifier, error) { return pushover.New(c, tmpl, l) })
-	}
-	if errs.Len() > 0 {
-		return nil, &errs
-	}
-	return integrations, nil
-}
-
 func main() {
 	os.Exit(run())
 }
@@ -191,7 +138,7 @@ func run() int {
 		httpTimeout    = kingpin.Flag("web.timeout", "Timeout for HTTP requests. If negative or zero, no timeout is set.").Default("0").Duration()
 
 		clusterBindAddr = kingpin.Flag("cluster.listen-address", "Listen address for cluster. Set to empty string to disable HA mode.").
-				Default(defaultClusterAddr).String()
+			Default(defaultClusterAddr).String()
 		clusterAdvertiseAddr = kingpin.Flag("cluster.advertise-address", "Explicit address to advertise in cluster.").String()
 		peers                = kingpin.Flag("cluster.peer", "Initial peers (may be repeated).").Strings()
 		peerTimeout          = kingpin.Flag("cluster.peer-timeout", "Time to wait between peers to send notifications.").Default("15s").Duration()
@@ -401,7 +348,7 @@ func run() int {
 				level.Info(configLogger).Log("msg", "skipping creation of receiver not referenced by any route", "receiver", rcv.Name)
 				continue
 			}
-			integrations, err := buildReceiverIntegrations(rcv, tmpl, logger)
+			integrations, err := integrationbuilder.BuildReceiverIntegrations(rcv, tmpl, logger)
 			if err != nil {
 				return err
 			}

--- a/cmd/alertmanager/main_test.go
+++ b/cmd/alertmanager/main_test.go
@@ -73,7 +73,7 @@ func TestBuildReceiverIntegrations(t *testing.T) {
 	} {
 		tc := tc
 		t.Run("", func(t *testing.T) {
-			integrations, err := buildReceiverIntegrations(tc.receiver, nil, nil)
+			integrations, err := BuildReceiverIntegrations(tc.receiver, nil, nil)
 			if tc.err {
 				require.Error(t, err)
 				return

--- a/integrationbuilder/receiver_integrations_builder.go
+++ b/integrationbuilder/receiver_integrations_builder.go
@@ -1,0 +1,63 @@
+package integrationbuilder
+
+import (
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/alertmanager/config"
+	"github.com/prometheus/alertmanager/notify"
+	"github.com/prometheus/alertmanager/notify/email"
+	"github.com/prometheus/alertmanager/notify/opsgenie"
+	"github.com/prometheus/alertmanager/notify/pagerduty"
+	"github.com/prometheus/alertmanager/notify/pushover"
+	"github.com/prometheus/alertmanager/notify/slack"
+	"github.com/prometheus/alertmanager/notify/victorops"
+	"github.com/prometheus/alertmanager/notify/webhook"
+	"github.com/prometheus/alertmanager/notify/wechat"
+	"github.com/prometheus/alertmanager/template"
+	"github.com/prometheus/alertmanager/types"
+)
+
+// BuildReceiverIntegrations builds a list of integration notifiers off of a
+// receiver config.
+func BuildReceiverIntegrations(nc *config.Receiver, tmpl *template.Template, logger log.Logger) ([]notify.Integration, error) {
+	var (
+		errs         types.MultiError
+		integrations []notify.Integration
+		add          = func(name string, i int, rs notify.ResolvedSender, f func(l log.Logger) (notify.Notifier, error)) {
+			n, err := f(log.With(logger, "integration", name))
+			if err != nil {
+				errs.Add(err)
+				return
+			}
+			integrations = append(integrations, notify.NewIntegration(n, rs, name, i))
+		}
+	)
+
+	for i, c := range nc.WebhookConfigs {
+		add("webhook", i, c, func(l log.Logger) (notify.Notifier, error) { return webhook.New(c, tmpl, l) })
+	}
+	for i, c := range nc.EmailConfigs {
+		add("email", i, c, func(l log.Logger) (notify.Notifier, error) { return email.New(c, tmpl, l), nil })
+	}
+	for i, c := range nc.PagerdutyConfigs {
+		add("pagerduty", i, c, func(l log.Logger) (notify.Notifier, error) { return pagerduty.New(c, tmpl, l) })
+	}
+	for i, c := range nc.OpsGenieConfigs {
+		add("opsgenie", i, c, func(l log.Logger) (notify.Notifier, error) { return opsgenie.New(c, tmpl, l) })
+	}
+	for i, c := range nc.WechatConfigs {
+		add("wechat", i, c, func(l log.Logger) (notify.Notifier, error) { return wechat.New(c, tmpl, l) })
+	}
+	for i, c := range nc.SlackConfigs {
+		add("slack", i, c, func(l log.Logger) (notify.Notifier, error) { return slack.New(c, tmpl, l) })
+	}
+	for i, c := range nc.VictorOpsConfigs {
+		add("victorops", i, c, func(l log.Logger) (notify.Notifier, error) { return victorops.New(c, tmpl, l) })
+	}
+	for i, c := range nc.PushoverConfigs {
+		add("pushover", i, c, func(l log.Logger) (notify.Notifier, error) { return pushover.New(c, tmpl, l) })
+	}
+	if errs.Len() > 0 {
+		return nil, &errs
+	}
+	return integrations, nil
+}

--- a/notify/email/email.go
+++ b/notify/email/email.go
@@ -327,6 +327,10 @@ func (n *Email) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 	return false, nil
 }
 
+func (n *Email) RenderConfiguration(ctx context.Context, as ...*types.Alert) (interface{}, error) {
+	return "", nil
+}
+
 type loginAuth struct {
 	username, password string
 }

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -50,6 +50,7 @@ const MinTimeout = 10 * time.Second
 // recoverable. This information is useful for a retry logic.
 type Notifier interface {
 	Notify(context.Context, ...*types.Alert) (bool, error)
+	RenderConfiguration(context.Context, ...*types.Alert) (interface{}, error)
 }
 
 // Integration wraps a notifier and its configuration to be uniquely identified
@@ -74,6 +75,11 @@ func NewIntegration(notifier Notifier, rs ResolvedSender, name string, idx int) 
 // Notify implements the Notifier interface.
 func (i *Integration) Notify(ctx context.Context, alerts ...*types.Alert) (bool, error) {
 	return i.notifier.Notify(ctx, alerts...)
+}
+
+// RenderNotification implements the Notifier interface.
+func (i *Integration) RenderConfiguration(ctx context.Context, alerts ...*types.Alert) (interface{}, error) {
+	return i.notifier.RenderConfiguration(ctx, alerts...)
 }
 
 // SendResolved implements the ResolvedSender interface.

--- a/notify/pagerduty/pagerduty.go
+++ b/notify/pagerduty/pagerduty.go
@@ -307,6 +307,10 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	return n.notifyV2(ctx, eventType, key, data, details, as...)
 }
 
+func (n *Notifier) RenderConfiguration(ctx context.Context, as ...*types.Alert) (interface{}, error) {
+	return "", nil
+}
+
 func errDetails(status int, body io.Reader) string {
 	// See https://v2.developer.pagerduty.com/docs/trigger-events for the v1 events API.
 	// See https://v2.developer.pagerduty.com/docs/send-an-event-events-api-v2 for the v2 events API.

--- a/notify/webhook/webhook.go
+++ b/notify/webhook/webhook.go
@@ -119,3 +119,7 @@ func (n *Notifier) Notify(ctx context.Context, alerts ...*types.Alert) (bool, er
 
 	return n.retrier.Check(resp.StatusCode, nil)
 }
+
+func (n *Notifier) RenderConfiguration(ctx context.Context, as ...*types.Alert) (interface{}, error) {
+	return "", nil
+}


### PR DESCRIPTION
Hi, I found quite difficult for users to write the Alertmanager templates.
Mainly it's quite difficult to test them. 

Now user has to:
1. run the alertmanager with the new configuration
1. send the test aler probably using amtool
1. have some receiver configured where he can check the result

I do not think this is much user-friendly and I hope we can do better.

This PR is just draft, because the changes required for it are quite big, so I'm not polishing it and finalizing it but just to show the idea:

The command would generate specified number of synthetic alerts which could be somehow parametrized (add custom annotation, label etc). These will be used for rendering of the templates. 

It's bit complicated to specify which templates should be rendered, by default it could render al of them possibly user could filter just specified type, id or name of receiver to render.

The rendered output as should be mainly human readable IMHO (but also reproducible in case someone would want to use it for testing for example.) That's why as initial implementation I did the templating as rendering the receiver config as yaml. That unfortunately required bigger refactoring of the receivers configs templating. 

Example tool help
```bash
$ ./amtool config templates render --config.file examples/ha/alertmanager.yml --help
usage: amtool config templates render

Flags:
  -h, --help                     Show context-sensitive help (also try --help-long and --help-man).
      --config.file=CONFIG.FILE  Config file to be used.
      --receiver.name=RECEIVER.NAME  
                                 Name of receiver to be used for templating.
      --receiver.type=RECEIVER.TYPE  
                                 Type of receiver to be used for templating.
      --receiver.id=-1           Id of receiver to be used for templating.
      --additional.labels="label-name=label-value"  
                                 Labels of the alert used for rendering of the templates.
      --additional.annotations="annotation-name=annotation-value"  
                                 Annotations of the alert used for rendering of the templates.
      --alert.count="annotation-name=annotation-value"  
                                 Number of alerts to be passed to the rendering.
```

Example usage output:
```bash
$ ./amtool config templates render --config.file examples/ha/alertmanager.yml 
--- # receiver:  type: opsgenie index: 1

send_resolved: true
http_config: {}
api_key: <secret>
api_url: https://api.opsgenie.com/
message: '[FIRING:1]  (bar)'
description: |+
  bar
  Alerts Firing:
  Labels:
   - foo = bar
  Annotations:
   - foo = bar
  Source: http://foo.bar
```

I'll be happy to finish this but I'm not 100% sure about the ideal form of output and input.
Would you be willing to accept such thing and if so, how should it look like ideally?

Thanks for any ideas!
