### PR TITLE
Add silence logging option

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -186,6 +186,7 @@ func run() int {
 		dataDir         = kingpin.Flag("storage.path", "Base path for data storage.").Default("data/").String()
 		retention       = kingpin.Flag("data.retention", "How long to keep data for.").Default("120h").Duration()
 		alertGCInterval = kingpin.Flag("alerts.gc-interval", "Interval between alert GC.").Default("30m").Duration()
+		silenceLogging  = kingpin.Flag("silences.logging", "Enable logging silences. If it is enabled, the status change of silence will be logged").Bool()
 
 		webConfig      = webflag.AddFlags(kingpin.CommandLine)
 		externalURL    = kingpin.Flag("web.external-url", "The URL under which Alertmanager is externally reachable (for example, if Alertmanager is served via a reverse proxy). Used for generating relative and absolute links back to Alertmanager itself. If the URL has a path portion, it will be used to prefix all HTTP endpoints served by Alertmanager. If omitted, relevant URL components will be derived automatically.").String()
@@ -278,6 +279,7 @@ func run() int {
 		Retention:    *retention,
 		Logger:       log.With(logger, "component", "silences"),
 		Metrics:      prometheus.DefaultRegisterer,
+		Logging:      *silenceLogging,
 	}
 
 	silences, err := silence.New(silenceOpts)

--- a/silence/silence.go
+++ b/silence/silence.go
@@ -23,8 +23,8 @@ import (
 	"os"
 	"reflect"
 	"regexp"
-	"strings"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -536,7 +536,7 @@ func (s *Silences) Set(sil *pb.Silence) (string, error) {
 	if ok {
 		if canUpdate(prev, sil, now) {
 			if s.logging {
-			    s.logginSilences("update silence", sil)
+				s.logginSilences("update silence", sil)
 			}
 			return sil.Id, s.setSilence(sil, now)
 		}
@@ -559,7 +559,7 @@ func (s *Silences) Set(sil *pb.Silence) (string, error) {
 	}
 
 	if s.logging {
-	    s.logginSilences("create silence", sil)
+		s.logginSilences("create silence", sil)
 	}
 
 	return sil.Id, s.setSilence(sil, now)
@@ -620,7 +620,7 @@ func (s *Silences) expire(id string) error {
 	}
 
 	if s.logging {
-	    s.logginSilences("expire silence", sil)
+		s.logginSilences("expire silence", sil)
 	}
 
 	return s.setSilence(sil, now)
@@ -962,27 +962,27 @@ func openReplace(filename string) (*replaceFile, error) {
 
 // logging silence status changes.
 func (s *Silences) logginSilences(msg string, sil *pb.Silence) {
-    var listMatchers []string
-    var matcher_type_operator = map[string]string{
-        "EQUAL": "=",
-        "REGEXP": "=~",
-        "NOT_EQUAL": "!=",
-        "NOT_REGEXP": "!~",
-    }
-    for _, matcher := range sil.Matchers {
-		ms := []string{matcher.Name, matcher_type_operator[matcher.Type.String()], matcher.Pattern}
-        m := strings.Join(ms, ``)
-        listMatchers = append(listMatchers, m)
+	var listMatchers []string
+	var matcher_type_operator = map[string]string{
+		"EQUAL":      "=",
+		"REGEXP":     "=~",
+		"NOT_EQUAL":  "!=",
+		"NOT_REGEXP": "!~",
 	}
-    strMatchers := strings.Join(listMatchers, `,`)
+	for _, matcher := range sil.Matchers {
+		ms := []string{matcher.Name, matcher_type_operator[matcher.Type.String()], matcher.Pattern}
+		m := strings.Join(ms, ``)
+		listMatchers = append(listMatchers, m)
+	}
+	strMatchers := strings.Join(listMatchers, `,`)
 
-    level.Info(s.logger).Log(
-        "msg", msg,
-        "Id", sil.Id,
-        "CreatedBy", sil.CreatedBy,
-        "Comment", sil.Comment,
-        "StartsAt", sil.StartsAt,
-        "EndsAt", sil.EndsAt,
-        "Matchers", strMatchers,
-    )
+	level.Info(s.logger).Log(
+		"msg", msg,
+		"Id", sil.Id,
+		"CreatedBy", sil.CreatedBy,
+		"Comment", sil.Comment,
+		"StartsAt", sil.StartsAt,
+		"EndsAt", sil.EndsAt,
+		"Matchers", strMatchers,
+	)
 }


### PR DESCRIPTION
Past silences are really important to postmortem our alert management operations.
We need to get "when" and "what kind of" create/edit/delete silences.
So this PR added optional function that logging silence change. 