### PR TITLE
Return no error when deleting expired silence

### DIFF
--- a/api/v2/api_test.go
+++ b/api/v2/api_test.go
@@ -209,7 +209,7 @@ func TestDeleteSilenceHandler(t *testing.T) {
 		responder.WriteResponse(w, p)
 		body, _ := ioutil.ReadAll(w.Result().Body)
 
-		require.Equal(t, tc.expectedCode, w.Code, fmt.Sprintf(fmt.Sprintf("test case: %d, response: %s", i, string(body))))
+		require.Equal(t, tc.expectedCode, w.Code, fmt.Sprintf("test case: %d, response: %s", i, string(body)))
 	}
 }
 
@@ -309,7 +309,7 @@ func TestPostSilencesHandler(t *testing.T) {
 		responder.WriteResponse(w, p)
 		body, _ := ioutil.ReadAll(w.Result().Body)
 
-		require.Equal(t, tc.expectedCode, w.Code, fmt.Sprintf(fmt.Sprintf("test case: %d, response: %s", i, string(body))))
+		require.Equal(t, tc.expectedCode, w.Code, fmt.Sprintf("test case: %d, response: %s", i, string(body)))
 	}
 }
 

--- a/api/v2/api_test.go
+++ b/api/v2/api_test.go
@@ -14,20 +14,31 @@
 package v2
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"testing"
 	"time"
 
+	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
 	open_api_models "github.com/prometheus/alertmanager/api/v2/models"
 	general_ops "github.com/prometheus/alertmanager/api/v2/restapi/operations/general"
+	silence_ops "github.com/prometheus/alertmanager/api/v2/restapi/operations/silence"
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/pkg/labels"
+	"github.com/prometheus/alertmanager/silence"
 	"github.com/prometheus/alertmanager/silence/silencepb"
 	"github.com/prometheus/alertmanager/types"
+
+	"github.com/go-kit/log"
 )
 
 // If api.peers == nil, Alertmanager cluster feature is disabled. Make sure to
@@ -71,6 +82,13 @@ var (
 	testComment = "comment"
 	createdBy   = "test"
 )
