### PR TITLE
check alerts length

### DIFF
--- a/notify/notify.go
+++ b/notify/notify.go
@@ -379,6 +379,9 @@ func (fs FanoutStage) Exec(ctx context.Context, l log.Logger, alerts ...*types.A
 		wg sync.WaitGroup
 		me types.MultiError
 	)
+	if len(alerts) == 0 {
+		return ctx, nil, nil
+	}
 	wg.Add(len(fs))
 
 	for _, s := range fs {


### PR DESCRIPTION
check alerts length in  FanoutStage.Exec , which is done in MultiStage.Exec.
```
if len(alerts) == 0
```
No need to create goroutines for each stages.