### PR TITLE
Fix empty isEqual in amtool.

### DIFF
--- a/cli/format/format.go
+++ b/cli/format/format.go
@@ -52,6 +52,11 @@ func FormatDate(input strfmt.DateTime) string {
 
 func labelsMatcher(m models.Matcher) *labels.Matcher {
 	var t labels.MatchType
+	// Support for older alertmanager releases, which did not support isEqual.
+	if m.IsEqual == nil {
+		isEqual := true
+		m.IsEqual = &isEqual
+	}
 	switch {
 	case !*m.IsRegex && *m.IsEqual:
 		t = labels.MatchEqual


### PR DESCRIPTION
This is the best we can do to make amtool support old releases.

Supersedes #2634
Fix #2666

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>