### PR TITLE
Make TrimSpace available for use in the template

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -89,7 +89,7 @@ templating.
 | title | string |[strings.Title](http://golang.org/pkg/strings/#Title), capitalises first character of each word. |
 | toUpper | string | [strings.ToUpper](http://golang.org/pkg/strings/#ToUpper), converts all characters to upper case. |
 | toLower | string | [strings.ToLower](http://golang.org/pkg/strings/#ToLower), converts all characters to lower case. |
-| trimSpace | string | [strings.TrimSpace](https://pkg.go.dev/strings#TrimSpace), trim leading and trailing white spaces. |
+| trimSpace | string | [strings.TrimSpace](https://pkg.go.dev/strings#TrimSpace), removes leading and trailing white spaces. |
 | match | pattern, string | [Regexp.MatchString](https://golang.org/pkg/regexp/#MatchString). Match a string using Regexp. |
 | reReplaceAll | pattern, replacement, text | [Regexp.ReplaceAllString](http://golang.org/pkg/regexp/#Regexp.ReplaceAllString) Regexp substitution, unanchored. |
 | join | sep string, s []string | [strings.Join](http://golang.org/pkg/strings/#Join), concatenates the elements of s to create a single string. The separator string sep is placed between elements in the resulting string. (note: argument order inverted for easier pipelining in templates.) |

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -89,6 +89,7 @@ templating.
 | title | string |[strings.Title](http://golang.org/pkg/strings/#Title), capitalises first character of each word. |
 | toUpper | string | [strings.ToUpper](http://golang.org/pkg/strings/#ToUpper), converts all characters to upper case. |
 | toLower | string | [strings.ToLower](http://golang.org/pkg/strings/#ToLower), converts all characters to lower case. |
+| trimSpace | string | [strings.TrimSpace](https://pkg.go.dev/strings#TrimSpace), trim leading and trailing white spaces. |
 | match | pattern, string | [Regexp.MatchString](https://golang.org/pkg/regexp/#MatchString). Match a string using Regexp. |
 | reReplaceAll | pattern, replacement, text | [Regexp.ReplaceAllString](http://golang.org/pkg/regexp/#Regexp.ReplaceAllString) Regexp substitution, unanchored. |
 | join | sep string, s []string | [strings.Join](http://golang.org/pkg/strings/#Join), concatenates the elements of s to create a single string. The separator string sep is placed between elements in the resulting string. (note: argument order inverted for easier pipelining in templates.) |

--- a/template/template.go
+++ b/template/template.go
@@ -168,8 +168,10 @@ func (t *Template) ExecuteHTMLString(html string, data interface{}) (string, err
 type FuncMap map[string]interface{}
 
 var DefaultFuncs = FuncMap{
-	"toUpper": strings.ToUpper,
-	"toLower": strings.ToLower,
+	"toUpper":   strings.ToUpper,
+	"toLower":   strings.ToLower,
+	"trimSpace": strings.TrimSpace,
+
 	"title":   cases.Title(language.AmericanEnglish).String,
 	// join is equal to strings.Join but inverts the argument order
 	// for easier pipelining in templates.

--- a/template/template.go
+++ b/template/template.go
@@ -172,7 +172,7 @@ var DefaultFuncs = FuncMap{
 	"toLower":   strings.ToLower,
 	"trimSpace": strings.TrimSpace,
 
-	"title":   cases.Title(language.AmericanEnglish).String,
+	"title": cases.Title(language.AmericanEnglish).String,
 	// join is equal to strings.Join but inverts the argument order
 	// for easier pipelining in templates.
 	"join": func(sep string, s []string) string {

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -329,6 +329,11 @@ func TestTemplateExpansion(t *testing.T) {
 			exp:   "Abc",
 		},
 		{
+			title: "Template using TrimSpace",
+			in:    `{{ " a b c " | trimSpace }}`,
+			exp:   "a b c",
+		},
+		{
 			title: "Template using positive match",
 			in:    `{{ if match "^a" "abc"}}abc{{ end }}`,
 			exp:   "abc",


### PR DESCRIPTION
What
----
Add [TrimSpace](https://pkg.go.dev/strings#TrimSpace) in the list of FuncMap to make it available while using templates.

Testing
----
Added a test along with this PR
```
➜  alertmanager git:(main) GO_ONLY=1 GOOPTS="-count=1 -run TestTemplateExpansion" make test | grep -i 'template'
go test -race -count=1 -run TestTemplateExpansion ./...
ok  	github.com/prometheus/alertmanager/template	4.355s
```
