### PR TITLE
provider: Avoid receive alerts after the listener closed

### DIFF
--- a/provider/mem/mem.go
+++ b/provider/mem/mem.go
@@ -202,6 +202,12 @@ func (a *Alerts) Put(alerts ...*types.Alert) error {
 		a.mtx.Lock()
 		for _, l := range a.listeners {
 			select {
+			case <-l.done:
+				continue
+			default:
+			}
+
+			select {
 			case l.alerts <- alert:
 			case <-l.done:
 			}


### PR DESCRIPTION
The closed listener takes 30m to `gc` by default, and it is possible to append an alert to the closed listener during the `Put` operation in this time.

The pr should not be a bug, just optimization.