### PR TITLE
fix wechat notifier response field name

### DIFF
--- a/notify/wechat/wechat.go
+++ b/notify/wechat/wechat.go
@@ -66,8 +66,8 @@ type weChatMessageContent struct {
 }
 
 type weChatResponse struct {
-	Code  int    `json:"code"`
-	Error string `json:"error"`
+	Code  int    `json:"errcode"`
+	Error string `json:"errmsg"`
 }
 
 // New returns a new Wechat notifier.


### PR DESCRIPTION
fix response json field name according to debug log:

`
ts=2023-04-17T07:49:52.559Z caller=wechat.go:178 level=debug integration=wechat response="{\"errcode\":60020,\"errmsg\":\"not allow to access from your ip, hint: [1681717792365202991262631], from ip: xxx.xxx.xxx.xxx, more info at https://open.work.weixin.qq.com/devtool/query?e=60020\"}" incident="{}:{alertname=\"不可用\"}"
`

and wechat api doc:
[https://developer.work.weixin.qq.com/document/path/90236](https://developer.work.weixin.qq.com/document/path/90236)