### PR TITLE
config: Fix duplicate header detection for all case variants

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -15,6 +15,7 @@ package config
 
 import (
 	"fmt"
+	"net/textproto"
 	"regexp"
 	"strings"
 	"time"
@@ -181,7 +182,7 @@ func (c *EmailConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	// Header names are case-insensitive, check for collisions.
 	normalizedHeaders := map[string]string{}
 	for h, v := range c.Headers {
-		normalized := strings.Title(h)
+		normalized := textproto.CanonicalMIMEHeaderKey(h)
 		if _, ok := normalizedHeaders[normalized]; ok {
 			return fmt.Errorf("duplicate header %q in email config", normalized)
 		}

--- a/config/notifiers_test.go
+++ b/config/notifiers_test.go
@@ -42,7 +42,7 @@ func TestEmailHeadersCollision(t *testing.T) {
 to: 'to@email.com'
 headers:
   Subject: 'Alert'
-  subject: 'New Alert'
+  sUbject: 'New Alert'
 `
 	var cfg EmailConfig
 	err := yaml.UnmarshalStrict([]byte(in), &cfg)


### PR DESCRIPTION
strings.Title only uppercases characters, it does not fully
canonicalise.

Signed-off-by: David Leadbeater <dgl@dgl.cx>