### PR TITLE
Fix resolved header in email template

### DIFF
--- a/template/email.tmpl
+++ b/template/email.tmpl
@@ -91,7 +91,7 @@ h4 {
             {{ if gt (len .Alerts.Firing) 0 }}
             <td class="alert alert-warning" style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; vertical-align: top; font-size: 16px; color: #fff; font-weight: 500; padding: 20px; text-align: center; border-radius: 3px 3px 0 0; background-color: #E6522C;" valign="top" align="center" bgcolor="#E6522C">
             {{ else }}
-            </td><td class="alert alert-good" style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; vertical-align: top; font-size: 16px; color: #fff; font-weight: 500; padding: 20px; text-align: center; border-radius: 3px 3px 0 0; background-color: #68B90F;" valign="top" align="center" bgcolor="#68B90F">
+            <td class="alert alert-good" style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; vertical-align: top; font-size: 16px; color: #fff; font-weight: 500; padding: 20px; text-align: center; border-radius: 3px 3px 0 0; background-color: #68B90F;" valign="top" align="center" bgcolor="#68B90F">
             {{ end }}
               {{ .Alerts | len }} alert{{ if gt (len .Alerts) 1 }}s{{ end }} for {{ range .GroupLabels.SortedPairs }}
                 {{ .Name }}={{ .Value }} 


### PR DESCRIPTION
# Background
We use a custom email template based on `alertmanager/template/email.tmpl`.

# Problem
The email template for resolved messages currently has a styling issue. Due to an extra `</td>`, the green heading is only shown in the top right corner, instead of covering the full width.

![image](https://user-images.githubusercontent.com/43773206/161736138-16a3edf2-edd0-449c-90b5-58cf954ce743.png)

# Solution
Removing the extra `</td>` solves the issue.

![image](https://user-images.githubusercontent.com/43773206/161736560-3e528941-9857-4a97-8847-e86c64eeec0a.png)
