### PR TITLE
Enable support for custom callbacks as part of maintenance

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -267,7 +267,7 @@ func run() int {
 	notificationLogOpts := []nflog.Option{
 		nflog.WithRetention(*retention),
 		nflog.WithSnapshot(filepath.Join(*dataDir, "nflog")),
-		nflog.WithMaintenance(15*time.Minute, stopc, wg.Done),
+		nflog.WithMaintenance(15*time.Minute, stopc, wg.Done, nil),
 		nflog.WithMetrics(prometheus.DefaultRegisterer),
 		nflog.WithLogger(log.With(logger, "component", "nflog")),
 	}
@@ -304,7 +304,7 @@ func run() int {
 	// Start providers before router potentially sends updates.
 	wg.Add(1)
 	go func() {
-		silences.Maintenance(15*time.Minute, filepath.Join(*dataDir, "silences"), stopc)
+		silences.Maintenance(15*time.Minute, filepath.Join(*dataDir, "silences"), stopc, nil)
 		wg.Done()
 	}()
 

--- a/nflog/nflog.go
+++ b/nflog/nflog.go
@@ -93,7 +93,7 @@ type Log struct {
 
 // MaintenanceFunc represents the function to run as part of the periodic maintenance for the nflog.
 // It returns the size of the snapshot taken or an error if it failed.
-type MaintenanceFunc func()(int64, error)
+type MaintenanceFunc func() (int64, error)
 
 type metrics struct {
 	gcDuration              prometheus.Summary

--- a/nflog/nflog.go
+++ b/nflog/nflog.go
@@ -360,7 +360,6 @@ func (l *Log) run() {
 		level.Debug(l.logger).Log("msg", "Maintenance done", "duration", l.now().Sub(start), "size", size)
 		l.metrics.snapshotSize.Set(float64(size))
 		return err
-
 	}
 
 Loop:

--- a/nflog/nflog.go
+++ b/nflog/nflog.go
@@ -85,11 +85,15 @@ type Log struct {
 
 	// For now we only store the most recently added log entry.
 	// The key is a serialized concatenation of group key and receiver.
-	mtx       sync.RWMutex
-	st        state
-	broadcast func([]byte)
-	mf        func() (int64, error)
+	mtx                 sync.RWMutex
+	st                  state
+	broadcast           func([]byte)
+	maintenanceOverride MaintenanceFunc
 }
+
+// MaintenanceFunc represents the function to run as part of the periodic maintenance for the nflog.
+// It returns the size of the snapshot taken or an error if it failed.
+type MaintenanceFunc func()(int64, error)
 
 type metrics struct {
 	gcDuration              prometheus.Summary
@@ -191,7 +195,8 @@ func WithMetrics(r prometheus.Registerer) Option {
 //
 // The maintenance terminates on receiving from the provided channel.
 // The done function is called after the final snapshot was completed.
-func WithMaintenance(d time.Duration, stopc chan struct{}, done func(), mf func() (int64, error)) Option {
+// If not nil, the last argument is an override for what to do as part of the maintenance - for advanced usage.
+func WithMaintenance(d time.Duration, stopc chan struct{}, done func(), maintenanceOverride MaintenanceFunc) Option {
 	return func(l *Log) error {
 		if d == 0 {
 			return errors.New("maintenance interval must not be 0")
@@ -199,7 +204,7 @@ func WithMaintenance(d time.Duration, stopc chan struct{}, done func(), mf func(
 		l.runInterval = d
 		l.stopc = stopc
 		l.done = done
-		l.mf = mf
+		l.maintenanceOverride = maintenanceOverride
 		return nil
 	}
 }
@@ -327,7 +332,8 @@ func (l *Log) run() {
 	t := time.NewTicker(l.runInterval)
 	defer t.Stop()
 
-	inner := func() (int64, error) {
+	var doMaintenance MaintenanceFunc
+	doMaintenance = func() (int64, error) {
 		var size int64
 		if _, err := l.GC(); err != nil {
 			return size, err
@@ -345,18 +351,18 @@ func (l *Log) run() {
 		return size, f.Close()
 	}
 
-	if l.mf != nil {
-		inner = l.mf
+	if l.maintenanceOverride != nil {
+		doMaintenance = l.maintenanceOverride
 	}
 
 	if l.done != nil {
 		defer l.done()
 	}
 
-	f := func(cb func() (int64, error)) error {
+	runMaintenance := func(do func() (int64, error)) error {
 		start := l.now()
 		level.Debug(l.logger).Log("msg", "Running maintenance")
-		size, err := cb()
+		size, err := do()
 		level.Debug(l.logger).Log("msg", "Maintenance done", "duration", l.now().Sub(start), "size", size)
 		l.metrics.snapshotSize.Set(float64(size))
 		return err
@@ -368,7 +374,7 @@ Loop:
 		case <-l.stopc:
 			break Loop
 		case <-t.C:
-			if err := f(inner); err != nil {
+			if err := runMaintenance(doMaintenance); err != nil {
 				level.Error(l.logger).Log("msg", "Running maintenance failed", "err", err)
 			}
 		}
@@ -377,7 +383,7 @@ Loop:
 	if l.snapf == "" {
 		return
 	}
-	if err := f(inner); err != nil {
+	if err := runMaintenance(doMaintenance); err != nil {
 		level.Error(l.logger).Log("msg", "Creating shutdown snapshot failed", "err", err)
 	}
 }

--- a/nflog/nflog_test.go
+++ b/nflog/nflog_test.go
@@ -15,7 +15,6 @@ package nflog
 
 import (
 	"bytes"
-	"github.com/prometheus/client_golang/prometheus"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -24,6 +23,8 @@ import (
 	"time"
 
 	pb "github.com/prometheus/alertmanager/nflog/nflogpb"
+
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 )
 

--- a/nflog/nflog_test.go
+++ b/nflog/nflog_test.go
@@ -135,7 +135,7 @@ func TestWithMaintenance_SupportsCustomCallback(t *testing.T) {
 	l, err := New(WithMetrics(prometheus.NewPedanticRegistry()), WithSnapshot(f.Name()), WithMaintenance(100*time.Millisecond, stopc, nil, func() (int64, error) {
 		mtx.Lock()
 		mc++
-		defer mtx.Unlock()
+		mtx.Unlock()
 
 		return 0, nil
 	}))

--- a/silence/silence.go
+++ b/silence/silence.go
@@ -201,10 +201,9 @@ type Silences struct {
 	mc        matcherCache
 }
 
-
 // MaintenanceFunc represents the function to run as part of the periodic maintenance for silences.
 // It returns the size of the snapshot taken or an error if it failed.
-type MaintenanceFunc func()(int64, error)
+type MaintenanceFunc func() (int64, error)
 
 type metrics struct {
 	gcDuration              prometheus.Summary

--- a/silence/silence_test.go
+++ b/silence/silence_test.go
@@ -19,6 +19,7 @@ import (
 	"io/ioutil"
 	"os"
 	"sort"
+	"sync"
 	"testing"
 	"time"
 
@@ -177,6 +178,32 @@ func TestSilencesSnapshot(t *testing.T) {
 
 		require.NoError(t, f.Close(), "closing snapshot file failed")
 	}
+}
+
+func TestSilences_Maintenance_SupportsCustomCallback(t *testing.T) {
+	f, err := ioutil.TempFile("", "snapshot")
+	require.NoError(t, err, "creating temp file failed")
+	s := &Silences{st: state{}, logger: log.NewNopLogger(), now: utcNow, metrics: newMetrics(nil, nil)}
+	stopc := make(chan struct{})
+	var mtx sync.Mutex
+	var mc int
+
+	go s.Maintenance(100*time.Millisecond, f.Name(), stopc, func() (int64, error) {
+		mtx.Lock()
+		mc++
+		mtx.Unlock()
+
+		return 0, nil
+	})
+
+	time.Sleep(200 * time.Millisecond)
+	close(stopc)
+
+	require.Eventually(t, func() bool {
+		mtx.Lock()
+		defer mtx.Unlock()
+		return mc >= 2 // At least, one for the regular schedule and one at shutdown.
+	}, 500*time.Millisecond, 100*time.Millisecond)
 }
 
 func TestSilencesSetSilence(t *testing.T) {


### PR DESCRIPTION
This enables support for custom Maintenance callbacks as part of the periodic maintenance of silences and notification logs.
Effectively a no-op for the Alertmanager but allows a downstream implementation to inject custom logic as part of it.

- [x] Does this requires a changelog? Given it's a no-op for anything alertmanager related.