### PR TITLE
Support loading Telegram bot token from file

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -739,6 +739,7 @@ type TelegramConfig struct {
 
 	APIUrl               *URL   `yaml:"api_url" json:"api_url,omitempty"`
 	BotToken             Secret `yaml:"bot_token,omitempty" json:"token,omitempty"`
+	BotTokenFile         string `yaml:"bot_token_file,omitempty" json:"token_file,omitempty"`
 	ChatID               int64  `yaml:"chat_id,omitempty" json:"chat,omitempty"`
 	Message              string `yaml:"message,omitempty" json:"message,omitempty"`
 	DisableNotifications bool   `yaml:"disable_notifications,omitempty" json:"disable_notifications,omitempty"`
@@ -752,8 +753,11 @@ func (c *TelegramConfig) UnmarshalYAML(unmarshal func(interface{}) error) error 
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
-	if c.BotToken == "" {
-		return fmt.Errorf("missing bot_token on telegram_config")
+	if c.BotToken == "" && c.BotTokenFile == "" {
+		return fmt.Errorf("missing bot_token or bot_token_file on telegram_config")
+	}
+	if c.BotToken != "" && c.BotTokenFile != "" {
+		return fmt.Errorf("at most one of bot_token & bot_token_file must be configured")
 	}
 	if c.ChatID == 0 {
 		return fmt.Errorf("missing chat_id on telegram_config")

--- a/config/notifiers_test.go
+++ b/config/notifiers_test.go
@@ -958,6 +958,70 @@ http_config:
 	}
 }
 
+func TestTelegramConfiguration(t *testing.T) {
+	tc := []struct {
+		name     string
+		in       string
+		expected error
+	}{
+		{
+			name: "with both bot_token & bot_token_file - it fails",
+			in: `
+bot_token: xyz
+bot_token_file: /file
+`,
+			expected: errors.New("at most one of bot_token & bot_token_file must be configured"),
+		},
+		{
+			name: "with no bot_token & bot_token_file - it fails",
+			in: `
+bot_token: ''
+bot_token_file: ''
+`,
+			expected: errors.New("missing bot_token or bot_token_file on telegram_config"),
+		},
+		{
+			name: "with bot_token and chat_id set - it succeeds",
+			in: `
+bot_token: xyz
+chat_id: 123
+`,
+		},
+		{
+			name: "with bot_token_file and chat_id set - it succeeds",
+			in: `
+bot_token_file: /file
+chat_id: 123
+`,
+		},
+		{
+			name: "with no chat_id set - it fails",
+			in: `
+bot_token: xyz
+`,
+			expected: errors.New("missing chat_id on telegram_config"),
+		},
+		{
+			name: "with unknown parse_mode - it fails",
+			in: `
+bot_token: xyz
+chat_id: 123
+parse_mode: invalid
+`,
+			expected: errors.New("unknown parse_mode on telegram_config, must be Markdown, MarkdownV2, HTML or empty string"),
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			var cfg TelegramConfig
+			err := yaml.UnmarshalStrict([]byte(tt.in), &cfg)
+
+			require.Equal(t, tt.expected, err)
+		})
+	}
+}
+
 func newBoolPointer(b bool) *bool {
 	return &b
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1050,8 +1050,11 @@ attributes:
 # If not specified, default API URL will be used.
 [ api_url: <string> | default = global.telegram_api_url ]
 
-# Telegram bot token.
+# Telegram bot token. It is mutually exclusive with `bot_token_file`.
 [ bot_token: <secret> ]
+
+# Read the Telegram bot token from a file. It is mutually exclusive with `bot_token`.
+[ bot_token_file: <filepath> ]
 
 # ID of the chat where to send the messages.
 [ chat_id: <int> ]


### PR DESCRIPTION
Adds support for loading Telegram bot token from file.

This PR is mainly inspired by #3131. I've made a few changes considering the conversation in #3131, done minor refactoring, added some tests, and rebased changes to the current main.