### PR TITLE
mark webhook URL as a secret

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -473,7 +473,8 @@ type WebhookConfig struct {
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
 	// URL to send POST request to.
-	URL *URL `yaml:"url" json:"url"`
+	URL *SecretURL `yaml:"url" json:"url"`
+
 	// MaxAlerts is the maximum number of alerts to be sent per webhook message.
 	// Alerts exceeding this threshold will be truncated. Setting this to 0
 	// allows an unlimited number of alerts.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1116,7 +1116,7 @@ The webhook receiver allows configuring a generic receiver.
 [ send_resolved: <boolean> | default = true ]
 
 # The endpoint to send HTTP POST requests to.
-url: <string>
+url: <secret>
 
 # The HTTP client's configuration.
 [ http_config: <http_config> | default = global.http_config ]

--- a/notify/webhook/webhook.go
+++ b/notify/webhook/webhook.go
@@ -103,7 +103,7 @@ func (n *Notifier) Notify(ctx context.Context, alerts ...*types.Alert) (bool, er
 
 	resp, err := notify.PostJSON(ctx, n.client, n.conf.URL.String(), &buf)
 	if err != nil {
-		return true, err
+		return true, notify.RedactURL(err)
 	}
 	defer notify.Drain(resp)
 

--- a/notify/webhook/webhook_test.go
+++ b/notify/webhook/webhook_test.go
@@ -37,7 +37,7 @@ func TestWebhookRetry(t *testing.T) {
 	}
 	notifier, err := New(
 		&config.WebhookConfig{
-			URL:        &config.URL{URL: u},
+			URL:        &config.SecretURL{URL: u},
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),
@@ -97,4 +97,22 @@ func TestWebhookTruncateAlerts(t *testing.T) {
 	truncatedAlerts, numTruncated = truncateAlerts(100, alerts)
 	require.Len(t, truncatedAlerts, 10)
 	require.EqualValues(t, numTruncated, 0)
+}
+
+func TestWebhookRedactedURL(t *testing.T) {
+	ctx, u, fn := test.GetContextWithCancelingURL()
+	defer fn()
+
+	secret := "secret"
+	notifier, err := New(
+		&config.WebhookConfig{
+			URL:        &config.SecretURL{URL: u},
+			HTTPConfig: &commoncfg.HTTPClientConfig{},
+		},
+		test.CreateTmpl(t),
+		log.NewNopLogger(),
+	)
+	require.NoError(t, err)
+
+	test.AssertNotifyLeaksNoSecret(ctx, t, notifier, secret)
 }


### PR DESCRIPTION
As discussed in https://github.com/prometheus/alertmanager/pull/3223

/cc @gotjosh @simonpasquier 