### PR TITLE
Make MaxGossipPacketSize public

### DIFF
--- a/cluster/channel.go
+++ b/cluster/channel.go
@@ -145,5 +145,5 @@ func (c *Channel) Broadcast(b []byte) {
 // OversizedMessage indicates whether or not the byte payload should be sent
 // via TCP.
 func OversizedMessage(b []byte) bool {
-	return len(b) > maxGossipPacketSize/2
+	return len(b) > MaxGossipPacketSize/2
 }

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -103,7 +103,7 @@ const (
 	DefaultReconnectInterval = 10 * time.Second
 	DefaultReconnectTimeout  = 6 * time.Hour
 	DefaultRefreshInterval   = 15 * time.Second
-	maxGossipPacketSize      = 1400
+	MaxGossipPacketSize      = 1400
 )
 
 func Create(
@@ -202,7 +202,7 @@ func Create(
 	cfg.ProbeInterval = probeInterval
 	cfg.LogOutput = &logWriter{l: l}
 	cfg.GossipNodes = retransmit
-	cfg.UDPBufferSize = maxGossipPacketSize
+	cfg.UDPBufferSize = MaxGossipPacketSize
 
 	if advertiseHost != "" {
 		cfg.AdvertiseAddr = advertiseHost


### PR DESCRIPTION
I understand `MaxGossipPacketSize` has several implications in the way clustering works (oversized messages are always propagated via TCP which influence the number of parallel connections we make) but also downstream implementations might want to configure this.

I don't think the alertmanager offers any guarantees if downstream implementations change this value so it should be safe to make public? 😄