### PR TITLE
Fix and improve AlertmanagerClusterFailedToSendAlerts

### DIFF
--- a/doc/alertmanager-mixin/config.libsonnet
+++ b/doc/alertmanager-mixin/config.libsonnet
@@ -24,5 +24,13 @@
     // Alertmanager cluster. All labels used here must also be present
     // in alertmanagerClusterLabels above.
     alertmanagerClusterName: '{{$labels.job}}',
+
+    // alertmanagerCriticalIntegrationsRegEx is matched against the
+    // value of the `integration` label to determine if the
+    // AlertmanagerClusterFailedToSendAlerts is critical or merely a
+    // warning. This can be used to avoid paging about a failed
+    // integration that is itself not used for critical alerts.
+    // Example: @'pagerduty|webhook'
+    alertmanagerCriticalIntegrationsRegEx: @'.*',
   },
 }


### PR DESCRIPTION
The alert was just looking at the minimum across integrations. So a
complete failure of one integration would be masked by a still working
other integration. With this fix, the `integration` label is retained
(as it was already expected by the `description`), and thus any
one failing integration will trigger the alert.

In addition, an `alertmanagerCriticalIntegrationsRegEx` is provided
that allows to mark integrations as critical. Integrations that are
not used to deliver critical alerts, or those that are just there for
auditing and logging purposes can now be configured to only trigger a
warning alert if they fail.

@duologic relevant to the recent firing of AlertmanagerClusterFailedToSendAlerts in our production environment.