### PR TITLE
Catch unknown matcher types in gossipped silences

### DIFF
--- a/silence/silence.go
+++ b/silence/silence.go
@@ -78,6 +78,8 @@ func (c matcherCache) add(s *pb.Silence) (labels.Matchers, error) {
 			mt = labels.MatchRegexp
 		case pb.Matcher_NOT_REGEXP:
 			mt = labels.MatchNotRegexp
+		default:
+			return nil, errors.Errorf("unknown matcher type %q", m.Type)
 		}
 		matcher, err := labels.NewMatcher(mt, m.Name, m.Pattern)
 		if err != nil {


### PR DESCRIPTION
This has been discussed in #2479. Even if the conclusion there was
that we don't need this in a bugfix release, it's still better to have
this kind of robustness. So this introduces the same check into the
main branch.

@vladimiroff @aSquare14 