### PR TITLE
docs: fix installation for go1.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ _API v2 is still under heavy development and thereby subject to change._
 
 Alternatively you can install with:
 ```
-go get github.com/prometheus/alertmanager/cmd/amtool
+$ go install github.com/prometheus/alertmanager/cmd/amtool@latest
 ```
 
 ### Examples


### PR DESCRIPTION
Signed-off-by: Furkan <furkan.turkal@trendyol.com>

'go get' is no longer supported outside a module. To install, I replaced installation with 'go install'.