### PR TITLE
amtool: Detect version drift and warn users

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -40,6 +40,7 @@ var (
 	output                string
 	timeout               time.Duration
 	tlsInsecureSkipVerify bool
+	versionCheck          bool
 
 	configFiles = []string{os.ExpandEnv("$HOME/.config/amtool/config.yml"), "/etc/amtool/config.yml"}
 	legacyFlags = map[string]string{"comment_required": "require-comment"}
@@ -97,6 +98,10 @@ func NewAlertmanagerClient(amURL *url.URL) *client.Alertmanager {
 
 	c := client.New(cr, strfmt.Default)
 
+	if !versionCheck {
+		return c
+	}
+
 	status, err := c.General.GetStatus(nil)
 	if err != nil || status.Payload.VersionInfo == nil || version.Version == "" {
 		// We can not get version info, or we do not know our own version. Let amtool continue.
@@ -123,6 +128,7 @@ func Execute() {
 	app.Flag("output", "Output formatter (simple, extended, json)").Short('o').Default("simple").EnumVar(&output, "simple", "extended", "json")
 	app.Flag("timeout", "Timeout for the executed command").Default("30s").DurationVar(&timeout)
 	app.Flag("tls.insecure.skip.verify", "Skip TLS certificate verification").BoolVar(&tlsInsecureSkipVerify)
+	app.Flag("version-check", "Check alertmanager version. Use --no-version-check to disable.").Default("true").BoolVar(&versionCheck)
 
 	app.Version(version.Print("amtool"))
 	app.GetFlag("help").Short('h')

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/xlab/treeprint v1.1.0
 	go.uber.org/atomic v1.9.0
+	golang.org/x/mod v0.4.2
 	golang.org/x/net v0.0.0-20210726213435-c6fcb2dbf985
 	golang.org/x/tools v0.1.5
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6


### PR DESCRIPTION
This change detects the alertmanager version when initiating the client.
It ignores most errors since I expect amtool to fail later.

If amtool is not compiled with proper version, we do not do anything
either.

We use MajorMinor for now as we have not reach 1.0, but we still allow
the bugfix version number (Z in x.y.Z) to differ.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>