### PR TITLE
Include pending silences for future muting decisions

### DIFF
--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -673,7 +673,7 @@ func TestMuteStageWithSilences(t *testing.T) {
 
 	// Set the second alert as previously silenced with an old version
 	// number. This is expected to get unsilenced by the stage.
-	marker.SetSilenced(inAlerts[1].Fingerprint(), 0, "123")
+	marker.SetSilenced(inAlerts[1].Fingerprint(), 0, []string{"123"}, nil)
 
 	_, alerts, err := stage.Exec(context.Background(), log.NewNopLogger(), inAlerts...)
 	if err != nil {

--- a/provider/mem/mem_test.go
+++ b/provider/mem/mem_test.go
@@ -296,7 +296,8 @@ func TestAlertsGC(t *testing.T) {
 	}
 
 	for _, a := range insert {
-		marker.SetActive(a.Fingerprint())
+		marker.SetSilenced(a.Fingerprint(), 0, nil, nil)
+		marker.SetInhibited(a.Fingerprint())
 		if !marker.Active(a.Fingerprint()) {
 			t.Errorf("error setting status: %v", a)
 		}

--- a/silence/silence_test.go
+++ b/silence/silence_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/kit/log"
 	"github.com/matttproud/golang_protobuf_extensions/pbutil"
 	pb "github.com/prometheus/alertmanager/silence/silencepb"
 	"github.com/prometheus/alertmanager/types"
@@ -913,7 +914,7 @@ func TestSilencer(t *testing.T) {
 	ss.now = func() time.Time { return now }
 
 	m := types.NewMarker(prometheus.NewRegistry())
-	s := NewSilencer(ss, m, nil)
+	s := NewSilencer(ss, m, log.NewNopLogger())
 
 	require.False(t, s.Mutes(model.LabelSet{"foo": "bar"}), "expected alert not silenced without any silences")
 

--- a/types/types.go
+++ b/types/types.go
@@ -44,29 +44,29 @@ type AlertStatus struct {
 	SilencedBy  []string   `json:"silencedBy"`
 	InhibitedBy []string   `json:"inhibitedBy"`
 
+	// For internal tracking, not exposed in the API.
+	pendingSilences []string
 	silencesVersion int
 }
 
 // Marker helps to mark alerts as silenced and/or inhibited.
 // All methods are goroutine-safe.
 type Marker interface {
-	// SetActive sets the provided alert to AlertStateActive and deletes all
-	// SilencedBy and InhibitedBy entries.
-	SetActive(alert model.Fingerprint)
 	// SetSilenced replaces the previous SilencedBy by the provided IDs of
-	// silences, including the version number of the silences state. The set
-	// of provided IDs is supposed to represent the complete set of relevant
-	// silences. If no ID is provided and InhibitedBy is already empty, this
-	// call is equivalent to SetActive. Otherwise, it sets
-	// AlertStateSuppressed.
-	SetSilenced(alert model.Fingerprint, version int, silenceIDs ...string)
+	// active and pending silences, including the version number of the
+	// silences state. The set of provided IDs is supposed to represent the
+	// complete set of relevant silences. If no active silence IDs are provided and
+	// InhibitedBy is already empty, it sets the provided alert to AlertStateActive.
+	// Otherwise, it sets the provided alert to AlertStateSuppressed.
+	SetSilenced(alert model.Fingerprint, version int, activeSilenceIDs []string, pendingSilenceIDs []string)
 	// SetInhibited replaces the previous InhibitedBy by the provided IDs of
 	// alerts. In contrast to SetSilenced, the set of provided IDs is not
 	// expected to represent the complete set of inhibiting alerts. (In
 	// practice, this method is only called with one or zero IDs. However,
-	// this expectation might change in the future.) If no ID is provided and
-	// SilencedBy is already empty, this call is equivalent to
-	// SetActive. Otherwise, it sets AlertStateSuppressed.
+	// this expectation might change in the future.) If no IDs are provided
+	// and InhibitedBy is already empty, it sets the provided alert to
+	// AlertStateActive. Otherwise, it sets the provided alert to
+	// AlertStateSuppressed.
 	SetInhibited(alert model.Fingerprint, alertIDs ...string)
 
 	// Count alerts of the given state(s). With no state provided, count all
@@ -79,13 +79,13 @@ type Marker interface {
 	Delete(model.Fingerprint)
 
 	// Various methods to inquire if the given alert is in a certain
-	// AlertState. Silenced also returns all the silencing silences, while
-	// Inhibited may return only a subset of inhibiting alerts. Silenced
-	// also returns the version of the silences state the result is based
-	// on.
+	// AlertState. Silenced also returns all the active and pending
+	// silences, while Inhibited may return only a subset of inhibiting
+	// alerts. Silenced also returns the version of the silences state the
+	// result is based on.
 	Unprocessed(model.Fingerprint) bool
 	Active(model.Fingerprint) bool
-	Silenced(model.Fingerprint) ([]string, int, bool)
+	Silenced(model.Fingerprint) (activeIDs []string, pendingIDs []string, version int, silenced bool)
 	Inhibited(model.Fingerprint) ([]string, bool)
 }
 
@@ -148,58 +148,7 @@ func (m *memMarker) Count(states ...AlertState) int {
 }
 
 // SetSilenced implements Marker.
-func (m *memMarker) SetSilenced(alert model.Fingerprint, version int, ids ...string) {
-	m.mtx.Lock()
-
-	s, found := m.m[alert]
-	if !found {
-		s = &AlertStatus{}
-		m.m[alert] = s
-	}
-	s.silencesVersion = version
-
-	// If there are any silence or alert IDs associated with the
-	// fingerprint, it is suppressed. Otherwise, set it to
-	// AlertStateUnprocessed.
-	if len(ids) == 0 && len(s.InhibitedBy) == 0 {
-		m.mtx.Unlock()
-		m.SetActive(alert)
-		return
-	}
-
-	s.State = AlertStateSuppressed
-	s.SilencedBy = ids
-
-	m.mtx.Unlock()
-}
-
-// SetInhibited implements Marker.
-func (m *memMarker) SetInhibited(alert model.Fingerprint, ids ...string) {
-	m.mtx.Lock()
-
-	s, found := m.m[alert]
-	if !found {
-		s = &AlertStatus{}
-		m.m[alert] = s
-	}
-
-	// If there are any silence or alert IDs associated with the
-	// fingerprint, it is suppressed. Otherwise, set it to
-	// AlertStateUnprocessed.
-	if len(ids) == 0 && len(s.SilencedBy) == 0 {
-		m.mtx.Unlock()
-		m.SetActive(alert)
-		return
-	}
-
-	s.State = AlertStateSuppressed
-	s.InhibitedBy = ids
-
-	m.mtx.Unlock()
-}
-
-// SetActive implements Marker.
-func (m *memMarker) SetActive(alert model.Fingerprint) {
+func (m *memMarker) SetSilenced(alert model.Fingerprint, version int, activeIDs []string, pendingIDs []string) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
@@ -208,10 +157,42 @@ func (m *memMarker) SetActive(alert model.Fingerprint) {
 		s = &AlertStatus{}
 		m.m[alert] = s
 	}
+	s.SilencedBy = activeIDs
+	s.pendingSilences = pendingIDs
+	s.silencesVersion = version
 
-	s.State = AlertStateActive
-	s.SilencedBy = []string{}
-	s.InhibitedBy = []string{}
+	// If there are any silence or alert IDs associated with the
+	// fingerprint, it is suppressed. Otherwise, set it to
+	// AlertStateActive.
+	if len(activeIDs) == 0 && len(s.InhibitedBy) == 0 {
+		s.State = AlertStateActive
+		return
+	}
+
+	s.State = AlertStateSuppressed
+}
+
+// SetInhibited implements Marker.
+func (m *memMarker) SetInhibited(alert model.Fingerprint, ids ...string) {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	s, found := m.m[alert]
+	if !found {
+		s = &AlertStatus{}
+		m.m[alert] = s
+	}
+	s.InhibitedBy = ids
+
+	// If there are any silence or alert IDs associated with the
+	// fingerprint, it is suppressed. Otherwise, set it to
+	// AlertStateActive.
+	if len(ids) == 0 && len(s.SilencedBy) == 0 {
+		s.State = AlertStateActive
+		return
+	}
+
+	s.State = AlertStateSuppressed
 }
 
 // Status implements Marker.
@@ -219,15 +200,14 @@ func (m *memMarker) Status(alert model.Fingerprint) AlertStatus {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 
-	s, found := m.m[alert]
-	if !found {
-		s = &AlertStatus{
-			State:       AlertStateUnprocessed,
-			SilencedBy:  []string{},
-			InhibitedBy: []string{},
-		}
+	if s, found := m.m[alert]; found {
+		return *s
 	}
-	return *s
+	return AlertStatus{
+		State:       AlertStateUnprocessed,
+		SilencedBy:  []string{},
+		InhibitedBy: []string{},
+	}
 }
 
 // Delete implements Marker.
@@ -258,9 +238,9 @@ func (m *memMarker) Inhibited(alert model.Fingerprint) ([]string, bool) {
 // Silenced returns whether the alert for the given Fingerprint is in the
 // Silenced state, any associated silence IDs, and the silences state version
 // the result is based on.
-func (m *memMarker) Silenced(alert model.Fingerprint) ([]string, int, bool) {
+func (m *memMarker) Silenced(alert model.Fingerprint) (activeIDs []string, pendingIDs []string, version int, silenced bool) {
 	s := m.Status(alert)
-	return s.SilencedBy, s.silencesVersion,
+	return s.SilencedBy, s.pendingSilences, s.silencesVersion,
 		s.State == AlertStateSuppressed && len(s.SilencedBy) > 0
 }
 


### PR DESCRIPTION
Previously, if a pending silence existed for an alert, and it later
became active without any silences getting added in the meantime, we
would miss the existence of that newly active silence.

This is my attempt to fix #2426 (and possibly others). This is a late night hack, and we should also add a unit test to expose the behavior. But I thought I put this out so that you can stop me if I'm on the wrong track here.

See #2586 for @waitstory's earlier attempt, which made me aware of the issue in the first place.