### PR TITLE
Allow telegram to get bottoken from file

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -685,7 +685,8 @@ type TelegramConfig struct {
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
 	APIUrl               *URL   `yaml:"api_url" json:"api_url,omitempty"`
-	BotToken             Secret `yaml:"bot_token,omitempty" json:"token,omitempty"`
+	BotToken             Secret `yaml:"bot_token,omitempty" json:"bot_token,omitempty"`
+	BotTokenFile         string `yaml:"bot_token_file,omitempty" json:"bot_token_file,omitempty"`
 	ChatID               int64  `yaml:"chat_id,omitempty" json:"chat,omitempty"`
 	Message              string `yaml:"message,omitempty" json:"message,omitempty"`
 	DisableNotifications bool   `yaml:"disable_notifications,omitempty" json:"disable_notifications,omitempty"`
@@ -699,8 +700,11 @@ func (c *TelegramConfig) UnmarshalYAML(unmarshal func(interface{}) error) error 
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
-	if c.BotToken == "" {
-		return fmt.Errorf("missing bot_token on telegram_config")
+	if c.BotToken != "" && len(c.BotTokenFile) > 0 {
+		return fmt.Errorf("at most one of bot_token & bot_token_file must be configured")
+	}
+	if c.BotToken == "" && len(c.BotTokenFile) == 0 {
+		return fmt.Errorf("missing bot_token or bot_token_file on telegram_config")
 	}
 	if c.ChatID == 0 {
 		return fmt.Errorf("missing chat_id on telegram_config")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1094,8 +1094,11 @@ API](http://admin.wechat.com/wiki/index.php?title=Customer_Service_Messages).
 # If not specified, default API URL will be used.
 [ api_url: <string> | default = global.telegram_api_url ]
 
-# Telegram bot token
+# Telegram bot token. It is mutually exclusive with `bot_token_file`.
 [ bot_token: <string> ]
+
+# Read Telegram bot token from a file. It is mutually exclusive with `bot_token`.
+[ bot_token_file: <filepath> ]
 
 # ID of the chat where to send the messages.
 [ chat_id: <int> ]

--- a/notify/telegram/telegram_test.go
+++ b/notify/telegram/telegram_test.go
@@ -16,6 +16,7 @@ package telegram
 import (
 	"fmt"
 	"net/url"
+	//"os"
 	"testing"
 
 	"github.com/go-kit/log"
@@ -73,3 +74,52 @@ func TestTelegramRetry(t *testing.T) {
 		require.Equal(t, expected, actual, fmt.Sprintf("error on status %d", statusCode))
 	}
 }
+
+/*
+func TestTelegramRedactedBotToken(t *testing.T) {
+	ctx, u, fn := test.GetContextWithCancelingURL()
+	defer fn()
+
+	botToken := "test"
+
+	notifier, err := New(
+		&config.TelegramConfig{
+			APIUrl: &config.URL{URL: u},
+			HTTPConfig: &commoncfg.HTTPClientConfig{},
+			ChatID:   1234,
+			BotToken: config.Secret(botToken),
+		},
+		test.CreateTmpl(t),
+		log.NewNopLogger(),
+	)
+	require.NoError(t, err)
+
+	test.AssertNotifyLeaksNoSecret(ctx, t, notifier, botToken)
+}
+
+func TestTelegramBotTokenFromFile(t *testing.T) {
+	ctx, u, fn := test.GetContextWithCancelingURL()
+	defer fn()
+
+	botToken := "test"
+
+	f, err := os.CreateTemp("", "telegram_test")
+	require.NoError(t, err, "creating temp file failed")
+	_, err = f.WriteString(botToken)
+	require.NoError(t, err, "writing to temp file failed")
+
+	notifier, err := New(
+		&config.TelegramConfig{
+			APIUrl: &config.URL{URL: u},
+			HTTPConfig: &commoncfg.HTTPClientConfig{},
+			ChatID:   1234,
+			BotTokenFile: f.Name(),
+		},
+		test.CreateTmpl(t),
+		log.NewNopLogger(),
+	)
+	require.NoError(t, err)
+
+	test.AssertNotifyLeaksNoSecret(ctx, t, notifier, botToken)
+}
+*/


### PR DESCRIPTION
This PR allows the user to specify `bot_token_file` in the Telegram config, which allows specifying token from a file.
Code largely copied from the Slack receiver.