### PR TITLE
Export `newMetrics` function and `metrics` struct

### DIFF
--- a/notify/notify.go
+++ b/notify/notify.go
@@ -231,7 +231,7 @@ type NotificationLog interface {
 	Query(params ...nflog.QueryParam) ([]*nflogpb.Entry, error)
 }
 
-type metrics struct {
+type Metrics struct {
 	numNotifications                   *prometheus.CounterVec
 	numTotalFailedNotifications        *prometheus.CounterVec
 	numNotificationRequestsTotal       *prometheus.CounterVec
@@ -239,8 +239,8 @@ type metrics struct {
 	notificationLatencySeconds         *prometheus.HistogramVec
 }
 
-func newMetrics(r prometheus.Registerer) *metrics {
-	m := &metrics{
+func NewMetrics(r prometheus.Registerer) *Metrics {
+	m := &Metrics{
 		numNotifications: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: "alertmanager",
 			Name:      "notifications_total",
@@ -293,12 +293,12 @@ func newMetrics(r prometheus.Registerer) *metrics {
 }
 
 type PipelineBuilder struct {
-	metrics *metrics
+	metrics *Metrics
 }
 
 func NewPipelineBuilder(r prometheus.Registerer) *PipelineBuilder {
 	return &PipelineBuilder{
-		metrics: newMetrics(r),
+		metrics: NewMetrics(r),
 	}
 }
 
@@ -332,7 +332,7 @@ func createReceiverStage(
 	integrations []Integration,
 	wait func() time.Duration,
 	notificationLog NotificationLog,
-	metrics *metrics,
+	metrics *Metrics,
 ) Stage {
 	var fs FanoutStage
 	for i := range integrations {
@@ -638,11 +638,11 @@ func (n *DedupStage) Exec(ctx context.Context, _ log.Logger, alerts ...*types.Al
 type RetryStage struct {
 	integration Integration
 	groupName   string
-	metrics     *metrics
+	metrics     *Metrics
 }
 
 // NewRetryStage returns a new instance of a RetryStage.
-func NewRetryStage(i Integration, groupName string, metrics *metrics) *RetryStage {
+func NewRetryStage(i Integration, groupName string, metrics *Metrics) *RetryStage {
 	return &RetryStage{
 		integration: i,
 		groupName:   groupName,

--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -392,7 +392,7 @@ func TestRetryStageWithError(t *testing.T) {
 	}
 	r := RetryStage{
 		integration: i,
-		metrics:     newMetrics(prometheus.NewRegistry()),
+		metrics:     NewMetrics(prometheus.NewRegistry()),
 	}
 
 	alerts := []*types.Alert{
@@ -433,7 +433,7 @@ func TestRetryStageNoResolved(t *testing.T) {
 	}
 	r := RetryStage{
 		integration: i,
-		metrics:     newMetrics(prometheus.NewRegistry()),
+		metrics:     NewMetrics(prometheus.NewRegistry()),
 	}
 
 	alerts := []*types.Alert{
@@ -487,7 +487,7 @@ func TestRetryStageSendResolved(t *testing.T) {
 	}
 	r := RetryStage{
 		integration: i,
-		metrics:     newMetrics(prometheus.NewRegistry()),
+		metrics:     NewMetrics(prometheus.NewRegistry()),
 	}
 
 	alerts := []*types.Alert{


### PR DESCRIPTION
We have `NewRetryStage` method which takes this `metrics` struct, and given both the struct and the method to create it is unexported, it is impossible to use vendored `NewRetryStage`. We would like to use it in Grafana. Can we export them?