### PR TITLE
Fix extended printing of regex sign

### DIFF
--- a/cli/format/format_extended.go
+++ b/cli/format/format_extended.go
@@ -139,7 +139,7 @@ func extendedFormatMatchers(matchers models.Matchers) string {
 
 func extendedFormatMatcher(matcher models.Matcher) string {
 	if *matcher.IsRegex {
-		return fmt.Sprintf("%s~=%s", *matcher.Name, *matcher.Value)
+		return fmt.Sprintf("%s=~%s", *matcher.Name, *matcher.Value)
 	}
 	return fmt.Sprintf("%s=%s", *matcher.Name, *matcher.Value)
 }


### PR DESCRIPTION
Fixed extended printing to use same regex that is expected to be used when creating silences.