### PR TITLE
Catch unknown matcher types in gossipped silences

### DIFF
--- a/silence/silence.go
+++ b/silence/silence.go
@@ -79,6 +79,8 @@ func (c matcherCache) add(s *pb.Silence) (types.Matchers, error) {
 			mt.IsRegex = false
 		case pb.Matcher_REGEXP:
 			mt.IsRegex = true
+		default:
+			return nil, errors.Errorf("unknown matcher type %q", m.Type)
 		}
 		err := mt.Init()
 		if err != nil {


### PR DESCRIPTION
I believe that gossibping between AM instances with different versions
of the silence protobuf could create a situation where an unknown
matcher type won't be recognized, thereby possibly inverting the
behavior of the silence.

This makes the matching more robust by error'ing out when facing an
unknown matcher type.

This has come to my attention during the recent work on silences with
negative matching. To make cluster upgrades more robust, this fix is
needed, and therefore I'm proposing it for a bugfix release of v0.21.

Signed-off-by: beorn7 <beorn@grafana.com>