### PR TITLE
Add check for templated Opsgenie receiver config

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -506,7 +506,7 @@ func (c *OpsGenieConfig) UnmarshalYAML(unmarshal func(interface{}) error) error 
 		}
 
 		if strings.Contains(r.Type, "{{") {
-			_, err := template.New("").Parse(r.Type);
+			_, err := template.New("").Parse(r.Type)
 			if err != nil {
 				return errors.Errorf("opsGenieConfig responder %v type is not a valid template: %v", r, err)
 			}

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"text/template"
 	"time"
 
 	"github.com/pkg/errors"
@@ -504,9 +505,16 @@ func (c *OpsGenieConfig) UnmarshalYAML(unmarshal func(interface{}) error) error 
 			return errors.Errorf("opsGenieConfig responder %v has to have at least one of id, username or name specified", r)
 		}
 
-		r.Type = strings.ToLower(r.Type)
-		if !opsgenieTypeMatcher.MatchString(r.Type) {
-			return errors.Errorf("opsGenieConfig responder %v type does not match valid options %s", r, opsgenieValidTypesRe)
+		if strings.Contains(r.Type, "{{") {
+			_, err := template.New("").Parse(r.Type);
+			if err != nil {
+				return errors.Errorf("opsGenieConfig responder %v type is not a valid template: %v", r, err)
+			}
+		} else {
+			r.Type = strings.ToLower(r.Type)
+			if !opsgenieTypeMatcher.MatchString(r.Type) {
+				return errors.Errorf("opsGenieConfig responder %v type does not match valid options %s", r, opsgenieValidTypesRe)
+			}
 		}
 	}
 

--- a/config/notifiers_test.go
+++ b/config/notifiers_test.go
@@ -637,6 +637,25 @@ api_url: http://example.com
 `,
 			err: true,
 		},
+		{
+			name: "valid responder type template",
+			in: `api_key: xyz
+responders:
+- id: foo
+  type: "{{/* valid comment */}}team"
+api_url: http://example.com
+`,
+		},
+		{
+			name: "invalid responder type template",
+			in: `api_key: xyz
+responders:
+- id: foo
+  type: "{{/* invalid comment }}team"
+api_url: http://example.com
+`,
+			err: true,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var cfg OpsGenieConfig


### PR DESCRIPTION
Solves #2887, where Opsgenie responder type can be templated according to [docs](https://prometheus.io/docs/alerting/latest/configuration/#responder), but configuration logic checked for specific list of values only.