### PR TITLE
Fix markdown list describing Alertmanager matchers

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -856,37 +856,37 @@ Here are some examples of valid string matchers:
 
 1. Shown below are two equality matchers combined in a long form YAML list.
 
-```yaml
-  matchers:
-   - foo = bar
-   - dings !=bums
-```
+    ```yaml
+    matchers:
+      - foo = bar
+      - dings !=bums
+    ```
 
 2. Similar to example 1, shown below are two equality matchers combined in a short form YAML list.
 
-```yaml
-matchers: [ foo = bar, dings != bums ]
-```
+    ```yaml
+    matchers: [ foo = bar, dings != bums ]
+    ```
 
-As shown below, in the short-form, it's generally better to quote the list elements to avoid problems with special characters like commas:
+    As shown below, in the short-form, it's generally better to quote the list elements to avoid problems with special characters like commas:
 
-```yaml
-matchers: [ "foo = bar,baz", "dings != bums" ]
-```
+    ```yaml
+    matchers: [ "foo = bar,baz", "dings != bums" ]
+    ```
 
 3. You can also put both matchers into one PromQL-like string. Single quotes for the whole string work best here.
 
-```yaml
-matchers: [ '{foo="bar",dings!="bums"}' ]
-```
+    ```yaml
+    matchers: [ '{foo="bar",dings!="bums"}' ]
+    ```
 
 4. To avoid any confusion about YAML string quoting and escaping, you can use YAML block quoting and then only worry about the OpenMetrics escaping inside the block. A complex example with a regular expression and different quotes inside the label value is shown below:
 
-```yaml
-matchers:
-  - |
-      {quote=~"She said: \"Hi, all!( How're you…)?\""}
-```
+    ```yaml
+    matchers:
+      - |
+          {quote=~"She said: \"Hi, all!( How're you…)?\""}
+    ```
 
 ## `<victorops_config>`
 


### PR DESCRIPTION
The Markdown variant used on prometheus.io is different from the GitHub one and
requires code blocks to be indented by four spaces to be recognized as part of
a list item vs. terminating the list.

<hr/>

**Before:**

![broken-format](https://user-images.githubusercontent.com/538008/152002309-916b02ab-9d3d-46f8-9530-3b8b4cf2e537.png)

<hr/>

**After:**

![fixed-format](https://user-images.githubusercontent.com/538008/152002313-ebdc5056-5bd8-4be7-b8a6-35cad2a96798.png)

Signed-off-by: Julius Volz <julius.volz@gmail.com>