### PR TITLE
adding support for accessing template.Data in prometheus rules/alerts

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -20,6 +20,9 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+
 	commoncfg "github.com/prometheus/common/config"
 	"github.com/prometheus/common/sigv4"
 )
@@ -189,7 +192,7 @@ func (c *EmailConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	// Header names are case-insensitive, check for collisions.
 	normalizedHeaders := map[string]string{}
 	for h, v := range c.Headers {
-		normalized := strings.Title(h)
+		normalized := cases.Title(language.AmericanEnglish).String(h)
 		if _, ok := normalizedHeaders[normalized]; ok {
 			return fmt.Errorf("duplicate header %q in email config", normalized)
 		}

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	go.uber.org/atomic v1.9.0
 	golang.org/x/mod v0.5.1
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f
+	golang.org/x/text v0.3.7
 	golang.org/x/tools v0.1.9
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/telebot.v3 v3.0.0

--- a/notify/opsgenie/opsgenie_test.go
+++ b/notify/opsgenie/opsgenie_test.go
@@ -208,6 +208,41 @@ func TestOpsGenie(t *testing.T) {
 			expectedBody: `{"alias":"6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b","message":"message","description":"description","details":{"Actions":"doThis,doThat","Description":"adjusted description","Entity":"test-domain","Message":"message","Note":"this is a note","Priority":"P1","ResponderName1":"TeamA","ResponderName2":"EscalationA","ResponderName3":"TeamA,TeamB","ResponderType1":"team","ResponderType2":"escalation","ResponderType3":"teams","Source":"http://prometheus","Tags":"tag1,tag2"},"source":"http://prometheus","responders":[{"name":"TeamA","type":"team"},{"name":"TeamB","type":"team"}],"tags":["tag1","tag2"],"note":"this is a note","priority":"P1"}
 `,
 		},
+		{
+			title: "config with details for template with << >> delims",
+			cfg: &config.OpsGenieConfig{
+				NotifierConfig: config.NotifierConfig{
+					VSendResolved: true,
+				},
+				Message:     `{{ .CommonLabels.Message }}`,
+				Description: `{{ .CommonLabels.Description }}`,
+				Source:      `{{ .CommonLabels.Source }}`,
+				Details: map[string]string{
+					"Description": `adjusted {{ .CommonLabels.Description }}`,
+					"AlertStatus": `<< (index .Alerts 0).Status >>`,
+				},
+				Responders: []config.OpsGenieConfigResponder{
+					{
+						Name: `{{ .CommonLabels.ResponderName1 }}`,
+						Type: `{{ .CommonLabels.ResponderType1 }}`,
+					},
+					{
+						Name: `{{ .CommonLabels.ResponderName2 }}`,
+						Type: `{{ .CommonLabels.ResponderType2 }}`,
+					},
+				},
+				Tags:       `{{ .CommonLabels.Tags }}`,
+				Note:       `{{ .CommonLabels.Note }}`,
+				Priority:   `{{ .CommonLabels.Priority }}`,
+				APIKey:     `{{ .ExternalURL }}`,
+				APIURL:     &config.URL{URL: u},
+				HTTPConfig: &commoncfg.HTTPClientConfig{},
+			},
+			expectedEmptyAlertBody: `{"alias":"6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b","message":"","details":{"AlertStatus":"firing","Description":"adjusted "},"source":""}
+`,
+			expectedBody: `{"alias":"6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b","message":"message","description":"description","details":{"Actions":"doThis,doThat","AlertStatus":"firing","Description":"adjusted description","Entity":"test-domain","Message":"message","Note":"this is a note","Priority":"P1","ResponderName1":"TeamA","ResponderName2":"EscalationA","ResponderName3":"TeamA,TeamB","ResponderType1":"team","ResponderType2":"escalation","ResponderType3":"teams","Source":"http://prometheus","Tags":"tag1,tag2"},"source":"http://prometheus","responders":[{"name":"TeamA","type":"team"},{"name":"EscalationA","type":"escalation"}],"tags":["tag1","tag2"],"note":"this is a note","priority":"P1"}
+`,
+		},
 	} {
 		t.Run(tc.title, func(t *testing.T) {
 			notifier, err := New(tc.cfg, tmpl, logger)
@@ -221,6 +256,9 @@ func TestOpsGenie(t *testing.T) {
 			// Empty alert.
 			alert1 := &types.Alert{
 				Alert: model.Alert{
+					Annotations: model.LabelSet{
+						"extra_delims": "<<,>>",
+					},
 					StartsAt: time.Now(),
 					EndsAt:   time.Now().Add(time.Hour),
 				},
@@ -237,6 +275,9 @@ func TestOpsGenie(t *testing.T) {
 			// Fully defined alert.
 			alert2 := &types.Alert{
 				Alert: model.Alert{
+					Annotations: model.LabelSet{
+						"extra_delims": "<<,>>",
+					},
 					Labels: model.LabelSet{
 						"Message":        "message",
 						"Description":    "description",

--- a/notify/util.go
+++ b/notify/util.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -101,7 +102,25 @@ func TmplText(tmpl *template.Template, data *template.Data, err *error) func(str
 		if *err != nil {
 			return
 		}
+
 		s, *err = tmpl.ExecuteTextString(name, data)
+		if *err != nil {
+			return s
+		}
+
+		extraDelimsAnnotation, hasAnnotation := data.CommonAnnotations[template.ExtraDelimsAnnotation]
+		if !hasAnnotation {
+			return s
+		}
+
+		delims := strings.Split(extraDelimsAnnotation, ",")
+		if len(delims) != 2 {
+			*err = errors.Errorf("invalid annotation %s - must be two delimiters comma separated (ie. '<<,>>')", template.ExtraDelimsAnnotation)
+			return s
+		}
+
+		s, *err = tmpl.ExecuteTextString(s, data, template.WithDelims(delims[0], delims[1]))
+
 		return s
 	}
 }
@@ -113,7 +132,25 @@ func TmplHTML(tmpl *template.Template, data *template.Data, err *error) func(str
 		if *err != nil {
 			return
 		}
+
 		s, *err = tmpl.ExecuteHTMLString(name, data)
+		if *err != nil {
+			return s
+		}
+
+		extraDelimsAnnotation, hasAnnotation := data.CommonAnnotations[template.ExtraDelimsAnnotation]
+		if !hasAnnotation {
+			return s
+		}
+
+		delims := strings.Split(extraDelimsAnnotation, ",")
+		if len(delims) != 2 {
+			*err = errors.Errorf("invalid annotation %s - must be two delimiters comma separated (ie. '<<,>>')", template.ExtraDelimsAnnotation)
+			return s
+		}
+
+		s, *err = tmpl.ExecuteHTMLString(s, data, template.WithDelims(delims[0], delims[1]))
+
 		return s
 	}
 }

--- a/template/template.go
+++ b/template/template.go
@@ -27,6 +27,8 @@ import (
 	"time"
 
 	"github.com/prometheus/common/model"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 
 	"github.com/prometheus/alertmanager/asset"
 	"github.com/prometheus/alertmanager/types"
@@ -182,7 +184,7 @@ type FuncMap map[string]interface{}
 var DefaultFuncs = FuncMap{
 	"toUpper": strings.ToUpper,
 	"toLower": strings.ToLower,
-	"title":   strings.Title,
+	"title":   cases.Title(language.AmericanEnglish).String,
 	// join is equal to strings.Join but inverts the argument order
 	// for easier pipelining in templates.
 	"join": func(sep string, s []string) string {


### PR DESCRIPTION
Right now, the only data that is usable in alert notification templates is the [following struct](https://github.com/prometheus/prometheus/blob/c40e269c3e514953299e9ba1f6265e067ab43e64/template/template.go#L348):
```go
struct {
	Labels         map[string]string
	ExternalLabels map[string]string
	Value          float64
}
```

It would be useful to have the ability to use the [template.Data](https://github.com/prometheus/alertmanager/blob/23f961ec6a9c8a15bf99c83815d35e13d66a4d5d/template/template.go#L236) struct in these alert notification templates.

One use case for this is being able to time-box a URL to the applications logs. We are currently adding an annotation that links to GCP logs for the application that the alert is for. The problem with this is, there's no way to drill down to the specific time the alert fired. So, unless that URL is clicked on right away, the logs that show are not at the time of the alert. 

What I was trying to do initially was something like this:
```yaml
groups:
- name: TestGroup
  rules:
  - alert: TestAlert
    expr: test-expr
    annotations:
      logs_url: https://www.our-logs-domain?app-name=test-application&startTime={{ (index .Alerts 0).StartsAt.Format "2006-01-02T15:04:05.999999999Z07:00" }}
```

This obviously doesn't work because the only fields available are `Labels`, `ExternalLabels`, and `Value`.

I'm proposing introducing a new annotation, `extra_delims`, that tells the template to evaluate the text one additional time with the delimiters provided in the annotation.

This would allow something like this in the prometheus alert definitions:
```yaml
groups:
- name: TestGroup
  rules:
  - alert: TestAlert
    expr: test-expr
    annotations:
      extra_delims: "<<,>>"
      logs_url: https://www.our-logs-domain?app-name=test-application&startTime=<< (index .Alerts 0).StartsAt.Format "2006-01-02T15:04:05.999999999Z07:00" >>
```

The other thing that this fixes is nested templates. For example, here is an alert manager config that injects data to a specific receiver that comes from the annotations of the prometheus rule/alert:
```yaml
receivers:
- name: opsgenie
  opsgenie_configs:
  - api_key: XXX
    details:
      logs_url: '{{ .CommonAnnotations.logs_url }}'
    ...
```

Once that is evaluated, it is at it's final state. So, if my annotation `logs_url` has data that I want to be evaluated by a template, it will never be evaluated. Currently, this evaluates the `logs_url` to the final value of: 
```
https://www.our-logs-domain?app-name=test-application&startTime=<< (index .Alerts 0).StartsAt.Format "2006-01-02T15:04:05.999999999Z07:00" >>
```

But, with the `extra_delims` annotation, this would be evaluated one additional time resulting in something like this:
```
https://www.our-logs-domain?app-name=test-application&startTime=2022-05-12T22:47:04.535890220Z
```