### PR TITLE
notify/webhook: allow configuring HTTP status codes to retry on

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -399,6 +399,9 @@ type WebhookConfig struct {
 	// Alerts exceeding this threshold will be truncated. Setting this to 0
 	// allows an unlimited number of alerts.
 	MaxAlerts uint64 `yaml:"max_alerts" json:"max_alerts"`
+
+	// Additional HTTP status codes that should be retried.
+	RetryCodes []int `yaml:"retry_codes,omitempty" json:"retry_codes,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/notify/webhook/webhook.go
+++ b/notify/webhook/webhook.go
@@ -56,6 +56,7 @@ func New(conf *config.WebhookConfig, t *template.Template, l log.Logger, httpOpt
 			CustomDetailsFunc: func(int, io.Reader) string {
 				return conf.URL.String()
 			},
+			RetryCodes: conf.RetryCodes,
 		},
 	}, nil
 }


### PR DESCRIPTION
Introduces a new webhook config `retry_codes` which is a list of
additional HTTP codes that the Webhook notifier should retry on.

A specific use case: This will allow users to honor HTTP 429 (rate limiting),
which is currently not supported.