### PR TITLE
Fix mashaling of URL, Regex wrappers with nil value, and empty Matchers.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -106,7 +106,7 @@ func (u URL) MarshalJSON() ([]byte, error) {
 	if u.URL != nil {
 		return json.Marshal(u.URL.String())
 	}
-	return nil, nil
+	return []byte("null"), nil
 }
 
 // UnmarshalJSON implements the json.Marshaler interface for URL.
@@ -867,7 +867,7 @@ func (re Regexp) MarshalJSON() ([]byte, error) {
 	if re.original != "" {
 		return json.Marshal(re.original)
 	}
-	return nil, nil
+	return []byte("null"), nil
 }
 
 // Matchers is label.Matchers with an added UnmarshalYAML method to implement the yaml.Unmarshaler interface
@@ -920,7 +920,7 @@ func (m *Matchers) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaler interface for Matchers.
 func (m Matchers) MarshalJSON() ([]byte, error) {
 	if len(m) == 0 {
-		return nil, nil
+		return []byte("[]"), nil
 	}
 	result := make([]string, len(m))
 	for i, matcher := range m {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,7 +25,6 @@ import (
 
 	commoncfg "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	yaml "gopkg.in/yaml.v2"
 )
@@ -567,11 +566,11 @@ func TestMarshalURL(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			j, err := json.Marshal(tc.input)
 			require.NoError(t, err)
-			assert.Equal(t, tc.expectedJSON, string(j), "URL not properly marshaled into JSON.")
+			require.Equal(t, tc.expectedJSON, string(j), "URL not properly marshaled into JSON.")
 
 			y, err := yaml.Marshal(tc.input)
 			require.NoError(t, err)
-			assert.Equal(t, tc.expectedYAML, string(y), "URL not properly marshaled into YAML.")
+			require.Equal(t, tc.expectedYAML, string(y), "URL not properly marshaled into YAML.")
 		})
 	}
 }


### PR DESCRIPTION
`MarshalJSON` method must return valid JSON or error.

This PR fixes JSON marshaling ~and unmarshalling~ of `config.URL` and `config.Regex` wrappers with `nil` values. Such values are now mashalled into `null` json literal ~, and can be unmarshalled properly as well. (Empty strings are also unmarshalled into wrappers with `nil` value).~

Also fixed JSON marshalling of empty `Matchers`.

I will send similar patch to `common` repository, which also has `config.URL`.

**Update: To avoid introducing breaking changes, I've removed changes to unmarshalling. Unit tests documenting current behaviour are left in place.**