### PR TITLE
docs: Fix list formatting

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -31,6 +31,7 @@ Note that some fields are evaluated as text, and others as HTML which will affec
 | ExternalURL | string | Backlink to the Alertmanager that sent the notification. |
 
 The `Alerts` type exposes functions for filtering alerts:
+
  - `Alerts.Firing` returns a list of currently firing alert objects in this group
  - `Alerts.Resolved` returns a list of resolved alert objects in this group
 


### PR DESCRIPTION
Add a line break before the list to make sure it is properly rendered on the documentation website.