### PR TITLE
Force close mock servers as part of v2 acceptance tests

### DIFF
--- a/test/with_api_v2/acceptance/api_test.go
+++ b/test/with_api_v2/acceptance/api_test.go
@@ -58,7 +58,7 @@ receivers:
 		Tolerance: 1 * time.Second,
 	})
 	co := at.Collector("webhook")
-	wh := a.NewWebhook(co)
+	wh := a.NewWebhook(t, co)
 
 	amc := at.AlertmanagerCluster(fmt.Sprintf(conf, wh.Address()), 1)
 	require.NoError(t, amc.Start())
@@ -89,8 +89,8 @@ receivers:
 	require.NoError(t, err)
 	// No silence has been created or inhibiting alert sent, alert should
 	// be active.
-	for _, alert := range resp.Payload {
-		require.Equal(t, models.AlertStatusStateActive, *alert.Status.State)
+	for _, al := range resp.Payload {
+		require.Equal(t, models.AlertStatusStateActive, *al.Status.State)
 	}
 
 	// Wait for group_wait, so that we are in the group_interval period,
@@ -121,11 +121,11 @@ receivers:
 
 	resp, err = am.Client().Alert.GetAlerts(nil)
 	require.NoError(t, err)
-	for _, alert := range resp.Payload {
-		require.Equal(t, models.AlertStatusStateSuppressed, *alert.Status.State)
-		require.Equal(t, fp.String(), *alert.Fingerprint)
-		require.Equal(t, 1, len(alert.Status.SilencedBy))
-		require.Equal(t, silenceID, alert.Status.SilencedBy[0])
+	for _, al := range resp.Payload {
+		require.Equal(t, models.AlertStatusStateSuppressed, *al.Status.State)
+		require.Equal(t, fp.String(), *al.Fingerprint)
+		require.Equal(t, 1, len(al.Status.SilencedBy))
+		require.Equal(t, silenceID, al.Status.SilencedBy[0])
 	}
 
 	// Create inhibiting alert and verify that original alert is
@@ -138,14 +138,14 @@ receivers:
 
 	resp, err = am.Client().Alert.GetAlerts(nil)
 	require.NoError(t, err)
-	for _, alert := range resp.Payload {
-		require.Equal(t, 1, len(alert.Status.SilencedBy))
-		require.Equal(t, silenceID, alert.Status.SilencedBy[0])
-		if fp.String() == *alert.Fingerprint {
-			require.Equal(t, models.AlertStatusStateSuppressed, *alert.Status.State)
-			require.Equal(t, fp.String(), *alert.Fingerprint)
-			require.Equal(t, 1, len(alert.Status.InhibitedBy))
-			require.Equal(t, inhibitingFP.String(), alert.Status.InhibitedBy[0])
+	for _, al := range resp.Payload {
+		require.Equal(t, 1, len(al.Status.SilencedBy))
+		require.Equal(t, silenceID, al.Status.SilencedBy[0])
+		if fp.String() == *al.Fingerprint {
+			require.Equal(t, models.AlertStatusStateSuppressed, *al.Status.State)
+			require.Equal(t, fp.String(), *al.Fingerprint)
+			require.Equal(t, 1, len(al.Status.InhibitedBy))
+			require.Equal(t, inhibitingFP.String(), al.Status.InhibitedBy[0])
 		}
 	}
 
@@ -157,12 +157,12 @@ receivers:
 	require.NoError(t, err)
 	// Silence has been deleted, inhibiting alert should be active.
 	// Original alert should still be inhibited.
-	for _, alert := range resp.Payload {
-		require.Equal(t, 0, len(alert.Status.SilencedBy))
-		if inhibitingFP.String() == *alert.Fingerprint {
-			require.Equal(t, models.AlertStatusStateActive, *alert.Status.State)
+	for _, al := range resp.Payload {
+		require.Equal(t, 0, len(al.Status.SilencedBy))
+		if inhibitingFP.String() == *al.Fingerprint {
+			require.Equal(t, models.AlertStatusStateActive, *al.Status.State)
 		} else {
-			require.Equal(t, models.AlertStatusStateSuppressed, *alert.Status.State)
+			require.Equal(t, models.AlertStatusStateSuppressed, *al.Status.State)
 		}
 	}
 }
@@ -195,7 +195,7 @@ receivers:
 		Tolerance: 1 * time.Second,
 	})
 	co := at.Collector("webhook")
-	wh := a.NewWebhook(co)
+	wh := a.NewWebhook(t, co)
 
 	amc := at.AlertmanagerCluster(fmt.Sprintf(conf, wh.Address()), 1)
 	require.NoError(t, amc.Start())
@@ -228,7 +228,7 @@ receivers:
 	resp, err := am.Client().Alert.GetAlerts(alert.NewGetAlertsParams().WithFilter(filter))
 	require.NoError(t, err)
 	require.Equal(t, 1, len(resp.Payload))
-	for _, alert := range resp.Payload {
-		require.Equal(t, models.AlertStatusStateActive, *alert.Status.State)
+	for _, al := range resp.Payload {
+		require.Equal(t, models.AlertStatusStateActive, *al.Status.State)
 	}
 }

--- a/test/with_api_v2/acceptance/cluster_test.go
+++ b/test/with_api_v2/acceptance/cluster_test.go
@@ -45,7 +45,7 @@ receivers:
 		Tolerance: 1 * time.Second,
 	})
 	co := at.Collector("webhook")
-	wh := a.NewWebhook(co)
+	wh := a.NewWebhook(t, co)
 
 	amc := at.AlertmanagerCluster(fmt.Sprintf(conf, wh.Address()), 3)
 
@@ -92,20 +92,20 @@ receivers:
 	amClusters := []*a.AlertmanagerCluster{}
 	wg := sync.WaitGroup{}
 
-	for i, t := range tests {
-		collectors = append(collectors, t.Collector("webhook"))
-		webhook := a.NewWebhook(collectors[i])
+	for i, tc := range tests {
+		collectors = append(collectors, tc.Collector("webhook"))
+		webhook := a.NewWebhook(t, collectors[i])
 
-		amClusters = append(amClusters, t.AlertmanagerCluster(fmt.Sprintf(conf, webhook.Address()), clusterSizes[i]))
+		amClusters = append(amClusters, tc.AlertmanagerCluster(fmt.Sprintf(conf, webhook.Address()), clusterSizes[i]))
 
 		wg.Add(1)
 	}
 
-	for _, time := range []float64{0, 2, 4, 6, 8} {
+	for _, alertTime := range []float64{0, 2, 4, 6, 8} {
 		for i, amc := range amClusters {
-			alert := a.Alert("alertname", fmt.Sprintf("test1-%v", time))
-			amc.Push(a.At(time), alert)
-			collectors[i].Want(a.Between(time, time+5), alert.Active(time))
+			alert := a.Alert("alertname", fmt.Sprintf("test1-%v", alertTime))
+			amc.Push(a.At(alertTime), alert)
+			collectors[i].Want(a.Between(alertTime, alertTime+5), alert.Active(alertTime))
 		}
 	}
 

--- a/test/with_api_v2/acceptance/inhibit_test.go
+++ b/test/with_api_v2/acceptance/inhibit_test.go
@@ -56,7 +56,7 @@ inhibit_rules:
 	})
 
 	co := at.Collector("webhook")
-	wh := NewWebhook(co)
+	wh := NewWebhook(t, co)
 
 	amc := at.AlertmanagerCluster(fmt.Sprintf(conf, wh.Address()), 1)
 
@@ -131,7 +131,7 @@ inhibit_rules:
 	})
 
 	co := at.Collector("webhook")
