### PR TITLE
Reduce memory utilization in downstream projects creating multiple Alertmanager instances

### DIFF
--- a/api/v2/restapi/operations/alertmanager_api.go
+++ b/api/v2/restapi/operations/alertmanager_api.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/go-openapi/analysis"
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/runtime"
@@ -41,7 +42,7 @@ import (
 )
 
 // NewAlertmanagerAPI creates a new Alertmanager instance
-func NewAlertmanagerAPI(spec *loads.Document) *AlertmanagerAPI {
+func NewAlertmanagerAPI(spec *loads.Document, specAnalysis *analysis.Spec) *AlertmanagerAPI {
 	return &AlertmanagerAPI{
 		handlers:            make(map[string]map[string]http.Handler),
 		formats:             strfmt.Default,
@@ -52,6 +53,7 @@ func NewAlertmanagerAPI(spec *loads.Document) *AlertmanagerAPI {
 		PreServerShutdown:   func() {},
 		ServerShutdown:      func() {},
 		spec:                spec,
+		specAnalysis:        specAnalysis,
 		ServeError:          errors.ServeError,
 		BasicAuthenticator:  security.BasicAuth,
 		APIKeyAuthenticator: security.APIKeyAuth,
@@ -94,6 +96,7 @@ func NewAlertmanagerAPI(spec *loads.Document) *AlertmanagerAPI {
 /*AlertmanagerAPI API of the Prometheus Alertmanager (https://github.com/prometheus/alertmanager) */
 type AlertmanagerAPI struct {
 	spec            *loads.Document
+	specAnalysis    *analysis.Spec
 	context         *middleware.Context
 	handlers        map[string]map[string]http.Handler
 	formats         strfmt.Registry
@@ -171,6 +174,7 @@ func (o *AlertmanagerAPI) SetDefaultConsumes(mediaType string) {
 // SetSpec sets a spec that will be served for the clients.
 func (o *AlertmanagerAPI) SetSpec(spec *loads.Document) {
 	o.spec = spec
+	o.specAnalysis = analysis.New(spec.Spec())
 }
 
 // DefaultProduces returns the default produces media type
@@ -308,7 +312,7 @@ func (o *AlertmanagerAPI) HandlerFor(method, path string) (http.Handler, bool) {
 // Context returns the middleware context for the alertmanager API
 func (o *AlertmanagerAPI) Context() *middleware.Context {
 	if o.context == nil {
-		o.context = middleware.NewRoutableContext(o.spec, o, nil)
+		o.context = middleware.NewRoutableContextWithAnalyzedSpec(o.spec, o.specAnalysis, o, nil)
 	}
 
 	return o.context

--- a/api/v2/restapi/operations/alertmanager_api.go
+++ b/api/v2/restapi/operations/alertmanager_api.go
@@ -24,7 +24,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/go-openapi/analysis"
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/runtime"
@@ -42,7 +41,7 @@ import (
 )
 
 // NewAlertmanagerAPI creates a new Alertmanager instance
-func NewAlertmanagerAPI(spec *loads.Document, specAnalysis *analysis.Spec) *AlertmanagerAPI {
+func NewAlertmanagerAPI(spec *loads.Document) *AlertmanagerAPI {
 	return &AlertmanagerAPI{
 		handlers:            make(map[string]map[string]http.Handler),
 		formats:             strfmt.Default,
@@ -53,7 +52,6 @@ func NewAlertmanagerAPI(spec *loads.Document, specAnalysis *analysis.Spec) *Aler
 		PreServerShutdown:   func() {},
 		ServerShutdown:      func() {},
 		spec:                spec,
-		specAnalysis:        specAnalysis,
 		ServeError:          errors.ServeError,
 		BasicAuthenticator:  security.BasicAuth,
 		APIKeyAuthenticator: security.APIKeyAuth,
@@ -96,7 +94,6 @@ func NewAlertmanagerAPI(spec *loads.Document, specAnalysis *analysis.Spec) *Aler
 /*AlertmanagerAPI API of the Prometheus Alertmanager (https://github.com/prometheus/alertmanager) */
 type AlertmanagerAPI struct {
 	spec            *loads.Document
-	specAnalysis    *analysis.Spec
 	context         *middleware.Context
 	handlers        map[string]map[string]http.Handler
 	formats         strfmt.Registry
@@ -174,7 +171,6 @@ func (o *AlertmanagerAPI) SetDefaultConsumes(mediaType string) {
 // SetSpec sets a spec that will be served for the clients.
 func (o *AlertmanagerAPI) SetSpec(spec *loads.Document) {
 	o.spec = spec
-	o.specAnalysis = analysis.New(spec.Spec())
 }
 
 // DefaultProduces returns the default produces media type
@@ -312,7 +308,7 @@ func (o *AlertmanagerAPI) HandlerFor(method, path string) (http.Handler, bool) {
 // Context returns the middleware context for the alertmanager API
 func (o *AlertmanagerAPI) Context() *middleware.Context {
 	if o.context == nil {
-		o.context = middleware.NewRoutableContextWithAnalyzedSpec(o.spec, o.specAnalysis, o, nil)
+		o.context = middleware.NewRoutableContext(o.spec, o, nil)
 	}
 
 	return o.context

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/go-kit/log v0.2.1
 	github.com/go-openapi/errors v0.20.3
 	github.com/go-openapi/loads v0.21.2
-	github.com/go-openapi/runtime v0.24.1
+	github.com/go-openapi/runtime v0.24.3-0.20221021160911-4425b20330b2
 	github.com/go-openapi/spec v0.20.7
 	github.com/go-openapi/strfmt v0.21.3
 	github.com/go-openapi/swag v0.22.3

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/cespare/xxhash/v2 v2.1.2
 	github.com/go-kit/log v0.2.1
+	github.com/go-openapi/analysis v0.21.4
 	github.com/go-openapi/errors v0.20.3
 	github.com/go-openapi/loads v0.21.2
 	github.com/go-openapi/runtime v0.24.3-0.20221021160911-4425b20330b2
@@ -54,7 +55,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
-	github.com/go-openapi/analysis v0.21.4 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.20.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,8 @@ github.com/go-openapi/jsonreference v0.20.0/go.mod h1:Ag74Ico3lPc+zR+qjn4XBUmXym
 github.com/go-openapi/loads v0.21.1/go.mod h1:/DtAMXXneXFjbQMGEtbamCZb+4x7eGwkvZCvBmwUG+g=
 github.com/go-openapi/loads v0.21.2 h1:r2a/xFIYeZ4Qd2TnGpWDIQNcP80dIaZgf704za8enro=
 github.com/go-openapi/loads v0.21.2/go.mod h1:Jq58Os6SSGz0rzh62ptiu8Z31I+OTHqmULx5e/gJbNw=
-github.com/go-openapi/runtime v0.24.1 h1:Sml5cgQKGYQHF+M7yYSHaH1eOjvTykrddTE/KtQVjqo=
-github.com/go-openapi/runtime v0.24.1/go.mod h1:AKurw9fNre+h3ELZfk6ILsfvPN+bvvlaU/M9q/r9hpk=
+github.com/go-openapi/runtime v0.24.3-0.20221021160911-4425b20330b2 h1:Vr08+BrsrnvcgikSlS273dkijppZ/M+fL/TMfc/LEJM=
+github.com/go-openapi/runtime v0.24.3-0.20221021160911-4425b20330b2/go.mod h1:AKurw9fNre+h3ELZfk6ILsfvPN+bvvlaU/M9q/r9hpk=
 github.com/go-openapi/spec v0.20.4/go.mod h1:faYFR1CvsJZ0mNsmsphTMSoRrNV3TEDoAM7FOEWeq8I=
 github.com/go-openapi/spec v0.20.6/go.mod h1:2OpW+JddWPrpXSCIX8eOx7lZ5iyuWj3RYR6VaaBKcWA=
 github.com/go-openapi/spec v0.20.7 h1:1Rlu/ZrOCCob0n+JKKJAWhNWMPW8bOZRg8FJaY+0SKI=


### PR DESCRIPTION
This PR is a follow up of https://github.com/prometheus/alertmanager/pull/3092 (see rationale explained there, please).The PR 3092 reduced Mimir Alertmanager by -50%, and this last PR has the potential to reduce another -50% on top of it (see https://github.com/grafana/mimir/issues/3273).

The `AlertmanagerAPI.Context()` calls `middleware.NewRoutableContext()` passing the `spec` which then is analysed:
https://github.com/go-openapi/runtime/blob/dc39dfcab95e469a2034283ec1bc196ff94f09ac/middleware/context.go#L193-L197

I've added a new function `NewRoutableContextWithAnalyzedSpec()` to `go-openapi/runtime` (see: https://github.com/go-openapi/runtime/pull/258). This PR builds on that and adds a singleton cache for the analyzed spec too.

Since the file `api/v2/restapi/operations/alertmanager_api.go` is generated from swagger specs and we can't edit it, I've changed the code to manually create the swagger API client context, passing the analyzed spec.