### PR TITLE
Add CLI args for snapshot intervals

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -195,6 +195,9 @@ func run() int {
 		retention       = kingpin.Flag("data.retention", "How long to keep data for.").Default("120h").Duration()
 		alertGCInterval = kingpin.Flag("alerts.gc-interval", "Interval between alert GC.").Default("30m").Duration()
 
+		silencesInterval = kingpin.Flag("silences.interval", "Interval between writing silences snapshot to disk.").Default("15m").Duration()
+		nflogsInterval   = kingpin.Flag("nflogs.interval", "Interval between writing nflogs snapshot to disk.").Default("15m").Duration()
+
 		webConfig      = webflag.AddFlags(kingpin.CommandLine)
 		externalURL    = kingpin.Flag("web.external-url", "The URL under which Alertmanager is externally reachable (for example, if Alertmanager is served via a reverse proxy). Used for generating relative and absolute links back to Alertmanager itself. If the URL has a path portion, it will be used to prefix all HTTP endpoints served by Alertmanager. If omitted, relevant URL components will be derived automatically.").String()
 		routePrefix    = kingpin.Flag("web.route-prefix", "Prefix for the internal routes of web endpoints. Defaults to path of --web.external-url.").String()
@@ -273,7 +276,7 @@ func run() int {
 	notificationLogOpts := []nflog.Option{
 		nflog.WithRetention(*retention),
 		nflog.WithSnapshot(filepath.Join(*dataDir, "nflog")),
-		nflog.WithMaintenance(15*time.Minute, stopc, wg.Done, nil),
+		nflog.WithMaintenance(*nflogsInterval, stopc, wg.Done, nil),
 		nflog.WithMetrics(prometheus.DefaultRegisterer),
 		nflog.WithLogger(log.With(logger, "component", "nflog")),
 	}
@@ -310,7 +313,7 @@ func run() int {
 	// Start providers before router potentially sends updates.
 	wg.Add(1)
 	go func() {
-		silences.Maintenance(15*time.Minute, filepath.Join(*dataDir, "silences"), stopc, nil)
+		silences.Maintenance(*silencesInterval, filepath.Join(*dataDir, "silences"), stopc, nil)
 		wg.Done()
 	}()
 

--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -195,8 +195,8 @@ func run() int {
 		retention       = kingpin.Flag("data.retention", "How long to keep data for.").Default("120h").Duration()
 		alertGCInterval = kingpin.Flag("alerts.gc-interval", "Interval between alert GC.").Default("30m").Duration()
 
-		silencesInterval = kingpin.Flag("silences.interval", "Interval between writing silences snapshot to disk.").Default("15m").Duration()
-		nflogsInterval   = kingpin.Flag("nflogs.interval", "Interval between writing nflogs snapshot to disk.").Default("15m").Duration()
+		silencesInterval = kingpin.Flag("silences.maintenance-interval", "Interval between garbage collection and snapshotting to disk of the silences.").Default("15m").Duration()
+		nflogsInterval   = kingpin.Flag("nflogs.maintenance-interval", "Interval between garbage collection and snapshotting to disk of the notification logs.").Default("15m").Duration()
 
 		webConfig      = webflag.AddFlags(kingpin.CommandLine)
 		externalURL    = kingpin.Flag("web.external-url", "The URL under which Alertmanager is externally reachable (for example, if Alertmanager is served via a reverse proxy). Used for generating relative and absolute links back to Alertmanager itself. If the URL has a path portion, it will be used to prefix all HTTP endpoints served by Alertmanager. If omitted, relevant URL components will be derived automatically.").String()

--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -190,13 +190,11 @@ func run() int {
 	}
 
 	var (
-		configFile      = kingpin.Flag("config.file", "Alertmanager configuration file name.").Default("alertmanager.yml").String()
-		dataDir         = kingpin.Flag("storage.path", "Base path for data storage.").Default("data/").String()
-		retention       = kingpin.Flag("data.retention", "How long to keep data for.").Default("120h").Duration()
-		alertGCInterval = kingpin.Flag("alerts.gc-interval", "Interval between alert GC.").Default("30m").Duration()
-
-		silencesInterval = kingpin.Flag("silences.maintenance-interval", "Interval between garbage collection and snapshotting to disk of the silences.").Default("15m").Duration()
-		nflogsInterval   = kingpin.Flag("nflogs.maintenance-interval", "Interval between garbage collection and snapshotting to disk of the notification logs.").Default("15m").Duration()
+		configFile          = kingpin.Flag("config.file", "Alertmanager configuration file name.").Default("alertmanager.yml").String()
+		dataDir             = kingpin.Flag("storage.path", "Base path for data storage.").Default("data/").String()
+		retention           = kingpin.Flag("data.retention", "How long to keep data for.").Default("120h").Duration()
+		maintenanceInterval = kingpin.Flag("data.maintenance-interval", "Interval between garbage collection and snapshotting to disk of the silences and the notification logs.").Default("15m").Duration()
+		alertGCInterval     = kingpin.Flag("alerts.gc-interval", "Interval between alert GC.").Default("30m").Duration()
 
 		webConfig      = webflag.AddFlags(kingpin.CommandLine)
 		externalURL    = kingpin.Flag("web.external-url", "The URL under which Alertmanager is externally reachable (for example, if Alertmanager is served via a reverse proxy). Used for generating relative and absolute links back to Alertmanager itself. If the URL has a path portion, it will be used to prefix all HTTP endpoints served by Alertmanager. If omitted, relevant URL components will be derived automatically.").String()
@@ -276,7 +274,7 @@ func run() int {
 	notificationLogOpts := []nflog.Option{
 		nflog.WithRetention(*retention),
 		nflog.WithSnapshot(filepath.Join(*dataDir, "nflog")),
-		nflog.WithMaintenance(*nflogsInterval, stopc, wg.Done, nil),
+		nflog.WithMaintenance(*maintenanceInterval, stopc, wg.Done, nil),
 		nflog.WithMetrics(prometheus.DefaultRegisterer),
 		nflog.WithLogger(log.With(logger, "component", "nflog")),
 	}
@@ -313,7 +311,7 @@ func run() int {
 	// Start providers before router potentially sends updates.
 	wg.Add(1)
 	go func() {
-		silences.Maintenance(*silencesInterval, filepath.Join(*dataDir, "silences"), stopc, nil)
+		silences.Maintenance(*maintenanceInterval, filepath.Join(*dataDir, "silences"), stopc, nil)
 		wg.Done()
 	}()
 


### PR DESCRIPTION
This PR adds two new CLI args to support custom snapshot intervals for nflogs and silences.

Fixes #2660.