### PR TITLE
Add ability to skip TLS verification for amtool

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,9 @@ output: extended
 
 # Set a default receiver
 receiver: team-X-pager
+
+# Skip TLS certificate verification
+skip.verify: true
 ```
 
 ### Routes

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ output: extended
 receiver: team-X-pager
 
 # Skip TLS certificate verification
-skip.verify: true
+tls.insecure.skip.verify: true
 ```
 
 ### Routes

--- a/README.md
+++ b/README.md
@@ -315,9 +315,6 @@ output: extended
 
 # Set a default receiver
 receiver: team-X-pager
-
-# Skip TLS certificate verification
-tls.insecure.skip.verify: true
 ```
 
 ### Routes

--- a/cli/root.go
+++ b/cli/root.go
@@ -81,7 +81,7 @@ func NewAlertmanagerClient(amURL *url.URL) *client.Alertmanager {
 
 	cr := clientruntime.New(address, path.Join(amURL.Path, defaultAmApiv2path), schemes)
 
-	if amURL.Scheme == "https" && skipVerify {
+	if skipVerify {
 		transport := http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}

--- a/cli/root.go
+++ b/cli/root.go
@@ -108,7 +108,7 @@ func Execute() {
 	app.Flag("alertmanager.url", "Alertmanager to talk to").URLVar(&alertmanagerURL)
 	app.Flag("output", "Output formatter (simple, extended, json)").Short('o').Default("simple").EnumVar(&output, "simple", "extended", "json")
 	app.Flag("timeout", "Timeout for the executed command").Default("30s").DurationVar(&timeout)
-	app.Flag("skip.verify", "Skip TLS certificate verification").BoolVar(&skipVerify)
+	app.Flag("tls.insecure.skip.verify", "Skip TLS certificate verification").BoolVar(&skipVerify)
 
 	app.Version(version.Print("amtool"))
 	app.GetFlag("help").Short('h')

--- a/cli/root.go
+++ b/cli/root.go
@@ -33,11 +33,11 @@ import (
 )
 
 var (
-	verbose         bool
-	alertmanagerURL *url.URL
-	output          string
-	timeout         time.Duration
-	skipVerify      bool
+	verbose               bool
+	alertmanagerURL       *url.URL
+	output                string
+	timeout               time.Duration
+	tlsInsecureSkipVerify bool
 
 	configFiles = []string{os.ExpandEnv("$HOME/.config/amtool/config.yml"), "/etc/amtool/config.yml"}
 	legacyFlags = map[string]string{"comment_required": "require-comment"}
@@ -81,7 +81,7 @@ func NewAlertmanagerClient(amURL *url.URL) *client.Alertmanager {
 
 	cr := clientruntime.New(address, path.Join(amURL.Path, defaultAmApiv2path), schemes)
 
-	if skipVerify {
+	if tlsInsecureSkipVerify {
 		transport := http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}
@@ -108,7 +108,7 @@ func Execute() {
 	app.Flag("alertmanager.url", "Alertmanager to talk to").URLVar(&alertmanagerURL)
 	app.Flag("output", "Output formatter (simple, extended, json)").Short('o').Default("simple").EnumVar(&output, "simple", "extended", "json")
 	app.Flag("timeout", "Timeout for the executed command").Default("30s").DurationVar(&timeout)
-	app.Flag("tls.insecure.skip.verify", "Skip TLS certificate verification").BoolVar(&skipVerify)
+	app.Flag("tls.insecure.skip.verify", "Skip TLS certificate verification").BoolVar(&tlsInsecureSkipVerify)
 
 	app.Version(version.Print("amtool"))
 	app.GetFlag("help").Short('h')
@@ -163,7 +163,7 @@ static configuration:
 	date.format
 		Sets the output format for dates. Defaults to "2006-01-02 15:04:05 MST"
 
-	skip.verify
+	tls.insecure.skip.verify
 		Skips TLS certificate verification for all HTTPS requests.
 		Defaults to false.
 `


### PR DESCRIPTION
Just like with prometheus or alertmanager endpoints, we sometimes need to disable TLS certificate check. We can do that providing `<tls_config>` section there.  
amtool is a simpler thing but it does provide us some basic features like providing custom port and performing basic auth. I think skipping tls verification will fit in here too.