### PR TITLE
Alert metric reports different results to what the user sees via API

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -339,7 +339,7 @@ func run() int {
 		go peer.Settle(ctx, *gossipInterval*10)
 	}
 
-	alerts, err := mem.NewAlerts(context.Background(), marker, *alertGCInterval, nil, logger)
+	alerts, err := mem.NewAlerts(context.Background(), marker, *alertGCInterval, nil, logger, prometheus.DefaultRegisterer)
 	if err != nil {
 		level.Error(logger).Log("err", err)
 		return 1

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -366,7 +366,7 @@ route:
 	logger := log.NewNopLogger()
 	route := NewRoute(conf.Route, nil)
 	marker := types.NewMarker(prometheus.NewRegistry())
-	alerts, err := mem.NewAlerts(context.Background(), marker, time.Hour, nil, logger)
+	alerts, err := mem.NewAlerts(context.Background(), marker, time.Hour, nil, logger, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -504,7 +504,7 @@ route:
 	logger := log.NewNopLogger()
 	route := NewRoute(conf.Route, nil)
 	marker := types.NewMarker(prometheus.NewRegistry())
-	alerts, err := mem.NewAlerts(context.Background(), marker, time.Hour, nil, logger)
+	alerts, err := mem.NewAlerts(context.Background(), marker, time.Hour, nil, logger, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -625,7 +625,7 @@ func newAlert(labels model.LabelSet) *types.Alert {
 func TestDispatcherRace(t *testing.T) {
 	logger := log.NewNopLogger()
 	marker := types.NewMarker(prometheus.NewRegistry())
-	alerts, err := mem.NewAlerts(context.Background(), marker, time.Hour, nil, logger)
+	alerts, err := mem.NewAlerts(context.Background(), marker, time.Hour, nil, logger, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -642,7 +642,7 @@ func TestDispatcherRaceOnFirstAlertNotDeliveredWhenGroupWaitIsZero(t *testing.T)
 
 	logger := log.NewNopLogger()
 	marker := types.NewMarker(prometheus.NewRegistry())
-	alerts, err := mem.NewAlerts(context.Background(), marker, time.Hour, nil, logger)
+	alerts, err := mem.NewAlerts(context.Background(), marker, time.Hour, nil, logger, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/provider/mem/mem_test.go
+++ b/provider/mem/mem_test.go
@@ -86,7 +86,7 @@ func init() {
 // a listener can not unsubscribe as the lock is hold by `alerts.Lock`.
 func TestAlertsSubscribePutStarvation(t *testing.T) {
 	marker := types.NewMarker(prometheus.NewRegistry())
-	alerts, err := NewAlerts(context.Background(), marker, 30*time.Minute, noopCallback{}, log.NewNopLogger())
+	alerts, err := NewAlerts(context.Background(), marker, 30*time.Minute, noopCallback{}, log.NewNopLogger(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -137,7 +137,7 @@ func TestAlertsSubscribePutStarvation(t *testing.T) {
 
 func TestAlertsPut(t *testing.T) {
 	marker := types.NewMarker(prometheus.NewRegistry())
-	alerts, err := NewAlerts(context.Background(), marker, 30*time.Minute, noopCallback{}, log.NewNopLogger())
+	alerts, err := NewAlerts(context.Background(), marker, 30*time.Minute, noopCallback{}, log.NewNopLogger(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -165,7 +165,7 @@ func TestAlertsSubscribe(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	alerts, err := NewAlerts(ctx, marker, 30*time.Minute, noopCallback{}, log.NewNopLogger())
+	alerts, err := NewAlerts(ctx, marker, 30*time.Minute, noopCallback{}, log.NewNopLogger(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -242,7 +242,7 @@ func TestAlertsSubscribe(t *testing.T) {
 
 func TestAlertsGetPending(t *testing.T) {
 	marker := types.NewMarker(prometheus.NewRegistry())
-	alerts, err := NewAlerts(context.Background(), marker, 30*time.Minute, noopCallback{}, log.NewNopLogger())
+	alerts, err := NewAlerts(context.Background(), marker, 30*time.Minute, noopCallback{}, log.NewNopLogger(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -285,7 +285,7 @@ func TestAlertsGetPending(t *testing.T) {
 
 func TestAlertsGC(t *testing.T) {
 	marker := types.NewMarker(prometheus.NewRegistry())
-	alerts, err := NewAlerts(context.Background(), marker, 200*time.Millisecond, noopCallback{}, log.NewNopLogger())
+	alerts, err := NewAlerts(context.Background(), marker, 200*time.Millisecond, noopCallback{}, log.NewNopLogger(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -322,7 +322,7 @@ func TestAlertsStoreCallback(t *testing.T) {
 	cb := &limitCountCallback{limit: 3}
 
 	marker := types.NewMarker(prometheus.NewRegistry())
-	alerts, err := NewAlerts(context.Background(), marker, 200*time.Millisecond, cb, log.NewNopLogger())
+	alerts, err := NewAlerts(context.Background(), marker, 200*time.Millisecond, cb, log.NewNopLogger(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -381,6 +381,45 @@ func TestAlertsStoreCallback(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestAlerts_Count(t *testing.T) {
+	marker := types.NewMarker(prometheus.NewRegistry())
+	alerts, err := NewAlerts(context.Background(), marker, 200*time.Millisecond, nil, log.NewNopLogger(), nil)
+	require.NoError(t, err)
+
+	states := []types.AlertState{types.AlertStateActive, types.AlertStateSuppressed, types.AlertStateUnprocessed}
+
+	countByState := func(st types.AlertState) int {
+		return alerts.count(st)
+	}
+	countTotal := func() int {
+		var count int
+		for _, st := range states {
+			count += countByState(st)
+		}
+		return count
+	}
+
+	// First, there shouldn't be any alerts.
+	require.Equal(t, 0, countTotal())
+
+	// When you insert a new alert that will eventually be active, it should be unprocessed first.
+	alerts.Put(alert1)
+	require.Equal(t, 1, countByState(types.AlertStateUnprocessed))
+	require.Equal(t, 1, countTotal())
+
+	// When we insert an alert and then silence it. It shows up with the correct filter.
+	alerts.Put(alert2)
+	marker.SetSilenced(alert2.Fingerprint(), 1, []string{"1"}, nil)
+	require.Equal(t, 1, countByState(types.AlertStateUnprocessed))
+	require.Equal(t, 1, countByState(types.AlertStateSuppressed))
+	require.Equal(t, 2, countTotal())
+
+	require.Eventually(t, func() bool {
+		// When the alerts eventually expire and are considered resolved they won't count.
+		return countTotal() == 0
+	}, 600*time.Millisecond, 100*time.Millisecond)
 }
 
 func alertsEqual(a1, a2 *types.Alert) bool {

--- a/types/types.go
+++ b/types/types.go
@@ -108,11 +108,11 @@ type memMarker struct {
 }
 
 func (m *memMarker) registerMetrics(r prometheus.Registerer) {
-	newAlertMetricByState := func(st AlertState) prometheus.GaugeFunc {
+	newMarkedAlertMetricByState := func(st AlertState) prometheus.GaugeFunc {
 		return prometheus.NewGaugeFunc(
 			prometheus.GaugeOpts{
-				Name:        "alertmanager_alerts",
-				Help:        "How many alerts by state.",
+				Name:        "alertmanager_marked_alerts",
+				Help:        "How many alerts by state are currently marked in the Alertmanager regardless of their expiry.",
 				ConstLabels: prometheus.Labels{"state": string(st)},
 			},
 			func() float64 {
@@ -121,11 +121,13 @@ func (m *memMarker) registerMetrics(r prometheus.Registerer) {
 		)
 	}
 
-	alertsActive := newAlertMetricByState(AlertStateActive)
-	alertsSuppressed := newAlertMetricByState(AlertStateSuppressed)
+	alertsActive := newMarkedAlertMetricByState(AlertStateActive)
+	alertsSuppressed := newMarkedAlertMetricByState(AlertStateSuppressed)
+	alertStateUnprocessed := newMarkedAlertMetricByState(AlertStateUnprocessed)
 
 	r.MustRegister(alertsActive)
 	r.MustRegister(alertsSuppressed)
+	r.MustRegister(alertStateUnprocessed)
 }
 
 // Count implements Marker.

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -25,6 +25,58 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestMemMarker_Count(t *testing.T) {
+	r := prometheus.NewRegistry()
+	marker := NewMarker(r)
+	now := time.Now()
+
+	states := []AlertState{AlertStateSuppressed, AlertStateActive, AlertStateUnprocessed}
+	countByState := func(state AlertState) int {
+		return marker.Count(state)
+	}
+
+	countTotal := func() int {
+		var count int
+		for _, s := range states {
+			count += countByState(s)
+		}
+		return count
+	}
+
+	require.Equal(t, 0, countTotal())
+
+	a1 := model.Alert{
+		StartsAt: now.Add(-2 * time.Minute),
+		EndsAt:   now.Add(2 * time.Minute),
+		Labels:   model.LabelSet{"test": "active"},
+	}
+	a2 := model.Alert{
+		StartsAt: now.Add(-2 * time.Minute),
+		EndsAt:   now.Add(2 * time.Minute),
+		Labels:   model.LabelSet{"test": "suppressed"},
+	}
+	a3 := model.Alert{
+		StartsAt: now.Add(-2 * time.Minute),
+		EndsAt:   now.Add(-1 * time.Minute),
+		Labels:   model.LabelSet{"test": "resolved"},
+	}
+
+	// Insert an active alert.
+	marker.SetSilenced(a1.Fingerprint(), 1, nil, nil)
+	require.Equal(t, 1, countByState(AlertStateActive))
+	require.Equal(t, 1, countTotal())
+
+	// Insert a suppressed alert.
+	marker.SetSilenced(a2.Fingerprint(), 1, []string{"1"}, nil)
+	require.Equal(t, 1, countByState(AlertStateSuppressed))
+	require.Equal(t, 2, countTotal())
+
+	// Insert a resolved alert - it'll count as active.
+	marker.SetSilenced(a3.Fingerprint(), 1, []string{"1"}, nil)
+	require.Equal(t, 1, countByState(AlertStateActive))
+	require.Equal(t, 3, countTotal())
+}
+
 func TestAlertMerge(t *testing.T) {
 	now := time.Now()
 


### PR DESCRIPTION
Fixes #1439 and #2619 (which are duplicates) 

The previous metric is not _technically_ reporting incorrect results as the alerts _are_ still around and will be re-used if that same alert (equal fingerprint) is received before it is GCed. Therefore, I have kept the old metric under a new name `alertmanager_marked_alerts` and repurposed the current metric to match what the user sees in the UI.

I have tested this (and you can too) with the following:

1. First, send a payload to the Alertmanager with different alerts to cover all the cases (make sure you edit the `endsAt` for `AlwaysFiringExpired`,  `AlwaysFiringExpiringSoon` and others as necessary) - you want one alert to be expired on reception and one that eventually expires to see how the metrics behave.

```bash
## Request
curl -X "POST" "http://localhost:9093/api/v2/alerts" \
     -H 'Content-Type: text/plain; charset=utf-8' \
     -d $'[
  {
    "labels": {
      "alertname": "AlwaysFiringExpiringSoon",
      "cluster": "us-central1",
      "namespace": "app2"
    },
    "generatorURL": "http://url.com",
    "endsAt": "2022-06-10 12:55:40"
  },
  {
    "labels": {
      "alertname": "AlwaysFiringExpired",
      "cluster": "us-central1",
      "namespace": "app2"
    },
    "generatorURL": "http://url.com",
    "endsAt": "2022-06-10 10:40:40"
  },
  {
    "labels": {
      "alertname": "AlwaysFiringToBeSilenced",
      "cluster": "us-central1",
      "namespace": "app2"
    },
    "generatorURL": "http://url.com",
    "endsAt": "2023-06-11 10:40:40"
  },
  {
    "labels": {
      "alertname": "AlwaysFiringActive",
      "cluster": "us-central1",
      "namespace": "app2"
    },
    "generatorURL": "http://url.com",
    "endsAt": "2023-06-11 10:40:40"
  }
]'

```

2. Make sure you set up silence for `AlwaysFiringToBeSilenced`.
3. In the UI, you should only see 1 alert after the silence and both expired alerts have disappeared: `AlwaysFiringActive`.
4. With this, the metrics are now accurate. Reporting 4 for the marker metrics but only 2 (one suppressed and 1 active for the new metric)

Marker 
<img width="994" alt="Screenshot 2022-06-15 at 19 54 26" src="https://user-images.githubusercontent.com/231583/173903456-066cae11-2271-4810-a1c8-c42f26d359ec.png">

New `alertmanager_alerts`
<img width="432" alt="Screenshot 2022-06-15 at 19 54 07" src="https://user-images.githubusercontent.com/231583/173903464-276d28ad-84fc-4d0c-beba-ad917665e7a6.png">

