### PR TITLE
Remove v1 client lib

### DIFF
--- a/test/with_api_v1/acceptance.go
+++ b/test/with_api_v1/acceptance.go
@@ -31,8 +31,6 @@ import (
 
 	"github.com/prometheus/client_golang/api"
 	"github.com/prometheus/common/model"
-
-	"github.com/prometheus/alertmanager/client"
 )
 
 // AcceptanceTest provides declarative definition of given inputs and expected
@@ -335,26 +333,26 @@ func (am *Alertmanager) cleanup() {
 // Push declares alerts that are to be pushed to the Alertmanager
 // server at a relative point in time.
 func (am *Alertmanager) Push(at float64, alerts ...*TestAlert) {
-	var cas []client.Alert
+	var cas []APIV1Alert
 	for i := range alerts {
 		a := alerts[i].nativeAlert(am.opts)
-		al := client.Alert{
-			Labels:       client.LabelSet{},
-			Annotations:  client.LabelSet{},
+		al := APIV1Alert{
+			Labels:       LabelSet{},
+			Annotations:  LabelSet{},
 			StartsAt:     a.StartsAt,
 			EndsAt:       a.EndsAt,
 			GeneratorURL: a.GeneratorURL,
 		}
 		for n, v := range a.Labels {
-			al.Labels[client.LabelName(n)] = client.LabelValue(v)
+			al.Labels[LabelName(n)] = LabelValue(v)
 		}
 		for n, v := range a.Annotations {
-			al.Annotations[client.LabelName(n)] = client.LabelValue(v)
+			al.Annotations[LabelName(n)] = LabelValue(v)
 		}
 		cas = append(cas, al)
 	}
 
-	alertAPI := client.NewAlertAPI(am.client)
+	alertAPI := NewAlertAPI(am.client)
 
 	am.t.Do(at, func() {
 		if err := alertAPI.Push(context.Background(), cas...); err != nil {

--- a/test/with_api_v1/helper.go
+++ b/test/with_api_v1/helper.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package client
+package test
 
 import (
 	"bytes"
@@ -158,11 +158,11 @@ type AlertAPI interface {
 	// List returns all the active alerts.
 	List(ctx context.Context, filter, receiver string, silenced, inhibited, active, unprocessed bool) ([]*ExtendedAlert, error)
 	// Push sends a list of alerts to the Alertmanager.
-	Push(ctx context.Context, alerts ...Alert) error
+	Push(ctx context.Context, alerts ...APIV1Alert) error
 }
 
-// Alert represents an alert as expected by the AlertManager's push alert API.
-type Alert struct {
+// APIV1Alert represents an alert as expected by the AlertManager's push alert API.
+type APIV1Alert struct {
 	Labels       LabelSet  `json:"labels"`
 	Annotations  LabelSet  `json:"annotations"`
 	StartsAt     time.Time `json:"startsAt,omitempty"`
@@ -172,7 +172,7 @@ type Alert struct {
 
 // ExtendedAlert represents an alert as returned by the AlertManager's list alert API.
 type ExtendedAlert struct {
-	Alert
+	APIV1Alert
 	Status      types.AlertStatus `json:"status"`
 	Receivers   []string          `json:"receivers"`
 	Fingerprint string            `json:"fingerprint"`
@@ -225,7 +225,7 @@ func (h *httpAlertAPI) List(ctx context.Context, filter, receiver string, silenc
 	return alts, err
 }
 
-func (h *httpAlertAPI) Push(ctx context.Context, alerts ...Alert) error {
+func (h *httpAlertAPI) Push(ctx context.Context, alerts ...APIV1Alert) error {
 	u := h.client.URL(epAlerts, nil)
 
 	var buf bytes.Buffer

--- a/test/with_api_v1/helper_test.go
+++ b/test/with_api_v1/helper_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package client
+package test
 
 import (
 	"bytes"
@@ -111,7 +111,7 @@ func TestAPI(t *testing.T) {
 		return api.Get(context.Background())
 	}
 
-	alertOne := Alert{
+	alertOne := APIV1Alert{
 		StartsAt:    now,
 		EndsAt:      now.Add(time.Duration(5 * time.Minute)),
 		Labels:      LabelSet{"label1": "test1"},
@@ -119,7 +119,7 @@ func TestAPI(t *testing.T) {
 	}
 	alerts := []*ExtendedAlert{
 		{
-			Alert:       alertOne,
+			APIV1Alert:  alertOne,
 			Fingerprint: "1c93eec3511dc156",
 			Status: types.AlertStatus{
 				State: types.AlertStateActive,
@@ -132,7 +132,7 @@ func TestAPI(t *testing.T) {
 	}
 	doAlertPush := func() (interface{}, error) {
 		api := httpAlertAPI{client: client}
-		return nil, api.Push(context.Background(), []Alert{alertOne}...)
+		return nil, api.Push(context.Background(), []APIV1Alert{alertOne}...)
 	}
 
 	silOne := &types.Silence{


### PR DESCRIPTION
This is confusing as it sits in the root of the repo. Considering we
have a v2 client lib at (https://github.com/prometheus/alertmanager/blob/main/api/v2/client/alertmanager_client.go) this commit removes the v1 one to try and avoid
that confusion

Solves #2762