### PR TITLE
Add wechat app group message

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -100,7 +100,6 @@ var (
 		ToUser:  `{{ template "wechat.default.to_user" . }}`,
 		ToParty: `{{ template "wechat.default.to_party" . }}`,
 		ToTag:   `{{ template "wechat.default.to_tag" . }}`,
-		AgentID: `{{ template "wechat.default.agent_id" . }}`,
 	}
 
 	// DefaultVictorOpsConfig defines default values for VictorOps configurations.
@@ -405,18 +404,20 @@ type WechatConfig struct {
 
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
-	APISecret   Secret `yaml:"api_secret,omitempty" json:"api_secret,omitempty"`
-	CorpID      string `yaml:"corp_id,omitempty" json:"corp_id,omitempty"`
-	Message     string `yaml:"message,omitempty" json:"message,omitempty"`
-	APIURL      *URL   `yaml:"api_url,omitempty" json:"api_url,omitempty"`
-	ToUser      string `yaml:"to_user,omitempty" json:"to_user,omitempty"`
-	ToParty     string `yaml:"to_party,omitempty" json:"to_party,omitempty"`
-	ToTag       string `yaml:"to_tag,omitempty" json:"to_tag,omitempty"`
-	AgentID     string `yaml:"agent_id,omitempty" json:"agent_id,omitempty"`
-	MessageType string `yaml:"message_type,omitempty" json:"message_type,omitempty"`
+	APISecret   Secret   `yaml:"api_secret,omitempty" json:"api_secret,omitempty"`
+	CorpID      string   `yaml:"corp_id,omitempty" json:"corp_id,omitempty"`
+	Message     string   `yaml:"message,omitempty" json:"message,omitempty"`
+	APIURL      *URL     `yaml:"api_url,omitempty" json:"api_url,omitempty"`
+	ToUser      string   `yaml:"to_user,omitempty" json:"to_user,omitempty"`
+	ToParty     string   `yaml:"to_party,omitempty" json:"to_party,omitempty"`
+	ToTag       string   `yaml:"to_tag,omitempty" json:"to_tag,omitempty"`
+	AgentID     string   `yaml:"agent_id,omitempty" json:"agent_id,omitempty"`
+	MessageType string   `yaml:"message_type,omitempty" json:"message_type,omitempty"`
+	GroupTitle  string   `yaml:"group_title,omitempty" json:"group_title,omitempty"`
+	GroupUsers  []string `yaml:"group_users,omitempty" json:"group_users,omitempty"`
 }
 
