### PR TITLE
Mixin: Rename exclusion rule from `panel-job-instance-rule` to `targert-instance-rule`

### DIFF
--- a/doc/alertmanager-mixin/.lint
+++ b/doc/alertmanager-mixin/.lint
@@ -1,7 +1,7 @@
 exclusions:
-  panel-job-instance-rule:
+  target-instance-rule:
     reason: no need to have every query contains two matchers within every selector - `{job=~"$job", instance=~"$instance"}`
-  template-job-rule: 
+  template-job-rule:
     entries:
     - dashboard: Alertmanager / Overview 
       reason: multi-select is not always required


### PR DESCRIPTION


Within https://github.com/grafana/dashboard-linter/commit/9a32e58ed01ee136ea674887f04a559a15eda3e6, the rules have been split into two different rules:

`target-job-rule`
`target-instance-rule`

All of our queries do contain the `job` label but as per the reason, we don't need both in this particular case.

Fixes #2899