### PR TITLE
add windows config path directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ amtool template render --template.glob='/foo/bar/*.tmpl' --template.text='{{ tem
 
 ### Configuration
 
-`amtool` allows a configuration file to specify some options for convenience. The default configuration file paths are `$HOME/.config/amtool/config.yml` or `/etc/amtool/config.yml`
+`amtool` allows a configuration file to specify some options for convenience. The default configuration file paths are `$HOME/.config/amtool/config.yml` or `/etc/amtool/config.yml` and `C:\Program Files\amtool`.
 
 An example configuration file might look like the following:
 

--- a/cli/root.go
+++ b/cli/root.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path"
 	"time"
+	"runtime"
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/go-openapi/strfmt"
@@ -40,8 +41,8 @@ var (
 	timeout         time.Duration
 	httpConfigFile  string
 	versionCheck    bool
+	configFiles     []string
 
-	configFiles = []string{os.ExpandEnv("$HOME/.config/amtool/config.yml"), "/etc/amtool/config.yml"}
 	legacyFlags = map[string]string{"comment_required": "require-comment"}
 )
 
@@ -127,6 +128,11 @@ func NewAlertmanagerClient(amURL *url.URL) *client.AlertmanagerAPI {
 
 // Execute is the main function for the amtool command
 func Execute() {
+	if runtime.GOOS == "windows" {
+		configFiles = []string{"C:/program files/amtool/config.yml"}
+	} else {
+		configFiles = []string{os.ExpandEnv("$HOME/.config/amtool/config.yml"), "/etc/amtool/config.yml"}
+	}
 	app := kingpin.New("amtool", helpRoot).UsageWriter(os.Stdout)
 
 	format.InitFormatFlags(app)


### PR DESCRIPTION
To address this issue: https://github.com/prometheus/alertmanager/issues/3331, I added a file path 'C:\Program Files\amtool' where the config.yml and credentials.yml can be stored. 
Since currently only `$HOME/.config/amtool/config.yml` or `/etc/amtool/config.yml` are used as sources for the config files, which do not exist on windows instances.