### PR TITLE
notify/telegram: Set API URL and ParseMode defaults

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -143,7 +143,7 @@ var (
 		},
 		DisableNotifications: false,
 		Message:              `{{ template "telegram.default.message" . }}`,
-		ParseMode:            "MarkdownV2",
+		ParseMode:            "HTML",
 	}
 )
 
@@ -660,9 +660,6 @@ func (c *TelegramConfig) UnmarshalYAML(unmarshal func(interface{}) error) error 
 	}
 	if c.ChatID == 0 {
 		return fmt.Errorf("missing chat_id on telegram_config")
-	}
-	if c.APIUrl == nil {
-		return fmt.Errorf("missing api_url on telegram_config")
 	}
 	if c.ParseMode != "" &&
 		c.ParseMode != "Markdown" &&

--- a/notify/telegram/telegram.go
+++ b/notify/telegram/telegram.go
@@ -16,6 +16,7 @@ package telegram
 import (
 	"context"
 	"net/http"
+	"net/url"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -42,6 +43,19 @@ func New(conf *config.TelegramConfig, t *template.Template, l log.Logger, httpOp
 	httpclient, err := commoncfg.NewClientFromConfig(*conf.HTTPConfig, "telegram", httpOpts...)
 	if err != nil {
 		return nil, err
+	}
+
+	if conf.APIUrl == nil {
+		apiURL, err := url.Parse("https://api.telegram.org")
+		if err != nil {
+			return nil, err
+		}
+		conf.APIUrl = &config.URL{URL: apiURL}
+	}
+	if conf.ParseMode == "" {
+		// The default Telegram template is in HTML,
+		// so we need to set the parse mode to HTML for Telegram not to return a parse error.
+		conf.ParseMode = "HTML"
 	}
 
 	client, err := createTelegramClient(conf.BotToken, conf.APIUrl.String(), conf.ParseMode, httpclient)

--- a/notify/telegram/telegram.go
+++ b/notify/telegram/telegram.go
@@ -16,7 +16,6 @@ package telegram
 import (
 	"context"
 	"net/http"
-	"net/url"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -43,19 +42,6 @@ func New(conf *config.TelegramConfig, t *template.Template, l log.Logger, httpOp
 	httpclient, err := commoncfg.NewClientFromConfig(*conf.HTTPConfig, "telegram", httpOpts...)
 	if err != nil {
 		return nil, err
-	}
-
-	if conf.APIUrl == nil {
-		apiURL, err := url.Parse("https://api.telegram.org")
-		if err != nil {
-			return nil, err
-		}
-		conf.APIUrl = &config.URL{URL: apiURL}
-	}
-	if conf.ParseMode == "" {
-		// The default Telegram template is in HTML,
-		// so we need to set the parse mode to HTML for Telegram not to return a parse error.
-		conf.ParseMode = "HTML"
 	}
 
 	client, err := createTelegramClient(conf.BotToken, conf.APIUrl.String(), conf.ParseMode, httpclient)

--- a/notify/telegram/telegram_test.go
+++ b/notify/telegram/telegram_test.go
@@ -47,7 +47,7 @@ receivers:
 	require.Equal(t, "https://api.telegram.org", c.Receivers[0].TelegramConfigs[0].APIUrl.String())
 	require.Equal(t, config.Secret("secret"), c.Receivers[0].TelegramConfigs[0].BotToken)
 	require.Equal(t, int64(1234), c.Receivers[0].TelegramConfigs[0].ChatID)
-	require.Equal(t, "MarkdownV2", c.Receivers[0].TelegramConfigs[0].ParseMode)
+	require.Equal(t, "HTML", c.Receivers[0].TelegramConfigs[0].ParseMode)
 }
 
 func TestTelegramRetry(t *testing.T) {

--- a/notify/telegram/telegram_test.go
+++ b/notify/telegram/telegram_test.go
@@ -21,13 +21,37 @@ import (
 	"github.com/go-kit/log"
 	commoncfg "github.com/prometheus/common/config"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
 
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify/test"
 )
 
+func TestTelegramUnmarshal(t *testing.T) {
+	in := `
+route:
+  receiver: test
+receivers:
+- name: test
+  telegram_configs:
+  - chat_id: 1234
+    bot_token: secret
+`
+	var c config.Config
+	err := yaml.Unmarshal([]byte(in), &c)
+	require.NoError(t, err)
+
+	require.Len(t, c.Receivers, 1)
+	require.Len(t, c.Receivers[0].TelegramConfigs, 1)
+
+	require.Equal(t, "https://api.telegram.org", c.Receivers[0].TelegramConfigs[0].APIUrl.String())
+	require.Equal(t, config.Secret("secret"), c.Receivers[0].TelegramConfigs[0].BotToken)
+	require.Equal(t, int64(1234), c.Receivers[0].TelegramConfigs[0].ChatID)
+	require.Equal(t, "MarkdownV2", c.Receivers[0].TelegramConfigs[0].ParseMode)
+}
+
 func TestTelegramRetry(t *testing.T) {
-	// Fake url for testing purpouses
+	// Fake url for testing purposes
 	fakeURL := config.URL{
 		URL: &url.URL{
 			Scheme: "https",


### PR DESCRIPTION
For Telegram, there is really just one API URL, and other than for testing I never saw anything changing it. Therefore, as asked in #2876 we can set the default.
The default Telegram template that's shipped with Alertmanager uses HTML and if send to Telegram without the parseMode set to `HTML` Telegram's API will return an error:
```
Bad Request: can't parse entities: Character '-' is reserved and must be escaped with the preceding '\\' (400)"
```
  
Closes #2866
Closes #2876