### PR TITLE
Add support for custom Go template delimiters

### DIFF
--- a/cli/check_config.go
+++ b/cli/check_config.go
@@ -82,9 +82,14 @@ func CheckConfig(args []string) error {
 			}
 			fmt.Printf(" - %d inhibit rules\n", len(cfg.InhibitRules))
 			fmt.Printf(" - %d receivers\n", len(cfg.Receivers))
-			fmt.Printf(" - %d templates\n", len(cfg.Templates))
-			if len(cfg.Templates) > 0 {
-				_, err = template.FromGlobs(cfg.Templates...)
+			fmt.Println(" - builtin templates")
+			tmpl, err := template.New()
+			if err != nil {
+				fmt.Printf("  FAILED: %s\n", err)
+				failed++
+			} else if len(cfg.Templates) > 0 {
+				fmt.Printf(" - %d templates\n", len(cfg.Templates))
+				err := tmpl.Delims(cfg.TemplateConfig.DelimLeft, cfg.TemplateConfig.DelimRight).ParseGlobs(cfg.Templates...)
 				if err != nil {
 					fmt.Printf("  FAILED: %s\n", err)
 					failed++

--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -409,8 +409,11 @@ func run() int {
 		configLogger,
 	)
 	configCoordinator.Subscribe(func(conf *config.Config) error {
-		tmpl, err = template.FromGlobs(conf.Templates...)
+		tmpl, err = template.New()
 		if err != nil {
+			return errors.Wrap(err, "failed to parse builtin templates")
+		}
+		if err := tmpl.Delims(conf.TemplateConfig.DelimLeft, conf.TemplateConfig.DelimRight).ParseGlobs(conf.Templates...); err != nil {
 			return errors.Wrap(err, "failed to parse templates")
 		}
 		tmpl.ExternalURL = amURL

--- a/config/config.go
+++ b/config/config.go
@@ -289,11 +289,12 @@ func (ti *TimeInterval) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // Config is the top-level configuration for Alertmanager's config files.
 type Config struct {
-	Global       *GlobalConfig  `yaml:"global,omitempty" json:"global,omitempty"`
-	Route        *Route         `yaml:"route,omitempty" json:"route,omitempty"`
-	InhibitRules []*InhibitRule `yaml:"inhibit_rules,omitempty" json:"inhibit_rules,omitempty"`
-	Receivers    []*Receiver    `yaml:"receivers,omitempty" json:"receivers,omitempty"`
-	Templates    []string       `yaml:"templates" json:"templates"`
+	Global         *GlobalConfig  `yaml:"global,omitempty" json:"global,omitempty"`
+	Route          *Route         `yaml:"route,omitempty" json:"route,omitempty"`
+	InhibitRules   []*InhibitRule `yaml:"inhibit_rules,omitempty" json:"inhibit_rules,omitempty"`
+	Receivers      []*Receiver    `yaml:"receivers,omitempty" json:"receivers,omitempty"`
+	Templates      []string       `yaml:"templates" json:"templates"`
+	TemplateConfig TemplateConfig `yaml:"template_config,omitempty" json:"template_config,omitempty"`
 	// Deprecated. Remove before v1.0 release.
 	MuteTimeIntervals []MuteTimeInterval `yaml:"mute_time_intervals,omitempty" json:"mute_time_intervals,omitempty"`
 	TimeIntervals     []TimeInterval     `yaml:"time_intervals,omitempty" json:"time_intervals,omitempty"`
@@ -997,4 +998,12 @@ func (m Matchers) MarshalJSON() ([]byte, error) {
 		result[i] = matcher.String()
 	}
 	return json.Marshal(result)
+}
+
+// TemplateConfig defines the configuration parameters for Golang templates.
+type TemplateConfig struct {
+	// String used as left delimiter
+	DelimLeft string `yaml:"delim_left,omitempty" json:"delim_left,omitempty"`
+	// String used as right delimiter
+	DelimRight string `yaml:"delim_right,omitempty" json:"delim_right,omitempty"`
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -105,6 +105,17 @@ global:
 templates:
   [ - <filepath> ... ]
 
+# Template configuration applied to <tmpl_string>, <tmpl_secret> and custom notification template files.
+template_config:
+  # String used as left delimiter.
+  # Using an empty string is equal to "{{".
+  # Using a non-default value requires overriding all default templated string values.
+  [ delim_left: <string> | default = "" ]
+  # String used as right delimiter.
+  # Using an empty string is equal to "}}".
+  # Using a non-default value requires overriding all default templated string values.
+  [ delim_right: <string> | default = "" ]
+
 # The root node of the routing tree.
 route: <route>
 

--- a/notify/email/email_test.go
+++ b/notify/email/email_test.go
@@ -183,7 +183,7 @@ func notifyEmailWithContext(ctx context.Context, cfg *config.EmailConfig, server
 		return nil, false, err
 	}
 
-	tmpl, err := template.FromGlobs()
+	tmpl, err := template.New()
 	if err != nil {
 		return nil, false, err
 	}

--- a/notify/test/test.go
+++ b/notify/test/test.go
@@ -128,7 +128,7 @@ func DefaultRetryCodes() []int {
 
 // CreateTmpl returns a ready-to-use template.
 func CreateTmpl(t *testing.T) *template.Template {
-	tmpl, err := template.FromGlobs()
+	tmpl, err := template.New()
 	require.NoError(t, err)
 	tmpl.ExternalURL, _ = url.Parse("http://am")
 	return tmpl

--- a/template/template.go
+++ b/template/template.go
@@ -40,9 +40,8 @@ type Template struct {
 	ExternalURL *url.URL
 }
 
-// FromGlobs calls ParseGlob on all path globs provided and returns the
-// resulting Template.
-func FromGlobs(paths ...string) (*Template, error) {
+// New returns a new Template with the default functions and templates applied.
+func New() (*Template, error) {
 	t := &Template{
 		text: tmpltext.New("").Option("missingkey=zero"),
 		html: tmplhtml.New("").Option("missingkey=zero"),
@@ -71,24 +70,39 @@ func FromGlobs(paths ...string) (*Template, error) {
 		}
 
 	}
+	return t, nil
+}
 
+// Delims sets the action delimiters to the specified strings, to be used
+// in subsequent calls to ParseGlobs, ExecuteTextString and ExecuteHTMLString.
+// An empty delimiter stands for the corresponding default: {{ or }}.
+// The return value is the template, so calls can be chained.
+func (t *Template) Delims(left, right string) *Template {
+	t.text = t.text.Delims(left, right)
+	t.html = t.html.Delims(left, right)
+	return t
+}
+
+// ParseGlobs calls ParseGlob on all path globs provided and returns the
+// resulting Template.
+func (t *Template) ParseGlobs(paths ...string) error {
 	for _, tp := range paths {
 		// ParseGlob in the template packages errors if not at least one file is
 		// matched. We want to allow empty matches that may be populated later on.
 		p, err := filepath.Glob(tp)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		if len(p) > 0 {
 			if t.text, err = t.text.ParseGlob(tp); err != nil {
-				return nil, err
+				return err
 			}
 			if t.html, err = t.html.ParseGlob(tp); err != nil {
-				return nil, err
+				return err
 			}
 		}
 	}
-	return t, nil
+	return nil
 }
 
 // ExecuteTextString needs a meaningful doc comment (TODO(fabxc)).


### PR DESCRIPTION
Alertmanager uses Go templates in different configuration parameters.
Many users generate the configuration using tools like Helm, ExternalSecret, etc.
Most of these tools are written in Go, and therfore use Go templates.
This creates problems when the configuration tool needs to skip the Alertmanager templates.
As a result users usually have to add escaping to the templates:
```go
{{ `{{ ... }}` }}
```

This change allows setting the template delimiters used in Alertmanager configuration.
This is already configurable in Go templates using `Delims()` functions for both `text` and `html`.
The newly added global configuration parameters allows users to set the left and right delimiters
used in Alertmanager templates and therfore avoid conflict with other configuration management tools:

```yaml
template_config:
  delim_left: "[["
  delim_right: "]]"
```

This change is backward compatible as empty delimiter parameters stands for the corresponding default: `{{` or `}}`.
The builtin templates are not affected by this change as custom delimiters are only applied to:
- `<tmpl_string>`
- `<tmpl_secret>`
- custom templates loaded by `templates: []`
