### PR TITLE
fix: do not validate silence if expiring it

### DIFF
--- a/silence/silence_test.go
+++ b/silence/silence_test.go
@@ -201,7 +201,7 @@ func TestSilencesSetSilence(t *testing.T) {
 	// setSilence() is always called with s.mtx locked()
 	go func() {
 		s.mtx.Lock()
-		require.NoError(t, s.setSilence(sil, now))
+		require.NoError(t, s.setSilence(sil, now, true))
 		s.mtx.Unlock()
 	}()
 


### PR DESCRIPTION
fixes #2415 , see it's description for details

Trivial fix, not sure if this is the right way to do it but it was the most straight forward :) 

Tested with build without validation to create silence and than using the generated `silences` file run the current master and fixed version.

Master returns `500 internal server error` with log
```
level=error ts=2020-11-12T22:41:17.199Z caller=api.go:678 component=api version=v2 path=/silence/e78ca547-5d3d-4385-b93a-e2d4184203fc method=DELETE msg="Failed to expire silence" err="silence invalid: at least one matcher must not match the empty string"
```

This version succeeds with the expiration.

The silences file for testing is attached here

[silences.zip](https://github.com/prometheus/alertmanager/files/5533735/silences.zip)

