### PR TITLE
Add tests to TestMatchers

### DIFF
--- a/pkg/labels/parse_test.go
+++ b/pkg/labels/parse_test.go
@@ -335,7 +335,6 @@ func TestMatchers(t *testing.T) {
 			err:   `bad matcher format: {foo=`,
 		},
 		{
-			// This looks like a bug which should be fixed
 			input: `{foo=`,
 			want: func() []*Matcher {
 				ms := []*Matcher{}
@@ -344,7 +343,6 @@ func TestMatchers(t *testing.T) {
 			}(),
 		},
 		{
-			// This also looks like a bug which should be fixed
 			input: `{foo=}b`,
 			want: func() []*Matcher {
 				ms := []*Matcher{}


### PR DESCRIPTION
This commit adds a number of tests to TestMatchers that asserts some of the more nuanced behavior when parsing label matchers.