### PR TITLE
Improve the AlertmanagerMembersInconsistent alert

### DIFF
--- a/doc/alertmanager-mixin/alerts.libsonnet
+++ b/doc/alertmanager-mixin/alerts.libsonnet
@@ -29,7 +29,7 @@
               < on (%(alertmanagerClusterLabels)s) group_left
                 count by (%(alertmanagerClusterLabels)s) (max_over_time(alertmanager_cluster_members{%(alertmanagerSelector)s}[5m]))
             ||| % $._config,
-            'for': '10m',
+            'for': '15m',
             labels: {
               severity: 'critical',
             },


### PR DESCRIPTION
The expression `alertmanager_cluster_members{job="alertmanager"}[5m])` is assumed to return
one series for each alertmanager instance in the cluster. When running inside Kubernetes,
alertmanager pods can get evicted and rescheduled. This can change the instance label and
produce a new series for that alertmanager instance.

When this happens, there will be a short interval in which Prometheus returns values from both
the new series and the old series. As a result, counting the number of
series for the `alertmanager_cluster_members` metric will overestimate the
number of instances in the given cluster.

This commit modifies the the AlertmanagerMembersInconsistent alert to group series by
`alertmanagerNameLabels` when calculating the number of alertmanagers in
the cluster.

Please refer to the following link for more information on how Prometheus deals with staleness: https://www.robustperception.io/staleness-and-promql

Signed-off-by: fpetkovski <filip.petkovsky@gmail.com>