### PR TITLE
Slack Notifier: Only return an error when it actually occurs

### DIFF
--- a/notify/slack/slack.go
+++ b/notify/slack/slack.go
@@ -216,8 +216,10 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	// https://api.slack.com/incoming-webhooks#handling_errors
 	// https://api.slack.com/changelog/2016-05-17-changes-to-errors-for-incoming-webhooks
 	retry, err := n.retrier.Check(resp.StatusCode, resp.Body)
-	err = errors.Wrap(err, fmt.Sprintf("channel %q", req.Channel))
-	reasonErr := notify.NewErrorWithReason(notify.GetFailureReasonFromStatusCode(resp.StatusCode), err)
+	if err != nil {
+		err = errors.Wrap(err, fmt.Sprintf("channel %q", req.Channel))
+		return retry, notify.NewErrorWithReason(notify.GetFailureReasonFromStatusCode(resp.StatusCode), err)
+	}
 
-	return retry, reasonErr
+	return false, nil
 }

--- a/notify/slack/slack_test.go
+++ b/notify/slack/slack_test.go
@@ -117,6 +117,7 @@ func TestNotifier_Notify_WithReason(t *testing.T) {
 		name           string
 		statusCode     int
 		expectedReason notify.Reason
+		noError        bool
 	}{
 		{
 			name:           "with a 4xx status code",
@@ -132,6 +133,11 @@ func TestNotifier_Notify_WithReason(t *testing.T) {
 			name:           "with any other status code",
 			statusCode:     http.StatusTemporaryRedirect,
 			expectedReason: notify.DefaultReason,
+		},
+		{
+			name:       "with a 2xx status code",
+			statusCode: http.StatusOK,
+			noError:    true,
 		},
 	}
 	for _, tt := range tests {
@@ -163,9 +169,13 @@ func TestNotifier_Notify_WithReason(t *testing.T) {
 				},
 			}
 			_, err = notifier.Notify(ctx, alert1)
-			reasonError, ok := err.(*notify.ErrorWithReason)
-			require.True(t, ok)
-			require.Equal(t, tt.expectedReason, reasonError.Reason)
+			if tt.noError {
+				require.NoError(t, err)
+			} else {
+				reasonError, ok := err.(*notify.ErrorWithReason)
+				require.True(t, ok)
+				require.Equal(t, tt.expectedReason, reasonError.Reason)
+			}
 		})
 	}
 }


### PR DESCRIPTION
This was introduced as part of #3252 and its a case I didn't really took into account.