### PR TITLE
Improve labels.Matcher

### DIFF
--- a/pkg/labels/matcher.go
+++ b/pkg/labels/matcher.go
@@ -90,7 +90,7 @@ func (m *Matcher) Matches(s string) bool {
 
 // openMetricsEscape is similar to the usual string escaping, but more
 // restricted. It merely replaces a new-line character with '\n', a double-quote
-// character with '\"', and a backslack with '\\', which is the escaping used by
+// character with '\"', and a backslash with '\\', which is the escaping used by
 // OpenMetrics.
 func openMetricsEscape(s string) string {
 	r := strings.NewReplacer(

--- a/pkg/labels/matcher.go
+++ b/pkg/labels/matcher.go
@@ -16,6 +16,7 @@ package labels
 import (
 	"fmt"
 	"regexp"
+	"strings"
 )
 
 // MatchType is an enum for label matching types.
@@ -69,7 +70,7 @@ func NewMatcher(t MatchType, n, v string) (*Matcher, error) {
 }
 
 func (m *Matcher) String() string {
-	return fmt.Sprintf("%s%s%q", m.Name, m.Type, m.Value)
+	return fmt.Sprintf(`%s%s"%s"`, m.Name, m.Type, openMetricsEscape(m.Value))
 }
 
 // Matches returns whether the matcher matches the given string value.
@@ -85,4 +86,17 @@ func (m *Matcher) Matches(s string) bool {
 		return !m.re.MatchString(s)
 	}
 	panic("labels.Matcher.Matches: invalid match type")
+}
+
+// openMetricsEscape is similar to the usual string escaping, but more
+// restricted. It merely replaces a new-line character with '\n', a double-quote
+// character with '\"', and a backslack with '\\', which is the escaping used by
+// OpenMetrics.
+func openMetricsEscape(s string) string {
+	r := strings.NewReplacer(
+		`\`, `\\`,
+		"\n", `\n`,
+		`"`, `\"`,
+	)
+	return r.Replace(s)
 }

--- a/pkg/labels/matcher_test.go
+++ b/pkg/labels/matcher_test.go
@@ -122,3 +122,72 @@ func TestMatcher(t *testing.T) {
 		}
 	}
 }
+
+func TestMatcherString(t *testing.T) {
+	tests := []struct {
+		name  string
+		op    MatchType
+		value string
+		want  string
+	}{
+		{
+			name:  `foo`,
+			op:    MatchEqual,
+			value: `bar`,
+			want:  `foo="bar"`,
+		},
+		{
+			name:  `foo`,
+			op:    MatchNotEqual,
+			value: `bar`,
+			want:  `foo!="bar"`,
+		},
+		{
+			name:  `foo`,
+			op:    MatchRegexp,
+			value: `bar`,
+			want:  `foo=~"bar"`,
+		},
+		{
+			name:  `foo`,
+			op:    MatchNotRegexp,
+			value: `bar`,
+			want:  `foo!~"bar"`,
+		},
+		{
+			name:  `foo`,
+			op:    MatchEqual,
+			value: `back\slash`,
+			want:  `foo="back\\slash"`,
+		},
+		{
+			name:  `foo`,
+			op:    MatchEqual,
+			value: `double"quote`,
+			want:  `foo="double\"quote"`,
+		},
+		{
+			name: `foo`,
+			op:   MatchEqual,
+			value: `new
+line`,
+			want: `foo="new\nline"`,
+		},
+		{
+			name: `foo`,
+			op:   MatchEqual,
+			value: `tab	stop`,
+			want: `foo="tab	stop"`,
+		},
+	}
+
+	for _, test := range tests {
+		m, err := NewMatcher(test.op, test.name, test.value)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := m.String(); got != test.want {
+			t.Errorf("Unexpected string representation of matcher; want %v, got %v", test.want, got)
+		}
+	}
+}

--- a/pkg/labels/matcher_test.go
+++ b/pkg/labels/matcher_test.go
@@ -79,6 +79,41 @@ func TestMatcher(t *testing.T) {
 			value:   "foo-bar",
 			match:   false,
 		},
