### PR TITLE
Emit warning-level logs when truncating messages in notifications

### DIFF
--- a/notify/opsgenie/opsgenie.go
+++ b/notify/opsgenie/opsgenie.go
@@ -34,6 +34,9 @@ import (
 	"github.com/prometheus/alertmanager/types"
 )
 
+// https://docs.opsgenie.com/docs/alert-api - 130 characters meaning runes.
+const maxMessageLenRunes = 130
+
 // Notifier implements a Notifier for OpsGenie notifications.
 type Notifier struct {
 	conf    *config.OpsGenieConfig
@@ -171,10 +174,9 @@ func (n *Notifier) createRequests(ctx context.Context, as ...*types.Alert) ([]*h
 		}
 		requests = append(requests, req.WithContext(ctx))
 	default:
-		// https://docs.opsgenie.com/docs/alert-api - 130 characters meaning runes.
-		message, truncated := notify.TruncateInRunes(tmpl(n.conf.Message), 130)
+		message, truncated := notify.TruncateInRunes(tmpl(n.conf.Message), maxMessageLenRunes)
 		if truncated {
-			level.Debug(n.logger).Log("msg", "Truncated message", "alert", key)
+			level.Debug(n.logger).Log("msg", "Truncated message", "alert", key, "runes", maxMessageLenRunes)
 		}
 
 		createEndpointURL := n.conf.APIURL.Copy()

--- a/notify/opsgenie/opsgenie.go
+++ b/notify/opsgenie/opsgenie.go
@@ -176,7 +176,7 @@ func (n *Notifier) createRequests(ctx context.Context, as ...*types.Alert) ([]*h
 	default:
 		message, truncated := notify.TruncateInRunes(tmpl(n.conf.Message), maxMessageLenRunes)
 		if truncated {
-			level.Warn(n.logger).Log("msg", "Truncated message", "alert", key, "runes", maxMessageLenRunes)
+			level.Warn(n.logger).Log("msg", "Truncated message", "alert", key, "max_runes", maxMessageLenRunes)
 		}
 
 		createEndpointURL := n.conf.APIURL.Copy()

--- a/notify/opsgenie/opsgenie.go
+++ b/notify/opsgenie/opsgenie.go
@@ -176,7 +176,7 @@ func (n *Notifier) createRequests(ctx context.Context, as ...*types.Alert) ([]*h
 	default:
 		message, truncated := notify.TruncateInRunes(tmpl(n.conf.Message), maxMessageLenRunes)
 		if truncated {
-			level.Debug(n.logger).Log("msg", "Truncated message", "alert", key, "runes", maxMessageLenRunes)
+			level.Warn(n.logger).Log("msg", "Truncated message", "alert", key, "runes", maxMessageLenRunes)
 		}
 
 		createEndpointURL := n.conf.APIURL.Copy()

--- a/notify/opsgenie/opsgenie.go
+++ b/notify/opsgenie/opsgenie.go
@@ -174,7 +174,7 @@ func (n *Notifier) createRequests(ctx context.Context, as ...*types.Alert) ([]*h
 		// https://docs.opsgenie.com/docs/alert-api - 130 characters meaning runes.
 		message, truncated := notify.TruncateInRunes(tmpl(n.conf.Message), 130)
 		if truncated {
-			level.Debug(n.logger).Log("msg", "truncated message", "truncated_message", message, "alert", key)
+			level.Warn(n.logger).Log("msg", "truncated message", "truncated_message", message, "alert", key)
 		}
 
 		createEndpointURL := n.conf.APIURL.Copy()

--- a/notify/opsgenie/opsgenie.go
+++ b/notify/opsgenie/opsgenie.go
@@ -174,7 +174,7 @@ func (n *Notifier) createRequests(ctx context.Context, as ...*types.Alert) ([]*h
 		// https://docs.opsgenie.com/docs/alert-api - 130 characters meaning runes.
 		message, truncated := notify.TruncateInRunes(tmpl(n.conf.Message), 130)
 		if truncated {
-			level.Warn(n.logger).Log("msg", "truncated message", "truncated_message", message, "alert", key)
+			level.Debug(n.logger).Log("msg", "Truncated message", "alert", key)
 		}
 
 		createEndpointURL := n.conf.APIURL.Copy()

--- a/notify/pagerduty/pagerduty.go
+++ b/notify/pagerduty/pagerduty.go
@@ -152,7 +152,7 @@ func (n *Notifier) notifyV1(
 	// https://developer.pagerduty.com/docs/ZG9jOjExMDI5NTgx-send-an-alert-event - 1204 characters or runes.
 	description, truncated := notify.TruncateInRunes(tmpl(n.conf.Description), 1024)
 	if truncated {
-		level.Debug(n.logger).Log("msg", "Truncated description", "description", description, "key", key)
+		level.Warn(n.logger).Log("msg", "Truncated description", "description", description, "key", key)
 	}
 
 	serviceKey := string(n.conf.ServiceKey)
@@ -218,7 +218,7 @@ func (n *Notifier) notifyV2(
 	// https://developer.pagerduty.com/docs/ZG9jOjExMDI5NTgx-send-an-alert-event - 1204 characters or runes.
 	summary, truncated := notify.TruncateInRunes(tmpl(n.conf.Description), 1024)
 	if truncated {
-		level.Debug(n.logger).Log("msg", "Truncated summary", "summary", summary, "key", key)
+		level.Warn(n.logger).Log("msg", "Truncated summary", "summary", summary, "key", key)
 	}
 
 	routingKey := string(n.conf.RoutingKey)

--- a/notify/pagerduty/pagerduty.go
+++ b/notify/pagerduty/pagerduty.go
@@ -157,7 +157,7 @@ func (n *Notifier) notifyV1(
 
 	description, truncated := notify.TruncateInRunes(tmpl(n.conf.Description), maxV1DescriptionLenRunes)
 	if truncated {
-		level.Warn(n.logger).Log("msg", "Truncated description", "key", key, "runes", maxV1DescriptionLenRunes)
+		level.Warn(n.logger).Log("msg", "Truncated description", "key", key, "max_runes", maxV1DescriptionLenRunes)
 	}
 
 	serviceKey := string(n.conf.ServiceKey)
@@ -222,7 +222,7 @@ func (n *Notifier) notifyV2(
 
 	summary, truncated := notify.TruncateInRunes(tmpl(n.conf.Description), maxV2SummaryLenRunes)
 	if truncated {
-		level.Warn(n.logger).Log("msg", "Truncated summary", "key", key, "runes", maxV2SummaryLenRunes)
+		level.Warn(n.logger).Log("msg", "Truncated summary", "key", key, "max_runes", maxV2SummaryLenRunes)
 	}
 
 	routingKey := string(n.conf.RoutingKey)

--- a/notify/pagerduty/pagerduty.go
+++ b/notify/pagerduty/pagerduty.go
@@ -152,7 +152,7 @@ func (n *Notifier) notifyV1(
 	// https://developer.pagerduty.com/docs/ZG9jOjExMDI5NTgx-send-an-alert-event - 1204 characters or runes.
 	description, truncated := notify.TruncateInRunes(tmpl(n.conf.Description), 1024)
 	if truncated {
-		level.Warn(n.logger).Log("msg", "Truncated description", "description", description, "key", key)
+		level.Warn(n.logger).Log("msg", "Truncated description", "key", key)
 	}
 
 	serviceKey := string(n.conf.ServiceKey)
@@ -218,7 +218,7 @@ func (n *Notifier) notifyV2(
 	// https://developer.pagerduty.com/docs/ZG9jOjExMDI5NTgx-send-an-alert-event - 1204 characters or runes.
 	summary, truncated := notify.TruncateInRunes(tmpl(n.conf.Description), 1024)
 	if truncated {
-		level.Warn(n.logger).Log("msg", "Truncated summary", "summary", summary, "key", key)
+		level.Warn(n.logger).Log("msg", "Truncated summary", "key", key)
 	}
 
 	routingKey := string(n.conf.RoutingKey)

--- a/notify/pushover/pushover.go
+++ b/notify/pushover/pushover.go
@@ -31,6 +31,15 @@ import (
 	"github.com/prometheus/alertmanager/types"
 )
 
+const (
+	// https://pushover.net/api#limits - 250 characters or runes.
+	maxTitleLenRunes = 250
+	// https://pushover.net/api#limits - 1024 characters or runes.
+	maxMessageLenRunes = 1024
+	// https://pushover.net/api#limits - 512 characters or runes.
+	maxURLLenRunes = 512
+)
+
 // Notifier implements a Notifier for Pushover notifications.
 type Notifier struct {
 	conf    *config.PushoverConfig
@@ -78,10 +87,9 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	parameters.Add("token", tmpl(string(n.conf.Token)))
 	parameters.Add("user", tmpl(string(n.conf.UserKey)))
 
-	// https://pushover.net/api#limits - 250 characters or runes.
-	title, truncated := notify.TruncateInRunes(tmpl(n.conf.Title), 250)
+	title, truncated := notify.TruncateInRunes(tmpl(n.conf.Title), maxTitleLenRunes)
 	if truncated {
-		level.Warn(n.logger).Log("msg", "Truncated title", "incident", key)
+		level.Warn(n.logger).Log("msg", "Truncated title", "incident", key, "runes", maxTitleLenRunes)
 	}
 	parameters.Add("title", title)
 
@@ -92,10 +100,9 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		message = tmpl(n.conf.Message)
 	}
 
-	// https://pushover.net/api#limits - 1024 characters or runes.
-	message, truncated = notify.TruncateInRunes(message, 1024)
+	message, truncated = notify.TruncateInRunes(message, maxMessageLenRunes)
 	if truncated {
-		level.Warn(n.logger).Log("msg", "Truncated message", "incident", key)
+		level.Warn(n.logger).Log("msg", "Truncated message", "incident", key, "runes", maxMessageLenRunes)
 	}
 	message = strings.TrimSpace(message)
 	if message == "" {
@@ -104,10 +111,9 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	}
 	parameters.Add("message", message)
 
-	// https://pushover.net/api#limits - 512 characters or runes.
-	supplementaryURL, truncated := notify.TruncateInRunes(tmpl(n.conf.URL), 512)
+	supplementaryURL, truncated := notify.TruncateInRunes(tmpl(n.conf.URL), maxURLLenRunes)
 	if truncated {
-		level.Warn(n.logger).Log("msg", "Truncated URL", "incident", key)
+		level.Warn(n.logger).Log("msg", "Truncated URL", "incident", key, "runes", maxURLLenRunes)
 	}
 	parameters.Add("url", supplementaryURL)
 	parameters.Add("url_title", tmpl(n.conf.URLTitle))

--- a/notify/pushover/pushover.go
+++ b/notify/pushover/pushover.go
@@ -89,7 +89,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 
 	title, truncated := notify.TruncateInRunes(tmpl(n.conf.Title), maxTitleLenRunes)
 	if truncated {
-		level.Warn(n.logger).Log("msg", "Truncated title", "incident", key, "runes", maxTitleLenRunes)
+		level.Warn(n.logger).Log("msg", "Truncated title", "incident", key, "max_runes", maxTitleLenRunes)
 	}
 	parameters.Add("title", title)
 
@@ -102,7 +102,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 
 	message, truncated = notify.TruncateInRunes(message, maxMessageLenRunes)
 	if truncated {
-		level.Warn(n.logger).Log("msg", "Truncated message", "incident", key, "runes", maxMessageLenRunes)
+		level.Warn(n.logger).Log("msg", "Truncated message", "incident", key, "max_runes", maxMessageLenRunes)
 	}
 	message = strings.TrimSpace(message)
 	if message == "" {
@@ -113,7 +113,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 
 	supplementaryURL, truncated := notify.TruncateInRunes(tmpl(n.conf.URL), maxURLLenRunes)
 	if truncated {
-		level.Warn(n.logger).Log("msg", "Truncated URL", "incident", key, "runes", maxURLLenRunes)
+		level.Warn(n.logger).Log("msg", "Truncated URL", "incident", key, "max_runes", maxURLLenRunes)
 	}
 	parameters.Add("url", supplementaryURL)
 	parameters.Add("url_title", tmpl(n.conf.URLTitle))

--- a/notify/pushover/pushover.go
+++ b/notify/pushover/pushover.go
@@ -81,7 +81,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	// https://pushover.net/api#limits - 250 characters or runes.
 	title, truncated := notify.TruncateInRunes(tmpl(n.conf.Title), 250)
 	if truncated {
-		level.Debug(n.logger).Log("msg", "Truncated title", "truncated_title", title, "incident", key)
+		level.Warn(n.logger).Log("msg", "Truncated title", "truncated_title", title, "incident", key)
 	}
 	parameters.Add("title", title)
 
@@ -95,7 +95,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	// https://pushover.net/api#limits - 1024 characters or runes.
 	message, truncated = notify.TruncateInRunes(message, 1024)
 	if truncated {
-		level.Debug(n.logger).Log("msg", "Truncated message", "truncated_message", message, "incident", key)
+		level.Warn(n.logger).Log("msg", "Truncated message", "truncated_message", message, "incident", key)
 	}
 	message = strings.TrimSpace(message)
 	if message == "" {
@@ -107,7 +107,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	// https://pushover.net/api#limits - 512 characters or runes.
 	supplementaryURL, truncated := notify.TruncateInRunes(tmpl(n.conf.URL), 512)
 	if truncated {
-		level.Debug(n.logger).Log("msg", "Truncated URL", "truncated_url", supplementaryURL, "incident", key)
+		level.Warn(n.logger).Log("msg", "Truncated URL", "truncated_url", supplementaryURL, "incident", key)
 	}
 	parameters.Add("url", supplementaryURL)
 	parameters.Add("url_title", tmpl(n.conf.URLTitle))

--- a/notify/pushover/pushover.go
+++ b/notify/pushover/pushover.go
@@ -81,7 +81,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	// https://pushover.net/api#limits - 250 characters or runes.
 	title, truncated := notify.TruncateInRunes(tmpl(n.conf.Title), 250)
 	if truncated {
-		level.Warn(n.logger).Log("msg", "Truncated title", "truncated_title", title, "incident", key)
+		level.Warn(n.logger).Log("msg", "Truncated title", "incident", key)
 	}
 	parameters.Add("title", title)
 
@@ -95,7 +95,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	// https://pushover.net/api#limits - 1024 characters or runes.
 	message, truncated = notify.TruncateInRunes(message, 1024)
 	if truncated {
-		level.Warn(n.logger).Log("msg", "Truncated message", "truncated_message", message, "incident", key)
+		level.Warn(n.logger).Log("msg", "Truncated message", "incident", key)
 	}
 	message = strings.TrimSpace(message)
 	if message == "" {
@@ -107,7 +107,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	// https://pushover.net/api#limits - 512 characters or runes.
 	supplementaryURL, truncated := notify.TruncateInRunes(tmpl(n.conf.URL), 512)
 	if truncated {
-		level.Warn(n.logger).Log("msg", "Truncated URL", "truncated_url", supplementaryURL, "incident", key)
+		level.Warn(n.logger).Log("msg", "Truncated URL", "incident", key)
 	}
 	parameters.Add("url", supplementaryURL)
 	parameters.Add("url_title", tmpl(n.conf.URLTitle))

--- a/notify/slack/slack.go
+++ b/notify/slack/slack.go
@@ -33,6 +33,9 @@ import (
 	"github.com/prometheus/alertmanager/types"
 )
 
+// https://api.slack.com/reference/messaging/attachments#legacy_fields - 1024, no units given, assuming runes or characters.
+const maxTitleLenRunes = 1024
+
 // Notifier implements a Notifier for Slack notifications.
 type Notifier struct {
 	conf    *config.SlackConfig
@@ -99,14 +102,14 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	} else {
 		markdownIn = n.conf.MrkdwnIn
 	}
-	// No reference in https://api.slack.com/reference/messaging/attachments#legacy_fields - assuming runes or characters.
-	title, truncated := notify.TruncateInRunes(tmplText(n.conf.Title), 1024)
+
+	title, truncated := notify.TruncateInRunes(tmplText(n.conf.Title), maxTitleLenRunes)
 	if truncated {
 		key, err := notify.ExtractGroupKey(ctx)
 		if err != nil {
 			return false, err
 		}
-		level.Warn(n.logger).Log("msg", "Truncated title", "key", key)
+		level.Warn(n.logger).Log("msg", "Truncated title", "key", key, "runes", maxTitleLenRunes)
 	}
 	att := &attachment{
 		Title:      title,

--- a/notify/slack/slack.go
+++ b/notify/slack/slack.go
@@ -109,7 +109,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		if err != nil {
 			return false, err
 		}
-		level.Warn(n.logger).Log("msg", "Truncated title", "key", key, "runes", maxTitleLenRunes)
+		level.Warn(n.logger).Log("msg", "Truncated title", "key", key, "max_runes", maxTitleLenRunes)
 	}
 	att := &attachment{
 		Title:      title,

--- a/notify/slack/slack.go
+++ b/notify/slack/slack.go
@@ -106,7 +106,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		if err != nil {
 			return false, err
 		}
-		level.Debug(n.logger).Log("msg", "Truncated title", "text", title, "key", key)
+		level.Warn(n.logger).Log("msg", "Truncated title", "text", title, "key", key)
 	}
 	att := &attachment{
 		Title:      title,

--- a/notify/slack/slack.go
+++ b/notify/slack/slack.go
@@ -106,7 +106,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		if err != nil {
 			return false, err
 		}
-		level.Warn(n.logger).Log("msg", "Truncated title", "text", title, "key", key)
+		level.Warn(n.logger).Log("msg", "Truncated title", "key", key)
 	}
 	att := &attachment{
 		Title:      title,

--- a/notify/telegram/telegram.go
+++ b/notify/telegram/telegram.go
@@ -68,7 +68,7 @@ func (n *Notifier) Notify(ctx context.Context, alert ...*types.Alert) (bool, err
 	// Telegram supports 4096 chars max - from https://limits.tginfo.me/en.
 	messageText, truncated := notify.TruncateInRunes(tmpl(n.conf.Message), 4096)
 	if truncated {
-		level.Warn(n.logger).Log("msg", "truncated message", "truncated_message", messageText)
+		level.Warn(n.logger).Log("msg", "Truncated message")
 	}
 
 	message, err := n.client.Send(telebot.ChatID(n.conf.ChatID), messageText, &telebot.SendOptions{

--- a/notify/telegram/telegram.go
+++ b/notify/telegram/telegram.go
@@ -68,7 +68,7 @@ func (n *Notifier) Notify(ctx context.Context, alert ...*types.Alert) (bool, err
 	// Telegram supports 4096 chars max - from https://limits.tginfo.me/en.
 	messageText, truncated := notify.TruncateInRunes(tmpl(n.conf.Message), 4096)
 	if truncated {
-		level.Debug(n.logger).Log("msg", "truncated message", "truncated_message", messageText)
+		level.Warn(n.logger).Log("msg", "truncated message", "truncated_message", messageText)
 	}
 
 	message, err := n.client.Send(telebot.ChatID(n.conf.ChatID), messageText, &telebot.SendOptions{

--- a/notify/telegram/telegram.go
+++ b/notify/telegram/telegram.go
@@ -76,7 +76,7 @@ func (n *Notifier) Notify(ctx context.Context, alert ...*types.Alert) (bool, err
 
 	messageText, truncated := notify.TruncateInRunes(tmpl(n.conf.Message), maxMessageLenRunes)
 	if truncated {
-		level.Warn(n.logger).Log("msg", "Truncated message", "alert", key, "runes", maxMessageLenRunes)
+		level.Warn(n.logger).Log("msg", "Truncated message", "alert", key, "max_runes", maxMessageLenRunes)
 	}
 
 	message, err := n.client.Send(telebot.ChatID(n.conf.ChatID), messageText, &telebot.SendOptions{

--- a/notify/victorops/victorops.go
+++ b/notify/victorops/victorops.go
@@ -139,7 +139,7 @@ func (n *Notifier) createVictorOpsPayload(ctx context.Context, as ...*types.Aler
 
 	stateMessage, truncated := notify.TruncateInRunes(stateMessage, maxMessageLenRunes)
 	if truncated {
-		level.Warn(n.logger).Log("msg", "truncated stateMessage", "incident", key, "runes", maxMessageLenRunes)
+		level.Warn(n.logger).Log("msg", "Truncated state_message", "incident", key, "runes", maxMessageLenRunes)
 	}
 
 	msg := map[string]string{

--- a/notify/victorops/victorops.go
+++ b/notify/victorops/victorops.go
@@ -34,6 +34,9 @@ import (
 	"github.com/prometheus/alertmanager/types"
 )
 
+// https://help.victorops.com/knowledge-base/incident-fields-glossary/ - 20480 characters.
+const maxMessageLenRunes = 20480
+
 // Notifier implements a Notifier for VictorOps notifications.
 type Notifier struct {
 	conf    *config.VictorOpsConfig
@@ -134,10 +137,9 @@ func (n *Notifier) createVictorOpsPayload(ctx context.Context, as ...*types.Aler
 		messageType = victorOpsEventResolve
 	}
 
-	// https://help.victorops.com/knowledge-base/incident-fields-glossary/ - 20480 characters.
-	stateMessage, truncated := notify.TruncateInRunes(stateMessage, 20480)
+	stateMessage, truncated := notify.TruncateInRunes(stateMessage, maxMessageLenRunes)
 	if truncated {
-		level.Warn(n.logger).Log("msg", "truncated stateMessage", "incident", key)
+		level.Warn(n.logger).Log("msg", "truncated stateMessage", "incident", key, "runes", maxMessageLenRunes)
 	}
 
 	msg := map[string]string{

--- a/notify/victorops/victorops.go
+++ b/notify/victorops/victorops.go
@@ -137,7 +137,7 @@ func (n *Notifier) createVictorOpsPayload(ctx context.Context, as ...*types.Aler
 	// https://help.victorops.com/knowledge-base/incident-fields-glossary/ - 20480 characters.
 	stateMessage, truncated := notify.TruncateInRunes(stateMessage, 20480)
 	if truncated {
-		level.Warn(n.logger).Log("msg", "truncated stateMessage", "truncated_state_message", stateMessage, "incident", key)
+		level.Warn(n.logger).Log("msg", "truncated stateMessage", "incident", key)
 	}
 
 	msg := map[string]string{

--- a/notify/victorops/victorops.go
+++ b/notify/victorops/victorops.go
@@ -139,7 +139,7 @@ func (n *Notifier) createVictorOpsPayload(ctx context.Context, as ...*types.Aler
 
 	stateMessage, truncated := notify.TruncateInRunes(stateMessage, maxMessageLenRunes)
 	if truncated {
-		level.Warn(n.logger).Log("msg", "Truncated state_message", "incident", key, "runes", maxMessageLenRunes)
+		level.Warn(n.logger).Log("msg", "Truncated state_message", "incident", key, "max_runes", maxMessageLenRunes)
 	}
 
 	msg := map[string]string{

--- a/notify/victorops/victorops.go
+++ b/notify/victorops/victorops.go
@@ -137,7 +137,7 @@ func (n *Notifier) createVictorOpsPayload(ctx context.Context, as ...*types.Aler
 	// https://help.victorops.com/knowledge-base/incident-fields-glossary/ - 20480 characters.
 	stateMessage, truncated := notify.TruncateInRunes(stateMessage, 20480)
 	if truncated {
-		level.Debug(n.logger).Log("msg", "truncated stateMessage", "truncated_state_message", stateMessage, "incident", key)
+		level.Warn(n.logger).Log("msg", "truncated stateMessage", "truncated_state_message", stateMessage, "incident", key)
 	}
 
 	msg := map[string]string{


### PR DESCRIPTION
Some integrations define maximum lengths of messages that they accept. We usually respect these, by truncating the user's message for them.

Since we are actively modifying what the user asked us to send, let's log this event at warning level. That way, operators can more easily see when their message is too long, and know that we changed it for them.

Fixes https://github.com/prometheus/alertmanager/issues/3134

We no longer log the full-blown message per https://github.com/prometheus/alertmanager/issues/3134#issuecomment-1315343535.
