### PR TITLE
api/v2: Delete silence respond with 404 when silence is not found

### DIFF
--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -618,6 +618,9 @@ func (api *API) deleteSilenceHandler(params silence_ops.DeleteSilenceParams) mid
 	sid := params.SilenceID.String()
 	if err := api.silences.Expire(sid); err != nil {
 		level.Error(logger).Log("msg", "Failed to expire silence", "err", err)
+		if err == silence.ErrNotFound {
+			return silence_ops.NewDeleteSilenceNotFound()
+		}
 		return silence_ops.NewDeleteSilenceInternalServerError().WithPayload(err.Error())
 	}
 	return silence_ops.NewDeleteSilenceOK()

--- a/api/v2/client/silence/delete_silence_responses.go
+++ b/api/v2/client/silence/delete_silence_responses.go
@@ -41,6 +41,12 @@ func (o *DeleteSilenceReader) ReadResponse(response runtime.ClientResponse, cons
 			return nil, err
 		}
 		return result, nil
+	case 404:
+		result := NewDeleteSilenceNotFound()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 500:
 		result := NewDeleteSilenceInternalServerError()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -70,6 +76,27 @@ func (o *DeleteSilenceOK) Error() string {
 }
 
 func (o *DeleteSilenceOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	return nil
+}
+
+// NewDeleteSilenceNotFound creates a DeleteSilenceNotFound with default headers values
+func NewDeleteSilenceNotFound() *DeleteSilenceNotFound {
+	return &DeleteSilenceNotFound{}
+}
+
+/*DeleteSilenceNotFound handles this case with default header values.
+
+A silence with the specified ID was not found
+*/
+type DeleteSilenceNotFound struct {
+}
+
+func (o *DeleteSilenceNotFound) Error() string {
+	return fmt.Sprintf("[DELETE /silence/{silenceID}][%d] deleteSilenceNotFound ", 404)
+}
+
+func (o *DeleteSilenceNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/api/v2/openapi.yaml
+++ b/api/v2/openapi.yaml
@@ -127,6 +127,8 @@ paths:
       responses:
         '200':
           description: Delete silence response
+        '404':
+          description: A silence with the specified ID was not found
         '500':
           $ref: '#/responses/InternalServerError'
   /alerts:

--- a/api/v2/restapi/embedded_spec.go
+++ b/api/v2/restapi/embedded_spec.go
@@ -272,6 +272,9 @@ func init() {
           "200": {
             "description": "Delete silence response"
           },
+          "404": {
+            "description": "A silence with the specified ID was not found"
+          },
           "500": {
             "$ref": "#/responses/InternalServerError"
           }
@@ -1076,6 +1079,9 @@ func init() {
         "responses": {
           "200": {
             "description": "Delete silence response"
+          },
+          "404": {
+            "description": "A silence with the specified ID was not found"
           },
           "500": {
             "description": "Internal server error",

--- a/api/v2/restapi/operations/silence/delete_silence_responses.go
+++ b/api/v2/restapi/operations/silence/delete_silence_responses.go
@@ -49,6 +49,30 @@ func (o *DeleteSilenceOK) WriteResponse(rw http.ResponseWriter, producer runtime
 	rw.WriteHeader(200)
 }
 
+// DeleteSilenceNotFoundCode is the HTTP code returned for type DeleteSilenceNotFound
+const DeleteSilenceNotFoundCode int = 404
+
+/*DeleteSilenceNotFound A silence with the specified ID was not found
+
+swagger:response deleteSilenceNotFound
+*/
+type DeleteSilenceNotFound struct {
+}
+
+// NewDeleteSilenceNotFound creates DeleteSilenceNotFound with default headers values
+func NewDeleteSilenceNotFound() *DeleteSilenceNotFound {
+
+	return &DeleteSilenceNotFound{}
+}
+
+// WriteResponse to the client
+func (o *DeleteSilenceNotFound) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
+
+	rw.WriteHeader(404)
+}
+
 // DeleteSilenceInternalServerErrorCode is the HTTP code returned for type DeleteSilenceInternalServerError
 const DeleteSilenceInternalServerErrorCode int = 500
 


### PR DESCRIPTION
Hi,
When a client attempts to delete a non-existent silence, respond with 404 instead of 500.

Signed-off-by: hateeyan <hateeyan@gmail.com>