### PR TITLE
Remove unneeded nil check before ranging over slice

### DIFF
--- a/dispatch/route.go
+++ b/dispatch/route.go
@@ -183,9 +183,6 @@ func (r *Route) Key() string {
 // Walk traverses the route tree in depth-first order.
 func (r *Route) Walk(visit func(*Route)) {
 	visit(r)
-	if r.Routes == nil {
-		return
-	}
 	for i := range r.Routes {
 		r.Routes[i].Walk(visit)
 	}


### PR DESCRIPTION
Ranging over a nil slice is just a noop as well.

Signed-off-by: Julius Volz <julius.volz@gmail.com>