### PR TITLE
Silence creator from HTTP header or Basic Auth username

### DIFF
--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -626,6 +626,17 @@ func (api *API) deleteSilenceHandler(params silence_ops.DeleteSilenceParams) mid
 func (api *API) postSilencesHandler(params silence_ops.PostSilencesParams) middleware.Responder {
 	logger := api.requestLogger(params.HTTPRequest)
 
+	username := api.usernameFromHeaderOrBasicAuth(params.HTTPRequest)
+	if username != "" {
+		if params.Silence.CreatedBy == nil {
+			params.Silence.CreatedBy = &username
+		}
+
+		if params.Silence.CreatedBy != &username {
+			return silence_ops.NewPostSilencesBadRequest().WithPayload(fmt.Sprintf("created_by does not match HTTP basic authentication or value of %s HTTP header", api.alertmanagerConfig.Global.UserHTTPHeader))
+		}
+	}
+
 	sil, err := PostableSilenceToProto(params.Silence)
 	if err != nil {
 		level.Error(logger).Log("msg", "Failed to marshal silence to proto", "err", err)
@@ -658,6 +669,18 @@ func (api *API) postSilencesHandler(params silence_ops.PostSilencesParams) middl
 	return silence_ops.NewPostSilencesOK().WithPayload(&silence_ops.PostSilencesOKBody{
 		SilenceID: sid,
 	})
+}
+
+// usernameFromHeaderOrBasicAuth returns the username specified as part of Basic Authentication. If no auth is provided,
+// it tries the specified HTTP header of UserHTTPHeader. If none are found it returns an empty string "".
+func (api *API) usernameFromHeaderOrBasicAuth(request *http.Request) string {
+	// First, let's try getting the username from Basic Authentication.
+	if user, _, ok := request.BasicAuth(); ok {
+		return user
+	}
+
+	// No Basic Authentication, let's try the header.
+	return request.Header.Get(api.alertmanagerConfig.Global.UserHTTPHeader)
 }
 
 func parseFilter(filter []string) ([]*labels.Matcher, error) {

--- a/config/config.go
+++ b/config/config.go
@@ -585,6 +585,8 @@ func DefaultGlobalConfig() GlobalConfig {
 		ResolveTimeout: model.Duration(5 * time.Minute),
 		HTTPConfig:     &defaultHTTPConfig,
 
+		UserHTTPHeader: "X-Alertmanager-User",
+
 		SMTPHello:       "localhost",
 		SMTPRequireTLS:  true,
 		PagerdutyURL:    mustParseURL("https://events.pagerduty.com/v2/enqueue"),
@@ -692,6 +694,8 @@ type GlobalConfig struct {
 	ResolveTimeout model.Duration `yaml:"resolve_timeout" json:"resolve_timeout"`
 
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
+
+	UserHTTPHeader string `yaml:"user_http_header" json:"user_http_header"`
 
 	SMTPFrom           string     `yaml:"smtp_from,omitempty" json:"smtp_from,omitempty"`
 	SMTPHello          string     `yaml:"smtp_hello,omitempty" json:"smtp_hello,omitempty"`


### PR DESCRIPTION
The discussion is long as part of #1196, so instead of building this in isolation - I'm putting this out there to gather some feedback as I know there's some historic context and I want people to voice their opinions.

The first step is the building block for the server part (I'd argue this is the easy part):

1. Try to infer the username from basic authentication
2. If no basic auth is present, try the header which is specified via a configuration option

The other bit is the front-end part (the actual hard one), a couple of thoughts:

- When the silence form is rendered, there's no HTTP call as part of that and we all know that is not possible to [access headers from javascript](https://stackoverflow.com/questions/220231/accessing-the-web-pages-http-headers-in-javascript).
- There are several approaches to solving the above, it can range from: Including the parsed username as part of the response to every HTTP call, creating a dedicated endpoint e.g. `/api/v1/me`, including it as part of the status endpoint and calling that as we render the silence form, etc. any opinions on what route should we take? I can start to see what Brian meant that this can very quickly turn into a scope creep for authentication things.
- The front-end experience that I have in my head is the following:
    - Sever tells you your current username (try basic auth first, if not then header)
    - If there's any, created by field gets filed in and disabled (greyed-out)
    - Any thoughts?

Fixes #1196

TODO

- [ ] tests
- [ ] front-end

Signed-off-by: gotjosh <josue.abreu@gmail.com>