### PR TITLE
cli: avoid nil dereference in silence update

### DIFF
--- a/cli/silence_update.go
+++ b/cli/silence_update.go
@@ -64,10 +64,10 @@ func (c *silenceUpdateCmd) update(ctx context.Context, _ *kingpin.ParseContext) 
 		params := silence.NewGetSilenceParams()
 		params.SilenceID = strfmt.UUID(silenceID)
 		response, err := amclient.Silence.GetSilence(params)
-		sil := response.Payload
 		if err != nil {
 			return err
 		}
+		sil := response.Payload
 		if c.start != "" {
 			startsAtTime, err := time.Parse(time.RFC3339, c.start)
 			if err != nil {


### PR DESCRIPTION
A trivial fix to avoid nil pointer dereference. It can occur when `amtool` fails to get silences in `amtool silence update`.

Before:

```shell
$ amtool silence update --alertmanager.url=INVALID-URL --duration=1h 94fbd24a-79fc-40d9-8a11-026c83ab9015
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1793415]

goroutine 1 [running]:
github.com/prometheus/alertmanager/cli.(*silenceUpdateCmd).update(0xc000322a80, 0x1b15d40, 0xc000322ae0, 0xc0000c6120, 0xc000322ae0, 0xc000588ed0)
	/Users/koki/go/src/github.com/prometheus/alertmanager/cli/silence_update.go:67 +0x3d5
github.com/prometheus/alertmanager/cli.execWithTimeout.func1(0xc0000c6120, 0x0, 0x0)
	/Users/koki/go/src/github.com/prometheus/alertmanager/cli/utils.go:165 +0xa1
github.com/prometheus/alertmanager/vendor/gopkg.in/alecthomas/kingpin%2ev2.(*actionMixin).applyActions(0xc0000cc618, 0xc0000c6120, 0x0, 0x0)
	/Users/koki/go/src/github.com/prometheus/alertmanager/vendor/gopkg.in/alecthomas/kingpin.v2/actions.go:28 +0x6d
github.com/prometheus/alertmanager/vendor/gopkg.in/alecthomas/kingpin%2ev2.(*Application).applyActions(0xc0000c2000, 0xc0000c6120, 0x0, 0x0)
	/Users/koki/go/src/github.com/prometheus/alertmanager/vendor/gopkg.in/alecthomas/kingpin.v2/app.go:557 +0xdc
github.com/prometheus/alertmanager/vendor/gopkg.in/alecthomas/kingpin%2ev2.(*Application).execute(0xc0000c2000, 0xc0000c6120, 0xc00058bd60, 0x2, 0x2, 0x0, 0x0, 0x0, 0x0)
	/Users/koki/go/src/github.com/prometheus/alertmanager/vendor/gopkg.in/alecthomas/kingpin.v2/app.go:390 +0x8f
github.com/prometheus/alertmanager/vendor/gopkg.in/alecthomas/kingpin%2ev2.(*Application).Parse(0xc0000c2000, 0xc0000321f0, 0x5, 0x5, 0x5, 0x0, 0x0, 0x10)
	/Users/koki/go/src/github.com/prometheus/alertmanager/vendor/gopkg.in/alecthomas/kingpin.v2/app.go:222 +0x1fe
github.com/prometheus/alertmanager/cli.Execute()
	/Users/koki/go/src/github.com/prometheus/alertmanager/cli/root.go:122 +0x8a9
main.main()
	/Users/koki/go/src/github.com/prometheus/alertmanager/cmd/amtool/main.go:19 +0x20
```

After

```shell
$ ./amtool silence update --alertmanager.url=INVALID-URL --duration=1h 94fbd24a-79fc-40d9-8a11-026c83ab9015
amtool: error: Get "http://localhost:9093/INVALID-URL/api/v2/silence/94fbd24a-79fc-40d9-8a11-026c83ab9015": dial tcp [::1]:9093: connect: connection refused```