### PR TITLE
Add timezone support to time intervals.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -321,9 +321,10 @@ Inclusive on both ends.
 Inclusive on both ends.
 
 `time_zone`: A string that matches an IANA time zone name. For example,
-`'Australia/Sydney'`. You may also use `'Local'` or `'UTC'`. **Note:** On Windows,
-only `Local` or `UTC` are supported unless you provide a custom time zone
-database using the `ZONEINFO` environment variable.
+`'Australia/Sydney'`. You may also use `'Local'` to use the local time of the
+server where Alertmanager is running or `'UTC'`. **Note:** On Windows, only
+`Local` or `UTC` are supported unless you provide a custom time zone database
+using the `ZONEINFO` environment variable.
 
 ## `<inhibit_rule>`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -289,8 +289,8 @@ supports the following fields:
 All fields are lists. Within each non-empty list, at least one element must be satisfied to match
 the field. If a field is left unspecified, any value will match the field. For an instant of time
 to match a complete time interval, all fields must match.
-Some fields support ranges and negative indices, and are detailed below. All definitions are
-taken to be in UTC, no other timezones are currently supported.
+Some fields support ranges and negative indices, and are detailed below. If a time zone is not
+specified, then the times are taken to be in UTC.
 
 `time_range` Ranges inclusive of the starting time and exclusive of the end time to
 make it easy to represent times that start/end on hour boundaries.
@@ -321,8 +321,7 @@ Inclusive on both ends.
 Inclusive on both ends.
 
 `time_zone`: A string that matches an IANA time zone name. For example,
-`'Australia/Sydney'`. You may also use `'Local'` to use the local time of the
-server where Alertmanager is running or `'UTC'`. **Note:** On Windows, only
+`'Australia/Sydney'`. The time zone will be used to You may also use `'Local'` to use the local time where Alertmanager is running or `'UTC'`. **Note:** On Windows, only
 `Local` or `UTC` are supported unless you provide a custom time zone database
 using the `ZONEINFO` environment variable.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -283,7 +283,7 @@ supports the following fields:
   [ - <month_range> ...]
   years:
   [ - <year_range> ...]
-  time_zone: <string>
+  location: <string>
 ```
 
 All fields are lists. Within each non-empty list, at least one element must be satisfied to match
@@ -320,10 +320,24 @@ Inclusive on both ends.
 `year_range`: A numerical list of years. Ranges are accepted. For example, `['2020:2022', '2030']`.
 Inclusive on both ends.
 
-`time_zone`: A string that matches an IANA time zone name. For example,
-`'Australia/Sydney'`. The time zone will be used to You may also use `'Local'` to use the local time where Alertmanager is running or `'UTC'`. **Note:** On Windows, only
-`Local` or `UTC` are supported unless you provide a custom time zone database
-using the `ZONEINFO` environment variable.
+`location`: A string that matches a location in the IANA time zone database. For
+example, `'Australia/Sydney'`. The location provides the time zone for the time
+interval. For example, a time interval with a location of `'Australia/Sydney'` that
+contained something like:
+
+        times:
+        - start_time: 09:00
+          end_time: 17:00
+        weekdays: ['monday:friday']
+
+would include any time that fell between the hours of 9:00AM and 5:00PM, between Monday
+and Friday, using the local time in Sydney, Australia.
+
+You may also use `'Local'` as a location to use the local time of the machine where
+Alertmanager is running, or `'UTC'` for UTC time. If no timezone is provided, the time
+interval is taken to be in UTC time.**Note:** On Windows, only `Local` or `UTC` are
+supported unless you provide a custom time zone database using the `ZONEINFO`
+environment variable.
 
 ## `<inhibit_rule>`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -283,6 +283,7 @@ supports the following fields:
   [ - <month_range> ...]
   years:
   [ - <year_range> ...]
+  time_zone: <string>
 ```
 
 All fields are lists. Within each non-empty list, at least one element must be satisfied to match
@@ -318,6 +319,11 @@ Inclusive on both ends.
 
 `year_range`: A numerical list of years. Ranges are accepted. For example, `['2020:2022', '2030']`.
 Inclusive on both ends.
+
+`time_zone`: A string that matches an IANA time zone name. For example,
+`'Australia/Sydney'`. You may also use `'Local'` or `'UTC'`. **Note:** On Windows,
+only `Local` or `UTC` are supported unless you provide a custom time zone
+database using the `ZONEINFO` environment variable.
 
 ## `<inhibit_rule>`
 

