### PR TITLE
Truncate messages with fewer characters

### DIFF
--- a/notify/util.go
+++ b/notify/util.go
@@ -90,7 +90,7 @@ func Truncate(s string, n int) (string, bool) {
 	if n <= 3 {
 		return string(r[:n]), true
 	}
-	return string(r[:n-3]) + "...", true
+	return string(r[:n-1]) + "…", true
 }
 
 // TmplText is using monadic error handling in order to make string templating

--- a/notify/util_test.go
+++ b/notify/util_test.go
@@ -46,7 +46,7 @@ func TestTruncate(t *testing.T) {
 		{
 			in:    "abcde",
 			n:     4,
-			out:   "a...",
+			out:   "abc…",
 			trunc: true,
 		},
 		{
@@ -58,7 +58,7 @@ func TestTruncate(t *testing.T) {
 		{
 			in:    "abcdefgh",
 			n:     5,
-			out:   "ab...",
+			out:   "abcd…",
 			trunc: true,
 		},
 		{
@@ -70,7 +70,7 @@ func TestTruncate(t *testing.T) {
 		{
 			in:    "a⌘cdef",
 			n:     5,
-			out:   "a⌘...",
+			out:   "a⌘cd…",
 			trunc: true,
 		},
 	}


### PR DESCRIPTION
Replace three dots characters `...` with ellipsis (U+2026) `…` characters to save 2 extra chars space.
Related issue: #3050 