### PR TITLE
Allow reading Pagerduty secrets from files

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -46,6 +46,43 @@ func init() {
 	secretTokenJSON = string(b)
 }
 
+// ResolveFileConfig takes two values - a config value and a file path and resolves it to an absolute value
+// if the value is set, that gets returned, otherwise if the file path is set, we return the contents of the file
+// otherwise, we error
+func ResolveFileConfigSecret(configValue Secret, filePath string) (Secret, error) {
+	if configValue != "" || filePath == "" {
+		return configValue, nil
+	}
+
+	val, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return "", err
+	}
+
+	return Secret(val), nil
+}
+
+// ResolveFileConfigSecretURL takes two values - a config URL and a file path and resolves it to an absolute value
+// if the value is set, that gets returned, otherwise if the file path is set, we return the contents of the file
+// otherwise, we error
+func ResolveFileConfigSecretURL(configValue *SecretURL, filePath string) (*SecretURL, error) {
+	if configValue != nil || filePath == "" {
+		return configValue, nil
+	}
+
+	val, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	urlVal, err := url.Parse(string(val))
+	if err != nil {
+		return nil, err
+	}
+
+	return &SecretURL{urlVal}, nil
+}
+
 // Secret is a string that must not be revealed on marshaling.
 type Secret string
 

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -188,19 +188,21 @@ type PagerdutyConfig struct {
 
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
-	ServiceKey  Secret            `yaml:"service_key,omitempty" json:"service_key,omitempty"`
-	RoutingKey  Secret            `yaml:"routing_key,omitempty" json:"routing_key,omitempty"`
-	URL         *URL              `yaml:"url,omitempty" json:"url,omitempty"`
-	Client      string            `yaml:"client,omitempty" json:"client,omitempty"`
-	ClientURL   string            `yaml:"client_url,omitempty" json:"client_url,omitempty"`
-	Description string            `yaml:"description,omitempty" json:"description,omitempty"`
-	Details     map[string]string `yaml:"details,omitempty" json:"details,omitempty"`
-	Images      []PagerdutyImage  `yaml:"images,omitempty" json:"images,omitempty"`
-	Links       []PagerdutyLink   `yaml:"links,omitempty" json:"links,omitempty"`
-	Severity    string            `yaml:"severity,omitempty" json:"severity,omitempty"`
-	Class       string            `yaml:"class,omitempty" json:"class,omitempty"`
-	Component   string            `yaml:"component,omitempty" json:"component,omitempty"`
-	Group       string            `yaml:"group,omitempty" json:"group,omitempty"`
+	ServiceKey     Secret            `yaml:"service_key,omitempty" json:"service_key,omitempty"`
+	ServiceKeyFile string            `yaml:"service_key_file,omitempty" json:"service_key_file,omitempty"`
+	RoutingKey     Secret            `yaml:"routing_key,omitempty" json:"routing_key,omitempty"`
+	RoutingKeyFile string            `yaml:"routing_key_file,omitempty" json:"routing_key_file,omitempty"`
+	URL            *URL              `yaml:"url,omitempty" json:"url,omitempty"`
+	Client         string            `yaml:"client,omitempty" json:"client,omitempty"`
+	ClientURL      string            `yaml:"client_url,omitempty" json:"client_url,omitempty"`
+	Description    string            `yaml:"description,omitempty" json:"description,omitempty"`
+	Details        map[string]string `yaml:"details,omitempty" json:"details,omitempty"`
+	Images         []PagerdutyImage  `yaml:"images,omitempty" json:"images,omitempty"`
+	Links          []PagerdutyLink   `yaml:"links,omitempty" json:"links,omitempty"`
+	Severity       string            `yaml:"severity,omitempty" json:"severity,omitempty"`
+	Class          string            `yaml:"class,omitempty" json:"class,omitempty"`
+	Component      string            `yaml:"component,omitempty" json:"component,omitempty"`
+	Group          string            `yaml:"group,omitempty" json:"group,omitempty"`
 }
 
 // PagerdutyLink is a link
@@ -223,7 +225,16 @@ func (c *PagerdutyConfig) UnmarshalYAML(unmarshal func(interface{}) error) error
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
-	if c.RoutingKey == "" && c.ServiceKey == "" {
+
+	if len(c.RoutingKey) > 0 && len(c.RoutingKeyFile) > 0 {
+		return fmt.Errorf("at most one of routing_key & routing_key_file must be configured")
+	}
+
+	if len(c.ServiceKey) > 0 && len(c.ServiceKeyFile) > 0 {
+		return fmt.Errorf("at most one of service_key & service_key_file must be configured")
+	}
+
+	if c.RoutingKey == "" && c.ServiceKey == "" && c.RoutingKeyFile == "" && c.ServiceKeyFile == "" {
 		return fmt.Errorf("missing service or routing key in PagerDuty config")
 	}
 	if c.Details == nil {


### PR DESCRIPTION
This commit adds two optional config values to pagerduty routing
configurations - service_key_file and routing_key_file. These function
the same as their non _file variants (and infact only one can be
specified), but allows reading the value from a file instead of
embedding the secret in the config file itself

Signed-off-by: sinkingpoint <colin@quirl.co.nz>

c.c. @roidelapluie as discussed, this trims that PR down to just the Pagerduty stuff