### PR TITLE
Trim contents of slack api urls from files

### DIFF
--- a/notify/slack/slack.go
+++ b/notify/slack/slack.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -194,7 +195,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		if err != nil {
 			return false, err
 		}
-		u = string(content)
+		u = strings.TrimSpace(string(content))
 	}
 
 	resp, err := notify.PostJSON(ctx, n.client, u, &buf)

--- a/notify/slack/slack_test.go
+++ b/notify/slack/slack_test.go
@@ -15,6 +15,7 @@ package slack
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"testing"
 

--- a/notify/slack/slack_test.go
+++ b/notify/slack/slack_test.go
@@ -80,3 +80,25 @@ func TestGettingSlackURLFromFile(t *testing.T) {
 
 	test.AssertNotifyLeaksNoSecret(ctx, t, notifier, u.String())
 }
+
+func TestTrimmingSlackURLFromFile(t *testing.T) {
+	ctx, u, fn := test.GetContextWithCancelingURL()
+	defer fn()
+
+	f, err := ioutil.TempFile("", "slack_test_newline")
+	require.NoError(t, err, "creating temp file failed")
+	_, err = f.WriteString(u.String() + "\n\n")
+	require.NoError(t, err, "writing to temp file failed")
+
+	notifier, err := New(
+		&config.SlackConfig{
+			APIURLFile: f.Name(),
+			HTTPConfig: &commoncfg.HTTPClientConfig{},
+		},
+		test.CreateTmpl(t),
+		log.NewNopLogger(),
+	)
+	require.NoError(t, err)
+
+	test.AssertNotifyLeaksNoSecret(ctx, t, notifier, u.String())
+}


### PR DESCRIPTION
Trailing newlines will almost always be present in a posixish file, so trim it away at first opportunity to prevent having invalid URLs we won't discover until a notification is sent.