### PR TITLE
config: fix validation of OpsGenie configuration

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -492,7 +492,7 @@ func (c *OpsGenieConfig) UnmarshalYAML(unmarshal func(interface{}) error) error 
 		return err
 	}
 
-	if c.APIURL != nil && len(c.APIKeyFile) > 0 {
+	if c.APIKey != "" && len(c.APIKeyFile) > 0 {
 		return fmt.Errorf("at most one of api_key & api_key_file must be configured")
 	}
 

--- a/config/notifiers_test.go
+++ b/config/notifiers_test.go
@@ -590,6 +590,72 @@ func TestOpsgenieTypeMatcher(t *testing.T) {
 	}
 }
 
+func TestOpsGenieConfiguration(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+
+		err bool
+	}{
+		{
+			name: "valid configuration",
+			in: `api_key: xyz
+responders:
+- id: foo
+  type: scheDule
+- name: bar
+  type: teams
+- username: fred
+  type: USER
+api_url: http://example.com
+`,
+		},
+		{
+			name: "api_key and api_key_file both defined",
+			in: `api_key: xyz
+api_key_file: xyz
+api_url: http://example.com
+`,
+			err: true,
+		},
+		{
+			name: "invalid responder type",
+			in: `api_key: xyz
+responders:
+- id: foo
+  type: wrong
+api_url: http://example.com
+`,
+			err: true,
+		},
+		{
+			name: "missing responder field",
+			in: `api_key: xyz
+responders:
+- type: schedule
+api_url: http://example.com
+`,
+			err: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var cfg OpsGenieConfig
+
+			err := yaml.UnmarshalStrict([]byte(tc.in), &cfg)
+			if tc.err {
+				if err == nil {
+					t.Fatalf("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
 func TestSNS(t *testing.T) {
 	for _, tc := range []struct {
 		in  string

--- a/doc/alertmanager-mixin/.lint
+++ b/doc/alertmanager-mixin/.lint
@@ -1,7 +1,7 @@
 exclusions:
-  panel-job-instance-rule:
+  target-instance-rule:
     reason: no need to have every query contains two matchers within every selector - `{job=~"$job", instance=~"$instance"}`
-  template-job-rule: 
+  template-job-rule:
     entries:
     - dashboard: Alertmanager / Overview 
       reason: multi-select is not always required


### PR DESCRIPTION
The validation should fail if both `api_key` and `api_key_file` are
defined. I think there was a typo in the original PR (#2728) that
enforced `api_url` and `api_key_file` not being defined at the same
time.

cc @jkroepke since you did the initial implementation.