### PR TITLE
Implement Stringer interface for Pairs and KVs

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -187,6 +187,19 @@ func (ps Pairs) Values() []string {
 	return vs
 }
 
+func (ps Pairs) String() string {
+	b := strings.Builder{}
+	for i, p := range ps {
+		b.WriteString(p.Name)
+		b.WriteRune('=')
+		b.WriteString(p.Value)
+		if i < len(ps)-1 {
+			b.WriteString(", ")
+		}
+	}
+	return b.String()
+}
+
 // KV is a set of key/value string pairs.
 type KV map[string]string
 
@@ -237,6 +250,10 @@ func (kv KV) Names() []string {
 // Values returns a list of the values in the LabelSet.
 func (kv KV) Values() []string {
 	return kv.SortedPairs().Values()
+}
+
+func (kv KV) String() string {
+	return kv.SortedPairs().String()
 }
 
 // Data is the data passed to notification templates and webhook pushes.

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -48,6 +48,13 @@ func TestPairValues(t *testing.T) {
 	require.EqualValues(t, expected, pairs.Values())
 }
 
+func TestPairsString(t *testing.T) {
+	pairs := Pairs{{"name1", "value1"}}
+	require.Equal(t, "name1=value1", pairs.String())
+	pairs = append(pairs, Pair{"name2", "value2"})
+	require.Equal(t, "name1=value1, name2=value2", pairs.String())
+}
+
 func TestKVSortedPairs(t *testing.T) {
 	kv := KV{"d": "dVal", "b": "bVal", "c": "cVal"}
 


### PR DESCRIPTION
This commit implements the `Stringer` interface for Pairs and KVs. It changes how Pairs are printed in templates from `map[name1:value1 name2:value2]` to `name1=value1, name2=value2`. KVs work similar, but are first sorted into pairs before being printed.

This should mean that Alertmanager has better text when using `{{ .Annotations }}` and `{{ .Labels }}`, as an example, without having to write a `range` with custom delimitation.