### PR TITLE
Add support for reading VictorOps API key from file

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -335,6 +335,10 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return fmt.Errorf("at most one of opsgenie_api_key & opsgenie_api_key_file must be configured")
 	}
 
+	if c.Global.VictorOpsAPIKey != "" && len(c.Global.VictorOpsAPIKeyFile) > 0 {
+		return fmt.Errorf("at most one of victorops_api_key & victorops_api_key_file must be configured")
+	}
+
 	if len(c.Global.SMTPAuthPassword) > 0 && len(c.Global.SMTPAuthPasswordFile) > 0 {
 		return fmt.Errorf("at most one of smtp_auth_password & smtp_auth_password_file must be configured")
 	}
@@ -476,11 +480,12 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			if !strings.HasSuffix(voc.APIURL.Path, "/") {
 				voc.APIURL.Path += "/"
 			}
-			if voc.APIKey == "" {
-				if c.Global.VictorOpsAPIKey == "" {
+			if voc.APIKey == "" && len(voc.APIKeyFile) == 0 {
+				if c.Global.VictorOpsAPIKey == "" && len(c.Global.VictorOpsAPIKeyFile) == 0 {
 					return fmt.Errorf("no global VictorOps API Key set")
 				}
 				voc.APIKey = c.Global.VictorOpsAPIKey
+				voc.APIKeyFile = c.Global.VictorOpsAPIKeyFile
 			}
 		}
 		for _, sns := range rcv.SNSConfigs {
@@ -718,6 +723,7 @@ type GlobalConfig struct {
 	WeChatAPICorpID      string     `yaml:"wechat_api_corp_id,omitempty" json:"wechat_api_corp_id,omitempty"`
 	VictorOpsAPIURL      *URL       `yaml:"victorops_api_url,omitempty" json:"victorops_api_url,omitempty"`
 	VictorOpsAPIKey      Secret     `yaml:"victorops_api_key,omitempty" json:"victorops_api_key,omitempty"`
+	VictorOpsAPIKeyFile  string     `yaml:"victorops_api_key_file,omitempty" json:"victorops_api_key_file,omitempty"`
 	TelegramAPIUrl       *URL       `yaml:"telegram_api_url,omitempty" json:"telegram_api_url,omitempty"`
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1016,11 +1016,12 @@ func TestVictorOpsDefaultAPIKey(t *testing.T) {
 	}
 
 	defaultKey := conf.Global.VictorOpsAPIKey
+	overrideKey := Secret("qwe456")
 	if defaultKey != conf.Receivers[0].VictorOpsConfigs[0].APIKey {
 		t.Fatalf("Invalid victorops key: %s\nExpected: %s", conf.Receivers[0].VictorOpsConfigs[0].APIKey, defaultKey)
 	}
-	if defaultKey == conf.Receivers[1].VictorOpsConfigs[0].APIKey {
-		t.Errorf("Invalid victorops key: %s\nExpected: %s", conf.Receivers[0].VictorOpsConfigs[0].APIKey, "qwe456")
+	if overrideKey != conf.Receivers[1].VictorOpsConfigs[0].APIKey {
+		t.Errorf("Invalid victorops key: %s\nExpected: %s", conf.Receivers[0].VictorOpsConfigs[0].APIKey, string(overrideKey))
 	}
 }
 
@@ -1031,11 +1032,12 @@ func TestVictorOpsDefaultAPIKeyFile(t *testing.T) {
 	}
 
 	defaultKey := conf.Global.VictorOpsAPIKeyFile
+	overrideKey := "/override_file"
 	if defaultKey != conf.Receivers[0].VictorOpsConfigs[0].APIKeyFile {
 		t.Fatalf("Invalid VictorOps key_file: %s\nExpected: %s", conf.Receivers[0].VictorOpsConfigs[0].APIKeyFile, defaultKey)
 	}
-	if defaultKey == conf.Receivers[1].VictorOpsConfigs[0].APIKeyFile {
-		t.Errorf("Invalid VictorOps key_file: %s\nExpected: %s", conf.Receivers[0].VictorOpsConfigs[0].APIKeyFile, "/override_file")
+	if overrideKey != conf.Receivers[1].VictorOpsConfigs[0].APIKeyFile {
+		t.Errorf("Invalid VictorOps key_file: %s\nExpected: %s", conf.Receivers[0].VictorOpsConfigs[0].APIKeyFile, overrideKey)
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1024,6 +1024,31 @@ func TestVictorOpsDefaultAPIKey(t *testing.T) {
 	}
 }
 
+func TestVictorOpsDefaultAPIKeyFile(t *testing.T) {
+	conf, err := LoadFile("testdata/conf.victorops-default-apikey-file.yml")
+	if err != nil {
+		t.Fatalf("Error parsing %s: %s", "testdata/conf.victorops-default-apikey-file.yml", err)
+	}
+
+	defaultKey := conf.Global.VictorOpsAPIKeyFile
+	if defaultKey != conf.Receivers[0].VictorOpsConfigs[0].APIKeyFile {
+		t.Fatalf("Invalid VictorOps key_file: %s\nExpected: %s", conf.Receivers[0].VictorOpsConfigs[0].APIKeyFile, defaultKey)
+	}
+	if defaultKey == conf.Receivers[1].VictorOpsConfigs[0].APIKeyFile {
+		t.Errorf("Invalid VictorOps key_file: %s\nExpected: %s", conf.Receivers[0].VictorOpsConfigs[0].APIKeyFile, "/override_file")
+	}
+}
+
+func TestVictorOpsBothAPIKeyAndFile(t *testing.T) {
+	_, err := LoadFile("testdata/conf.victorops-both-file-and-apikey.yml")
+	if err == nil {
+		t.Fatalf("Expected an error parsing %s: %s", "testdata/conf.victorops-both-file-and-apikey.yml", err)
+	}
+	if err.Error() != "at most one of victorops_api_key & victorops_api_key_file must be configured" {
+		t.Errorf("Expected: %s\nGot: %s", "at most one of victorops_api_key & victorops_api_key_file must be configured", err.Error())
+	}
+}
+
 func TestVictorOpsNoAPIKey(t *testing.T) {
 	_, err := LoadFile("testdata/conf.victorops-no-apikey.yml")
 	if err == nil {

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -540,7 +540,7 @@ type VictorOpsConfig struct {
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
 	APIKey            Secret            `yaml:"api_key,omitempty" json:"api_key,omitempty"`
-	APIKeyFile        Secret            `yaml:"api_key_file,omitempty" json:"api_key_file,omitempty"`
+	APIKeyFile        string            `yaml:"api_key_file,omitempty" json:"api_key_file,omitempty"`
 	APIURL            *URL              `yaml:"api_url" json:"api_url"`
 	RoutingKey        string            `yaml:"routing_key" json:"routing_key"`
 	MessageType       string            `yaml:"message_type" json:"message_type"`
@@ -559,6 +559,9 @@ func (c *VictorOpsConfig) UnmarshalYAML(unmarshal func(interface{}) error) error
 	}
 	if c.RoutingKey == "" {
 		return fmt.Errorf("missing Routing key in VictorOps config")
+	}
+	if c.APIKey != "" && len(c.APIKeyFile) > 0 {
+		return fmt.Errorf("at most one of api_key & api_key_file must be configured")
 	}
 
 	reservedFields := []string{"routing_key", "message_type", "state_message", "entity_display_name", "monitoring_tool", "entity_id", "entity_state"}

--- a/config/notifiers_test.go
+++ b/config/notifiers_test.go
@@ -299,7 +299,6 @@ api_key_file: /global_file
 `
 		var cfg VictorOpsConfig
 		err := yaml.UnmarshalStrict([]byte(in), &cfg)
-
 		if err != nil {
 			t.Fatalf("no error was expected:\n%v", err)
 		}

--- a/config/notifiers_test.go
+++ b/config/notifiers_test.go
@@ -291,21 +291,55 @@ http_config:
 	}
 }
 
-func TestVictorOpsRoutingKeyIsPresent(t *testing.T) {
-	in := `
+func TestVictorOpsConfiguration(t *testing.T) {
+	t.Run("valid configuration", func(t *testing.T) {
+		in := `
+routing_key: test
+api_key_file: /global_file
+`
+		var cfg VictorOpsConfig
+		err := yaml.UnmarshalStrict([]byte(in), &cfg)
+
+		if err != nil {
+			t.Fatalf("no error was expected:\n%v", err)
+		}
+	})
+
+	t.Run("routing key is missing", func(t *testing.T) {
+		in := `
 routing_key: ''
 `
-	var cfg VictorOpsConfig
-	err := yaml.UnmarshalStrict([]byte(in), &cfg)
+		var cfg VictorOpsConfig
+		err := yaml.UnmarshalStrict([]byte(in), &cfg)
 
-	expected := "missing Routing key in VictorOps config"
+		expected := "missing Routing key in VictorOps config"
 
-	if err == nil {
-		t.Fatalf("no error returned, expected:\n%v", expected)
-	}
-	if err.Error() != expected {
-		t.Errorf("\nexpected:\n%v\ngot:\n%v", expected, err.Error())
-	}
+		if err == nil {
+			t.Fatalf("no error returned, expected:\n%v", expected)
+		}
+		if err.Error() != expected {
+			t.Errorf("\nexpected:\n%v\ngot:\n%v", expected, err.Error())
+		}
+	})
+
+	t.Run("api_key and api_key_file both defined", func(t *testing.T) {
+		in := `
+routing_key: test
+api_key: xyz
+api_key_file: /global_file
+`
+		var cfg VictorOpsConfig
+		err := yaml.UnmarshalStrict([]byte(in), &cfg)
+
+		expected := "at most one of api_key & api_key_file must be configured"
+
+		if err == nil {
+			t.Fatalf("no error returned, expected:\n%v", expected)
+		}
+		if err.Error() != expected {
+			t.Errorf("\nexpected:\n%v\ngot:\n%v", expected, err.Error())
+		}
+	})
 }
 
 func TestVictorOpsCustomFieldsValidation(t *testing.T) {

--- a/config/testdata/conf.victorops-both-file-and-apikey.yml
+++ b/config/testdata/conf.victorops-both-file-and-apikey.yml
@@ -1,0 +1,21 @@
+global:
+  victorops_api_key: asd132
+  victorops_api_key_file: '/global_file'
+route:
+  group_by: ['alertname', 'cluster', 'service']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 3h
+  receiver: team-Y-victorops
+  routes:
+    - match:
+        service: foo
+      receiver: team-X-victorops
+receivers:
+  - name: 'team-X-victorops'
+    victorops_configs:
+      - routing_key: 'team-X'
+  - name: 'team-Y-victorops'
+    victorops_configs:
+      - routing_key: 'team-Y'
+        api_key: qwe456

--- a/config/testdata/conf.victorops-default-apikey-file.yml
+++ b/config/testdata/conf.victorops-default-apikey-file.yml
@@ -1,0 +1,20 @@
+global:
+  victorops_api_key_file: '/global_file'
+route:
+  group_by: ['alertname', 'cluster', 'service']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 3h
+  receiver: team-Y-victorops
+  routes:
+    - match:
+        service: foo
+      receiver: team-X-victorops
+receivers:
+  - name: 'team-X-victorops'
+    victorops_configs:
+      - routing_key: 'team-X'
+  - name: 'team-Y-victorops'
+    victorops_configs:
+      - routing_key: 'team-Y'
+        api_key: qwe456

--- a/config/testdata/conf.victorops-default-apikey-file.yml
+++ b/config/testdata/conf.victorops-default-apikey-file.yml
@@ -17,4 +17,4 @@ receivers:
   - name: 'team-Y-victorops'
     victorops_configs:
       - routing_key: 'team-Y'
-        api_key: qwe456
+        api_key_file: /override_file

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -975,6 +975,9 @@ VictorOps notifications are sent out via the [VictorOps API](https://help.victor
 # The API key to use when talking to the VictorOps API.
 [ api_key: <secret> | default = global.victorops_api_key ]
 
+# The filepath to API key to use when talking to the VictorOps API. Conflicts with api_key.
+[ api_key_file: <filepath> | default = global.victorops_api_key_file ]
+
 # The VictorOps API URL.
 [ api_url: <string> | default = global.victorops_api_url ]
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -977,7 +977,8 @@ VictorOps notifications are sent out via the [VictorOps API](https://help.victor
 # It is mutually exclusive with `api_key_file`.
 [ api_key: <secret> | default = global.victorops_api_key ]
 
-# The filepath to API key to use when talking to the VictorOps API. Conflicts with api_key.
+# Reads the API key to use when talking to the VictorOps API from a file.
+# It is mutually exclusive with `api_key`.
 [ api_key_file: <filepath> | default = global.victorops_api_key_file ]
 
 # The VictorOps API URL.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -974,6 +974,7 @@ VictorOps notifications are sent out via the [VictorOps API](https://help.victor
 [ send_resolved: <boolean> | default = true ]
 
 # The API key to use when talking to the VictorOps API.
+# It is mutually exclusive with `api_key_file`.
 [ api_key: <secret> | default = global.victorops_api_key ]
 
 # The filepath to API key to use when talking to the VictorOps API. Conflicts with api_key.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,6 +85,7 @@ global:
   [ slack_api_url: <secret> ]
   [ slack_api_url_file: <filepath> ]
   [ victorops_api_key: <secret> ]
+  [ victorops_api_key_file: <filepath> ]
   [ victorops_api_url: <string> | default = "https://alert.victorops.com/integrations/generic/20131114/alert/" ]
   [ pagerduty_url: <string> | default = "https://events.pagerduty.com/v2/enqueue" ]
   [ opsgenie_api_key: <secret> ]

--- a/notify/victorops/victorops.go
+++ b/notify/victorops/victorops.go
@@ -18,13 +18,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/pkg/errors"
 	"net/http"
 	"os"
 	"strings"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/pkg/errors"
 	commoncfg "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 


### PR DESCRIPTION
Related to issue #2498. Basically a copy of https://github.com/prometheus/alertmanager/pull/2728.

https://github.com/prometheus/alertmanager/pull/2554 can be closed as a result.

Signed-off-by: Oktarian Tilney-Bassett 😄 