### PR TITLE
Mixin: Fix linter erorrs

### DIFF
--- a/doc/alertmanager-mixin/.lint
+++ b/doc/alertmanager-mixin/.lint
@@ -9,3 +9,7 @@ exclusions:
     entries:
     - dashboard: Alertmanager / Overview
       reason: multi-select is not always required
+  panel-units-rule:
+    entries:
+    - dashboard: Alertmanager / Overview
+      reason: Dashboard does not benefit from specific unit specification.

--- a/doc/alertmanager-mixin/dashboards/overview.libsonnet
+++ b/doc/alertmanager-mixin/dashboards/overview.libsonnet
@@ -42,6 +42,7 @@ local graphPanel = grafana.graphPanel;
       local alerts =
         graphPanel.new(
           'Alerts',
+          description='current set of alerts stored in the Alertmanager',
           datasource='$datasource',
           span=6,
           format='none',
@@ -54,6 +55,7 @@ local graphPanel = grafana.graphPanel;
       local alertsRate =
         graphPanel.new(
           'Alerts receive rate',
+          description='rate of successful and invalid alerts received by the Alertmanager',
           datasource='$datasource',
           span=6,
           format='ops',
@@ -67,6 +69,7 @@ local graphPanel = grafana.graphPanel;
       local notifications =
         graphPanel.new(
           '$integration: Notifications Send Rate',
+          description='rate of successful and invalid notifications sent by the Alertmanager',
           datasource='$datasource',
           format='ops',
           stack=true,
@@ -80,6 +83,7 @@ local graphPanel = grafana.graphPanel;
       local notificationDuration =
         graphPanel.new(
           '$integration: Notification Duration',
+          description='latency of notifications sent by the Alertmanager',
           datasource='$datasource',
           format='s',
           stack=false,


### PR DESCRIPTION
In accordance with a new rule introduced as part of https://github.com/grafana/dashboard-linter/pull/79 this is now required. However, for the new rule of `panel-unit-rule` we don't reap any benefits from specifying a particular unit for our panels, the defaults work perfectly fine so I've chosen to ignore that rule instead.

Signed-off-by: gotjosh <josue.abreu@gmail.com>