### PR TITLE
Remove ioutil

### DIFF
--- a/api/v1/api_test.go
+++ b/api/v1/api_test.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -150,7 +150,7 @@ func TestAddAlerts(t *testing.T) {
 
 		api.addAlerts(w, r)
 		res := w.Result()
-		body, _ := ioutil.ReadAll(res.Body)
+		body, _ := io.ReadAll(res.Body)
 
 		require.Equal(t, tc.code, w.Code, fmt.Sprintf("test case: %d, StartsAt %v, EndsAt %v, Response: %s", i, tc.start, tc.end, string(body)))
 	}
@@ -282,7 +282,7 @@ func TestListAlerts(t *testing.T) {
 		w := httptest.NewRecorder()
 
 		api.listAlerts(w, r)
-		body, _ := ioutil.ReadAll(w.Result().Body)
+		body, _ := io.ReadAll(w.Result().Body)
 
 		var res response
 		err = json.Unmarshal(body, &res)

--- a/api/v2/api_test.go
+++ b/api/v2/api_test.go
@@ -16,7 +16,7 @@ package v2
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -204,7 +204,7 @@ func TestDeleteSilenceHandler(t *testing.T) {
 			HTTPRequest: r,
 		})
 		responder.WriteResponse(w, p)
-		body, _ := ioutil.ReadAll(w.Result().Body)
+		body, _ := io.ReadAll(w.Result().Body)
 
 		require.Equal(t, tc.expectedCode, w.Code, fmt.Sprintf("test case: %d, response: %s", i, string(body)))
 	}
@@ -290,7 +290,7 @@ func TestPostSilencesHandler(t *testing.T) {
 					Silence:     &silence,
 				})
 				responder.WriteResponse(w, p)
