### PR TITLE
Add support for Slack Block Kit

### DIFF
--- a/config/testdata/conf.good.yml
+++ b/config/testdata/conf.good.yml
@@ -133,4 +133,17 @@ receivers:
 - name: slack-receiver
   slack_configs:
     - channel: '#my-channel'
-      image_url: 'http://some.img.com/img.png'
+      blocks:
+        - config:
+            type: header
+            text:
+              type: plain_text
+              text: '{{ template "slack.default.title" . }}'
+        - repeat_for: firing
+          config:
+            type: section
+            text:
+              type: mrkdwn
+              text: >-
+                *Alert:* '{{ .Annotations.summary }} - `{{ .Labels.severity }}`
+                *Description:* '{{ .Annotations.description }}'


### PR DESCRIPTION
Implements #2217

This is a draft PR in which I started implementing support for Slack Block Kit. It’s still missing a lot (from actual implementation to unit and acceptance tests), but I think it’s a good first step.

I’m still willing to work on this but I find it a bit messy and I’d rather have a first review/validation from project maintainers especially concerning:
* what to do regarding the inability for `encoding/json` to marshal `map[interfaces{}]interfaces{}` (see comment on `SlackBlock.Config` at line 407 in `config/notifiers.go`) and
* how to iterate with at lines 151 and 170 in `notify/slack/slack.go` (my first idea was to use reflect to find string values and apply the templating function on them).

Discussion on a “design” have taken place in #2217 and this might not be the best way to implement this feature. Let me know.