### PR TITLE
Update xxhash to v2.1.1 and improve pooling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/alecthomas/units v0.0.0-20210208195552-ff826a37aa15
 	github.com/aws/aws-sdk-go v1.40.11
 	github.com/cenkalti/backoff/v4 v4.1.1
-	github.com/cespare/xxhash v1.1.0
+	github.com/cespare/xxhash/v2 v2.1.1
 	github.com/go-kit/log v0.1.0
 	github.com/go-openapi/errors v0.20.0
 	github.com/go-openapi/loads v0.20.2

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,6 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
-github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
@@ -71,8 +69,6 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/cenkalti/backoff/v4 v4.1.1 h1:G2HAfAmvm/GcKan2oOQpBXOd2tT2G57ZnZGWa1PxPBQ=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
-github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
@@ -447,8 +443,6 @@ github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPx
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
-github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
-github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
-	"github.com/cespare/xxhash"
+	"github.com/cespare/xxhash/v2"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -511,27 +511,21 @@ func utcNow() time.Time {
 	return time.Now().UTC()
 }
 
-var hashBuffers = sync.Pool{}
-
-func getHashBuffer() []byte {
-	b := hashBuffers.Get()
-	if b == nil {
-		return make([]byte, 0, 1024)
-	}
-	return b.([]byte)
+// Wrap a slice in a struct so we can store a pointer in sync.Pool
+type hashBuffer struct {
+	buf []byte
 }
 
-func putHashBuffer(b []byte) {
-	b = b[:0]
-	//nolint:staticcheck // Ignore SA6002 relax staticcheck verification.
-	hashBuffers.Put(b)
+var hashBuffers = sync.Pool{
+	New: func() interface{} { return &hashBuffer{buf: make([]byte, 0, 1024)} },
 }
 
 func hashAlert(a *types.Alert) uint64 {
 	const sep = '\xff'
 
-	b := getHashBuffer()
-	defer putHashBuffer(b)
+	hb := hashBuffers.Get().(*hashBuffer)
+	defer hashBuffers.Put(hb)
+	b := hb.buf[:0]
 
 	names := make(model.LabelNames, 0, len(a.Labels))
 

--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -817,3 +817,14 @@ func TestTimeMuteStage(t *testing.T) {
 		t.Fatalf("Expected %d alerts after time mute stage but got %d", nonMuteCount, len(outAlerts))
 	}
 }
+
+func BenchmarkHashAlert(b *testing.B) {
+	alert := &types.Alert{
+		Alert: model.Alert{
+			Labels: model.LabelSet{"foo": "the_first_value", "bar": "the_second_value", "another": "value"},
+		},
+	}
+	for i := 0; i < b.N; i++ {
+		hashAlert(alert)
+	}
+}


### PR DESCRIPTION
I started on this because I didn't like to see my program linking two versions of xxhash.
The way it's used in Alertmanager it makes no practical difference; I just wanted to tidy up.

Then, while I was looking at it, I decided the buffer pooling could be made more idiomatic.
By putting pointer-valued objects into the pool we avoid boxing a slice value; this saves one memory allocation every time.

I added a benchmark to illustrate:
```
name         old time/op    new time/op    delta
HashAlert-4     529ns ± 1%     490ns ± 2%   -7.29%  (p=0.008 n=5+5)

name         old alloc/op   new alloc/op   delta
HashAlert-4     96.0B ± 0%     72.0B ± 0%  -25.00%  (p=0.008 n=5+5)

name         old allocs/op  new allocs/op  delta
HashAlert-4      3.00 ± 0%      2.00 ± 0%  -33.33%  (p=0.008 n=5+5)
```

(I also tried re-coding using `xxhash.New()`, but that is slower, probably because it uses the Go implementation and not the assembly one).