### PR TITLE
fix: silence mismatch by empty label matcher

### DIFF
--- a/pkg/labels/matcher.go
+++ b/pkg/labels/matcher.go
@@ -178,6 +178,17 @@ func (ms Matchers) Less(i, j int) bool {
 // Matches checks whether all matchers are fulfilled against the given label set.
 func (ms Matchers) Matches(lset model.LabelSet) bool {
 	for _, m := range ms {
+		if !m.Matches(string(lset[model.LabelName(m.Name)])) {
+			return false
+		}
+	}
+	return true
+}
+
+// MatchesSilence checks matchers against the given label set used by silence situation
+// to avoid empty matcher mismatch
+func (ms Matchers) MatchesSilence(lset model.LabelSet) bool {
+	for _, m := range ms {
 		value, ok := lset[model.LabelName(m.Name)]
 		if !ok {
 			return false

--- a/pkg/labels/matcher.go
+++ b/pkg/labels/matcher.go
@@ -178,7 +178,11 @@ func (ms Matchers) Less(i, j int) bool {
 // Matches checks whether all matchers are fulfilled against the given label set.
 func (ms Matchers) Matches(lset model.LabelSet) bool {
 	for _, m := range ms {
-		if !m.Matches(string(lset[model.LabelName(m.Name)])) {
+		value, ok := lset[model.LabelName(m.Name)]
+		if !ok {
+			return false
+		}
+		if !m.Matches(string(value)) {
 			return false
 		}
 	}

--- a/silence/silence.go
+++ b/silence/silence.go
@@ -648,7 +648,7 @@ func QMatches(set model.LabelSet) QueryParam {
 			if err != nil {
 				return true, err
 			}
-			return m.Matches(set), nil
+			return m.MatchesSilence(set), nil
 		}
 		q.filters = append(q.filters, f)
 		return nil

--- a/silence/silence_test.go
+++ b/silence/silence_test.go
@@ -527,6 +527,24 @@ func TestQMatches(t *testing.T) {
 			},
 			drop: false,
 		},
+		{
+			sil: &pb.Silence{
+				Matchers: []*pb.Matcher{
+					{Name: "job", Pattern: "test", Type: pb.Matcher_EQUAL},
+					{Name: "foo", Pattern: "", Type: pb.Matcher_EQUAL},
+				},
+			},
+			drop: false,
+		},
+		{
+			sil: &pb.Silence{
+				Matchers: []*pb.Matcher{
+					{Name: "job", Pattern: "test", Type: pb.Matcher_REGEXP},
+					{Name: "foo", Pattern: "", Type: pb.Matcher_REGEXP},
+				},
+			},
+			drop: false,
+		},
 	}
 	for _, c := range cases {
 		drop, err := f(c.sil, &Silences{mc: matcherCache{}, st: state{}}, time.Time{})


### PR DESCRIPTION
If a label name does't exist in matchers, directly return false. 
otherwise, empty matcher might mismatch the label set

for example:
```
labelset := {foo="foo",bar="bar"} 
matchers := {foo="foo",baz=""}
```

matchers.Matches(labelset) == true
which is not expected.

this caused a mismatch problem in our production environment, all alerts had been silenced for about 2 hours until we found the reason: a silence that contains empty matcher

In my opinion, as empty matcher is necessary, a check before match could solve this problem 

appreciated for reviews and suggestions

Signed-off-by: wangyingtao <wangyingtao@bilibili.com>