### PR TITLE
Remove unneeded stopping of nil Dispatcher

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -347,7 +347,9 @@ func run() int {
 	defer alerts.Close()
 
 	var disp *dispatch.Dispatcher
-	defer disp.Stop()
+	defer func() {
+		disp.Stop()
+	}()
 
 	groupFn := func(routeFilter func(*dispatch.Route) bool, alertFilter func(*types.Alert, time.Time) bool) (dispatch.AlertGroups, map[model.Fingerprint][]string) {
 		return disp.Groups(routeFilter, alertFilter)


### PR DESCRIPTION
The function value and parameters of a defer statement are immediately
evaluated, so this "disp" value is always nil, and calling Stop() on a nil
dispatcher is a no-op, so this does nothing, but is confusing.

Signed-off-by: Julius Volz <julius.volz@gmail.com>