### PR TITLE
Lift moratorium on AlertManager receivers with long-term maintenance plan

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -426,6 +426,8 @@ A `tls_config` allows configuring TLS connections.
 
 Receiver is a named configuration of one or more notification integrations.
 
+Note: As part of lifting the past moratorium on new receivers it was agreed that, in addition to the existing requirements, new notification integrations will be required to have a committed maintainer with push access.
+
 ```yaml
 # The unique name of the receiver.
 name: <string>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -426,8 +426,6 @@ A `tls_config` allows configuring TLS connections.
 
 Receiver is a named configuration of one or more notification integrations.
 
-__We're not actively adding new receivers, we recommend implementing custom notification integrations via the [webhook](#webhook_config) receiver.__
-
 ```yaml
 # The unique name of the receiver.
 name: <string>


### PR DESCRIPTION
This documentation change is intended to lift moratorium on new AlertManager receivers with long-term maintenance plan.