### PR TITLE
Allow filtering silences by createdBy author

### DIFF
--- a/cli/silence_query.go
+++ b/cli/silence_query.go
@@ -28,10 +28,11 @@ import (
 )
 
 type silenceQueryCmd struct {
-	expired  bool
-	quiet    bool
-	matchers []string
-	within   time.Duration
+	expired   bool
+	quiet     bool
+	createdBy string
+	matchers  []string
+	within    time.Duration
 }
 
 const querySilenceHelp = `Query Alertmanager silences.
@@ -84,6 +85,7 @@ func configureSilenceQueryCmd(cc *kingpin.CmdClause) {
 
 	queryCmd.Flag("expired", "Show expired silences instead of active").BoolVar(&c.expired)
 	queryCmd.Flag("quiet", "Only show silence ids").Short('q').BoolVar(&c.quiet)
+	queryCmd.Flag("created-by", "Show silences that belong to this creator").StringVar(&c.createdBy)
 	queryCmd.Arg("matcher-groups", "Query filter").StringsVar(&c.matchers)
 	queryCmd.Flag("within", "Show silences that will expire or have expired within a duration").DurationVar(&c.within)
 	queryCmd.Action(execWithTimeout(c.query))
@@ -125,6 +127,10 @@ func (c *silenceQueryCmd) query(ctx context.Context, _ *kingpin.ParseContext) er
 		}
 		// skip silences that expired before "--within"
 		if c.expired && int64(c.within) > 0 && time.Time(*silence.EndsAt).Before(time.Now().UTC().Add(-c.within)) {
+			continue
+		}
+		// Skip silences if the author doesn't match.
+		if c.createdBy != "" && *silence.CreatedBy != c.createdBy {
 			continue
 		}
 


### PR DESCRIPTION
This PR adds a `--created-by` argument to the `amtool silence query` command so that silences can be filtered by the author they were created with in `amtool silence add --author=<name>`.

Fixes https://github.com/prometheus/alertmanager/issues/2410, fixes https://github.com/prometheus/alertmanager/issues/2476.