### PR TITLE
Improve the notify error log.

### DIFF
--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -349,7 +349,8 @@ func (d *Dispatcher) processAlert(alert *types.Alert, route *Route) {
 				// message should only be logged at the debug level.
 				lvl = level.Debug(d.logger)
 			}
-			lvl.Log("msg", "Notify for alerts failed", "num_alerts", len(alerts), "err", err)
+			lvl.Log("msg", "Notify for alerts failed", "err", err,
+				"num_alerts", len(alerts), "alert_names", types.JoinAlertNames(5, alerts...))
 		}
 		return err == nil
 	})

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -737,7 +737,8 @@ func (r RetryStage) exec(ctx context.Context, l log.Logger, alerts ...*types.Ale
 				}
 				if ctx.Err() == nil && (iErr == nil || err.Error() != iErr.Error()) {
 					// Log the error if the context isn't done and the error isn't the same as before.
-					level.Warn(l).Log("msg", "Notify attempt failed, will retry later", "attempts", i, "err", err)
+					level.Warn(l).Log("msg", "Notify attempt failed, will retry later", "attempts", i, "err", err,
+						"num_alerts", len(sent), "alert_names", types.JoinAlertNames(5, sent...))
 				}
 
 				// Save this error to be able to return the last seen error by an

--- a/types/types.go
+++ b/types/types.go
@@ -343,6 +343,30 @@ func Alerts(alerts ...*Alert) model.Alerts {
 	return res
 }
 
+// JoinAlertNames returns a string that contains the names of the given
+// alerts separated by a comma. If there are more than limit alerts, the
+// remaining names are represented by an ellipsis "...".
+func JoinAlertNames(limit int, alerts ...*Alert) string {
+	if len(alerts) == 0 || limit < 1 {
+		return ""
+	}
+
+	s := strings.Builder{}
+	s.WriteString(alerts[0].Name())
+	for i, a := range alerts[1:] {
+		s.WriteString(",")
+
+		if i+1 < limit {
+			s.WriteString(a.Name())
+		} else {
+			s.WriteString("...")
+			return s.String()
+		}
+	}
+
+	return s.String()
+}
+
 // Merge merges the timespan of two alerts based and overwrites annotations
 // based on the authoritative timestamp.  A new alert is returned, the labels
 // are assumed to be equal.


### PR DESCRIPTION
Improve the notify error log by including the number of alerts that the notification attempt included, as well as a summary of the names of the alerts. In most cases, the number of alerts being notified on is small, so the summary will contain all the alert names. Including the alert names can give the operator a hint on where to look to diagnose a notification problem.