### PR TITLE
Added note on data retention to documentation for repeat_interval

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -194,8 +194,8 @@ matchers:
 
 # How long to wait before sending a notification again if it has already
 # been sent successfully for an alert. (Usually ~3h or more).
-# Note that this parameter is implicitly bound by AlertManager's data
-# retention configuration. Notifications will be resent after either
+# Note that this parameter is implicitly bound by Alertmanager's
+# `--data.retention` configuration flag. Notifications will be resent after either
 # repeat_interval or the data retention period have passed, whichever
 # occurs first.
 [ repeat_interval: <duration> | default = 4h ]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -194,6 +194,10 @@ matchers:
 
 # How long to wait before sending a notification again if it has already
 # been sent successfully for an alert. (Usually ~3h or more).
+# Note that this parameter is implicitly bound by AlertManager's data
+# retention configuration. Notifications will be resent after either
+# repeat_interval or the data retention period have passed, whichever
+# occurs first.
 [ repeat_interval: <duration> | default = 4h ]
 
 # Times when the route should be muted. These must match the name of a


### PR DESCRIPTION
Added an extra note to the documentation for repeat_interval regarding its relation to data retention.

Some projects that build on top of AlertManager (Cortex comes to mind) haven't ported over the change in #1993 , and so users/tenants are surprised when they see alerts being resent more frequently than expected.

In addition to the logging, it would be better to document up front the affect of data retention on alert resend behaviour (as suggested in #2934).

Signed-off-by: Soon-Ping Phang <soonping@amazon.com>