### PR TITLE
Clustering: Interface for Peers in other packages

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -56,7 +56,7 @@ type Options struct {
 	// alert. Mandatory.
 	StatusFunc func(model.Fingerprint) types.AlertStatus
 	// Peer from the gossip cluster. If nil, no clustering will be used.
-	Peer *cluster.Peer
+	Peer cluster.ClusterPeer
 	// Timeout for all HTTP connections. The zero value (and negative
 	// values) result in no timeout.
 	Timeout time.Duration

--- a/api/v1/api.go
+++ b/api/v1/api.go
@@ -72,7 +72,7 @@ type API struct {
 	config   *config.Config
 	route    *dispatch.Route
 	uptime   time.Time
-	peer     *cluster.Peer
+	peer     cluster.ClusterPeer
 	logger   log.Logger
 	m        *metrics.Alerts
 
@@ -88,7 +88,7 @@ func New(
 	alerts provider.Alerts,
 	silences *silence.Silences,
 	sf getAlertStatusFn,
-	peer *cluster.Peer,
+	peer cluster.ClusterPeer,
 	l log.Logger,
 	r prometheus.Registerer,
 ) *API {
@@ -208,7 +208,7 @@ type clusterStatus struct {
 	Peers  []peerStatus `json:"peers"`
 }
 
-func getClusterStatus(p *cluster.Peer) *clusterStatus {
+func getClusterStatus(p cluster.ClusterPeer) *clusterStatus {
 	if p == nil {
 		return nil
 	}
@@ -216,7 +216,7 @@ func getClusterStatus(p *cluster.Peer) *clusterStatus {
 
 	for _, n := range p.Peers() {
 		s.Peers = append(s.Peers, peerStatus{
-			Name:    n.Name,
+			Name:    n.String(),
 			Address: n.Address(),
 		})
 	}

--- a/api/v1/api.go
+++ b/api/v1/api.go
@@ -216,7 +216,7 @@ func getClusterStatus(p cluster.ClusterPeer) *clusterStatus {
 
 	for _, n := range p.Peers() {
 		s.Peers = append(s.Peers, peerStatus{
-			Name:    n.String(),
+			Name:    n.Name(),
 			Address: n.Address(),
 		})
 	}

--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -179,7 +179,7 @@ func (api *API) getStatusHandler(params general_ops.GetStatusParams) middleware.
 		peers := []*open_api_models.PeerStatus{}
 		for _, n := range api.peer.Peers() {
 			address := n.Address()
-			name := n.String()
+			name := n.Name()
 			peers = append(peers, &open_api_models.PeerStatus{
 				Name:    &name,
 				Address: &address,

--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -52,7 +52,7 @@ import (
 
 // API represents an Alertmanager API v2
 type API struct {
-	peer           *cluster.Peer
+	peer           cluster.ClusterPeer
 	silences       *silence.Silences
 	alerts         provider.Alerts
 	alertGroups    groupsFn
@@ -83,7 +83,7 @@ func NewAPI(
 	gf groupsFn,
 	sf getAlertStatusFn,
 	silences *silence.Silences,
-	peer *cluster.Peer,
+	peer cluster.ClusterPeer,
 	l log.Logger,
 	r prometheus.Registerer,
 ) (*API, error) {
@@ -179,8 +179,9 @@ func (api *API) getStatusHandler(params general_ops.GetStatusParams) middleware.
 		peers := []*open_api_models.PeerStatus{}
 		for _, n := range api.peer.Peers() {
 			address := n.Address()
+			name := n.String()
 			peers = append(peers, &open_api_models.PeerStatus{
-				Name:    &n.Name,
+				Name:    &name,
 				Address: &address,
 			})
 		}

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -613,8 +613,10 @@ func (p *Peer) Self() *memberlist.Node {
 type Member struct {
 	*memberlist.Node
 }
+
 // Name implements cluster.ClusterMember
 func (m Member) Name() string { return m.Node.Name }
+
 // Address implements cluster.ClusterMember
 func (m Member) Address() string { return m.Node.Address() }
 

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -616,21 +616,21 @@ func (p *Peer) Self() *memberlist.Node {
 
 // Member represents a member in the cluster.
 type Member struct {
-	*memberlist.Node
+	node *memberlist.Node
 }
 
 // Name implements cluster.ClusterMember
-func (m Member) Name() string { return m.Node.Name }
+func (m Member) Name() string { return m.node.Name }
 
 // Address implements cluster.ClusterMember
-func (m Member) Address() string { return m.Node.Address() }
+func (m Member) Address() string { return m.node.Address() }
 
 // Peers returns the peers in the cluster.
 func (p *Peer) Peers() []ClusterMember {
 	peers := make([]ClusterMember, 0, len(p.mlist.Members()))
 	for _, member := range p.mlist.Members() {
 		peers = append(peers, Member{
-			Node: member,
+			node: member,
 		})
 	}
 	return peers

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -51,6 +51,11 @@ type ClusterMember interface {
 	Address() string
 }
 
+// ClusterChannel supports state broadcasting across peers.
+type ClusterChannel interface {
+	Broadcast([]byte)
+}
+
 // Peer is a single peer in a gossip cluster.
 type Peer struct {
 	mlist    *memberlist.Memberlist
@@ -530,7 +535,7 @@ func (p *Peer) peerUpdate(n *memberlist.Node) {
 
 // AddState adds a new state that will be gossiped. It returns a channel to which
 // broadcast messages for the state can be sent.
-func (p *Peer) AddState(key string, s State, reg prometheus.Registerer) *Channel {
+func (p *Peer) AddState(key string, s State, reg prometheus.Registerer) ClusterChannel {
 	p.states[key] = s
 	send := func(b []byte) {
 		p.delegate.bcast.QueueBroadcast(simpleBroadcast(b))

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -33,7 +33,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// Peer is a single peer in a gossip cluster.
+// ClusterPeer represents a single Peer in a gossip cluster.
 type ClusterPeer interface {
 	// Name returns the unique identifier of this peer in the cluster.
 	Name() string

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -28,7 +28,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 
-	"github.com/prometheus/alertmanager/cluster"
 	"github.com/prometheus/alertmanager/inhibit"
 	"github.com/prometheus/alertmanager/nflog"
 	"github.com/prometheus/alertmanager/nflog/nflogpb"
@@ -39,6 +38,12 @@ import (
 // ResolvedSender returns true if resolved notifications should be sent.
 type ResolvedSender interface {
 	SendResolved() bool
+}
+
+// Peer represents the cluster node from where we are the sending the notification.
+type Peer interface {
+	// WaitReady waits until the node silences and notifications have settled before attempting to send a notification.
+	WaitReady()
 }
 
 // MinTimeout is the minimum timeout that is set for the context of a call
@@ -290,7 +295,7 @@ func (pb *PipelineBuilder) New(
 	inhibitor *inhibit.Inhibitor,
 	silencer *silence.Silencer,
 	notificationLog NotificationLog,
-	peer *cluster.Peer,
+	peer Peer,
 ) RoutingStage {
 	rs := make(RoutingStage, len(receivers))
 
@@ -399,11 +404,11 @@ func (fs FanoutStage) Exec(ctx context.Context, l log.Logger, alerts ...*types.A
 
 // GossipSettleStage waits until the Gossip has settled to forward alerts.
 type GossipSettleStage struct {
-	peer *cluster.Peer
+	peer Peer
 }
 
 // NewGossipSettleStage returns a new GossipSettleStage.
-func NewGossipSettleStage(p *cluster.Peer) *GossipSettleStage {
+func NewGossipSettleStage(p Peer) *GossipSettleStage {
 	return &GossipSettleStage{peer: p}
 }
 


### PR DESCRIPTION
A Peer as defined by the `cluster` package represents the node in the
cluster. It is used in other packages to know the status of all of the
members or how long should we wait to know if a notification has already fired.

In Cortex, we'd like to implement a slightly different way of
clustering (using gRPC for communication and a
hash ring for node discovery).

This is a small change to support that by changing the consumer of other
packages to an interface.

~~Silences and Notification channels don't need an interface as they take
a `func([]byte) error` as a parameter.~~

Edit: Ended up creating an interface for it as I think it's somewhat useful.

Signed-off-by: gotjosh <josue@grafana.com>