### PR TITLE
Alert store not calling callback when an alert is deleted

### DIFF
--- a/provider/mem/mem.go
+++ b/provider/mem/mem.go
@@ -77,7 +77,7 @@ func NewAlerts(ctx context.Context, m types.Marker, intervalGC time.Duration, al
 		logger:    log.With(l, "component", "provider"),
 		callback:  alertCallback,
 	}
-	a.alerts.SetGCCallback(func(alerts []*types.Alert) {
+	a.alerts.SetResolvedCallback(func(alerts []*types.Alert) {
 		for _, alert := range alerts {
 			// As we don't persist alerts, we no longer consider them after
 			// they are resolved. Alerts waiting for resolved notifications are

--- a/store/store.go
+++ b/store/store.go
@@ -48,8 +48,9 @@ func NewAlerts() *Alerts {
 	return a
 }
 
-// SetGCCallback sets a GC callback to be executed after each GC.
-func (a *Alerts) SetGCCallback(cb func([]*types.Alert)) {
+// SetResolvedCallback sets a GC callback to be executed after each GC.
+// The callback receives resolved alerts as an argument.
+func (a *Alerts) SetResolvedCallback(cb func([]*types.Alert)) {
 	a.Lock()
 	defer a.Unlock()
 
@@ -111,7 +112,13 @@ func (a *Alerts) Delete(fp model.Fingerprint) error {
 	a.Lock()
 	defer a.Unlock()
 
+	alert, ok := a.c[fp]
+	if !ok {
+		return nil
+	}
+
 	delete(a.c, fp)
+	a.cb([]*types.Alert{alert})
 	return nil
 }
 


### PR DESCRIPTION
The garbage collection process within the store is in charge of
determining if an alert is resolved, deleting it, and then communicating
this back to the callback set.

When an alert was explicitly deleted, these were not being communicated
back to the callback and caused the metric to report incorrect results.

Fixes #2619