--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -775,10 +775,19 @@ func TestTimeMuteStage(t *testing.T) {
 			shouldMute: true,
 		},
 		{
-			// Ensure comparisons with other time zones work as expected.
+			fireTime:   "14 Nov 21 21:30 +0000",
+			labels:     model.LabelSet{"mute": "utc"},
+			shouldMute: true,
+		},
+		{
 			fireTime:   "15 Nov 22 14:30 +0900",
 			labels:     model.LabelSet{"kst": "dont_mute"},
 			shouldMute: false,
+		},
+		{
+			fireTime:   "15 Nov 21 02:00 -0500",
+			labels:     model.LabelSet{"mute": "0500"},
+			shouldMute: true,
 		},
 	}
 	var intervals []timeinterval.TimeInterval

--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -728,7 +728,7 @@ func TestTimeMuteStage(t *testing.T) {
 	muteIn := `
 ---
 - weekdays: ['monday:friday']
-  time_zone: 'Australia/Sydney'
+  location: 'Australia/Sydney'
   months: ['November']
   times:
    - start_time: '00:00'
@@ -737,7 +737,7 @@ func TestTimeMuteStage(t *testing.T) {
      end_time: '24:00'
 - weekdays: ['saturday', 'sunday']
   months: ['November']
-  time_zone: 'Australia/Sydney'`
+  location: 'Australia/Sydney'`
 
 	cases := []struct {
 		fireTime   string

--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -724,7 +724,7 @@ func TestMuteStageWithSilences(t *testing.T) {
 }
 
 func TestTimeMuteStage(t *testing.T) {
-	// Route mutes alerts outside business hours in November, using the AEDT timezone.
+	// Route mutes alerts outside business hours in November, using the +1100 timezone.
 	muteIn := `
 ---
 - weekdays: ['monday:friday']
@@ -746,37 +746,37 @@ func TestTimeMuteStage(t *testing.T) {
 	}{
 		{
 			// Friday during business hours
-			fireTime:   "19 Nov 21 13:00 AEDT",
+			fireTime:   "19 Nov 21 13:00 +1100",
 			labels:     model.LabelSet{"foo": "bar"},
 			shouldMute: false,
 		},
 		{
 			// Tuesday before 5pm
-			fireTime:   "16 Nov 21 16:59 AEDT",
+			fireTime:   "16 Nov 21 16:59 +1100",
 			labels:     model.LabelSet{"dont": "mute"},
 			shouldMute: false,
 		},
 		{
 			// Saturday
-			fireTime:   "20 Nov 21 10:00 AEDT",
+			fireTime:   "20 Nov 21 10:00 +1100",
 			labels:     model.LabelSet{"mute": "me"},
 			shouldMute: true,
 		},
 		{
 			// Wednesday before 9am
-			fireTime:   "17 Nov 21 05:00 AEDT",
+			fireTime:   "17 Nov 21 05:00 +1100",
 			labels:     model.LabelSet{"mute": "me"},
 			shouldMute: true,
 		},
 		{
 			// Ensure comparisons with other time zones work as expected.
-			fireTime:   "14 Nov 21 20:00 KST",
+			fireTime:   "14 Nov 21 20:00 +0900",
 			labels:     model.LabelSet{"mute": "kst"},
 			shouldMute: true,
 		},
 		{
 			// Ensure comparisons with other time zones work as expected.
-			fireTime:   "14 Nov 21 22:00 KST",
+			fireTime:   "15 Nov 22 14:30 +0900",
 			labels:     model.LabelSet{"kst": "dont_mute"},
 			shouldMute: false,
 		},
@@ -792,7 +792,7 @@ func TestTimeMuteStage(t *testing.T) {
 	outAlerts := []*types.Alert{}
 	nonMuteCount := 0
 	for _, tc := range cases {
-		now, err := time.Parse(time.RFC822, tc.fireTime)
+		now, err := time.Parse(time.RFC822Z, tc.fireTime)
 		if err != nil {
 			t.Fatalf("Couldn't parse fire time %s %s", tc.fireTime, err)
 		}

--- a/timeinterval/timeinterval.go
+++ b/timeinterval/timeinterval.go
@@ -172,23 +172,6 @@ var monthsInv = map[int]string{
 	12: "december",
 }
 
-// UnmarshalYAML implements the Unmarshaller interface for TimeInterval
-// Most fields are handled via their own UnmarshalYAML function, however we handle
-// TimeZones here to ensure they always default to UTC if nothing is supplied.
-// func (ti *TimeInterval) UnmarshalYAML(unmarshal func(interface{}) error) error {
-// 	type temp TimeInterval
-// 	var timeInterval temp
-// 	err := unmarshal(&timeInterval)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	if timeInterval.TimeZone == nil {
-// 		timeInterval.TimeZone = &TimeZone{time.UTC}
-// 	}
-// 	*ti = TimeInterval(timeInterval)
-// 	return nil
-// }
-
 // UnmarshalYAML implements the Unmarshaller interface for Timezone.
 func (tz *TimeZone) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var str string

--- a/timeinterval/timeinterval.go
+++ b/timeinterval/timeinterval.go
@@ -35,7 +35,7 @@ type TimeInterval struct {
 	DaysOfMonth []DayOfMonthRange `yaml:"days_of_month,flow,omitempty" json:"days_of_month,omitempty"`
 	Months      []MonthRange      `yaml:"months,flow,omitempty" json:"months,omitempty"`
 	Years       []YearRange       `yaml:"years,flow,omitempty" json:"years,omitempty"`
-	Location    *Location         `yaml:"time_zone,flow,omitempty" json:"time_zone,omitempty"`
+	Location    *Location         `yaml:"location,flow,omitempty" json:"location,omitempty"`
 }
 
 // TimeRange represents a range of minutes within a 1440 minute day, exclusive of the End minute. A day consists of 1440 minutes.

--- a/timeinterval/timeinterval.go
+++ b/timeinterval/timeinterval.go
@@ -34,7 +34,7 @@ type TimeInterval struct {
 	DaysOfMonth []DayOfMonthRange `yaml:"days_of_month,flow,omitempty" json:"days_of_month,omitempty"`
 	Months      []MonthRange      `yaml:"months,flow,omitempty" json:"months,omitempty"`
 	Years       []YearRange       `yaml:"years,flow,omitempty" json:"years,omitempty"`
-	TimeZone    *TimeZone         `yaml:"time_zone,flow,omitempty" json:"time_zone,omitempty"`
+	Location    *Location         `yaml:"time_zone,flow,omitempty" json:"time_zone,omitempty"`
 }
 
 // TimeRange represents a range of minutes within a 1440 minute day, exclusive of the End minute. A day consists of 1440 minutes.
@@ -70,8 +70,8 @@ type YearRange struct {
 	InclusiveRange
 }
 
-// A Timezone is a container for a time.Location, used for custom unmarshalling/validation logic.
-type TimeZone struct {
+// A Location is a container for a time.Location, used for custom unmarshalling/validation logic.
+type Location struct {
 	*time.Location
 }
 
@@ -172,8 +172,8 @@ var monthsInv = map[int]string{
 	12: "december",
 }
 
-// UnmarshalYAML implements the Unmarshaller interface for Timezone.
-func (tz *TimeZone) UnmarshalYAML(unmarshal func(interface{}) error) error {
+// UnmarshalYAML implements the Unmarshaller interface for Location.
+func (tz *Location) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var str string
 	if err := unmarshal(&str); err != nil {
 		return err
@@ -187,13 +187,13 @@ func (tz *TimeZone) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 
-	*tz = TimeZone{loc}
+	*tz = Location{loc}
 	return nil
 }
 
-// UnmarshalJSON implements the json.Unmarshaler interface for TimeZOne.
+// UnmarshalJSON implements the json.Unmarshaler interface for Location.
 // It delegates to the YAML unmarshaller as it can parse JSON and has validation logic.
-func (tz *TimeZone) UnmarshalJSON(in []byte) error {
+func (tz *Location) UnmarshalJSON(in []byte) error {
 	return yaml.Unmarshal(in, tz)
 }
 
@@ -394,23 +394,23 @@ func (tr TimeRange) MarshalJSON() (out []byte, err error) {
 	return json.Marshal(yTr)
 }
 
-// MarshalText implements the econding.TextMarshaler interface for TimeZone.
-// It marshals a TimeZone back into a string that represents a time.Location.
-func (tz TimeZone) MarshalText() ([]byte, error) {
+// MarshalText implements the econding.TextMarshaler interface for Location.
+// It marshals a Location back into a string that represents a time.Location.
+func (tz Location) MarshalText() ([]byte, error) {
 	if tz.Location == nil {
-		return nil, fmt.Errorf("unable to convert nil time zone into string")
+		return nil, fmt.Errorf("unable to convert nil location into string")
 	}
 	return []byte(tz.Location.String()), nil
 }
 
-//MarshalYAML implements the yaml.Marshaler interface for TimeZone.
-func (tz TimeZone) MarshalYAML() (interface{}, error) {
+//MarshalYAML implements the yaml.Marshaler interface for Location.
+func (tz Location) MarshalYAML() (interface{}, error) {
 	bytes, err := tz.MarshalText()
 	return string(bytes), err
 }
 
-//MarshalJSON implements the json.Marshaler interface for TimeZone.
-func (tz TimeZone) MarshalJSON() (out []byte, err error) {
+//MarshalJSON implements the json.Marshaler interface for Location.
+func (tz Location) MarshalJSON() (out []byte, err error) {
 	return json.Marshal(tz.String())
 }
 
@@ -457,8 +457,8 @@ func clamp(n, min, max int) int {
 
 // ContainsTime returns true if the TimeInterval contains the given time, otherwise returns false.
 func (tp TimeInterval) ContainsTime(t time.Time) bool {
-	if tp.TimeZone != nil {
-		t = t.In(tp.TimeZone.Location)
+	if tp.Location != nil {
+		t = t.In(tp.Location.Location)
 	}
 	if tp.Times != nil {
 		in := false

--- a/timeinterval/timeinterval.go
+++ b/timeinterval/timeinterval.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -181,8 +182,11 @@ func (tz *Location) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	loc, err := time.LoadLocation(str)
 	if err != nil {
-		if runtime.GOOS == "windows" && str != "Local" && str != "UTC" {
-			return fmt.Errorf("unable to load time location. Timezones other than 'Local' and 'UTC' may not be supported on Windows without using a custom timezone file: %w", err)
+		if runtime.GOOS == "windows" {
+			if zoneinfo := os.Getenv("ZONEINFO"); zoneinfo != "" {
+				return fmt.Errorf("%w (ZONEINFO=%q)", err, zoneinfo)
+			}
+			return fmt.Errorf("%w (on Windows platforms, you may have to pass the time zone database using the ZONEINFO environment variable, see https://pkg.go.dev/time#LoadLocation for details)", err)
 		}
 		return err
 	}

--- a/timeinterval/timeinterval.go
+++ b/timeinterval/timeinterval.go
@@ -457,13 +457,9 @@ func clamp(n, min, max int) int {
 
 // ContainsTime returns true if the TimeInterval contains the given time, otherwise returns false.
 func (tp TimeInterval) ContainsTime(t time.Time) bool {
-	var location *time.Location
-	if tp.TimeZone == nil {
-		location = time.UTC
-	} else {
-		location = tp.TimeZone.Location
+	if tp.TimeZone != nil {
+		t = t.In(tp.TimeZone.Location)
 	}
-	t = t.In(location)
 	if tp.Times != nil {
 		in := false
 		for _, validMinutes := range tp.Times {

--- a/timeinterval/timeinterval_test.go
+++ b/timeinterval/timeinterval_test.go
@@ -30,9 +30,9 @@ var timeIntervalTestCases = []struct {
 	{
 		timeInterval: TimeInterval{},
 		validTimeStrings: []string{
-			"02 Jan 06 15:04 UTC",
-			"03 Jan 07 10:04 UTC",
-			"04 Jan 06 09:04 UTC",
+			"02 Jan 06 15:04 +0000",
+			"03 Jan 07 10:04 +0000",
+			"04 Jan 06 09:04 +0000",
 		},
 		invalidTimeStrings: []string{},
 	},
@@ -43,14 +43,14 @@ var timeIntervalTestCases = []struct {
 			Weekdays: []WeekdayRange{{InclusiveRange{Begin: 1, End: 5}}},
 		},
 		validTimeStrings: []string{
-			"04 May 20 15:04 UTC",
-			"05 May 20 10:04 UTC",
-			"09 Jun 20 09:04 UTC",
+			"04 May 20 15:04 +0000",
+			"05 May 20 10:04 +0000",
+			"09 Jun 20 09:04 +0000",
 		},
 		invalidTimeStrings: []string{
-			"03 May 20 15:04 UTC",
-			"04 May 20 08:59 UTC",
-			"05 May 20 05:00 UTC",
+			"03 May 20 15:04 +0000",
+			"04 May 20 08:59 +0000",
+			"05 May 20 05:00 +0000",
 		},
 	},
 	{
@@ -61,16 +61,16 @@ var timeIntervalTestCases = []struct {
 			Years:       []YearRange{{InclusiveRange{Begin: 2020, End: 2020}}},
 		},
 		validTimeStrings: []string{
-			"04 Apr 20 15:04 UTC",
-			"05 Apr 20 00:00 UTC",
-			"06 Apr 20 23:05 UTC",
+			"04 Apr 20 15:04 +0000",
+			"05 Apr 20 00:00 +0000",
+			"06 Apr 20 23:05 +0000",
 		},
 		invalidTimeStrings: []string{
-			"03 May 18 15:04 UTC",
-			"03 Apr 20 23:59 UTC",
-			"04 Jun 20 23:59 UTC",
-			"06 Apr 19 23:59 UTC",
-			"07 Apr 20 00:00 UTC",
+			"03 May 18 15:04 +0000",
+			"03 Apr 20 23:59 +0000",
+			"04 Jun 20 23:59 +0000",
+			"06 Apr 19 23:59 +0000",
+			"07 Apr 20 00:00 +0000",
 		},
 	},
 	{
@@ -79,20 +79,20 @@ var timeIntervalTestCases = []struct {
 			DaysOfMonth: []DayOfMonthRange{{InclusiveRange{Begin: -3, End: -1}}},
 		},
 		validTimeStrings: []string{
-			"31 Jan 20 15:04 UTC",
-			"30 Jan 20 15:04 UTC",
-			"29 Jan 20 15:04 UTC",
-			"30 Jun 20 00:00 UTC",
-			"29 Feb 20 23:05 UTC",
+			"31 Jan 20 15:04 +0000",
+			"30 Jan 20 15:04 +0000",
+			"29 Jan 20 15:04 +0000",
+			"30 Jun 20 00:00 +0000",
+			"29 Feb 20 23:05 +0000",
 		},
 		invalidTimeStrings: []string{
-			"03 May 18 15:04 UTC",
-			"27 Jan 20 15:04 UTC",
-			"03 Apr 20 23:59 UTC",
-			"04 Jun 20 23:59 UTC",
-			"06 Apr 19 23:59 UTC",
-			"07 Apr 20 00:00 UTC",
-			"01 Mar 20 00:00 UTC",
+			"03 May 18 15:04 +0000",
+			"27 Jan 20 15:04 +0000",
+			"03 Apr 20 23:59 +0000",
+			"04 Jun 20 23:59 +0000",
+			"06 Apr 19 23:59 +0000",
+			"07 Apr 20 00:00 +0000",
+			"01 Mar 20 00:00 +0000",
 		},
 	},
 	{
@@ -102,12 +102,12 @@ var timeIntervalTestCases = []struct {
 			DaysOfMonth: []DayOfMonthRange{{InclusiveRange{Begin: -31, End: 31}}},
 		},
 		validTimeStrings: []string{
-			"30 Jun 20 00:00 UTC",
-			"01 Jun 20 00:00 UTC",
+			"30 Jun 20 00:00 +0000",
+			"01 Jun 20 00:00 +0000",
 		},
 		invalidTimeStrings: []string{
-			"31 May 20 00:00 UTC",
-			"1 Jul 20 00:00 UTC",
+			"31 May 20 00:00 +0000",
+			"1 Jul 20 00:00 +0000",
 		},
 	},
 	{
@@ -119,10 +119,10 @@ var timeIntervalTestCases = []struct {
 			TimeZone: &TimeZone{mustLoadLocation("Australia/Sydney")},
 		},
 		validTimeStrings: []string{
-			"06 Apr 21 13:00 AEST",
+			"06 Apr 21 13:00 +1000",
 		},
 		invalidTimeStrings: []string{
-			"06 Apr 21 13:00 UTC",
+			"06 Apr 21 13:00 +0000",
 		},
 	},
 	{
@@ -134,11 +134,11 @@ var timeIntervalTestCases = []struct {
 			TimeZone: &TimeZone{mustLoadLocation("Australia/Sydney")},
 		},
 		validTimeStrings: []string{
-			"01 Nov 21 09:00 AEDT",
-			"31 Oct 21 22:00 UTC",
+			"01 Nov 21 09:00 +1100",
+			"31 Oct 21 22:00 +0000",
 		},
 		invalidTimeStrings: []string{
-			"31 Oct 21 21:00 UTC",
+			"31 Oct 21 21:00 +0000",
 		},
 	},
 }
@@ -219,12 +219,12 @@ var yamlUnmarshalTestCases = []struct {
 			},
 		},
 		contains: []string{
-			"08 Jul 20 09:00 UTC",
-			"08 Jul 20 16:59 UTC",
+			"08 Jul 20 09:00 +0000",
+			"08 Jul 20 16:59 +0000",
 		},
 		excludes: []string{
-			"08 Jul 20 05:00 UTC",
-			"08 Jul 20 08:59 UTC",
+			"08 Jul 20 05:00 +0000",
+			"08 Jul 20 08:59 +0000",
 		},
 		expectError: false,
 	},
@@ -251,18 +251,18 @@ var yamlUnmarshalTestCases = []struct {
 			},
 		},
 		contains: []string{
-			"27 Jan 21 09:00 UTC",
-			"28 Jan 21 16:59 UTC",
-			"29 Jan 21 13:00 UTC",
-			"31 Mar 25 13:00 UTC",
-			"31 Mar 25 13:00 UTC",
-			"31 Jan 35 13:00 UTC",
+			"27 Jan 21 09:00 +0000",
+			"28 Jan 21 16:59 +0000",
+			"29 Jan 21 13:00 +0000",
+			"31 Mar 25 13:00 +0000",
+			"31 Mar 25 13:00 +0000",
+			"31 Jan 35 13:00 +0000",
 		},
 		excludes: []string{
-			"30 Jan 21 13:00 UTC", // Saturday
-			"01 Apr 21 13:00 UTC", // 4th month
-			"30 Jan 26 13:00 UTC", // 2026
-			"31 Jan 35 17:01 UTC", // After 5pm
+			"30 Jan 21 13:00 +0000", // Saturday
+			"01 Apr 21 13:00 +0000", // 4th month
+			"30 Jan 26 13:00 +0000", // 2026
+			"31 Jan 35 17:01 +0000", // After 5pm
 		},
 		expectError: false,
 	},
@@ -280,7 +280,7 @@ var yamlUnmarshalTestCases = []struct {
 			},
 		},
 		contains: []string{
-			"01 Apr 21 13:00 GMT",
+			"01 Apr 21 13:00 +0000",
 		},
 	},
 	{
@@ -480,7 +480,7 @@ func TestYamlUnmarshal(t *testing.T) {
 			t.Errorf("Error unmarshalling %s: Want %+v, got %+v", tc.in, tc.intervals, ti)
 		}
 		for _, ts := range tc.contains {
-			_t, _ := time.Parse(time.RFC822, ts)
+			_t, _ := time.Parse(time.RFC822Z, ts)
 			isContained := false
 			for _, interval := range ti {
 				if interval.ContainsTime(_t) {
@@ -492,7 +492,7 @@ func TestYamlUnmarshal(t *testing.T) {
 			}
 		}
 		for _, ts := range tc.excludes {
-			_t, _ := time.Parse(time.RFC822, ts)
+			_t, _ := time.Parse(time.RFC822Z, ts)
 			isContained := false
 			for _, interval := range ti {
 				if interval.ContainsTime(_t) {
@@ -509,13 +509,13 @@ func TestYamlUnmarshal(t *testing.T) {
 func TestContainsTime(t *testing.T) {
 	for _, tc := range timeIntervalTestCases {
 		for _, ts := range tc.validTimeStrings {
-			_t, _ := time.Parse(time.RFC822, ts)
+			_t, _ := time.Parse(time.RFC822Z, ts)
 			if !tc.timeInterval.ContainsTime(_t) {
 				t.Errorf("Expected period %+v to contain %+v", tc.timeInterval, _t)
 			}
 		}
 		for _, ts := range tc.invalidTimeStrings {
-			_t, _ := time.Parse(time.RFC822, ts)
+			_t, _ := time.Parse(time.RFC822Z, ts)
 			if tc.timeInterval.ContainsTime(_t) {
 				t.Errorf("Period %+v not expected to contain %+v", tc.timeInterval, _t)
 			}
@@ -600,13 +600,13 @@ years: ['2020:2023']
 months: ['january:march']
 `,
 		contains: []string{
-			"10 Jan 21 13:00 GMT",
-			"30 Jan 21 14:24 GMT",
+			"10 Jan 21 13:00 +0000",
+			"30 Jan 21 14:24 +0000",
 		},
 		excludes: []string{
-			"09 Jan 21 13:00 GMT",
-			"20 Jan 21 12:59 GMT",
-			"02 Feb 21 13:00 GMT",
+			"09 Jan 21 13:00 +0000",
+			"20 Jan 21 12:59 +0000",
+			"02 Feb 21 13:00 +0000",
 		},
 	},
 	{
@@ -618,7 +618,7 @@ years: ['2020:2023']
 months: ['february']
 `,
 		excludes: []string{
-			"28 Feb 21 13:00 GMT",
+			"28 Feb 21 13:00 +0000",
 		},
 	},
 }
@@ -631,7 +631,7 @@ func TestTimeIntervalComplete(t *testing.T) {
 			t.Error(err)
 		}
 		for _, ts := range tc.contains {
-			tt, err := time.Parse(time.RFC822, ts)
+			tt, err := time.Parse(time.RFC822Z, ts)
 			if err != nil {
 				t.Error(err)
 			}
@@ -640,7 +640,7 @@ func TestTimeIntervalComplete(t *testing.T) {
 			}
 		}
 		for _, ts := range tc.excludes {
-			tt, err := time.Parse(time.RFC822, ts)
+			tt, err := time.Parse(time.RFC822Z, ts)
 			if err != nil {
 				t.Error(err)
 			}

--- a/timeinterval/timeinterval_test.go
+++ b/timeinterval/timeinterval_test.go
@@ -116,7 +116,7 @@ var timeIntervalTestCases = []struct {
 		timeInterval: TimeInterval{
 			Times:    []TimeRange{{StartMinute: 540, EndMinute: 1020}},
 			Weekdays: []WeekdayRange{{InclusiveRange{Begin: 1, End: 5}}},
-			TimeZone: &TimeZone{mustLoadLocation("Australia/Sydney")},
+			Location: &Location{mustLoadLocation("Australia/Sydney")},
 		},
 		validTimeStrings: []string{
 			"06 Apr 21 13:00 +1000",
@@ -131,7 +131,7 @@ var timeIntervalTestCases = []struct {
 			Times:    []TimeRange{{StartMinute: 540, EndMinute: 1020}},
 			Weekdays: []WeekdayRange{{InclusiveRange{Begin: 1, End: 5}}},
 			Months:   []MonthRange{{InclusiveRange{Begin: 11, End: 11}}},
-			TimeZone: &TimeZone{mustLoadLocation("Australia/Sydney")},
+			Location: &Location{mustLoadLocation("Australia/Sydney")},
 		},
 		validTimeStrings: []string{
 			"01 Nov 21 09:00 +1100",
@@ -420,7 +420,7 @@ var yamlUnmarshalTestCases = []struct {
 		intervals: []TimeInterval{
 			{
 				Years:    []YearRange{{InclusiveRange{2020, 2022}}},
-				TimeZone: &TimeZone{mustLoadLocation("Australia/Sydney")},
+				Location: &Location{mustLoadLocation("Australia/Sydney")},
 			},
 		},
 	},

--- a/timeinterval/timeinterval_test.go
+++ b/timeinterval/timeinterval_test.go
@@ -30,9 +30,9 @@ var timeIntervalTestCases = []struct {
 	{
 		timeInterval: TimeInterval{},
 		validTimeStrings: []string{
-			"02 Jan 06 15:04 MST",
-			"03 Jan 07 10:04 MST",
-			"04 Jan 06 09:04 MST",
+			"02 Jan 06 15:04 UTC",
+			"03 Jan 07 10:04 UTC",
+			"04 Jan 06 09:04 UTC",
 		},
 		invalidTimeStrings: []string{},
 	},
@@ -43,14 +43,14 @@ var timeIntervalTestCases = []struct {
 			Weekdays: []WeekdayRange{{InclusiveRange{Begin: 1, End: 5}}},
 		},
 		validTimeStrings: []string{
-			"04 May 20 15:04 MST",
-			"05 May 20 10:04 MST",
-			"09 Jun 20 09:04 MST",
+			"04 May 20 15:04 UTC",
+			"05 May 20 10:04 UTC",
+			"09 Jun 20 09:04 UTC",
 		},
 		invalidTimeStrings: []string{
-			"03 May 20 15:04 MST",
-			"04 May 20 08:59 MST",
-			"05 May 20 05:00 MST",
+			"03 May 20 15:04 UTC",
+			"04 May 20 08:59 UTC",
+			"05 May 20 05:00 UTC",
 		},
 	},
 	{
@@ -61,16 +61,16 @@ var timeIntervalTestCases = []struct {
 			Years:       []YearRange{{InclusiveRange{Begin: 2020, End: 2020}}},
 		},
 		validTimeStrings: []string{
-			"04 Apr 20 15:04 MST",
-			"05 Apr 20 00:00 MST",
-			"06 Apr 20 23:05 MST",
+			"04 Apr 20 15:04 UTC",
+			"05 Apr 20 00:00 UTC",
+			"06 Apr 20 23:05 UTC",
 		},
 		invalidTimeStrings: []string{
-			"03 May 18 15:04 MST",
-			"03 Apr 20 23:59 MST",
-			"04 Jun 20 23:59 MST",
-			"06 Apr 19 23:59 MST",
-			"07 Apr 20 00:00 MST",
+			"03 May 18 15:04 UTC",
+			"03 Apr 20 23:59 UTC",
+			"04 Jun 20 23:59 UTC",
+			"06 Apr 19 23:59 UTC",
+			"07 Apr 20 00:00 UTC",
 		},
 	},
 	{
@@ -79,20 +79,20 @@ var timeIntervalTestCases = []struct {
 			DaysOfMonth: []DayOfMonthRange{{InclusiveRange{Begin: -3, End: -1}}},
 		},
 		validTimeStrings: []string{
-			"31 Jan 20 15:04 MST",
-			"30 Jan 20 15:04 MST",
-			"29 Jan 20 15:04 MST",
-			"30 Jun 20 00:00 MST",
-			"29 Feb 20 23:05 MST",
+			"31 Jan 20 15:04 UTC",
+			"30 Jan 20 15:04 UTC",
+			"29 Jan 20 15:04 UTC",
+			"30 Jun 20 00:00 UTC",
+			"29 Feb 20 23:05 UTC",
 		},
 		invalidTimeStrings: []string{
-			"03 May 18 15:04 MST",
-			"27 Jan 20 15:04 MST",
-			"03 Apr 20 23:59 MST",
-			"04 Jun 20 23:59 MST",
-			"06 Apr 19 23:59 MST",
-			"07 Apr 20 00:00 MST",
-			"01 Mar 20 00:00 MST",
+			"03 May 18 15:04 UTC",
+			"27 Jan 20 15:04 UTC",
+			"03 Apr 20 23:59 UTC",
+			"04 Jun 20 23:59 UTC",
+			"06 Apr 19 23:59 UTC",
+			"07 Apr 20 00:00 UTC",
+			"01 Mar 20 00:00 UTC",
 		},
 	},
 	{
@@ -188,12 +188,12 @@ var yamlUnmarshalTestCases = []struct {
 			},
 		},
 		contains: []string{
-			"08 Jul 20 09:00 MST",
-			"08 Jul 20 16:59 MST",
+			"08 Jul 20 09:00 UTC",
+			"08 Jul 20 16:59 UTC",
 		},
 		excludes: []string{
-			"08 Jul 20 05:00 MST",
-			"08 Jul 20 08:59 MST",
+			"08 Jul 20 05:00 UTC",
+			"08 Jul 20 08:59 UTC",
 		},
 		expectError: false,
 	},
@@ -220,18 +220,18 @@ var yamlUnmarshalTestCases = []struct {
 			},
 		},
 		contains: []string{
-			"27 Jan 21 09:00 MST",
-			"28 Jan 21 16:59 MST",
-			"29 Jan 21 13:00 MST",
-			"31 Mar 25 13:00 MST",
-			"31 Mar 25 13:00 MST",
-			"31 Jan 35 13:00 MST",
+			"27 Jan 21 09:00 UTC",
+			"28 Jan 21 16:59 UTC",
+			"29 Jan 21 13:00 UTC",
+			"31 Mar 25 13:00 UTC",
+			"31 Mar 25 13:00 UTC",
+			"31 Jan 35 13:00 UTC",
 		},
 		excludes: []string{
-			"30 Jan 21 13:00 MST", // Saturday
-			"01 Apr 21 13:00 MST", // 4th month
-			"30 Jan 26 13:00 MST", // 2026
-			"31 Jan 35 17:01 MST", // After 5pm
+			"30 Jan 21 13:00 UTC", // Saturday
+			"01 Apr 21 13:00 UTC", // 4th month
+			"30 Jan 26 13:00 UTC", // 2026
+			"31 Jan 35 17:01 UTC", // After 5pm
 		},
 		expectError: false,
 	},

--- a/timeinterval/timeinterval_test.go
+++ b/timeinterval/timeinterval_test.go
@@ -414,7 +414,7 @@ var yamlUnmarshalTestCases = []struct {
 		in: `
 ---
 - years: ['2020:2022']
-  time_zone: 'Australia/Sydney'
+  location: 'Australia/Sydney'
 `,
 		expectError: false,
 		intervals: []TimeInterval{


### PR DESCRIPTION
This PR addresses #2771 by adding a `time_zone` field to time interval definitions, which accepts an IANA time zone name (like 'Australia/Sydney') and if supplied means that the time intervals are defined inside that time zone.

On Windows machines the only time zones that are accepted are 'Local' and 'UTC', but I think that is probably enough for 99% of users who just want to use their local server time zone. I have noted this in the documentation, and also added some more info to the error message when a timezone fails to load on Windows mentioning that the user may need to supply their own time zone database.

I think it's also probably worth changing the default to be the server's local time rather than UTC as this would probably be unexpected for most users, but it is breaking behavior so I'm not sure how we should proceed with that but open to the ideas.

Feedback on the approach (particularly dealing with Windows) is more than welcome. Cheers!
