### PR TITLE
Fix race condition causing 1st alert to not be immediately delivered when group_wait is 0s

### DIFF
--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -540,7 +540,7 @@ func TestDispatcherRace(t *testing.T) {
 }
 
 func TestDispatcherRaceOnFirstAlertNotDeliveredWhenGroupWaitIsZero(t *testing.T) {
-	const numAlerts = 100000
+	const numAlerts = 8000
 
 	logger := log.NewNopLogger()
 	marker := types.NewMarker(prometheus.NewRegistry())


### PR DESCRIPTION
This PR should fix #2562.

_Please see the issue for more details. I also suggest to review this with enabling "Hide whitespace changes"._