### PR TITLE
docs: Fix default value of send_resolved for sns_configs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -696,7 +696,7 @@ value: <tmpl_string>
 ## `<sns_configs>`
 ```yaml
 # Whether or not to notify about resolved alerts.
-[ send_resolved: <boolean> | default = false ]
+[ send_resolved: <boolean> | default = true ]
 
 # The SNS API URL i.e. https://sns.us-east-2.amazonaws.com.
 #  If not specified, the SNS API URL from the SNS SDK will be used.


### PR DESCRIPTION
Docs says the default value of `send_resolved` of `sns_configs`, introduced at https://github.com/prometheus/alertmanager/pull/2615, is `false`. On the other hand, implementation says it's `true`.

https://github.com/prometheus/alertmanager/blob/e35efbddb66a73fd8723be5334477e76f21fbd19/config/notifiers.go#L133-L136

Personally I prefer it's `false`, but this feature has been already released. So I leave the value as it is and fix the docs.
