### PR TITLE
config: root route should have empty matchers

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -471,7 +471,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if len(c.Route.Receiver) == 0 {
 		return fmt.Errorf("root route must specify a default receiver")
 	}
-	if len(c.Route.Match) > 0 || len(c.Route.MatchRE) > 0 {
+	if len(c.Route.Match) > 0 || len(c.Route.MatchRE) > 0 || len(c.Route.Matchers) > 0 {
 		return fmt.Errorf("root route must not have any matchers")
 	}
 	if len(c.Route.MuteTimeIntervals) > 0 {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -359,26 +359,47 @@ route:
 }
 
 func TestRootRouteHasNoMatcher(t *testing.T) {
-	in := `
+	testCases := []struct {
+		name string
+		in   string
+	}{
+		{
+			name: "Test deprecated matchers on root route not allowed",
+			in: `
 route:
   receiver: 'team-X'
   match:
     severity: critical
-
 receivers:
 - name: 'team-X'
-`
-	_, err := Load(in)
-
+`,
+		},
+		{
+			name: "Test matchers not allowed on root route",
+			in: `
+route:
+  receiver: 'team-X'
+  matchers:
+    - severity=critical
+receivers:
+- name: 'team-X'
+`,
+		},
+	}
 	expected := "root route must not have any matchers"
 
-	if err == nil {
-		t.Fatalf("no error returned, expected:\n%q", expected)
-	}
-	if err.Error() != expected {
-		t.Errorf("\nexpected:\n%q\ngot:\n%q", expected, err.Error())
-	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Load(tc.in)
 
+			if err == nil {
+				t.Fatalf("no error returned, expected:\n%q", expected)
+			}
+			if err.Error() != expected {
+				t.Errorf("\nexpected:\n%q\ngot:\n%q", expected, err.Error())
+			}
+		})
+	}
 }
 
 func TestContinueErrorInRouteRoot(t *testing.T) {


### PR DESCRIPTION
Unmarshal should validate that the root route does not contain any matchers. Prior to this change,
only the deprecated match structures were checked. It adds a check for matchers provided with the updated matching syntax.