### PR TITLE
Bump Docker version for remote Docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,6 +150,7 @@ workflows:
             - test_frontend
             - test
             - build_all
+          docker_version: "20.10.18"
           filters:
             branches:
               only: main
@@ -159,6 +160,7 @@ workflows:
             - test_frontend
             - test
             - build_all
+          docker_version: "20.10.18"
           filters:
             tags:
               only: /^v[0-9]+(\.[0-9]+){2}(-.+|[^-.]*)$/


### PR DESCRIPTION
It should fix the publish_main and publish_release jobs in CircleCI.

Signed-off-by: Simon Pasquier <spasquie@redhat.com>