-	wh := NewWebhook(co)
+	wh := NewWebhook(t, co)
 
 	amc := at.AlertmanagerCluster(fmt.Sprintf(conf, wh.Address()), 1)
 

--- a/test/with_api_v2/acceptance/send_test.go
+++ b/test/with_api_v2/acceptance/send_test.go
@@ -56,7 +56,7 @@ receivers:
 	})
 
 	co := at.Collector("webhook")
-	wh := NewWebhook(co)
+	wh := NewWebhook(t, co)
 
 	am := at.AlertmanagerCluster(fmt.Sprintf(conf, wh.Address()), 1)
 
@@ -136,7 +136,7 @@ receivers:
 	co := at.Collector("webhook")
 	// Run something that satisfies the webhook interface to which the
 	// Alertmanager pushes as defined by its configuration.
-	wh := NewWebhook(co)
+	wh := NewWebhook(t, co)
 
 	// Create a new Alertmanager process listening to a random port
 	am := at.AlertmanagerCluster(fmt.Sprintf(conf, wh.Address()), 1)
@@ -191,10 +191,10 @@ receivers:
 	})
 
 	co1 := at.Collector("webhook")
-	wh1 := NewWebhook(co1)
+	wh1 := NewWebhook(t, co1)
 
 	co2 := at.Collector("webhook_failing")
