### PR TITLE
Add more tests to TestMatchers

### DIFF
--- a/pkg/labels/parse_test.go
+++ b/pkg/labels/parse_test.go
@@ -29,6 +29,14 @@ func TestMatchers(t *testing.T) {
 			want:  make([]*Matcher, 0),
 		},
 		{
+			input: `,`,
+			err:   "bad matcher format: ",
+		},
+		{
+			input: `{,}`,
+			err:   "bad matcher format: ",
+		},
+		{
 			input: `{foo='}`,
 			want: func() []*Matcher {
 				ms := []*Matcher{}


### PR DESCRIPTION
As part of #3353, I'd like confidence in the current test suite to catch any regressions from introducing a new parser.

This adds two cases where we expect to parsing to fail. 