### PR TITLE
chore: Let git ignore temporary files for ui/app

### DIFF
--- a/ui/app/.gitignore
+++ b/ui/app/.gitignore
@@ -2,3 +2,5 @@ dist/
 elm-stuff/
 script.js
 .elm
+/elm-*
+/openapi-*


### PR DESCRIPTION
A command `make ui/app/script.js` sometimes generates temporary files and does not remove them correctly. This is because the following line is evaluated by Make even if `script.js` was already generated.

https://github.com/prometheus/alertmanager/blob/1b8afe7cb5aafe59442e35979ec57401145ea26b/ui/app/Makefile#L45

It is difficult to remove these files perfectly because BSD mktemp(1) may create multiple files before returning a file name.

https://www.freebsd.org/cgi/man.cgi?query=mktemp&sektion=1

> Any number	of temporary files may be created in a single invocation, including one based on the internal template	resulting from the `-t` flag.

So I just ignore them by `.gitignore`.

(Note that they are removed when running `make clean`: <https://github.com/prometheus/alertmanager/blob/1b8afe7cb5aafe59442e35979ec57401145ea26b/ui/app/Makefile#L69>)

Signed-off-by: nekketsuuu <nekketsuuu@users.noreply.github.com>