### PR TITLE
Update CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,15 +42,15 @@ jobs:
   test:
     docker:
     # Whenever the Go version is updated here, .promu.yml should also be updated.
-    - image: circleci/golang:1.14
+    - image: circleci/golang:1.15
     # maildev containers are for running the email tests against a "real" SMTP server.
     # See notify/email_test.go for details.
-    - image: djfarrelly/maildev@sha256:624e0ec781e11c3531da83d9448f5861f258ee008c1b2da63b3248bfd680acfa
+    - image: djfarrelly/maildev:1.1.0
       name: maildev-noauth
       entrypoint: bin/maildev
       command:
       - -v
-    - image: djfarrelly/maildev@sha256:624e0ec781e11c3531da83d9448f5861f258ee008c1b2da63b3248bfd680acfa
+    - image: djfarrelly/maildev:1.1.0
       name: maildev-auth
       entrypoint: bin/maildev
       command:
@@ -102,13 +102,13 @@ jobs:
   mixin:
     docker:
     # Whenever the Go version is updated here, .promu.yml should also be updated.
-    - image: circleci/golang:1.14
+    - image: circleci/golang:1.16
 
     steps:
     - checkout
-    - run: cd doc/alertmanager-mixin; go install github.com/monitoring-mixins/mixtool/cmd/mixtool
-    - run: cd doc/alertmanager-mixin; go install github.com/google/go-jsonnet/cmd/jsonnetfmt
-    - run: cd doc/alertmanager-mixin; make lint
+    - run: go install github.com/monitoring-mixins/mixtool/cmd/mixtool@latest
+    - run: go install github.com/google/go-jsonnet/cmd/jsonnetfmt@latest
+    - run: make -C doc/alertmanager-mixin lint
 
 workflows:
   version: 2

--- a/doc/alertmanager-mixin/go.mod
+++ b/doc/alertmanager-mixin/go.mod
@@ -1,8 +1,0 @@
-module github.com/prometheus/alertmanager/doc/alertmanager-mixin
-
-go 1.14
-
-require (
-	github.com/google/go-jsonnet v0.17.0 // indirect
-	github.com/monitoring-mixins/mixtool v0.0.0-20201127170310-63dca667103c // indirect
-)


### PR DESCRIPTION
* Use Go 1.16.
* Update djfarrelly/maildev container.
* Update mixintests for Go 1.16 syntax.

Signed-off-by: SuperQ <superq@gmail.com>