### PR TITLE
Expose the fields from MuteTimeInterval in JSON using the YAML field name

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -250,8 +250,8 @@ func resolveFilepaths(baseDir string, cfg *Config) {
 
 // MuteTimeInterval represents a named set of time intervals for which a route should be muted.
 type MuteTimeInterval struct {
-	Name          string                      `yaml:"name"`
-	TimeIntervals []timeinterval.TimeInterval `yaml:"time_intervals"`
+	Name          string                      `yaml:"name" json:"name"`
+	TimeIntervals []timeinterval.TimeInterval `yaml:"time_intervals" json:"time_intervals"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for MuteTimeInterval.


### PR DESCRIPTION
Before this PR, when marshalling to JSON, the go variable name would be taken (respective 'Name' and 'TimeIntervals') as JSON field name. With this PR we take instead the same name as for the YAML fields as everywhere else in the configuration.