### PR TITLE
Trim space from webhook url_file content

### DIFF
--- a/notify/webhook/webhook.go
+++ b/notify/webhook/webhook.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -110,7 +111,7 @@ func (n *Notifier) Notify(ctx context.Context, alerts ...*types.Alert) (bool, er
 		if err != nil {
 			return false, fmt.Errorf("read url_file: %w", err)
 		}
-		url = string(content)
+		url = strings.TrimSpace(string(content))
 	}
 
 	resp, err := notify.PostJSON(ctx, n.client, url, &buf)

--- a/notify/webhook/webhook_test.go
+++ b/notify/webhook/webhook_test.go
@@ -124,7 +124,7 @@ func TestWebhookReadingURLFromFile(t *testing.T) {
 
 	f, err := os.CreateTemp("", "webhook_url")
 	require.NoError(t, err, "creating temp file failed")
-	_, err = f.WriteString(u.String())
+	_, err = f.WriteString(u.String() + "\n")
 	require.NoError(t, err, "writing to temp file failed")
 
 	notifier, err := New(


### PR DESCRIPTION
It's common to have empty lines at the end of a file therefore it would be good if the code handles it correctly, also it will align the webhook url_file behaviour with the slack api_url_file.