+		{
+			matcher: mustNewMatcher(t, MatchRegexp, `foo.bar`),
+			value:   "foo-bar",
+			match:   true,
+		},
+		{
+			matcher: mustNewMatcher(t, MatchRegexp, `foo\.bar`),
+			value:   "foo-bar",
+			match:   false,
+		},
+		{
+			matcher: mustNewMatcher(t, MatchRegexp, `foo\.bar`),
+			value:   "foo.bar",
+			match:   true,
+		},
+		{
+			matcher: mustNewMatcher(t, MatchEqual, "foo\nbar"),
+			value:   "foo\nbar",
+			match:   true,
+		},
+		{
+			matcher: mustNewMatcher(t, MatchRegexp, "foo.bar"),
+			value:   "foo\nbar",
+			match:   false,
+		},
+		{
+			matcher: mustNewMatcher(t, MatchRegexp, "(?s)foo.bar"),
+			value:   "foo\nbar",
+			match:   true,
+		},
+		{
+			matcher: mustNewMatcher(t, MatchEqual, "~!=\""),
+			value:   "~!=\"",
+			match:   true,
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/labels/parse.go
+++ b/pkg/labels/parse.go
@@ -38,7 +38,7 @@ var (
 // ParseMatchers parses a comma-separated list of Matchers. A leading '{' and/or
 // a trailing '}' is optional and will be trimmed before further
 // parsing. Individual Matchers are separated by commas outside of quoted parts
-// of the input string. Those commas may be sorrounded by whitespace. Parts of the
+// of the input string. Those commas may be surrounded by whitespace. Parts of the
 // string inside unescaped double quotes ('"…"') are considered quoted (and
 // commas don't act as separators there). If double quotes are escaped with a
 // single backslash ('\"'), they are ignored for the purpose of identifying
@@ -49,10 +49,11 @@ var (
 // Examples for valid input strings:
 //   {foo = "bar", dings != "bums", }
 //   foo=bar,dings!=bums
+//   foo=bar, dings!=bums
 //   {quote="She said: \"Hi, ladies! That's gender-neutral…\""}
 //   statuscode=~"5.."
 //
-// See ParseMatcher for details how an individual Matcher is parsed.
+// See ParseMatcher for details on how an individual Matcher is parsed.
 func ParseMatchers(s string) ([]*Matcher, error) {
 	matchers := []*Matcher{}
 	s = strings.TrimPrefix(s, "{")


### PR DESCRIPTION
@aSquare14 is working on using the same `labels.Matcher` that we already use in the UI and API for the matchers in the configuration, i.e. routing tree and inhibition rules. This will also introduce negative matching as requested in #1023 and simplify the syntax. See #2434. This will also help with making our code more DRY as we currently have two matcher implementation that do more or less the same: `labels.Matcher` and `types.Matcher`. We will still need the latter for silences, as their structure is directly marshaled into the HTTP API responses, so replacing them is a bit more involved.

Anyway, that's just for context.

While discussing all of this with @aSquare14, I realized that `labels.Matcher` has a few issues:
- It doesn't validate that the name is a valid Prometheus label name.
- It doesn't validate that the value is a valid UTF-8 string.
- It does not allow `=`, `~`, or `!` in the value, but these are perfectly valid parts of a value.
- There is no way to put a literal `"` into the value.
- While a line break is in principle fine to include, the UI doesn't allow it, and there is no escaping like `\n`.
- It kind of tries to be liberal (curly braces are optional, quoting is optional), but has quite strict requirements at other places (e.g. no whitespace around the comparison operator).

This PR adds more validation, allows all legal value elements, and at the same time becomes even more liberal.
It introduces OpenMetrics-style escaping (but keeps accepting single `\` where there is no ambiguity, so that this is very unlikely to break existing usage, like most commonly something like `\.` in a regexp).

It also adds doc comments to precisely explain the behavior. Once this is in, we should make sure the same is documented in the user docs. (Possibly, we need adjustments in the Elm UI code to allow the new features. But for use in the config, see #2434, it should be fine out of the box.)