### PR TITLE
Add Andrey as maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,1 +1,2 @@
-* Simon Pasquier <pasquier.simon@gmail.com>
+* Simon Pasquier <pasquier.simon@gmail.com> @simonpasquier
+* Andrey Kuzmin <unsoundscapes@gmail.com> @w0rm


### PR DESCRIPTION
Following  Andrey's amazing work in the alertmanager UI, I am formally inviting him to join the project as maintainer.

According to our governance https://prometheus.io/governance/ , this change is subject to lazy consensus.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>