### PR TITLE
docs: correct the accepted value for X-XSS-Protection header

### DIFF
--- a/docs/https.md
+++ b/docs/https.md
@@ -89,7 +89,7 @@ http_server_config:
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
     [ X-Content-Type-Options: <string> ]
     # Set the X-XSS-Protection header to all responses.
-    # Unset if blank. Accepted value is nosniff.
+    # Unset if blank.
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
     [ X-XSS-Protection: <string> ]
     # Set the Strict-Transport-Security header to HTTP responses.


### PR DESCRIPTION
May refer to https://github.com/prometheus/exporter-toolkit/blob/14464f8d9bad4970fb2bbb16d64af22075aa4ec9/web/handler.go#L35

Signed-off-by: heylongdacoder <heylongdacoder@gmail.com>