+
+func newSilences(t *testing.T) *silence.Silences {
+	silences, err := silence.New(silence.Options{})
+	require.NoError(t, err)
+
+	return silences
+}
 
 func gettableSilence(id string, state string,
 	updatedAt string, start string, end string,
@@ -128,6 +146,170 @@ func TestGetSilencesHandler(t *testing.T) {
 
 	for i, sil := range silences {
 		assertEqualStrings(t, "silence-"+strconv.Itoa(i)+"-"+*sil.Status.State, *sil.ID)
+	}
+}
+
+func TestDeleteSilenceHandler(t *testing.T) {
+	now := time.Now()
+	silences := newSilences(t)
+
+	m := &silencepb.Matcher{Type: silencepb.Matcher_EQUAL, Name: "a", Pattern: "b"}
+
+	unexpiredSil := &silencepb.Silence{
+		Matchers:  []*silencepb.Matcher{m},
+		StartsAt:  now,
+		EndsAt:    now.Add(time.Hour),
+		UpdatedAt: now,
+	}
+	unexpiredSid, err := silences.Set(unexpiredSil)
+	require.NoError(t, err)
+
+	expiredSil := &silencepb.Silence{
+		Matchers:  []*silencepb.Matcher{m},
+		StartsAt:  now.Add(-time.Hour),
+		EndsAt:    now.Add(time.Hour),
+		UpdatedAt: now,
+	}
+	expiredSid, err := silences.Set(expiredSil)
+	require.NoError(t, err)
+	require.NoError(t, silences.Expire(expiredSid))
+
+	for i, tc := range []struct {
+		sid          string
+		expectedCode int
+	}{
+		{
+			"unknownSid",
+			500,
+		},
+		{
+			unexpiredSid,
+			200,
+		},
+		{
+			expiredSid,
+			200,
+		},
+	} {
+		api := API{
+			uptime:   time.Now(),
+			silences: silences,
+			logger:   log.NewNopLogger(),
+		}
+
+		r, err := http.NewRequest("DELETE", "/api/v2/silence/${tc.sid}", nil)
+		require.NoError(t, err)
+
+		w := httptest.NewRecorder()
+		p := runtime.TextProducer()
+		responder := api.deleteSilenceHandler(silence_ops.DeleteSilenceParams{
+			SilenceID:   strfmt.UUID(tc.sid),
+			HTTPRequest: r,
+		})
+		responder.WriteResponse(w, p)
+		body, _ := ioutil.ReadAll(w.Result().Body)
+
+		require.Equal(t, tc.expectedCode, w.Code, fmt.Sprintf(fmt.Sprintf("test case: %d, response: %s", i, string(body))))
+	}
+}
+
+func TestPostSilencesHandler(t *testing.T) {
+	now := time.Now()
+	silences := newSilences(t)
+
+	m := &silencepb.Matcher{Type: silencepb.Matcher_EQUAL, Name: "a", Pattern: "b"}
+
+	unexpiredSil := &silencepb.Silence{
+		Matchers:  []*silencepb.Matcher{m},
+		StartsAt:  now,
+		EndsAt:    now.Add(time.Hour),
+		UpdatedAt: now,
+	}
+	unexpiredSid, err := silences.Set(unexpiredSil)
+	require.NoError(t, err)
+
+	expiredSil := &silencepb.Silence{
+		Matchers:  []*silencepb.Matcher{m},
+		StartsAt:  now.Add(-time.Hour),
+		EndsAt:    now.Add(time.Hour),
+		UpdatedAt: now,
+	}
+	expiredSid, err := silences.Set(expiredSil)
+	require.NoError(t, err)
+	require.NoError(t, silences.Expire(expiredSid))
+
+	for i, tc := range []struct {
+		sid          string
+		start, end   time.Time
+		expectedCode int
+	}{
+		{
+			"unknownSid",
+			now.Add(time.Hour),
+			now.Add(time.Hour * 2),
+			404,
+		},
+		{
+			"",
+			now.Add(time.Hour),
+			now.Add(time.Hour * 2),
+			200,
+		},
+		{
+			unexpiredSid,
+			now.Add(time.Hour),
+			now.Add(time.Hour * 2),
+			200,
+		},
+		{
+			expiredSid,
+			now.Add(time.Hour),
+			now.Add(time.Hour * 2),
+			200,
+		},
+	} {
+		createdBy := "silenceCreator"
+		comment := "test"
+		matcherName := "a"
+		matcherValue := "b"
+		isRegex := false
+		startsAt := strfmt.DateTime(tc.start)
+		endsAt := strfmt.DateTime(tc.end)
+
+		sil := open_api_models.PostableSilence{
+			ID: tc.sid,
+			Silence: open_api_models.Silence{
+				Matchers:  open_api_models.Matchers{&open_api_models.Matcher{Name: &matcherName, Value: &matcherValue, IsRegex: &isRegex}},
+				StartsAt:  &startsAt,
+				EndsAt:    &endsAt,
+				CreatedBy: &createdBy,
+				Comment:   &comment,
+			},
+		}
+		b, err := json.Marshal(&sil)
+		if err != nil {
+			t.Errorf("Unexpected error %v", err)
+		}
+
+		api := API{
+			uptime:   time.Now(),
+			silences: silences,
+			logger:   log.NewNopLogger(),
+		}
+
+		r, err := http.NewRequest("POST", "/api/v2/silence/${tc.sid}", bytes.NewReader(b))
+		require.NoError(t, err)
+
+		w := httptest.NewRecorder()
+		p := runtime.TextProducer()
+		responder := api.postSilencesHandler(silence_ops.PostSilencesParams{
+			HTTPRequest: r,
+			Silence:     &sil,
+		})
+		responder.WriteResponse(w, p)
+		body, _ := ioutil.ReadAll(w.Result().Body)
+
+		require.Equal(t, tc.expectedCode, w.Code, fmt.Sprintf(fmt.Sprintf("test case: %d, response: %s", i, string(body))))
 	}
 }
 

--- a/silence/silence.go
+++ b/silence/silence.go
@@ -622,7 +622,7 @@ func (s *Silences) expire(id string) error {
 
 	switch getState(sil, now) {
 	case types.SilenceStateExpired:
-		return errors.Errorf("silence %s already expired", id)
+		return nil
 	case types.SilenceStateActive:
 		sil.EndsAt = now
 	case types.SilenceStatePending:

--- a/silence/silence.go
+++ b/silence/silence.go
@@ -622,6 +622,7 @@ func (s *Silences) expire(id string) error {
 
 	switch getState(sil, now) {
 	case types.SilenceStateExpired:
+		// returning nil ensures idempotent behaviour, at least in the short term before the silence is gc'd
 		return nil
 	case types.SilenceStateActive:
 		sil.EndsAt = now

--- a/silence/silence.go
+++ b/silence/silence.go
@@ -622,7 +622,7 @@ func (s *Silences) expire(id string) error {
 
 	switch getState(sil, now) {
 	case types.SilenceStateExpired:
-		// Returning nil ensures idempotent behaviour, at least in the short term before the silence is gc'd
+		// Returning nil ensures idempotent behaviour, at least in the short term before the silence is gc'd.
 		return nil
 	case types.SilenceStateActive:
 		sil.EndsAt = now

--- a/silence/silence.go
+++ b/silence/silence.go
@@ -612,6 +612,8 @@ func (s *Silences) Expire(id string) error {
 }
 
 // Expire the silence with the given ID immediately.
+// It is idempotent, nil is returned if the silence already expired before it is GC'd.
+// If the silence is not found an error is returned.
 func (s *Silences) expire(id string) error {
 	sil, ok := s.getSilence(id)
 	if !ok {
@@ -622,7 +624,6 @@ func (s *Silences) expire(id string) error {
 
 	switch getState(sil, now) {
 	case types.SilenceStateExpired:
-		// Returning nil ensures idempotent behaviour, at least in the short term before the silence is gc'd.
 		return nil
 	case types.SilenceStateActive:
 		sil.EndsAt = now

--- a/silence/silence.go
+++ b/silence/silence.go
@@ -622,7 +622,7 @@ func (s *Silences) expire(id string) error {
 
 	switch getState(sil, now) {
 	case types.SilenceStateExpired:
-		// returning nil ensures idempotent behaviour, at least in the short term before the silence is gc'd
+		// Returning nil ensures idempotent behaviour, at least in the short term before the silence is gc'd
 		return nil
 	case types.SilenceStateActive:
 		sil.EndsAt = now

--- a/silence/silence_test.go
+++ b/silence/silence_test.go
@@ -835,9 +835,7 @@ func TestSilenceExpire(t *testing.T) {
 	require.NoError(t, s.Expire("pending"))
 	require.NoError(t, s.Expire("active"))
 
-	err = s.Expire("expired")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "already expired")
+	require.NoError(t, s.Expire("expired"))
 
 	sil, err := s.QueryOne(QIDs("pending"))
 	require.NoError(t, err)
@@ -935,9 +933,7 @@ func TestSilenceExpireWithZeroRetention(t *testing.T) {
 	require.NoError(t, s.Expire("pending"))
 	require.NoError(t, s.Expire("active"))
 
-	err = s.Expire("expired")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "already expired")
+	require.NoError(t, s.Expire("expired"))
 
 	_, err = s.QueryOne(QIDs("pending"))
 	require.NoError(t, err)


### PR DESCRIPTION
Delete silence currently returns HTTP 500 if called on an expired silence.  This makes it non-idempotent, as the following call sequence can result:

```
T0 initial: DELETE /api/v1/silence/MySilence => Timeout (but actually succeeded)
T1 retry:   DELETE /api/v1/silence/MySilence => 500
```

After this sequence, the user is left uncertain whether there's a problem in AlertManager/Prometheus.  Even fetching the silence to verify its state won't confirm whether the 500 was indicative of a separate underlying problem that could manifest in other ways later.

Prometheus exposes the delete_series API which does exhibit idempotent behaviour -- calling delete_series on an already deleted series returns the same status as the initial delete_series call:  HTTP 200.

This PR changes Silences.expire(id) to return nil for expired silences, which impacts APIs as follows:
- DELETE silence will no longer fail if the silence was already expired
- PUT silence will no longer fail if the silence exists and was already expired
  https://github.com/prometheus/alertmanager/blob/c91717bc89aadd3253063ddca9f56a7c4a4c2736/silence/silence.go#L561-L562