### PR TITLE
Github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,41 +17,14 @@ jobs:
       - run: git diff --exit-code
 
   test:
-    name: Test with maildev
+    name: Test
     runs-on: ubuntu-latest
     # Whenever the Go version is updated here, .promu.yml
     # should also be updated.
     container:
       image: quay.io/prometheus/golang-builder:1.19-base
-    services:
-      # run two maildev containers for auth and noauth
-      maildev-noauth:
-        # image: docker.io/maildev/maildev
-        image: quay.io/jfajersk/prom-maildev:latest
-      maildev-auth:
-        # image: docker.io/maildev/maildev
-        image: quay.io/jfajersk/prom-maildev:latest
-        env:
-          MAILDEV_INCOMING_USER: user
-          MAILDEV_INCOMING_PASS: pass
-          MAILDEV_INCOMING_SECURE: true
-          MAILDEV_HIDE_STARTTLS: false
-    env:
-      EMAIL_NO_AUTH_CONFIG: /tmp/smtp_no_auth.yml
-      EMAIL_AUTH_CONFIG: /tmp/smtp_auth.yml
     steps:
       - uses: actions/checkout@v3
       - uses: prometheus/promci@v0.0.2
       - uses: ./.github/promci/actions/setup_environment
-      - run: |
-          cat <<EOF > "$EMAIL_NO_AUTH_CONFIG"
-          smarthost: maildev-noauth:1025
-          server: http://maildev-noauth:1080/
-          EOF
-          cat <<EOF > "$EMAIL_AUTH_CONFIG"
-          smarthost: maildev-auth:1025
-          server: http://maildev-auth:1080/
-          username: user
-          password: pass
-          EOF
       - run: make

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+---
+name: CI
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+  workflow_call:
+jobs:
+  test_frontend:
+    name: Test alertmanager frontend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: make clean
+      - run: make all
+        working-directory: ./ui/app
+      - run: make assets
+      - run: make apiv2
+      - run: git diff --exit-code
+
+  test:
+    name: Test with maildev
+    runs-on: ubuntu-latest
+    # Whenever the Go version is updated here, .promu.yml
+    # should also be updated.
+    container:
+      image: quay.io/prometheus/golang-builder:1.19-base
+    services:
+      # run two maildev containers for auth and noauth
+      maildev-noauth:
+        # image: docker.io/maildev/maildev
+        image: quay.io/jfajersk/prom-maildev:latest
+      maildev-auth:
+        # image: docker.io/maildev/maildev
+        image: quay.io/jfajersk/prom-maildev:latest
+        env:
+          MAILDEV_INCOMING_USER: user
+          MAILDEV_INCOMING_PASS: pass
+          MAILDEV_INCOMING_SECURE: true
+          MAILDEV_HIDE_STARTTLS: false
+    env:
+      EMAIL_NO_AUTH_CONFIG: /tmp/smtp_no_auth.yml
+      EMAIL_AUTH_CONFIG: /tmp/smtp_auth.yml
+    steps:
+      - uses: actions/checkout@v3
+      - uses: prometheus/promci@v0.0.2
+      - uses: ./.github/promci/actions/setup_environment
+      - run: |
+          cat <<EOF > "$EMAIL_NO_AUTH_CONFIG"
+          smarthost: maildev-noauth:1025
+          server: http://maildev-noauth:1080/
+          EOF
+          cat <<EOF > "$EMAIL_AUTH_CONFIG"
+          smarthost: maildev-auth:1025
+          server: http://maildev-auth:1080/
+          username: user
+          password: pass
+          EOF
+      - run: make

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,26 @@
+name: golangci-lint
+on:
+  pull_request:
+    paths:
+      - "go.sum"
+      - "go.mod"
+      - "**.go"
+      - "scripts/errcheck_excludes.txt"
+      - ".github/workflows/golangci-lint.yml"
+      - ".golangci.yml"
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.19.x
+      - name: Lint
+        uses: golangci/golangci-lint-action@v3.4.0
+        with:
+          version: v1.51.2

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.19.x
+      - run: make build
       - name: Lint
         uses: golangci/golangci-lint-action@v3.4.0
         with:

