### PR TITLE
Sort receiver stage constructions by pipeline order

### DIFF
--- a/notify/notify.go
+++ b/notify/notify.go
@@ -330,9 +330,9 @@ func (pb *PipelineBuilder) New(
 
 	ms := NewGossipSettleStage(peer)
 	is := NewMuteStage(inhibitor)
-	ss := NewMuteStage(silencer)
-	tms := NewTimeMuteStage(times)
 	tas := NewTimeActiveStage(times)
+	tms := NewTimeMuteStage(times)
+	ss := NewMuteStage(silencer)
 
 	for name := range receivers {
 		st := createReceiverStage(name, receivers[name], wait, notificationLog, pb.metrics)


### PR DESCRIPTION
This is less confusing to read if the receiver stages are constructed in the
same order as they are used in the pipeline below.

Signed-off-by: Julius Volz <julius.volz@gmail.com>