### PR TITLE
Fix corruption in templates that use title function

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -171,8 +171,11 @@ var DefaultFuncs = FuncMap{
 	"toUpper":   strings.ToUpper,
 	"toLower":   strings.ToLower,
 	"trimSpace": strings.TrimSpace,
-
-	"title": cases.Title(language.AmericanEnglish).String,
+	"title": func(text string) string {
+		// casers should not be shared between goroutines, instead
+		// create a new caser each time this function is called
+		return cases.Title(language.AmericanEnglish).String(text)
+	},
 	// join is equal to strings.Join but inverts the argument order
 	// for easier pipelining in templates.
 	"join": func(sep string, s []string) string {

--- a/template/template.go
+++ b/template/template.go
@@ -168,14 +168,14 @@ func (t *Template) ExecuteHTMLString(html string, data interface{}) (string, err
 type FuncMap map[string]interface{}
 
 var DefaultFuncs = FuncMap{
-	"toUpper":   strings.ToUpper,
-	"toLower":   strings.ToLower,
-	"trimSpace": strings.TrimSpace,
+	"toUpper": strings.ToUpper,
+	"toLower": strings.ToLower,
 	"title": func(text string) string {
 		// casers should not be shared between goroutines, instead
 		// create a new caser each time this function is called
 		return cases.Title(language.AmericanEnglish).String(text)
 	},
+	"trimSpace": strings.TrimSpace,
 	// join is equal to strings.Join but inverts the argument order
 	// for easier pipelining in templates.
 	"join": func(sep string, s []string) string {

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -16,6 +16,7 @@ package template
 import (
 	tmplhtml "html/template"
 	"net/url"
+	"sync"
 	"testing"
 	tmpltext "text/template"
 	"time"
@@ -462,6 +463,63 @@ func TestTemplateExpansionWithOptions(t *testing.T) {
 			}
 			require.NoError(t, err)
 			require.Equal(t, tc.exp, got)
+		})
+	}
+}
+
+// This test asserts that template functions are thread-safe.
+func TestTemplateFuncs(t *testing.T) {
+	tmpl, err := FromGlobs([]string{})
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		title string
+		in    string
+		data  interface{}
+		exp   string
+	}{{
+		title: "Template using toUpper",
+		in:    `{{ "abc" | toUpper }}`,
+		exp:   "ABC",
+	}, {
+		title: "Template using toLower",
+		in:    `{{ "ABC" | toLower }}`,
+		exp:   "abc",
+	}, {
+		title: "Template using title",
+		in:    `{{ "abc" | title }}`,
+		exp:   "Abc",
+	}, {
+		title: "Template using trimSpace",
+		in:    `{{ " abc " | trimSpace }}`,
+		exp:   "abc",
+	}, {
+		title: "Template using join",
+		in:    `{{ . | join "," }}`,
+		data:  []string{"abc", "def"},
+		exp:   "abc,def",
+	}, {
+		title: "Template using match",
+		in:    `{{ match "[a-z]+" "abc" }}`,
+		exp:   "true",
+	}, {
+		title: "Template using reReplaceAll",
+		in:    `{{ reReplaceAll "ab" "AB" "abc" }}`,
+		exp:   "ABc",
+	}} {
+		tc := tc
+		t.Run(tc.title, func(t *testing.T) {
+			wg := sync.WaitGroup{}
+			for i := 0; i < 10; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					got, err := tmpl.ExecuteTextString(tc.in, tc.data)
+					require.NoError(t, err)
+					require.Equal(t, tc.exp, got)
+				}()
+			}
+			wg.Wait()
 		})
 	}
 }


### PR DESCRIPTION
This commit fixes data corruption in templates that use the title function as it used a shared cases.Title when casers should not be shared between goroutines. When templates that used the title function were executed at the same time, data corruption would occur in the text that was being cased. This is fixed using a separate caser for each function call.

Here is an example of the issue as explained [here](https://github.com/prometheus/alertmanager/issues/3277#issuecomment-1453800831):

```
2023/03/03 16:40:51 Waltz, BaD
2023/03/03 16:40:51 Waltz, Bad Nymph, For Quick Jigs Vex
2023/03/03 16:40:51 Waltz, Bad Nymph, For Quick Jigs Vex
2023/03/03 16:40:51 Waltz, Bad Nymph, For Quick Jigs Vex
2023/03/03 16:40:51 Waltz, Bad Nymph, For Quick Jigs Vex
2023/03/03 16:40:51 Waltz, Bad Nymph, For Quick Jigs Vex
2023/03/03 16:40:51  Nym
2023/03/03 16:40:51 Wph, For icc Jigs Vex
2023/03/03 16:40:51 Waltz, Bad Nymph, For Quick Jigs Vex
2023/03/03 16:40:51 Waltz, Bad Nymph, For Quick Jigs Vex
```

and with the fix:

```
2023/03/03 21:33:15 Waltz, Bad Nymph, For Quick Jigs Vex
2023/03/03 21:33:15 Waltz, Bad Nymph, For Quick Jigs Vex
2023/03/03 21:33:15 Waltz, Bad Nymph, For Quick Jigs Vex
2023/03/03 21:33:15 Waltz, Bad Nymph, For Quick Jigs Vex
2023/03/03 21:33:15 Waltz, Bad Nymph, For Quick Jigs Vex
2023/03/03 21:33:15 Waltz, Bad Nymph, For Quick Jigs Vex
2023/03/03 21:33:15 Waltz, Bad Nymph, For Quick Jigs Vex
2023/03/03 21:33:15 Waltz, Bad Nymph, For Quick Jigs Vex
2023/03/03 21:33:15 Waltz, Bad Nymph, For Quick Jigs Vex
2023/03/03 21:33:15 Waltz, Bad Nymph, For Quick Jigs Vex
```

Fixes #3277 