### PR TITLE
VictorOps api-key <SECRET> via file feature

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -301,6 +301,9 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		*c.Global = DefaultGlobalConfig()
 	}
 
+	if c.Global.VictorOpsAPIKey != nil && len(c.Global.VictorOpsAPIKeyFile) > 0 {
+		return fmt.Errorf("at most one of victorops_api_key & victorops_api_key_file must be configured")
+	}
 	names := map[string]struct{}{}
 
 	for _, rcv := range c.Receivers {
@@ -435,11 +438,12 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			if !strings.HasSuffix(voc.APIURL.Path, "/") {
 				voc.APIURL.Path += "/"
 			}
-			if voc.APIKey == "" {
-				if c.Global.VictorOpsAPIKey == "" {
-					return fmt.Errorf("no global VictorOps API Key set")
+			if voc.APIKey == "" && len(voc.APIKeyFile) == 0  {
+				if c.Global.VictorOpsAPIKey == "" && len(c.Global.VictorOpsAPIKeyFile) == 0  {
+					return fmt.Errorf("no global VictorOps API Key set either inline or in a file")
 				}
 				voc.APIKey = c.Global.VictorOpsAPIKey
+				voc.APIKeyFile = c.Global.VictorOpsAPIKeyFile
 			}
 		}
 		names[rcv.Name] = struct{}{}
@@ -640,6 +644,7 @@ type GlobalConfig struct {
 	WeChatAPICorpID  string     `yaml:"wechat_api_corp_id,omitempty" json:"wechat_api_corp_id,omitempty"`
 	VictorOpsAPIURL  *URL       `yaml:"victorops_api_url,omitempty" json:"victorops_api_url,omitempty"`
 	VictorOpsAPIKey  Secret     `yaml:"victorops_api_key,omitempty" json:"victorops_api_key,omitempty"`
+	VictorOpsAPIKeyFile  Secret     `yaml:"victorops_api_key_file,omitempty" json:"victorops_api_key_file,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for GlobalConfig.

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -490,7 +490,8 @@ type VictorOpsConfig struct {
 
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
-	APIKey            Secret            `yaml:"api_key" json:"api_key"`
+	APIKey            Secret            `yaml:"api_key,omitempty" json:"api_key,omitempty"`
+	APIKeyFile        Secret            `yaml:"api_key_file,omitempty" json:"api_key_file,omitempty"`
 	APIURL            *URL              `yaml:"api_url" json:"api_url"`
 	RoutingKey        string            `yaml:"routing_key" json:"routing_key"`
 	MessageType       string            `yaml:"message_type" json:"message_type"`
@@ -507,6 +508,13 @@ func (c *VictorOpsConfig) UnmarshalYAML(unmarshal func(interface{}) error) error
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
+
+	if c.APIKey != nil && len(c.APIKeyFile) > 0 {
+		return fmt.Errorf("at most one of api_key & api_key_file must be configured")
+	}
+
+	return nil
+
 	if c.RoutingKey == "" {
 		return fmt.Errorf("missing Routing key in VictorOps config")
 	}

--- a/config/testdata/conf.victorops-api-key-both-file-and-inline.yml
+++ b/config/testdata/conf.victorops-api-key-both-file-and-inline.yml
@@ -1,0 +1,13 @@
+global:
+  victorops_api_key: "<SECRET>"
+  victorops_api_key_file: '/global_file'
+
+route:
+  receiver: 'victorops-notifications'
+  group_by: [alertname, datacenter, app]
+
+receivers:
+- name: 'victorops-notifications'
+  slack_configs:
+  - channel: '#alerts1'
+    text: 'test'

--- a/config/testdata/conf.victorops-default-api-key-file.yml
+++ b/config/testdata/conf.victorops-default-api-key-file.yml
@@ -1,0 +1,21 @@
+global:
+  victorops_api_key_file: '/global_file'
+
+route:
+  receiver: 'victorops-notifications'
+  group_by: [alertname, datacenter, app]
+
+receivers:
+- name: 'victorops-notifications'
+  slack_configs:
+  # Use global
+  - channel: '#alerts1'
+    text: 'test'
+  # Override global with other file
+  - channel: '#alerts2'
+    text: 'test'
+    victorops_api_key_file: '/override_file'
+  # Override global with inline URL
+  - channel: '#alerts3'
+    text: 'test'
+    victorops_api_key: '<SECRET>'

--- a/notify/victorops/victorops_test.go
+++ b/notify/victorops/victorops_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"


### PR DESCRIPTION
Adding features for inserting VictorOps-api-key secret through file - as suggested in this [issue](https://github.com/prometheus/alertmanager/issues/2498). I haven't tested in local not much familiar with GO, working on that. Any high level review will be really helpful - if I am going in right direction or not. Thanks