### PR TITLE
validate sns message attributes and remove if invalid

### DIFF
--- a/notify/sns/sns.go
+++ b/notify/sns/sns.go
@@ -15,8 +15,10 @@ package sns
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 	"unicode/utf8"
 
@@ -35,6 +37,31 @@ import (
 	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/alertmanager/types"
 )
+
+const (
+	// Message components
+	MessageAttribute = "MessageAttribute"
+
+	// Modified Message attribute value format
+	ComponentAndModifiedReason = "%s: %s"
+
+	// The errors
+	MessageAttributeNotValidKeyOrValue = "Error - %d of message attributes have been removed because of invalid MessageAttributeKey or MessageAttributeValue"
+
+	// Message components size limit
+	messageAttributeKeyLimitInCharacters = 256
+	// Max message size for a message in a SNS publish request is 256KB, except for SMS messages where the limit is 1600 characters/runes.
+)
+
+var isInvalidMessageAttributeKeyPrefix = regexp.MustCompile(`^(AWS\.)|^(Amazon\.)|^(\.)`).MatchString
+var isInvalidMessageAttributeKeySuffix = regexp.MustCompile(`\.$`).MatchString
+var isInvalidMessageAttributeKeySubstring = regexp.MustCompile(`\.{2}`).MatchString
+var isValidMessageAttributeKeyCharacters = regexp.MustCompile(`^[a-zA-Z0-9_\-.]*$`).MatchString
+
+var modifiedMessageAttributeKey = "modified"
+
+//Used for testing
+var jsonMarshal = json.Marshal
 
 // Notifier implements a Notifier for SNS notifications.
 type Notifier struct {
@@ -141,8 +168,9 @@ func (n *Notifier) createSNSClient(tmpl func(string) string) (*sns.SNS, error) {
 }
 
 func (n *Notifier) createPublishInput(ctx context.Context, tmpl func(string) string) (*sns.PublishInput, error) {
+	var modifiedReasons []string
 	publishInput := &sns.PublishInput{}
-	messageAttributes := n.createMessageAttributes(tmpl)
+	messageAttributes := n.createAndValidateMessageAttributes(tmpl, &modifiedReasons)
 	// Max message size for a message in a SNS publish request is 256KB, except for SMS messages where the limit is 1600 characters/runes.
 	messageSizeLimit := 256 * 1024
 	if n.conf.TopicARN != "" {
@@ -177,6 +205,11 @@ func (n *Notifier) createPublishInput(ctx context.Context, tmpl func(string) str
 		messageAttributes["truncated"] = &sns.MessageAttributeValue{DataType: aws.String("String"), StringValue: aws.String("true")}
 	}
 
+	err = addModifiedMessageAttributes(messageAttributes, modifiedReasons)
+	if err != nil {
+		return nil, err
+	}
+
 	publishInput.SetMessage(messageToSend)
 	publishInput.SetMessageAttributes(messageAttributes)
 
@@ -200,11 +233,71 @@ func validateAndTruncateMessage(message string, maxMessageSizeInBytes int) (stri
 	return string(truncated), true, nil
 }
 
-func (n *Notifier) createMessageAttributes(tmpl func(string) string) map[string]*sns.MessageAttributeValue {
+func addModifiedMessageAttributes(attributes map[string]*sns.MessageAttributeValue, modifiedReasons []string) error {
+	if len(modifiedReasons) > 0 {
+		valueString, err := getModifiedReasonMessageAttributeValue(modifiedReasons)
+		if err != nil {
+			return err
+		}
+		attributes[modifiedMessageAttributeKey] = &sns.MessageAttributeValue{DataType: aws.String("String.Array"), StringValue: aws.String(valueString)}
+	}
+
+	return nil
+}
+
+func getModifiedReasonMessageAttributeValue(modifiedReasons []string) (string, error) {
+	jsonString, err := jsonMarshal(modifiedReasons)
+	if err != nil {
+		return "", err
+	}
+
+	return string(jsonString), nil
+}
+
+func (n *Notifier) createAndValidateMessageAttributes(tmpl func(string) string, modifiedReasons *[]string) map[string]*sns.MessageAttributeValue {
+	numberOfInvalidMessageAttributes := 0
 	// Convert the given attributes map into the AWS Message Attributes Format.
 	attributes := make(map[string]*sns.MessageAttributeValue, len(n.conf.Attributes))
 	for k, v := range n.conf.Attributes {
-		attributes[tmpl(k)] = &sns.MessageAttributeValue{DataType: aws.String("String"), StringValue: aws.String(tmpl(v))}
+		attributeKey := tmpl(k)
+		attributeValue := tmpl(v)
+		if !isValidateMessageAttribute(attributeKey, attributeValue) {
+			numberOfInvalidMessageAttributes++
+			level.Debug(n.logger).Log("msg", "messageAttribute has been removed because of invalid key/value", "attributeKey", attributeKey, "attributeValue", attributeValue)
+			continue
+		}
+		attributes[attributeKey] = &sns.MessageAttributeValue{DataType: aws.String("String"), StringValue: aws.String(attributeValue)}
+	}
+
+	if numberOfInvalidMessageAttributes > 0 {
+		level.Info(n.logger).Log("msg", "messageAttributes has been removed because of invalid key/value", "numberOfRemovedAttributes", numberOfInvalidMessageAttributes)
+		*modifiedReasons = append(
+			*modifiedReasons,
+			fmt.Sprintf(ComponentAndModifiedReason, MessageAttribute, fmt.Sprintf(MessageAttributeNotValidKeyOrValue, numberOfInvalidMessageAttributes)),
+		)
 	}
 	return attributes
+}
+
+func isValidateMessageAttribute(messageAttributeKey string, messageAttributeValue string) bool {
+	if len(messageAttributeKey) == 0 || len(messageAttributeValue) == 0 {
+		return false
+	}
+
+	if !isValidMessageAttributeKeyCharacters(messageAttributeKey) ||
+		isInvalidMessageAttributeKeyPrefix(messageAttributeKey) ||
+		isInvalidMessageAttributeKeySuffix(messageAttributeKey) ||
+		isInvalidMessageAttributeKeySubstring(messageAttributeKey) {
+		return false
+	}
+
+	if utf8.RuneCountInString(messageAttributeKey) > messageAttributeKeyLimitInCharacters {
+		return false
+	}
+
+	if !utf8.ValidString(messageAttributeValue) {
+		return false
+	}
+
+	return true
 }

--- a/notify/sns/sns_test.go
+++ b/notify/sns/sns_test.go
@@ -14,10 +14,17 @@
 package sns
 
 import (
+	"github.com/go-kit/log"
+	"github.com/prometheus/alertmanager/config"
+	"github.com/prometheus/alertmanager/template"
+	commoncfg "github.com/prometheus/common/config"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+var logger = log.NewNopLogger()
 
 func TestValidateAndTruncateMessage(t *testing.T) {
 	sBuff := make([]byte, 257*1024)
@@ -42,4 +49,54 @@ func TestValidateAndTruncateMessage(t *testing.T) {
 	invalidUtf8String := "\xc3\x28"
 	_, _, err = validateAndTruncateMessage(invalidUtf8String, 100)
 	require.Error(t, err)
+}
+
+func TestCreateAndValidateMessageAttributes(t *testing.T) {
+	var modifiedReasons []string
+	attributes := map[string]string{
+		"Invalid0":        "",
+		".Invalid1":       "123",
+		"Invalid2.":       "123",
+		"AWS.Invalid3":    "123",
+		"Amazon.Invalid4": "123",
+		"Invalid..5":      "123",
+		"Valid0":          "123",
+		"AmazonValid1":    "123",
+		"valid.2":         "123",
+		"valid-_3":        "123",
+	}
+	notifier, err := New(
+		&config.SNSConfig{
+			Attributes: attributes,
+			HTTPConfig: &commoncfg.HTTPClientConfig{},
+		},
+		CreateTmpl(t),
+		logger,
+	)
+	require.NoError(t, err)
+
+	attributesAfterValidation := notifier.createAndValidateMessageAttributes(temlFunction(t), &modifiedReasons)
+
+	require.Equal(t, 4, len(attributesAfterValidation))
+	require.Equal(t, true, attributesAfterValidation["Valid0"] != nil)
+	require.Equal(t, true, attributesAfterValidation["AmazonValid1"] != nil)
+	require.Equal(t, true, attributesAfterValidation["valid.2"] != nil)
+	require.Equal(t, true, attributesAfterValidation["valid-_3"] != nil)
+	require.Equal(t, len(modifiedReasons), 1)
+	require.Equal(t, "MessageAttribute: Error - 6 of message attributes have been removed because of invalid MessageAttributeKey or MessageAttributeValue", modifiedReasons[0])
+}
+
+// CreateTmpl returns a ready-to-use template.
+func CreateTmpl(t *testing.T) *template.Template {
+	tmpl, err := template.FromGlobs()
+	require.NoError(t, err)
+	tmpl.ExternalURL, _ = url.Parse("http://am")
+	return tmpl
+}
+
+// CreateTmpl returns a ready-to-use template.
+func temlFunction(t *testing.T) func(string) string {
+	return func(input string) string {
+		return input
+	}
 }


### PR DESCRIPTION
Add validation for message attribute, if not a validate attribute, we will remove the attribute

Separate from https://github.com/prometheus/alertmanager/pull/2808