### PR TITLE
fix gracefully-exiting stuck due to adding one more for `WaitGroup`

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -277,7 +277,6 @@ func run() int {
 
 	stopc := make(chan struct{})
 	var wg sync.WaitGroup
-	wg.Add(1)
 
 	notificationLogOpts := nflog.Options{
 		SnapshotFile: filepath.Join(*dataDir, "nflog"),


### PR DESCRIPTION
In the main function, `WaitGroup` done twice, but add three times, so it will get stuck when exiting.

Currently, `AlertManager` cannot gracefully-exiting, because [wg.Wait()](https://github.com/prometheus/alertmanager/blob/6450c9ff18a4f7a6ebcefa83e157e80485014a4b/cmd/alertmanager/main.go#L333) for two done, but added three times

Signed-off-by:  chengjoey <zchengjoey@gmail.com>