### PR TITLE
api: check silence matching by string comparison in getSilences

### DIFF
--- a/api/v2/api_test.go
+++ b/api/v2/api_test.go
@@ -183,7 +183,36 @@ func TestCheckSilenceMatchesFilterLabels(t *testing.T) {
 			[]*labels.Matcher{createLabelMatcher("label", "value", labels.MatchEqual)},
 			false,
 		},
-
+		{
+			[]*silencepb.Matcher{createSilenceMatcher("label", "value", silencepb.Matcher_NOT_EQUAL)},
+			[]*labels.Matcher{createLabelMatcher("label", "value", labels.MatchNotEqual)},
+			true,
+		},
+		{
+			[]*silencepb.Matcher{createSilenceMatcher("label", "value", silencepb.Matcher_NOT_REGEXP)},
+			[]*labels.Matcher{createLabelMatcher("label", "value", labels.MatchNotRegexp)},
+			true,
+		},
+		{
+			[]*silencepb.Matcher{createSilenceMatcher("label", "value", silencepb.Matcher_EQUAL)},
+			[]*labels.Matcher{createLabelMatcher("label", "value", labels.MatchNotEqual)},
+			false,
+		},
+		{
+			[]*silencepb.Matcher{createSilenceMatcher("label", "value", silencepb.Matcher_REGEXP)},
+			[]*labels.Matcher{createLabelMatcher("label", "value", labels.MatchNotRegexp)},
+			false,
+		},
+		{
+			[]*silencepb.Matcher{createSilenceMatcher("label", "value", silencepb.Matcher_NOT_EQUAL)},
+			[]*labels.Matcher{createLabelMatcher("label", "value", labels.MatchNotRegexp)},
+			false,
+		},
+		{
+			[]*silencepb.Matcher{createSilenceMatcher("label", "value", silencepb.Matcher_NOT_REGEXP)},
+			[]*labels.Matcher{createLabelMatcher("label", "value", labels.MatchNotEqual)},
+			false,
+		},
 		{
 			[]*silencepb.Matcher{
 				createSilenceMatcher("label", "(foo|bar)", silencepb.Matcher_REGEXP),


### PR DESCRIPTION
Fixes #2283.

This PR changes how `gettableSilenceMatchesFilterLabels` in api/v2 checks whether a silence matches a given filter, especially for regex cases. In short,

- before: a silence matches a filter if a pattern value in the silence matches pattern strings of the filter by regex.
- after: a silence matches a filter if a pattern value in the silence and pattern strings of the filter are equivalent.

For instance, as shown in figure #2283, a silence `alertname~=(foo|bar)` didn't match a filter of the same pattern `alertname~=(foo|bar)`, since the regex match fails. After the fix, the silence and filter will match as we use string comparison instead. 

![d0d03c3c0cdc3d9ee27a3c30cac4fb70](https://user-images.githubusercontent.com/276860/103148807-e78f3f00-47a6-11eb-9b52-b298293ad75b.gif)
