### PR TITLE
Reduce memory utilization in downstream projects creating multiple Alertmanager instances

### DIFF
--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -694,7 +694,7 @@ func getSwaggerSpec() (*loads.Document, error) {
 	// Load embedded swagger file.
 	swaggerSpec, err := loads.Analyzed(restapi.SwaggerJSON, "")
 	if err != nil {
-		return nil, fmt.Errorf("failed to load embedded swagger file: %v", err.Error())
+		return nil, fmt.Errorf("failed to load embedded swagger file: %w", err)
 	}
 
 	swaggerSpecCache = swaggerSpec


### PR DESCRIPTION
Grafana Mimir vendors the Prometheus Alertmanager. Specifically, Grafana Mimir (which is a multi-tenant system) creates a Prometheus Alertmanager instance for each tenant. This means that, in a given process, there could be hundreds or thousands of Prometheus Alertmanager instances (one for each tenant).

While investigating some high memory utilization, I noticed that in some clusters the memory allocated by `loads.Analyzed()` (swagger spec) takes about 50% of memory.

![Screenshot 2022-10-05 at 14 03 45](https://user-images.githubusercontent.com/1701904/194056172-2a47ddcd-8240-4e76-9181-7b41f371aa81.png)

In this PR I'm proposing to lazy load and then cache the swagger spec. To my understanding, the swagger spec is immutable, so shouldn't be an issue sharing it between different Aletmanager instances.

WDYT?