### PR TITLE
Creating new metric for filtering 4xx errors

### DIFF
--- a/notify/util.go
+++ b/notify/util.go
@@ -210,3 +210,11 @@ func (r *Retrier) Check(statusCode int, body io.Reader) (bool, error) {
 	}
 	return retry, errors.New(s)
 }
+
+func Check4xxStatus(statusCode int) bool {
+	var is4xx = false
+	if statusCode/100 == 4 {
+		is4xx = true
+	}
+	return is4xx
+}


### PR DESCRIPTION

1. Creating a new metric for filtering 4xx errors - ```numTotal4xxFailedNotifications```
2. Modifying the return of Notify function to return a boolean value **is4xx**. We will use this value to update the above metric in **notify.go**.
``` 
func (n *Notifier) Notify(ctx context.Context, alert ...*types.Alert) (bool, bool, error) { }
```

```
retry, is4xx, err := r.integration.Notify(ctx, sent...)
```

 
3. For this change we have to update the Notify function in all the integrations. For now masked this change by returning false for this variable from all other integrations. only updated this variable when coming from SNS. Will update this boolean value for other integrations after discussion with the community. 
4. The is4xx variable is used to increment the metric inside **exec** function of the retry Stage. This variable helps in identifying if the error thrown is 4xx or not. 
```
if is4xx {
       r.metrics.numTotal4xxFailedNotifications.WithLabelValues(r.integration.Name()).Inc()
}
```
5. Wrote a test **TestRetryStageWithErrorCode** in **notify_test.go** to test if this metric is getting incremented or not.
### Files Impacted:
 notify/email/email.go
 notify/email/email_test.go
 notify/notify.go
 notify/notify_test.go
 notify/opsgenie/opsgenie.go
 notify/pagerduty/pagerduty.go
 notify/pagerduty/pagerduty_test.go
 notify/pushover/pushover.go
 notify/slack/slack.go
 notify/sns/sns.go
 notify/telegram/telegram.go
 notify/test/test.go
 notify/victorops/victorops.go
 notify/victorops/victorops_test.go
 notify/webhook/webhook.go
 notify/wechat/wechat.go
