### PR TITLE
Update configuration doc to reflect tls_config in oauth2

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -436,6 +436,10 @@ token_url: <string>
 # Optional parameters to append to the token URL.
 endpoint_params:
   [ <string>: <string> ... ]
+  
+# Configures the token request's TLS settings.
+tls_config:
+  [ <tls_config> ]  
 ```
 
 ## `<tls_config>`


### PR DESCRIPTION
Updated for this change: https://github.com/prometheus/common/pull/331

Bringing in line with Prometheus docs: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#oauth2