### PR TITLE
Document that matchers are ANDed together

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -162,7 +162,7 @@ match:
 match_re:
   [ <labelname>: <regex>, ... ]
 
-# A list of matchers (ANDed together) that an alert has to fulfill to match the node.
+# A list of matchers that an alert has to fulfill to match the node.
 matchers:
   [ - <matcher> ... ]
 
@@ -310,7 +310,7 @@ target_match:
 target_match_re:
   [ <labelname>: <regex>, ... ]
 
-# A list of matchers (ANDed together) that have to be fulfilled by the target
+# A list of matchers that have to be fulfilled by the target
 # alerts to be muted.
 target_matchers:
   [ - <matcher> ... ]
@@ -324,7 +324,7 @@ source_match:
 source_match_re:
   [ <labelname>: <regex>, ... ]
 
-# A list of matchers (ANDed together) for which one or more alerts have
+# A list of matchers for which one or more alerts have
 # to exist for the inhibition to take effect.
 source_matchers:
   [ - <matcher> ... ]


### PR DESCRIPTION
When trying to create more complex matchers, I wasn't sure whether the alert's labels had to match all matchers (AND) or just one (OR) in order to be sent. Looks like the source code indicates matchers are always ANDed together anywhere the `Matchers` type is used: https://github.com/prometheus/alertmanager/blob/fd0929ba9fc58737a9c91f24771862692fa72d17/pkg/labels/matcher.go#L179-L185

Also I see my editor trimmed trailing whitespace. I figure that's desirable, but I can undo it if need-be.

It does feel like "ANDed" is a weird word, but I guess it's somewhat common: https://english.stackexchange.com/a/79744

If there's a less obscure way to describe logical AND, I'm open to changing it.