-	wh2 := NewWebhook(co2)
+	wh2 := NewWebhook(t, co2)
 
 	wh2.Func = func(ts float64) bool {
 		// Fail the first interval period but eventually succeed in the third
@@ -241,7 +241,7 @@ receivers:
 	})
 
 	co := at.Collector("webhook")
-	wh := NewWebhook(co)
+	wh := NewWebhook(t, co)
 
 	am := at.AlertmanagerCluster(fmt.Sprintf(conf, wh.Address()), 1)
 
@@ -308,7 +308,7 @@ receivers:
 		})
 
 		co := at.Collector("webhook")
-		wh := NewWebhook(co)
+		wh := NewWebhook(t, co)
 
 		am := at.AlertmanagerCluster(fmt.Sprintf(conf, wh.Address()), 1)
 
@@ -367,10 +367,10 @@ receivers:
 	})
 
 	co1 := at.Collector("webhook1")
-	wh1 := NewWebhook(co1)
+	wh1 := NewWebhook(t, co1)
 
 	co2 := at.Collector("webhook2")
-	wh2 := NewWebhook(co2)
+	wh2 := NewWebhook(t, co2)
 
 	amc := at.AlertmanagerCluster(fmt.Sprintf(conf, wh1.Address(), wh2.Address()), 1)
 
@@ -444,7 +444,7 @@ receivers:
 	})
 
 	co := at.Collector("webhook")
-	wh := NewWebhook(co)
+	wh := NewWebhook(t, co)
 
 	amc := at.AlertmanagerCluster(fmt.Sprintf(conf, wh.Address()), 1)
 

--- a/test/with_api_v2/acceptance/silence_test.go
+++ b/test/with_api_v2/acceptance/silence_test.go
@@ -43,7 +43,7 @@ receivers:
 	})
 
 	co := at.Collector("webhook")
-	wh := NewWebhook(co)
+	wh := NewWebhook(t, co)
 
 	amc := at.AlertmanagerCluster(fmt.Sprintf(conf, wh.Address()), 1)
 
@@ -97,7 +97,7 @@ receivers:
 	})
 
 	co := at.Collector("webhook")
-	wh := NewWebhook(co)
+	wh := NewWebhook(t, co)
 
 	amc := at.AlertmanagerCluster(fmt.Sprintf(conf, wh.Address()), 1)
 


### PR DESCRIPTION
While merging #2944, I noticed the CI failed: https://app.circleci.com/pipelines/github/prometheus/alertmanager/2686/workflows/b6f87b0a-20c3-455b-b706-432c38a77511/jobs/12028.

It seemed like a deadlock between uncoordinated routines but I couldn't pin point (or reproduce, I tried with -race and -count) the exact problem. However, from the logs, I could point out where the problem originated and kind of have a hunch it had to do with the way net listeners are handled by the TODO removed.

The more worrying bit of the CI failure is that it took 10m to timeout, with this change we'll force close the connection with a 5s deadline so at the very least we'll get the feedback faster.

Along the way, I fixed a couple of instances of variables shadowing package names which should be pretty harmless. All the functionality of the tests should remain intact.