### PR TITLE
Metrics: Notification log maintenance success and failure

### DIFF
--- a/nflog/nflog_test.go
+++ b/nflog/nflog_test.go
@@ -22,14 +22,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus/testutil"
-	"go.uber.org/atomic"
-
 	pb "github.com/prometheus/alertmanager/nflog/nflogpb"
 
 	"github.com/benbjohnson/clock"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 )
 
 func TestLogGC(t *testing.T) {
@@ -157,7 +156,6 @@ func TestWithMaintenance_SupportsCustomCallback(t *testing.T) {
 			calls.Add(1)
 			return 0, nil
 		})
-
 	}()
 	gosched()
 


### PR DESCRIPTION
Due to various reasons, we've observed different kind of errors on this area. From read-only disks to silly code bugs. Errors during maintenance are effectively a data loss and therefore we should encourage proper monitoring of this area.

Similar to https://github.com/prometheus/alertmanager/pull/3285