### PR TITLE
Mixin: `template-job-rule` now only validates `job` and not `instance` and `job` labels

### DIFF
--- a/doc/alertmanager-mixin/.lint
+++ b/doc/alertmanager-mixin/.lint
@@ -5,3 +5,7 @@ exclusions:
     entries:
     - dashboard: Alertmanager / Overview 
       reason: multi-select is not always required
+  template-instance-rule:
+    entries:
+    - dashboard: Alertmanager / Overview
+      reason: multi-select is not always required


### PR DESCRIPTION
With https://github.com/grafana/dashboard-linter/pull/49 `template-job-rule` no longer validates both `instance` and `job` labels. Add the new rule of `template-instance-rule` to the exclusions to preserve the previous behaviour.

This should fix the CI for the mixin.