### PR TITLE
Support setting the Gossip cluster "label"

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -142,6 +142,7 @@ func Create(
 	probeInterval time.Duration,
 	tlsTransportConfig *TLSTransportConfig,
 	allowInsecureAdvertise bool,
+	gossipLabel string,
 ) (*Peer, error) {
 	bindHost, bindPortStr, err := net.SplitHostPort(bindAddr)
 	if err != nil {
@@ -242,6 +243,11 @@ func Create(
 		if err != nil {
 			return nil, errors.Wrap(err, "tls transport")
 		}
+	}
+
+	if gossipLabel != "" {
+		level.Info(l).Log("msg", fmt.Sprintf("using gossip label %s", gossipLabel))
+		cfg.Label = gossipLabel
 	}
 
 	ml, err := memberlist.Create(cfg)

--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -226,6 +226,7 @@ func run() int {
 		peerReconnectTimeout   = kingpin.Flag("cluster.reconnect-timeout", "Length of time to attempt to reconnect to a lost peer.").Default(cluster.DefaultReconnectTimeout.String()).Duration()
 		tlsConfigFile          = kingpin.Flag("cluster.tls-config", "[EXPERIMENTAL] Path to config yaml file that can enable mutual TLS within the gossip protocol.").Default("").String()
 		allowInsecureAdvertise = kingpin.Flag("cluster.allow-insecure-public-advertise-address-discovery", "[EXPERIMENTAL] Allow alertmanager to discover and listen on a public IP address.").Bool()
+		gossipLabel            = kingpin.Flag("cluster.gossip-label", "[EXPERIMENTAL] Only accept gossip messages with this label.").Envar("ALERTMANAGER_CLUSTER_GOSSIP_LABEL").String()
 	)
 
 	promlogflag.AddFlags(kingpin.CommandLine, &promlogConfig)
@@ -267,6 +268,7 @@ func run() int {
 			*probeInterval,
 			tlsTransportConfig,
 			*allowInsecureAdvertise,
+			*gossipLabel,
 		)
 		if err != nil {
 			level.Error(logger).Log("msg", "unable to initialize gossip mesh", "err", err)


### PR DESCRIPTION
This is an alternate mechanism for isolating Alertmanager clusters without having to set up the right components of TLS.

It should solve issues such as <https://github.com/prometheus/alertmanager/issues/2250>, although enabling this feature will lead to loss of non-persisted state. (For example, if you rely on alertmanager cluster peering to maintain silences instead of using persistent volume storage in Kubernetes.) The Gossip label serves as the "cluster ID" idea mentioned in <https://github.com/prometheus/alertmanager/issues/2250#issuecomment-961933082>.

You can enable with the command-line flag, `--cluster.gossip-label`; any non-empty string will form an effective namespace for gossip communication.

If you use Prometheus Operator, you can set the `ALERTMANAGER_CLUSTER_GOSSIP_LABEL` environment variable (as Prometheus Operator does not have a way of adding additional command-line flags). You would need to modify your Alertmanager object something like:

```
kind: Alertmanager
...
spec:
  ...
  containers:
    - name: alertmanager
      env:
        - name: ALERTMANAGER_CLUSTER_GOSSIP_LABEL
          value: infrastructure-eu-west-2
  ...
```

This is low-security mechanism, suitable for use with Alertmanager configuration where anyone can add or remove a silence. It protects against surprising cluster expansion due to IP:port re-use.