### PR TITLE
Docs: target_match and source_match are DEPRECATED

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,9 @@ route:
 # We use this to mute any warning-level notifications if the same alert is
 # already critical.
 inhibit_rules:
-- source_match:
+- source_matchers:
     severity: 'critical'
-  target_match:
+  target_matchers:
     severity: 'warning'
   # Apply inhibition if the alertname is the same.
   # CAUTION: 

--- a/README.md
+++ b/README.md
@@ -149,10 +149,10 @@ route:
 # We use this to mute any warning-level notifications if the same alert is
 # already critical.
 inhibit_rules:
-- source_matchers:
-    severity: 'critical'
+- source_matchers: 
+    - severity="critical"
   target_matchers:
-    severity: 'warning'
+    - severity="warning"
   # Apply inhibition if the alertname is the same.
   # CAUTION: 
   #   If all label names listed in `equal` are missing 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ route:
 # We use this to mute any warning-level notifications if the same alert is
 # already critical.
 inhibit_rules:
-- source_matchers: 
+- source_matchers:
     - severity="critical"
   target_matchers:
     - severity="warning"


### PR DESCRIPTION
Via original docs https://prometheus.io/docs/alerting/latest/configuration/#inhibit_rule