-				body, _ := ioutil.ReadAll(w.Result().Body)
+				body, _ := io.ReadAll(w.Result().Body)
 
 				require.Equal(t, tc.expectedCode, w.Code, fmt.Sprintf("test case: %d, response: %s", i, string(body)))
 			})

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -14,7 +14,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -37,7 +36,7 @@ func NewResolver(files []string, legacyFlags map[string]string) (*Resolver, erro
 		if _, err := os.Stat(f); err != nil {
 			continue
 		}
-		b, err := ioutil.ReadFile(f)
+		b, err := os.ReadFile(f)
 		if err != nil {
 			if os.IsNotExist(err) {
 				continue

--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -14,7 +14,7 @@
 package config
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -30,8 +30,8 @@ func newApp() *kingpin.Application {
 	id = new(string)
 
 	app := kingpin.New("app", "")
-	app.UsageWriter(ioutil.Discard)
-	app.ErrorWriter(ioutil.Discard)
+	app.UsageWriter(io.Discard)
+	app.ErrorWriter(io.Discard)
 	app.Terminate(nil)
 
 	app.Flag("url", "").StringVar(url)

--- a/cli/config/http_config.go
+++ b/cli/config/http_config.go
@@ -14,7 +14,7 @@
 package config
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	promconfig "github.com/prometheus/common/config"
@@ -23,7 +23,7 @@ import (
 
 // LoadHTTPConfigFile returns HTTPClientConfig for the given http_config file
 func LoadHTTPConfigFile(filename string) (*promconfig.HTTPClientConfig, error) {
-	b, err := ioutil.ReadFile(filename)
+	b, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/template_render.go
+++ b/cli/template_render.go
@@ -17,7 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"time"
 
@@ -121,7 +121,7 @@ func (c *templateRenderCmd) render(ctx context.Context, _ *kingpin.ParseContext)
 	if c.templateData == nil {
 		data = defaultData
 	} else {
-		content, err := ioutil.ReadAll(c.templateData)
+		content, err := io.ReadAll(c.templateData)
 		if err != nil {
 			return err
 		}

--- a/cluster/tls_config.go
+++ b/cluster/tls_config.go
@@ -14,7 +14,7 @@
 package cluster
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/prometheus/common/config"
@@ -31,7 +31,7 @@ func GetTLSTransportConfig(configPath string) (*TLSTransportConfig, error) {
 	if configPath == "" {
 		return nil, nil
 	}
-	bytes, err := ioutil.ReadFile(configPath)
+	bytes, err := os.ReadFile(configPath)
 	if err != nil {
 		return nil, err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -16,9 +16,9 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/url"
+	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -192,7 +192,7 @@ func Load(s string) (*Config, error) {
 
 // LoadFile parses the given YAML file into a Config.
 func LoadFile(filename string) (*Config, error) {
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/webhook/echo.go
+++ b/examples/webhook/echo.go
@@ -16,14 +16,14 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 )
 
 func main() {
 	log.Fatal(http.ListenAndServe(":5001", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			panic(err)
 		}

--- a/nflog/nflog_test.go
+++ b/nflog/nflog_test.go
@@ -15,7 +15,7 @@ package nflog
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"sync"
@@ -98,7 +98,7 @@ func TestLogSnapshot(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		f, err := ioutil.TempFile("", "snapshot")
+		f, err := os.CreateTemp("", "snapshot")
 		require.NoError(t, err, "creating temp file failed")
 
 		l1 := &Log{
@@ -127,7 +127,7 @@ func TestLogSnapshot(t *testing.T) {
 }
 
 func TestWithMaintenance_SupportsCustomCallback(t *testing.T) {
-	f, err := ioutil.TempFile("", "snapshot")
+	f, err := os.CreateTemp("", "snapshot")
 	require.NoError(t, err, "creating temp file failed")
 
 	stopc := make(chan struct{})
@@ -154,7 +154,7 @@ func TestWithMaintenance_SupportsCustomCallback(t *testing.T) {
 }
 
 func TestReplaceFile(t *testing.T) {
-	dir, err := ioutil.TempDir("", "replace_file")
+	dir, err := os.MkdirTemp("", "replace_file")
 	require.NoError(t, err, "creating temp dir failed")
 
 	origFilename := filepath.Join(dir, "testfile")
@@ -176,7 +176,7 @@ func TestReplaceFile(t *testing.T) {
 	require.NoError(t, err, "opening original file failed")
 	defer ofr.Close()
 
-	res, err := ioutil.ReadAll(ofr)
+	res, err := io.ReadAll(ofr)
 	require.NoError(t, err, "reading original file failed")
 	require.Equal(t, "test", string(res), "unexpected file contents")
 }

--- a/notify/email/email_test.go
+++ b/notify/email/email_test.go
@@ -31,7 +31,7 @@ package email
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -128,7 +128,7 @@ func (m *mailDev) doEmailRequest(method, path string) (int, []byte, error) {
 		return 0, nil, err
 	}
 	defer res.Body.Close()
-	b, err := ioutil.ReadAll(res.Body)
+	b, err := io.ReadAll(res.Body)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -145,7 +145,7 @@ type emailTestConfig struct {
 
 func loadEmailTestConfiguration(f string) (emailTestConfig, error) {
 	c := emailTestConfig{}
-	b, err := ioutil.ReadFile(f)
+	b, err := os.ReadFile(f)
 	if err != nil {
 		return c, err
 	}

--- a/notify/opsgenie/opsgenie.go
+++ b/notify/opsgenie/opsgenie.go
@@ -18,8 +18,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/go-kit/log"
@@ -276,7 +276,7 @@ func (n *Notifier) createRequests(ctx context.Context, as ...*types.Alert) ([]*h
 	if n.conf.APIKey != "" {
 		apiKey = tmpl(string(n.conf.APIKey))
 	} else {
-		content, err := ioutil.ReadFile(n.conf.APIKeyFile)
+		content, err := os.ReadFile(n.conf.APIKeyFile)
 		if err != nil {
 			return nil, false, errors.Wrap(err, "read key_file error")
 		}

--- a/notify/opsgenie/opsgenie_test.go
+++ b/notify/opsgenie/opsgenie_test.go
@@ -16,9 +16,10 @@ package opsgenie
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"testing"
 	"time"
 
@@ -75,7 +76,7 @@ func TestGettingOpsGegineApikeyFromFile(t *testing.T) {
 
 	key := "key"
 
-	f, err := ioutil.TempFile("", "opsgenie_test")
+	f, err := os.CreateTemp("", "opsgenie_test")
 	require.NoError(t, err, "creating temp file failed")
 	_, err = f.WriteString(key)
 	require.NoError(t, err, "writing to temp file failed")
@@ -322,7 +323,7 @@ func TestOpsGenieWithUpdate(t *testing.T) {
 
 func readBody(t *testing.T, r *http.Request) string {
 	t.Helper()
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	require.NoError(t, err)
 	return string(body)
 }

--- a/notify/slack/slack.go
+++ b/notify/slack/slack.go
@@ -18,8 +18,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -190,7 +190,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	if n.conf.APIURL != nil {
 		u = n.conf.APIURL.String()
 	} else {
-		content, err := ioutil.ReadFile(n.conf.APIURLFile)
+		content, err := os.ReadFile(n.conf.APIURLFile)
 		if err != nil {
 			return false, err
 		}

--- a/notify/slack/slack_test.go
+++ b/notify/slack/slack_test.go
@@ -15,7 +15,7 @@ package slack
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/go-kit/log"
@@ -63,7 +63,7 @@ func TestGettingSlackURLFromFile(t *testing.T) {
 	ctx, u, fn := test.GetContextWithCancelingURL()
 	defer fn()
 
-	f, err := ioutil.TempFile("", "slack_test")
+	f, err := os.CreateTemp("", "slack_test")
 	require.NoError(t, err, "creating temp file failed")
 	_, err = f.WriteString(u.String())
 	require.NoError(t, err, "writing to temp file failed")

--- a/notify/util.go
+++ b/notify/util.go
@@ -18,7 +18,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 
@@ -78,7 +77,7 @@ func request(ctx context.Context, client *http.Client, method, url, bodyType str
 // Drain consumes and closes the response's body to make sure that the
 // HTTP client can reuse existing connections.
 func Drain(r *http.Response) {
-	io.Copy(ioutil.Discard, r.Body)
+	io.Copy(io.Discard, r.Body)
 	r.Body.Close()
 }
 
@@ -161,7 +160,7 @@ func readAll(r io.Reader) string {
 	if r == nil {
 		return ""
 	}
-	bs, err := ioutil.ReadAll(r)
+	bs, err := io.ReadAll(r)
 	if err != nil {
 		return ""
 	}

--- a/notify/util_test.go
+++ b/notify/util_test.go
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"testing"
 
@@ -156,7 +155,7 @@ func TestRetrierCheck(t *testing.T) {
 				if status != http.StatusServiceUnavailable {
 					return "invalid"
 				}
-				bs, _ := ioutil.ReadAll(b)
+				bs, _ := io.ReadAll(b)
 				return fmt.Sprintf("server response is %q", string(bs))
 			}},
 			status: http.StatusServiceUnavailable,

--- a/notify/wechat/wechat.go
+++ b/notify/wechat/wechat.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -171,7 +171,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		return true, fmt.Errorf("unexpected status code %v", resp.StatusCode)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return true, err
 	}

--- a/scripts/errcheck_excludes.txt
+++ b/scripts/errcheck_excludes.txt
@@ -1,4 +1,4 @@
-// Don't flag lines such as "io.Copy(ioutil.Discard, resp.Body)".
+// Don't flag lines such as "io.Copy(io.Discard, resp.Body)".
 io.Copy
 // The next two are used in HTTP handlers, any error is handled by the server itself.
 io.WriteString

--- a/silence/silence_test.go
+++ b/silence/silence_test.go
@@ -16,7 +16,6 @@ package silence
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"sort"
@@ -156,7 +155,7 @@ func TestSilencesSnapshot(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		f, err := ioutil.TempFile("", "snapshot")
+		f, err := os.CreateTemp("", "snapshot")
 		require.NoError(t, err, "creating temp file failed")
 
 		s1 := &Silences{st: state{}, metrics: newMetrics(nil, nil)}
@@ -184,7 +183,7 @@ func TestSilencesSnapshot(t *testing.T) {
 
 // This tests a regression introduced by https://github.com/prometheus/alertmanager/pull/2689.
 func TestSilences_Maintenance_DefaultMaintenanceFuncDoesntCrash(t *testing.T) {
-	f, err := ioutil.TempFile("", "snapshot")
+	f, err := os.CreateTemp("", "snapshot")
 	require.NoError(t, err, "creating temp file failed")
 	clock := clock.NewMock()
 	s := &Silences{st: state{}, logger: log.NewNopLogger(), clock: clock, metrics: newMetrics(nil, nil)}
@@ -204,7 +203,7 @@ func TestSilences_Maintenance_DefaultMaintenanceFuncDoesntCrash(t *testing.T) {
 }
 
 func TestSilences_Maintenance_SupportsCustomCallback(t *testing.T) {
-	f, err := ioutil.TempFile("", "snapshot")
+	f, err := os.CreateTemp("", "snapshot")
 	require.NoError(t, err, "creating temp file failed")
 	clock := clock.NewMock()
 	s := &Silences{st: state{}, logger: log.NewNopLogger(), clock: clock, metrics: newMetrics(nil, nil)}

--- a/template/template.go
+++ b/template/template.go
@@ -16,7 +16,7 @@ package template
 import (
 	"bytes"
 	tmplhtml "html/template"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"path"
 	"path/filepath"
@@ -59,7 +59,7 @@ func FromGlobs(paths ...string) (*Template, error) {
 			return nil, err
 		}
 		defer f.Close()
-		b, err := ioutil.ReadAll(f)
+		b, err := io.ReadAll(f)
 		if err != nil {
 			return nil, err
 		}

--- a/test/cli/acceptance.go
+++ b/test/cli/acceptance.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -145,7 +145,7 @@ func (t *AcceptanceTest) AlertmanagerCluster(conf string, size int) *Alertmanage
 			opts: t.opts,
 		}
 
-		dir, err := ioutil.TempDir("", "am_test")
+		dir, err := os.MkdirTemp("", "am_test")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -362,7 +362,7 @@ func (am *Alertmanager) Start(additionalArg []string) error {
 		if resp.StatusCode != http.StatusOK {
 			return fmt.Errorf("starting alertmanager failed: expected HTTP status '200', got '%d'", resp.StatusCode)
 		}
-		_, err = ioutil.ReadAll(resp.Body)
+		_, err = io.ReadAll(resp.Body)
 		if err != nil {
 			return fmt.Errorf("starting alertmanager failed: %s", err)
 		}

--- a/test/with_api_v1/acceptance.go
+++ b/test/with_api_v1/acceptance.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -115,7 +115,7 @@ func (t *AcceptanceTest) Alertmanager(conf string) *Alertmanager {
 		opts: t.opts,
 	}
 
-	dir, err := ioutil.TempDir("", "am_test")
+	dir, err := os.MkdirTemp("", "am_test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -300,7 +300,7 @@ func (am *Alertmanager) Start() {
 		if resp.StatusCode != http.StatusOK {
 			am.t.Fatalf("Starting alertmanager failed: expected HTTP status '200', got '%d'", resp.StatusCode)
 		}
-		_, err = ioutil.ReadAll(resp.Body)
+		_, err = io.ReadAll(resp.Body)
 		if err != nil {
 			am.t.Fatalf("Starting alertmanager failed: %s", err)
 		}
@@ -377,7 +377,7 @@ func (am *Alertmanager) SetSilence(at float64, sil *TestSilence) {
 		}
 		defer resp.Body.Close()
 
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		if err != nil {
 			panic(err)
 		}

--- a/test/with_api_v2/acceptance.go
+++ b/test/with_api_v2/acceptance.go
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -125,7 +124,7 @@ func (t *AcceptanceTest) AlertmanagerCluster(conf string, size int) *Alertmanage
 			opts: t.opts,
 		}
 
-		dir, err := ioutil.TempDir("", "am_test")
+		dir, err := os.MkdirTemp("", "am_test")
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
`ioutil` is deprecated from go1.16 (ref: https://go.dev/doc/go1.16#ioutil).
So removed them.

