### PR TITLE
Correctly call default silence maintenance function

### DIFF
--- a/silence/silence.go
+++ b/silence/silence.go
@@ -378,7 +378,7 @@ func (s *Silences) Maintenance(interval time.Duration, snapf string, stopc <-cha
 		return size, f.Close()
 	}
 
-	if doMaintenance != nil {
+	if override != nil {
 		doMaintenance = override
 	}
 


### PR DESCRIPTION
https://github.com/prometheus/alertmanager/pull/2689 introduced a
regression where the default maintenance function would no longer be
called even if no override was specified. The Alertmanager now crashes
on any silence maintenance run without this fix.

Signed-off-by: Julius Volz <julius.volz@gmail.com>