### PR TITLE
Allow Reading Secrets from Files

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -397,8 +397,14 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			if ec.AuthPassword == "" {
 				ec.AuthPassword = c.Global.SMTPAuthPassword
 			}
+			if ec.AuthPasswordFile == "" {
+				ec.AuthPasswordFile = c.Global.SMTPAuthPasswordFile
+			}
 			if ec.AuthSecret == "" {
 				ec.AuthSecret = c.Global.SMTPAuthSecret
+			}
+			if ec.AuthSecretFile == "" {
+				ec.AuthSecretFile = c.Global.SMTPAuthSecretFile
 			}
 			if ec.AuthIdentity == "" {
 				ec.AuthIdentity = c.Global.SMTPAuthIdentity
@@ -450,10 +456,11 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 				ogc.APIURL.Path += "/"
 			}
 			if ogc.APIKey == "" {
-				if c.Global.OpsGenieAPIKey == "" {
+				if c.Global.OpsGenieAPIKey == "" && c.Global.OpsGenieAPIKeyFile == "" {
 					return fmt.Errorf("no global OpsGenie API Key set")
 				}
 				ogc.APIKey = c.Global.OpsGenieAPIKey
+				ogc.APIKeyFile = c.Global.OpsGenieAPIKeyFile
 			}
 		}
 		for _, wcc := range rcv.WechatConfigs {
@@ -469,10 +476,11 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			}
 
 			if wcc.APISecret == "" {
-				if c.Global.WeChatAPISecret == "" {
+				if c.Global.WeChatAPISecret == "" && c.Global.WeChatAPISecretFile == "" {
 					return fmt.Errorf("no global Wechat ApiSecret set")
 				}
 				wcc.APISecret = c.Global.WeChatAPISecret
+				wcc.APISecretFile = c.Global.WeChatAPISecretFile
 			}
 
 			if wcc.CorpID == "" {
@@ -500,10 +508,11 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 				voc.APIURL.Path += "/"
 			}
 			if voc.APIKey == "" {
-				if c.Global.VictorOpsAPIKey == "" {
+				if c.Global.VictorOpsAPIKey == "" && c.Global.VictorOpsAPIKeyFile == "" {
 					return fmt.Errorf("no global VictorOps API Key set")
 				}
 				voc.APIKey = c.Global.VictorOpsAPIKey
+				voc.APIKeyFile = c.Global.VictorOpsAPIKeyFile
 			}
 		}
 		names[rcv.Name] = struct{}{}

--- a/config/config.go
+++ b/config/config.go
@@ -50,7 +50,7 @@ func init() {
 // if the value is set, that gets returned, otherwise if the file path is set, we return the contents of the file
 // otherwise, we error
 func ResolveFileConfigSecret(configValue Secret, filePath string) (Secret, error) {
-	if configValue != "" {
+	if configValue != "" || filePath == "" {
 		return configValue, nil
 	}
 
@@ -66,7 +66,7 @@ func ResolveFileConfigSecret(configValue Secret, filePath string) (Secret, error
 // if the value is set, that gets returned, otherwise if the file path is set, we return the contents of the file
 // otherwise, we error
 func ResolveFileConfigSecretURL(configValue *SecretURL, filePath string) (*SecretURL, error) {
-	if configValue != nil {
+	if configValue != nil || filePath == "" {
 		return configValue, nil
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -901,6 +901,28 @@ func TestSMTPHello(t *testing.T) {
 	}
 }
 
+func TestSMTPBothPasswords(t *testing.T) {
+	_, err := LoadFile("testdata/conf.smtp.both_passwords_set.yml")
+	if err == nil {
+		t.Fatalf("Expected an error parsing %s: %s", "testdata/conf.smtp.both_passwords_set.yml", err)
+	}
+
+	if err.Error() != "at most one of smtp_auth_password & smtp_auth_password_file must be configured" {
+		t.Errorf("Expected: %s\nGot: %s", "at most one of smtp_auth_password & smtp_auth_password_file must be configured", err.Error())
+	}
+}
+
+func TestSMTPBothSecrets(t *testing.T) {
+	_, err := LoadFile("testdata/conf.smtp.both_secrets_set.yml")
+	if err == nil {
+		t.Fatalf("Expected an error parsing %s: %s", "testdata/conf.smtp.both_secrets_set.yml", err)
+	}
+
+	if err.Error() != "at most one of smtp_auth_secret & smtp_auth_secret_file must be configured" {
+		t.Errorf("Expected: %s\nGot: %s", "at most one of smtp_auth_secret & smtp_auth_secret_file must be configured", err.Error())
+	}
+}
+
 func TestGroupByAll(t *testing.T) {
 	c, err := LoadFile("testdata/conf.group-by-all.yml")
 	if err != nil {
@@ -937,6 +959,16 @@ func TestVictorOpsNoAPIKey(t *testing.T) {
 	}
 }
 
+func TestVictorOpsBothAPIKeysSet(t *testing.T) {
+	_, err := LoadFile("testdata/conf.victorops.both-apikeys-set.yml")
+	if err == nil {
+		t.Fatalf("Expected an error parsing %s: %s", "testdata/conf.victorops.both-apikeys-set.yml", err)
+	}
+	if err.Error() != "at most one of victorops_api_key & victorops_api_key_file must be configured" {
+		t.Errorf("Expected: %s\nGot: %s", "at most one of victorops_api_key & victorops_api_key_file must be configured", err.Error())
+	}
+}
+
 func TestOpsGenieDefaultAPIKey(t *testing.T) {
 	conf, err := LoadFile("testdata/conf.opsgenie-default-apikey.yml")
 	if err != nil {
@@ -959,6 +991,17 @@ func TestOpsGenieNoAPIKey(t *testing.T) {
 	}
 	if err.Error() != "no global OpsGenie API Key set" {
 		t.Errorf("Expected: %s\nGot: %s", "no global OpsGenie API Key set", err.Error())
+	}
+}
+
+func TestOpsGenieBothAPIKeys(t *testing.T) {
+	_, err := LoadFile("testdata/conf.opsgenie.both-apikeys-set.yml")
+	if err == nil {
+		t.Fatalf("Expected an error parsing %s: %s", "testdata/conf.opsgenie.both-apikeys-set.yml", err)
+	}
+
+	if err.Error() != "at most one of opsgenie_api_key & opsgenie_api_key_file must be configured" {
+		t.Errorf("Expected: %s\nGot: %s", "at most one of opsgenie_api_key & opsgenie_api_key_file must be configured", err.Error())
 	}
 }
 
@@ -1017,6 +1060,17 @@ func TestSlackGlobalAPIURLFile(t *testing.T) {
 	thirdConfig := conf.Receivers[0].SlackConfigs[2]
 	if thirdConfig.APIURL.String() != "http://mysecret.example.com/" || thirdConfig.APIURLFile != "" {
 		t.Fatalf("Invalid Slack URL: %s\nExpected: %s", thirdConfig.APIURL.String(), "http://mysecret.example.com/")
+	}
+}
+
+func TestWeChatBothAPISecretsSet(t *testing.T) {
+	_, err := LoadFile("testdata/conf.wechat.both-apisecrets-set.yml")
+	if err == nil {
+		t.Fatalf("Expected an error parsing %s: %s", "testdata/conf.wechat.both-apisecrets-set.yml", err)
+	}
+
+	if err.Error() != "at most one of wechat_api_secret & wechat_api_secret_file must be configured" {
+		t.Errorf("Expected: %s\nGot: %s", "at most one of wechat_api_secret & wechat_api_secret_file must be configured", err.Error())
 	}
 }
 

--- a/config/testdata/conf.opsgenie.both-apikeys-set.yml
+++ b/config/testdata/conf.opsgenie.both-apikeys-set.yml
@@ -1,0 +1,27 @@
+global:
+  opsgenie_api_key: asd132
+  opsgenie_api_key_file: test_file
+
+route:
+  group_by: ['alertname', 'cluster', 'service']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 3h
+  receiver: escalation-Y-opsgenie
+  routes:
+  - match:
+      service: foo
+    receiver: team-X-opsgenie
+
+receivers:
+- name: 'team-X-opsgenie'
+  opsgenie_configs:
+  - responders:
+    - name: 'team-X'
+      type: 'team'
+- name: 'escalation-Y-opsgenie'
+  opsgenie_configs:
+  - responders:
+    - name: 'escalation-Y'
+      type: 'escalation'
+    api_key: qwe456

--- a/config/testdata/conf.smtp.both_passwords_set.yml
+++ b/config/testdata/conf.smtp.both_passwords_set.yml
@@ -1,0 +1,14 @@
+global:
+  smtp_smarthost: localhost:25
+  smtp_from: alertmanager@example.com
+  smtp_auth_password: test
+  smtp_auth_password_file: test_file
+
+route:
+  receiver: 'team-X-mails'
+  group_by: [alertname, datacenter, app]
+
+receivers:
+  - name: 'team-X-mails'
+    email_configs:
+    - to: 'team-X+alerts@example.org'

--- a/config/testdata/conf.smtp.both_secrets_set.yml
+++ b/config/testdata/conf.smtp.both_secrets_set.yml
@@ -1,0 +1,14 @@
+global:
+  smtp_smarthost: localhost:25
+  smtp_from: alertmanager@example.com
+  smtp_auth_secret: test
+  smtp_auth_secret_file: test_file
+
+route:
+  receiver: 'team-X-mails'
+  group_by: [alertname, datacenter, app]
+
+receivers:
+  - name: 'team-X-mails'
+    email_configs:
+    - to: 'team-X+alerts@example.org'

--- a/config/testdata/conf.victorops.both-apikeys-set.yml
+++ b/config/testdata/conf.victorops.both-apikeys-set.yml
@@ -1,0 +1,19 @@
+global:
+  victorops_api_key: asd132
+  victorops_api_key_file: asd132
+
+route:
+  group_by: ['alertname', 'cluster', 'service']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 3h
+  receiver: team-X-victorops
+  routes:
+  - match:
+      service: foo
+    receiver: team-X-victorops
+
+receivers:
+- name: 'team-X-victorops'
+  victorops_configs:
+  - routing_key: 'team-X'

--- a/config/testdata/conf.wechat.both-apisecrets-set.yml
+++ b/config/testdata/conf.wechat.both-apisecrets-set.yml
@@ -1,0 +1,12 @@
+global:
+  wechat_api_secret: test
+  wechat_api_secret_file: testfile
+
+route:
+  receiver: 'team-X-mails'
+  group_by: [alertname, datacenter, app]
+
+receivers:
+  - name: 'team-X-mails'
+    email_configs:
+    - to: 'team-X+alerts@example.org'

--- a/notify/email/email_test.go
+++ b/notify/email/email_test.go
@@ -606,3 +606,41 @@ func TestEmailNoUsernameStillOk(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, a)
 }
+
+func TestEmailSecretFromFile(t *testing.T) {
+	f, err := ioutil.TempFile("", "email_test")
+	require.NoError(t, err, "creating temp file failed")
+	_, err = f.WriteString("test_password")
+
+	require.NoError(t, err, "writing to temp file failed")
+	email := &Email{
+		conf: &config.EmailConfig{
+			AuthSecretFile: f.Name(),
+		}, tmpl: &template.Template{}, logger: log.NewNopLogger(),
+	}
+
+	a, err := email.auth("CRAM-MD5")
+	require.NoError(t, err)
+	require.Nil(t, a)
+}
+
+func TestEmailPasswordFromFile(t *testing.T) {
+	f, err := ioutil.TempFile("", "email_test")
+	require.NoError(t, err, "creating temp file failed")
+	_, err = f.WriteString("test_password")
+	require.NoError(t, err, "writing to temp file failed")
+
+	email := &Email{
+		conf: &config.EmailConfig{
+			AuthSecretFile: f.Name(),
+		}, tmpl: &template.Template{}, logger: log.NewNopLogger(),
+	}
+
+	a, err := email.auth("PLAIN")
+	require.NoError(t, err)
+	require.Nil(t, a)
+
+	a, err = email.auth("LOGIN")
+	require.NoError(t, err)
+	require.Nil(t, a)
+}

--- a/notify/opsgenie/opsgenie.go
+++ b/notify/opsgenie/opsgenie.go
@@ -182,7 +182,12 @@ func (n *Notifier) createRequest(ctx context.Context, as ...*types.Alert) (*http
 		}
 	}
 
-	apiKey := tmpl(string(n.conf.APIKey))
+	apiKeyVal, fileErr := config.ResolveFileConfigSecret(n.conf.APIKey, n.conf.APIKeyFile)
+	if fileErr != nil {
+		return nil, false, errors.Wrap(fileErr, "templating error")
+	}
+
+	apiKey := tmpl(string(apiKeyVal))
 
 	if err != nil {
 		return nil, false, errors.Wrap(err, "templating error")

--- a/notify/opsgenie/opsgenie_test.go
+++ b/notify/opsgenie/opsgenie_test.go
@@ -69,6 +69,32 @@ func TestOpsGenieRedactedURL(t *testing.T) {
 	test.AssertNotifyLeaksNoSecret(t, ctx, notifier, key)
 }
 
+func TestOpsGenieAPIKeyFromFile(t *testing.T) {
+	f, err := ioutil.TempFile("", "opsgenie_test")
+	require.NoError(t, err, "creating temp file failed")
+	_, err = f.WriteString("test_password")
+	require.NoError(t, err, "writing to temp file failed")
+
+	ctx, u, fn := test.GetContextWithCancelingURL()
+	defer fn()
+
+	key := "key"
+	notifier, err := New(
+		&config.OpsGenieConfig{
+			APIURL:     &config.URL{URL: u},
+			APIKeyFile: f.Name(),
+			HTTPConfig: &commoncfg.HTTPClientConfig{},
+		},
+		test.CreateTmpl(t),
+		log.NewNopLogger(),
+	)
+	require.NoError(t, err)
+
+	// Call this just to call notify - we just care that Notify works, with
+	// the secret being read from a file
+	test.AssertNotifyLeaksNoSecret(t, ctx, notifier, key)
+}
+
 func TestOpsGenie(t *testing.T) {
 	u, err := url.Parse("https://opsgenie/api")
 	if err != nil {

--- a/notify/pushover/pushover.go
+++ b/notify/pushover/pushover.go
@@ -74,9 +74,19 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	tmpl := notify.TmplText(n.tmpl, data, &err)
 	tmplHTML := notify.TmplHTML(n.tmpl, data, &err)
 
+	token, fileErr := config.ResolveFileConfigSecret(n.conf.Token, n.conf.TokenFile)
+	if fileErr != nil {
+		return false, fileErr
+	}
+
+	userKey, fileErr := config.ResolveFileConfigSecret(n.conf.UserKey, n.conf.UserKeyFile)
+	if fileErr != nil {
+		return false, fileErr
+	}
+
 	parameters := url.Values{}
-	parameters.Add("token", tmpl(string(n.conf.Token)))
-	parameters.Add("user", tmpl(string(n.conf.UserKey)))
+	parameters.Add("token", tmpl(string(token)))
+	parameters.Add("user", tmpl(string(userKey)))
 
 	title, truncated := notify.Truncate(tmpl(n.conf.Title), 250)
 	if truncated {

--- a/notify/victorops/victorops.go
+++ b/notify/victorops/victorops.go
@@ -71,7 +71,13 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		tmpl   = notify.TmplText(n.tmpl, data, &err)
 		apiURL = n.conf.APIURL.Copy()
 	)
-	apiURL.Path += fmt.Sprintf("%s/%s", n.conf.APIKey, tmpl(n.conf.RoutingKey))
+
+	apiKey, fileErr := config.ResolveFileConfigSecret(n.conf.APIKey, n.conf.APIKeyFile)
+	if fileErr != nil {
+		return false, fmt.Errorf("templating error: %s", fileErr)
+	}
+
+	apiURL.Path += fmt.Sprintf("%s/%s", apiKey, tmpl(n.conf.RoutingKey))
 	if err != nil {
 		return false, fmt.Errorf("templating error: %s", err)
 	}

--- a/notify/wechat/wechat.go
+++ b/notify/wechat/wechat.go
@@ -98,7 +98,13 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	// Refresh AccessToken over 2 hours
 	if n.accessToken == "" || time.Since(n.accessTokenAt) > 2*time.Hour {
 		parameters := url.Values{}
-		parameters.Add("corpsecret", tmpl(string(n.conf.APISecret)))
+
+		secret, fileErr := config.ResolveFileConfigSecret(n.conf.APISecret, n.conf.APISecretFile)
+		if fileErr != nil {
+			return false, err
+		}
+
+		parameters.Add("corpsecret", tmpl(string(secret)))
 		parameters.Add("corpid", tmpl(string(n.conf.CorpID)))
 		if err != nil {
 			return false, fmt.Errorf("templating error: %s", err)


### PR DESCRIPTION
As discussed in #2498 , it would be nice to be able to read secrets from files. It's a rainy day here, so in this PR we introduce that support for all secrets in the global and individual notifier configs, based on the existing support for this in the SlackAPIKeyFile config var.

On a sort of personal node: This is useful for any alertmanager deployed in K8s as you can now use Kubernetes Secrets to manage individual config components rather than the whole config file

Comments/Criticism welcome - It's been a really interesting traipse around the codebase