### PR TITLE
add windows configuration path

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ amtool template render --template.glob='/foo/bar/*.tmpl' --template.text='{{ tem
 
 ### Configuration
 
-`amtool` allows a configuration file to specify some options for convenience. The default configuration file paths are `$HOME/.config/amtool/config.yml` or `/etc/amtool/config.yml`
+`amtool` allows a configuration file to specify some options for convenience. The default configuration file paths are `$HOME/.config/amtool/config.yml` or `/etc/amtool/ and `C:\Program Files\amtool`.config.yml`
 
 An example configuration file might look like the following:
 

--- a/cli/root.go
+++ b/cli/root.go
@@ -18,6 +18,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"runtime"
 	"time"
 
 	"github.com/alecthomas/kingpin/v2"
@@ -127,6 +128,11 @@ func NewAlertmanagerClient(amURL *url.URL) *client.AlertmanagerAPI {
 
 // Execute is the main function for the amtool command
 func Execute() {
+	if runtime.GOOS == "windows" {
+		configFiles = []string{"C:/program files/amtool/config.yml"}
+	} else {
+		configFiles = []string{os.ExpandEnv("$HOME/.config/amtool/config.yml"), "/etc/amtool/config.yml"}
+	}
 	app := kingpin.New("amtool", helpRoot).UsageWriter(os.Stdout)
 
 	format.InitFormatFlags(app)

--- a/test/with_api_v2/acceptance.go
+++ b/test/with_api_v2/acceptance.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"syscall"
 	"testing"
@@ -381,8 +382,10 @@ func (amc *AlertmanagerCluster) Terminate() {
 // data.
 func (am *Alertmanager) Terminate() {
 	am.t.Helper()
-	if err := syscall.Kill(am.cmd.Process.Pid, syscall.SIGTERM); err != nil {
-		am.t.Logf("Error sending SIGTERM to Alertmanager process: %v", err)
+	if runtime.GOOS != "windows" {
+		if err := syscall.Kill(am.cmd.Process.Pid, syscall.SIGTERM); err != nil {
+			am.t.Logf("Error sending SIGTERM to Alertmanager process: %v", err)
+		}
 	}
 }
 
@@ -396,8 +399,10 @@ func (amc *AlertmanagerCluster) Reload() {
 // Reload sends the reloading signal to the Alertmanager process.
 func (am *Alertmanager) Reload() {
 	am.t.Helper()
-	if err := syscall.Kill(am.cmd.Process.Pid, syscall.SIGHUP); err != nil {
-		am.t.Fatalf("Error sending SIGHUP to Alertmanager process: %v", err)
+	if runtime.GOOS != "windows" {
+		if err := syscall.Kill(am.cmd.Process.Pid, syscall.SIGHUP); err != nil {
+			am.t.Fatalf("Error sending SIGHUP to Alertmanager process: %v", err)
+		}
 	}
 }
 


### PR DESCRIPTION
### Explanation
When using amtool.exe on a windows machine, the config.yml and credentials.yml location does not exist. To avoid having to provide the --alertmanager.url and --http.config.file flags each time.

 ### Related Issue
Closes https://github.com/prometheus/alertmanager/issues/3331

### Proposed Changes
- add the path 'c:\program files\amtool' to the possible config file directories. In the alertmanager cli: amtool, I added a filepath that works on windows as well (/cli/root.go). I also had to add a switch on an acceptance test (/test/with_api_v2/acceptance.go) since the syscall package does not support windows.

I compiled it to an executable and i was able to use amtool with a config.yml and credentials.yml in the configuration directory.