### PR TITLE
/-/{healthy,ready}/ respond to HEAD

### DIFF
--- a/docs/management_api.md
+++ b/docs/management_api.md
@@ -12,6 +12,7 @@ Alertmanager provides a set of management API to ease automation and integration
 
 ```
 GET /-/healthy
+HEAD /-/healthy
 ```
 
 This endpoint always returns 200 and should be used to check Alertmanager health.
@@ -21,6 +22,7 @@ This endpoint always returns 200 and should be used to check Alertmanager health
 
 ```
 GET /-/ready
+HEAD /-/ready
 ```
 
 This endpoint returns 200 when Alertmanager is ready to serve traffic (i.e. respond to queries).

--- a/ui/web.go
+++ b/ui/web.go
@@ -76,9 +76,15 @@ func Register(r *route.Router, reloadCh chan<- chan error, logger log.Logger) {
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, "OK")
 	}))
+	r.Head("/-/healthy", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
 	r.Get("/-/ready", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, "OK")
+	}))
+	r.Head("/-/ready", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
 	}))
 
 	r.Get("/debug/*subpath", http.DefaultServeMux.ServeHTTP)


### PR DESCRIPTION
Some frameworks issue HEAD requests to determine health.

This is meant to be the alertmanager equivalent of prometheus/prometheus#11160

Signed-off-by: Nicolas Dumazet <nicdumz.commits@gmail.com>