### PR TITLE
Dispatch: Make sure mutex gets unlocked on call to Stop

### DIFF
--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -258,12 +258,13 @@ func (d *Dispatcher) Stop() {
 		return
 	}
 	d.mtx.Lock()
-	defer d.mtx.Unlock()
 	if d.cancel == nil {
+		d.mtx.Unlock()
 		return
 	}
 	d.cancel()
 	d.cancel = nil
+	d.mtx.Unlock()
 
 	<-d.done
 }

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -258,12 +258,12 @@ func (d *Dispatcher) Stop() {
 		return
 	}
 	d.mtx.Lock()
+	defer d.mtx.Unlock()
 	if d.cancel == nil {
 		return
 	}
 	d.cancel()
 	d.cancel = nil
-	d.mtx.Unlock()
 
 	<-d.done
 }


### PR DESCRIPTION
It looks as if `Dispatch.Stop` doesn't unlock the mutex if `d.cancel == nil`. I'm rectifying it to unlock it also if `d.cancel == nil` and the method returns early. It seems to fix a deadlock in Grafana (on server shutdown), during our test suite.

[Here](https://gist.github.com/aknuds1/a9dcff50dd8cba2b82f570ed6b942923)'s a stacktrace of the involved goroutines when the deadlock occurs.

Let me know if you want me to write a test also.