--- a/.github/workflows/mixin.yml
+++ b/.github/workflows/mixin.yml
@@ -1,0 +1,22 @@
+name: mixin
+on:
+  pull_request:
+    paths:
+      - "doc/alertmanager-mixin/**"
+
+jobs:
+  mixin:
+    name: mixin-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.19.x
+      # pin the mixtool version until https://github.com/monitoring-mixins/mixtool/issues/135 is merged.
+      - run: go install github.com/monitoring-mixins/mixtool/cmd/mixtool@2282201396b69055bb0f92f187049027a16d2130
+      - run: go install github.com/google/go-jsonnet/cmd/jsonnetfmt@latest
+      - run: go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
+      - run: make -C doc/alertmanager-mixin lint

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,24 @@
+---
+name: Publish
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - main
+jobs:
+  ci:
+    name: Run ci
+    uses: ./.github/workflows/ci.yml
+
+  publish_main:
+    name: Publish main branch artefacts
+    runs-on: ubuntu-latest
+    needs: ci
+    steps:
+      - uses: actions/checkout@v3
+      - uses: prometheus/promci@v0.0.2
+      - uses: ./.github/promci/actions/publish_main
+        with:
+          docker_hub_login: ${{ secrets.docker_hub_login }}
+          docker_hub_password: ${{ secrets.docker_hub_password }}
+          quay_io_login: ${{ secrets.quay_io_login }}
+          quay_io_password: ${{ secrets.quay_io_password }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+---
+name: Release
+on:  # yamllint disable-line rule:truthy
+  push:
+    tags:
+      - v*
+jobs:
+  ci:
+    name: Run ci
+    uses: ./.github/workflows/ci.yml
+
+  publish_release:
+    name: Publish release arfefacts
+    runs-on: ubuntu-latest
+    needs: ci
+    steps:
+      - uses: actions/checkout@v3
+      - uses: prometheus/promci@v0.0.2
+      - uses: ./.github/promci/actions/publish_release
+        with:
+          docker_hub_login: ${{ secrets.docker_hub_login }}
+          docker_hub_password: ${{ secrets.docker_hub_password }}
+          quay_io_login: ${{ secrets.quay_io_login }}
+          quay_io_password: ${{ secrets.quay_io_password }}
+          github_token: ${{ secrets.PROMBOT_GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@
 !/.travis.yml
 !/.promu.yml
 !/api/v2/openapi.yaml
+!.github/workflows/*.yml

--- a/Makefile
+++ b/Makefile
@@ -78,3 +78,11 @@ clean:
                   template/email.tmpl \
                   api/v2/models api/v2/restapi api/v2/client
 	- @cd $(FRONTEND_DIR) && $(MAKE) clean
+
+# In github actions we skip the email test for now. Service containers in github
+# actions currently have a bug, see https://github.com/prometheus/alertmanager/pull/3299
+# So define a test target, that skips the email test for now.
+.PHONY: test
+test: $(GOTEST_DIR)
+	@echo ">> running all tests, except notify/email"
+	$(GOTEST) $(test-flags) $(GOOPTS) `go list ./... | grep -v notify/email`


### PR DESCRIPTION
This is a first draft to move from CircleCI to Github Actions.
Generally I tried to trigger workflows only for relevant changes, e.g. the mixin-lint is only triggered if a file in the mixins change.

Two things are tbd:

1. This doesn't yet store the frontend asset tarball anywhere. I wasn't exactly sure how this is currently handled in the CircleCI setup, any pointer are appreciated.
2. ~This currently uses my fork of `maildev` at https://github.com/jan--f/maildev/tree/hide-starttls-when-user-password, which simply re-enables `STARTTLS`, which was disabled in [v1.1.1](https://github.com/maildev/maildev/pull/276/). There is a [PR](https://github.com/maildev/maildev/pull/435) up that looks promising in order for Alertmanager to switch back to upstream `maildev`. The current PR version doesn't work, since I believe it no longer sets up self-signed certificates. Otoh we could simply create those certs ourselves and pass them via the proposed arguments.~ This still requires a fix to maildev, see https://github.com/maildev/maildev/pull/469. So I'll keep my forked image in here for now.

Looking forward to any feedback.