### PR TITLE
Move api error logs to debug

### DIFF
--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -227,14 +227,14 @@ func (api *API) getAlertsHandler(params alert_ops.GetAlertsParams) middleware.Re
 
 	matchers, err := parseFilter(params.Filter)
 	if err != nil {
-		level.Error(logger).Log("msg", "Failed to parse matchers", "err", err)
+		level.Debug(logger).Log("msg", "Failed to parse matchers", "err", err)
 		return alertgroup_ops.NewGetAlertGroupsBadRequest().WithPayload(err.Error())
 	}
 
 	if params.Receiver != nil {
 		receiverFilter, err = regexp.Compile("^(?:" + *params.Receiver + ")$")
 		if err != nil {
-			level.Error(logger).Log("msg", "Failed to compile receiver regex", "err", err)
+			level.Debug(logger).Log("msg", "Failed to compile receiver regex", "err", err)
 			return alert_ops.
 				NewGetAlertsBadRequest().
 				WithPayload(
@@ -356,7 +356,7 @@ func (api *API) getAlertGroupsHandler(params alertgroup_ops.GetAlertGroupsParams
 
 	matchers, err := parseFilter(params.Filter)
 	if err != nil {
-		level.Error(logger).Log("msg", "Failed to parse matchers", "err", err)
+		level.Debug(logger).Log("msg", "Failed to parse matchers", "err", err)
 		return alertgroup_ops.NewGetAlertGroupsBadRequest().WithPayload(err.Error())
 	}
 
@@ -494,7 +494,7 @@ func (api *API) getSilencesHandler(params silence_ops.GetSilencesParams) middlew
 		for _, matcherString := range params.Filter {
 			matcher, err := labels.ParseMatcher(matcherString)
 			if err != nil {
-				level.Error(logger).Log("msg", "Failed to parse matchers", "err", err)
+				level.Debug(logger).Log("msg", "Failed to parse matchers", "err", err)
 				return alert_ops.NewGetAlertsBadRequest().WithPayload(err.Error())
 			}
 


### PR DESCRIPTION
This is a of a nitpicky change, but having error logs on bad requests
is a bit of a pain. This means that a bad client can spam the logs with
bad requests that are really not actually an issue for the server -
we just send back the error and move on. This commit moves a couple of logs
from `Error` to `Debug` so that they can be filtered a bit better

Signed-off-by: sinkingpoint <colin@quirl.co.nz>