### PR TITLE
OpsGenie: refer to alert instead of incident

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -761,14 +761,14 @@ OpsGenie notifications are sent via the [OpsGenie API](https://docs.opsgenie.com
 # Alert text limited to 130 characters.
 [ message: <tmpl_string> ]
 
-# A description of the incident.
+# A description of the alert.
 [ description: <tmpl_string> | default = '{{ template "opsgenie.default.description" . }}' ]
 
 # A backlink to the sender of the notification.
 [ source: <tmpl_string> | default = '{{ template "opsgenie.default.source" . }}' ]
 
 # A set of arbitrary key/value pairs that provide further detail
-# about the incident.
+# about the alert.
 # All common labels are included as details by default.
 [ details: { <string>: <tmpl_string>, ... } ]
 

--- a/notify/opsgenie/opsgenie.go
+++ b/notify/opsgenie/opsgenie.go
@@ -116,7 +116,7 @@ func (n *Notifier) createRequest(ctx context.Context, as ...*types.Alert) (*http
 	}
 	data := notify.GetTemplateData(ctx, n.tmpl, as, n.logger)
 
-	level.Debug(n.logger).Log("incident", key)
+	level.Debug(n.logger).Log("alert", key)
 
 	tmpl := notify.TmplText(n.tmpl, data, &err)
 
@@ -146,7 +146,7 @@ func (n *Notifier) createRequest(ctx context.Context, as ...*types.Alert) (*http
 	default:
 		message, truncated := notify.Truncate(tmpl(n.conf.Message), 130)
 		if truncated {
-			level.Debug(n.logger).Log("msg", "truncated message", "truncated_message", message, "incident", key)
+			level.Debug(n.logger).Log("msg", "truncated message", "truncated_message", message, "alert", key)
 		}
 
 		apiURL.Path += "v2/alerts"


### PR DESCRIPTION
* OpsGenie provides management of both alerts and incidents.
* package opsgenie uses OpsGenie alert api, so let's refer to
  alert instead of incident in logs and doc to avoid confusion.