-const wechatValidTypesRe = `^(text|markdown)$`
+const wechatValidTypesRe = `^(text|markdown|groupText|groupMarkdown)$`
 
 var wechatTypeMatcher = regexp.MustCompile(wechatValidTypesRe)
 

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -540,7 +540,7 @@ func TestDispatcherRace(t *testing.T) {
 }
 
 func TestDispatcherRaceOnFirstAlertNotDeliveredWhenGroupWaitIsZero(t *testing.T) {
-	const numAlerts = 100000
+	const numAlerts = 8000
 
 	logger := log.NewNopLogger()
 	marker := types.NewMarker(prometheus.NewRegistry())

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -912,4 +912,10 @@ API](http://admin.wechat.com/wiki/index.php?title=Customer_Service_Messages).
 [ to_user: <string> | default = '{{ template "wechat.default.to_user" . }}' ]
 [ to_party: <string> | default = '{{ template "wechat.default.to_party" . }}' ]
 [ to_tag: <string> | default = '{{ template "wechat.default.to_tag" . }}' ]
+# groupTitle is the unique identifier of the group，create if not exists；
+# the example config at: wechat_alertmanager.yml; the template at: examples/ha/wechat_xxx.tmpl
+[ group_title: <string> | default = '{{ template "wechat.default.groupTitle" . }}' ]
+# the example config at: wechat_alertmanager.yml; the template at: examples/ha/wechat_xxx.tmpl
+# group_users strings array ,the group member min 2 people, max 2000 （企业微信规定群成员id列表 至少2人，最多2000人）
+[ group_users: <[]string> | default = '' ]
 ```

--- a/examples/ha/wechat_alertmanager.yml
+++ b/examples/ha/wechat_alertmanager.yml
@@ -1,0 +1,42 @@
+global:
+  wechat_api_url: 'https://qyapi.weixin.qq.com/cgi-bin/'
+  wechat_api_secret: '#wechat_api_secret'
+  wechat_api_corp_id: '#wechat corp id '
+  resolve_timeout: 1m
+
+route:
+  group_by: ['application']
+  group_wait: 30s
+  group_interval: 1m
+  repeat_interval: 1m
+  receiver: 'groupWechat'
+
+templates:
+  - /etc/alertmanager/config/*.tmpl
+receivers:
+  - name: 'groupWechat'
+    wechat_configs:
+      - send_resolved: true
+        to_tag: '服务报警'
+        message_type:  'groupMarkdown'
+        message: '{{ template "wechat.default.groupMessage" . }}'
+        agent_id: '#wechat agent id'
+        group_title: '{{ template "wechat.default.groupTitle" . }}'    #create group chatId
+        group_users:
+          - haizhu
+          - FengYu
+  - name: 'wechat'
+    wechat_configs:
+      - send_resolved: true
+        to_user: "xxx"
+        to_tag: '服务报警'
+        message_type:  'groupMarkdown'
+        message: '{{ template "wechat.default.message" . }}'
+        agent_id: '#wechat agent id'
+
+inhibit_rules:
+  - source_match:
+      severity: 'critical'
+    target_match:
+      severity: 'warning'
+    equal: ['alertname', 'dev', 'instance']

--- a/examples/ha/wechat_group_alerts.sh
+++ b/examples/ha/wechat_group_alerts.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+alerts1='[
+    {
+        "labels": {
+            "application": "app1",
+            "instance": "instance1",
+            "groupTitle": "微服务测试"
+        },
+        "startsAt": "2021-01-20T14:31:39.000Z",
+        "endsAt": "2021-06-28T04:09:43.534Z",
+        "annotations": {
+            "summary": "summary info",
+            "message": "message content"
+        },
+        "generatorURL": "http://GecyXAtxISsqBCNScCD.xldw-xtmZQKncZJequKpc,2CQ1J7lE-SKEx2i1dYxWDbo071rZFoiN7OQEbKltIARN+"
+    },
+    {
+        "labels": {
+            "application": "app1",
+            "instance": "instance1",
+            "groupTitle": "微服务测试"
+        },
+        "startsAt": "2021-01-20T14:31:39.000Z",
+        "endsAt": "2021-06-28T04:09:43.534Z",
+        "annotations": {
+            "summary": "summary info2",
+            "message": "message content2"
+        },
+        "generatorURL": "http://GecyXAtxISsqBCNScCD.xldw-xtmZQKncZJequKpc,2CQ1J7lE-SKEx2i1dYxWDbo071rZFoiN7OQEbKltIARN+"
+    }
+]'
+curl -XPOST -d"$alerts1" -H "Content-Type:application/json" http://localhost:9093/api/v2/alerts

--- a/examples/ha/wechat_group_markdown.tmpl
+++ b/examples/ha/wechat_group_markdown.tmpl
@@ -1,0 +1,36 @@
+{{ define "wechat.default.groupMessage" }}
+{{- if gt (len .Alerts.Firing) 0 -}}
+{{- range $index, $alert := .Alerts -}}
+#  监控报警：{{ $alert.Labels.alertname }}
+- 告警状态：<font color="warning">{{   .Status }}</font>
+- 告警主题：[{{ $alert.Labels.alertname }}-点击查看]({{ $alert.GeneratorURL  }})
+- 告警级别：{{ $alert.Labels.level }}
+- 告警服务：{{ $alert.Labels.application }}
+- 故障主机: {{ $alert.Labels.instance }}
+- 告警主题: {{ $alert.Annotations.summary }}
+- 告警详情: {{ $alert.Annotations.message }}{{ $alert.Annotations.description}}
+- 故障时间: {{ ($alert.StartsAt.Add 28800e9).Format "2006-01-02 15:04:05" }}
+
+{{- end }}
+{{- end }}
+
+{{- if gt (len .Alerts.Resolved) 0 -}}
+{{- range $index, $alert := .Alerts -}}
+#  异常恢复：{{ $alert.Labels.alertname }}
+- 告警类型：{{ .Labels.alertname }}
+- 告警状态：<font color="info">{{   .Status }}</font>
+- 告警主题：[{{ $alert.Labels.alertname }}-点击查看]({{ $alert.GeneratorURL  }})
+- 告警级别：{{ $alert.Labels.level }}
+- 告警服务：{{ $alert.Labels.application }}
+- 故障主机: {{ $alert.Labels.instance }}
+- 告警主题: {{ $alert.Annotations.summary }}
+- 告警详情: {{ $alert.Annotations.message }}{{ $alert.Annotations.description}}
+- 故障时间: {{ ($alert.StartsAt.Add 28800e9).Format "2006-01-02 15:04:05" }}
+- 恢复时间: {{ ($alert.EndsAt.Add 28800e9).Format "2006-01-02 15:04:05" }}
+- 持续时间：{{ ($alert.EndsAt.Sub .StartsAt).Truncate 1000000000}}
+{{- if gt (len $alert.Labels.instance) 0 }}
+实例信息: {{ $alert.Labels.instance }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/examples/ha/wechat_group_title.tmpl
+++ b/examples/ha/wechat_group_title.tmpl
@@ -1,0 +1,7 @@
+{{ define "wechat.default.groupTitle" }}
+{{- range $index, $alert := .Alerts -}}
+{{- if eq $index 0 }}
+{{ $alert.Labels.application }}{{ $alert.Labels.groupTitle }}
+{{- end }}
+{{- end }}
+{{ end }}

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/oklog/ulid v1.3.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.10.0
-	github.com/prometheus/common v0.23.0
+	github.com/prometheus/common v0.24.0
 	github.com/prometheus/exporter-toolkit v0.5.1
 	github.com/rs/cors v1.7.0
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749

--- a/go.sum
+++ b/go.sum
@@ -445,8 +445,8 @@ github.com/prometheus/common v0.7.0/go.mod h1:DjGbpBbp5NYNiECxcL/VnbXCCaQpKd3tt2
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
 github.com/prometheus/common v0.15.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
 github.com/prometheus/common v0.18.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
-github.com/prometheus/common v0.23.0 h1:GXWvPYuTUenIa+BhOq/x+L/QZzCqASkVRny5KTlPDGM=
-github.com/prometheus/common v0.23.0/go.mod h1:H6QK/N6XVT42whUeIdI3dp36w49c+/iMDk7UAI2qm7Q=
+github.com/prometheus/common v0.24.0 h1:aIycr3wRFxPUq8XlLQlGQ9aNXV3dFi5y62pe/SB262k=
+github.com/prometheus/common v0.24.0/go.mod h1:H6QK/N6XVT42whUeIdI3dp36w49c+/iMDk7UAI2qm7Q=
 github.com/prometheus/exporter-toolkit v0.5.1 h1:9eqgis5er9xN613ZSADjypCJaDGj9ZlcWBvsIHa8/3c=
 github.com/prometheus/exporter-toolkit v0.5.1/go.mod h1:OCkM4805mmisBhLmVFw858QYi3v0wKdY6/UxrT0pZVg=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=

--- a/notify/wechat/wechat.go
+++ b/notify/wechat/wechat.go
@@ -16,11 +16,13 @@ package wechat
 import (
 	"bytes"
 	"context"
+	"crypto/md5"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/go-kit/kit/log"
@@ -36,13 +38,15 @@ import (
 
 // Notifier implements a Notifier for wechat notifications.
 type Notifier struct {
-	conf   *config.WechatConfig
-	tmpl   *template.Template
+	conf *config.WechatConfig
+	tmpl *template.Template
+
 	logger log.Logger
 	client *http.Client
 
 	accessToken   string
 	accessTokenAt time.Time
+	existGroup    map[string]bool
 }
 
 // token is the AccessToken with corpid and corpsecret.
@@ -59,6 +63,7 @@ type weChatMessage struct {
 	Safe     string               `yaml:"safe,omitempty" json:"safe,omitempty"`
 	Type     string               `yaml:"msgtype,omitempty" json:"msgtype,omitempty"`
 	Markdown weChatMessageContent `yaml:"markdown,omitempty" json:"markdown,omitempty"`
+	ChatId   string               `yaml:"chatid,omitempty" json:"chatid,omitempty"`
 }
 
 type weChatMessageContent struct {
@@ -68,6 +73,13 @@ type weChatMessageContent struct {
 type weChatResponse struct {
 	Code  int    `json:"code"`
 	Error string `json:"error"`
+}
+
+type requestChatInfo struct {
+	Name     string   `json:"name"`
+	UserList []string `json:"userlist"`
+	ChatId   string   `json:"chatid"`
+	Owner    string   `json:"owner"`
 }
 
 // New returns a new Wechat notifier.
@@ -134,68 +146,90 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		n.accessToken = wechatToken.AccessToken
 		n.accessTokenAt = time.Now()
 	}
-
 	msg := &weChatMessage{
-		ToUser:  tmpl(n.conf.ToUser),
-		ToParty: tmpl(n.conf.ToParty),
-		Totag:   tmpl(n.conf.ToTag),
-		AgentID: tmpl(n.conf.AgentID),
-		Type:    n.conf.MessageType,
-		Safe:    "0",
+		Safe: "0",
 	}
+	postMessageURL := n.conf.APIURL.Copy()
 
-	if msg.Type == "markdown" {
+	switch n.conf.MessageType {
+	case "groupMarkdown":
+		postMessageURL.Path += "appchat/send"
+		var users []string
+		for _, user := range n.conf.GroupUsers {
+			users = append(users, tmpl(user))
+		}
+		groupTitle := tmpl(n.conf.GroupTitle)
+		chat, md5err := n.md5(groupTitle)
+		if md5err != nil {
+			return false, err
+		}
+		if err = n.checkCreateGroupChat(ctx, chat, users, groupTitle); err != nil {
+			return false, err
+		}
+		msg.Type = "markdown"
+		msg.ChatId = chat
 		msg.Markdown = weChatMessageContent{
 			Content: tmpl(n.conf.Message),
 		}
-	} else {
+	case "groupText":
+		postMessageURL.Path += "appchat/send"
+		var users []string
+		for _, user := range n.conf.GroupUsers {
+			users = append(users, tmpl(user))
+		}
+		groupTitle := tmpl(n.conf.GroupTitle)
+		chat, md5err := n.md5(groupTitle)
+		if md5err != nil {
+			return false, err
+		}
+		if err = n.checkCreateGroupChat(ctx, chat, users, groupTitle); err != nil {
+			return false, err
+		}
+		msg.Type = "text"
+		msg.ChatId = chat
+		msg.Text = weChatMessageContent{
+			Content: tmpl(n.conf.Message),
+		}
+	case "markdown":
+		postMessageURL.Path += "message/send"
+		msg.ToUser = tmpl(n.conf.ToUser)
+		msg.ToParty = tmpl(n.conf.ToParty)
+		msg.Totag = tmpl(n.conf.ToTag)
+		msg.AgentID = tmpl(n.conf.AgentID)
+		msg.Type = "markdown"
+		msg.Markdown = weChatMessageContent{
+			Content: tmpl(n.conf.Message),
+		}
+	default:
+		postMessageURL.Path += "message/send"
+		msg.ToUser = tmpl(n.conf.ToUser)
+		msg.ToParty = tmpl(n.conf.ToParty)
+		msg.Totag = tmpl(n.conf.ToTag)
+		msg.AgentID = tmpl(n.conf.AgentID)
+		msg.Type = "text"
 		msg.Text = weChatMessageContent{
 			Content: tmpl(n.conf.Message),
 		}
 	}
+
 	if err != nil {
 		return false, fmt.Errorf("templating error: %s", err)
 	}
 
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(msg); err != nil {
-		return false, err
-	}
-
-	postMessageURL := n.conf.APIURL.Copy()
-	postMessageURL.Path += "message/send"
 	q := postMessageURL.Query()
 	q.Set("access_token", n.accessToken)
 	postMessageURL.RawQuery = q.Encode()
 
-	req, err := http.NewRequest(http.MethodPost, postMessageURL.String(), &buf)
+	weResp, err := n.sendRequest(ctx, postMessageURL.String(), http.MethodPost, &msg)
+
 	if err != nil {
-		return true, err
-	}
-
-	resp, err := n.client.Do(req.WithContext(ctx))
-	if err != nil {
-		return true, notify.RedactURL(err)
-	}
-	defer notify.Drain(resp)
-
-	if resp.StatusCode != 200 {
-		return true, fmt.Errorf("unexpected status code %v", resp.StatusCode)
-	}
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return true, err
-	}
-	level.Debug(n.logger).Log("response", string(body), "incident", key)
-
-	var weResp weChatResponse
-	if err := json.Unmarshal(body, &weResp); err != nil {
+		level.Info(n.logger).Log("send chat err  ", err)
 		return true, err
 	}
 
 	// https://work.weixin.qq.com/api/doc#10649
 	if weResp.Code == 0 {
+		level.Info(n.logger).Log("sendRequest response body", fmt.Sprintf("%v", weResp))
 		return false, nil
 	}
 
@@ -206,4 +240,90 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	}
 
 	return false, errors.New(weResp.Error)
+}
+
+func (*Notifier) md5(src interface{}) (string, error) {
+	if data, err := json.Marshal(src); err == nil {
+		has := md5.Sum(data)
+		md5str1 := fmt.Sprintf("%x", has) //将[]byte转成16进制
+		return md5str1, nil
+	} else {
+		return "", err
+	}
+
+}
+
+// create group chat if not exists,else get it;  groupTitle is the unique identifier of the group
+//https://open.work.weixin.qq.com/api/doc/90000/90135/90245
+func (n *Notifier) checkCreateGroupChat(ctx context.Context, chatId string, users []string, groupTitle string) error {
+
+	if len(users) < 2 || len(users) > 2000 {
+		return errors.New("the group member min 2 people, max 2000 （群成员id列表。至少2人，至多2000人）")
+	}
+
+	if n.existGroup == nil {
+		n.existGroup = make(map[string]bool)
+	}
+	groupTitle = strings.Trim(groupTitle, "\n")
+	if n.existGroup[chatId] {
+		level.Debug(n.logger).Log("groupTitle:", groupTitle, " chat exists")
+		return nil
+	}
+
+	chatInfo := requestChatInfo{
+		ChatId:   chatId,
+		UserList: users,
+		Name:     strings.Trim(groupTitle, "\n"),
+		Owner:    users[0], //the group owner is the first group member
+	}
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(&chatInfo); err != nil {
+		return err
+	}
+	postMessageURL := n.conf.APIURL.Copy()
+	postMessageURL.Path += "appchat/create"
+	q := postMessageURL.Query()
+	q.Set("access_token", n.accessToken)
+	postMessageURL.RawQuery = q.Encode()
+	weResp, err := n.sendRequest(ctx, postMessageURL.String(), http.MethodPost, &chatInfo)
+	if err != nil {
+		return err
+	}
+	// https://work.weixin.qq.com/api/doc#10649
+	// https://open.work.weixin.qq.com/devtool/query?e=86215
+	if weResp.Code == 0 || weResp.Code == 86215 {
+		n.existGroup[chatId] = true
+		return nil
+	}
+	// AccessToken is expired
+	if weResp.Code == 42001 {
+		n.accessToken = ""
+		return errors.New(weResp.Error)
+	}
+	return nil
+
+}
+
+func (n *Notifier) sendRequest(ctx context.Context, url string, methodPost string, request interface{}) (res weChatResponse, err error) {
+	var buf bytes.Buffer
+	if err = json.NewEncoder(&buf).Encode(request); err != nil {
+		return
+	}
+	req, err := http.NewRequest(methodPost, url, &buf)
+	if err != nil {
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := n.client.Do(req.WithContext(ctx))
+	if err != nil {
+		return res, notify.RedactURL(err)
+	}
+	defer notify.Drain(resp)
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return
+	}
+	level.Debug(n.logger).Log("sendRequest response body", string(body))
+	err = json.Unmarshal(body, &res)
+	return res, err
 }


### PR DESCRIPTION
- Added support for WeChat groups to facilitate communication and sharing of alarm information
添加支持微信群组，便于交流分享报警信息

- add wechat group chat type groupText and groupMarkdown

- add test config and script  and screenshot

  the config at examples/ha/wechat_alertmanager.yml  
  send a alert msg with script: examples/ha/wechat_group_alerts.sh
  the template at : examples/ha/wechat_group*.tmpl

the result group msg:
![image](https://user-images.githubusercontent.com/2637274/118209116-96a08e80-b49a-11eb-89c5-53010cd43a32.png)

