### PR TITLE
Allow filtering silences by creator

### DIFF
--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -643,6 +643,7 @@ func gettableSilenceMatchesFilterLabels(s open_api_models.GettableSilence, match
 	for _, m := range s.Matchers {
 		sms[*m.Name] = *m.Value
 	}
+	sms["createdBy"] = *s.CreatedBy
 
 	return matchFilterLabels(matchers, sms)
 }


### PR DESCRIPTION
Allow using the filter `createdBy` for the get silences endpoint.


https://user-images.githubusercontent.com/6402556/107154279-4bbd2b00-692f-11eb-96af-cc3b7b67b863.mov



Closes #2476