### PR TITLE
amtool: Fix behavior of adding silence with duration option

### DIFF
--- a/cli/silence_add.go
+++ b/cli/silence_add.go
@@ -108,6 +108,17 @@ func (c *silenceAddCmd) add(ctx context.Context, _ *kingpin.ParseContext) error 
 		return fmt.Errorf("no matchers specified")
 	}
 
+	var startsAt time.Time
+	if c.start != "" {
+		startsAt, err = time.Parse(time.RFC3339, c.start)
+		if err != nil {
+			return err
+		}
+
+	} else {
+		startsAt = time.Now().UTC()
+	}
+
 	var endsAt time.Time
 	if c.end != "" {
 		endsAt, err = time.Parse(time.RFC3339, c.end)
@@ -122,26 +133,15 @@ func (c *silenceAddCmd) add(ctx context.Context, _ *kingpin.ParseContext) error 
 		if d == 0 {
 			return fmt.Errorf("silence duration must be greater than 0")
 		}
-		endsAt = time.Now().UTC().Add(time.Duration(d))
-	}
-
-	if c.requireComment && c.comment == "" {
-		return errors.New("comment required by config")
-	}
-
-	var startsAt time.Time
-	if c.start != "" {
-		startsAt, err = time.Parse(time.RFC3339, c.start)
-		if err != nil {
-			return err
-		}
-
-	} else {
-		startsAt = time.Now().UTC()
+		endsAt = startsAt.UTC().Add(time.Duration(d))
 	}
 
 	if startsAt.After(endsAt) {
 		return errors.New("silence cannot start after it ends")
+	}
+
+	if c.requireComment && c.comment == "" {
+		return errors.New("comment required by config")
 	}
 
 	start := strfmt.DateTime(startsAt)


### PR DESCRIPTION
Closes #2490, also closes #2740.

`amtool` treats `--duration` option differently between `amtool silence add` and `amtool silence update`; `amtool silence add` calculates `endsAt` as `time.Now()` + `duration`, while `amtool silence update` calculates `endsAt` as `startsAt` + `duration`.

According to <https://github.com/prometheus/alertmanager/pull/1298#discussion_r177469894>, it seems that `startsAt` + `duration` is preferable. That also resolves the confusion such as #2490 and #2740.

So I changed behavior of `--duration` option of `amtool silence add`. Note that this is a breaking change.

Local test:

```console
$ # This raises an error "silence cannot start after it ends" using amtool 0.23.0.
$ ./amtool silence add alertname=testing --start=2022-01-01T00:00:00Z --duration=30m --comment=testing --alertmanager.url=http://localhost:9093
aa6c19aa-3a14-4760-9075-d726c8bd9cb9
$ ./amtool silence --alertmanager.url=http://localhost:9093
ID                                    Matchers             Ends At                  Created By  Comment  
aa6c19aa-3a14-4760-9075-d726c8bd9cb9  alertname="testing"  2022-01-01 00:30:00 UTC  nek         testing  
```

It may be better to add tests for these CLI options. Adding tests, however, will be a little large change to `cli` package because almost all functions of `cli` package are not exported. So I skipped adding tests in this patch.

Signed-off-by: nekketsuuu \<nekketsuuu@users.noreply.github.com\>