### PR TITLE
Add the route ID to uuid

### DIFF
--- a/dispatch/route.go
+++ b/dispatch/route.go
@@ -180,7 +180,8 @@ func (r *Route) Key() string {
 	return b.String()
 }
 
-// ID returns a key for the route. It should uniquely identify the route in general.
+// ID returns a key for the route. It should uniquely identify the route in general,
+// it is different than Key() as it adds the route's position on its parent's children.
 func (r *Route) ID() string {
 	b := strings.Builder{}
 

--- a/dispatch/route.go
+++ b/dispatch/route.go
@@ -180,8 +180,7 @@ func (r *Route) Key() string {
 	return b.String()
 }
 
-// ID returns a key for the route. It should uniquely identify the route in general,
-// it is different than Key() as it adds the route's position on its parent's children.
+// ID returns a unique identifier for the route, unlike Key().
 func (r *Route) ID() string {
 	b := strings.Builder{}
 

--- a/dispatch/route.go
+++ b/dispatch/route.go
@@ -180,25 +180,26 @@ func (r *Route) Key() string {
 	return b.String()
 }
 
-// ID returns a unique identifier for the route, unlike Key().
+// ID returns a unique identifier for the route, unlike Key(). This need to be called after full route tree
+// finish generated as it need to know the position of this route in the whole tree
 func (r *Route) ID() string {
 	b := strings.Builder{}
 
-	var position *int
+	position := -1
 	if r.parent != nil {
 		// Find the position in the same level leaf.
 		for i, cr := range r.parent.Routes {
 			if cr == r {
-				position = &i
+				position = i
 				break
 			}
 		}
 	}
 	b.WriteString(r.Key())
 
-	if position != nil {
+	if position > -1 {
 		b.WriteRune('/')
-		b.WriteString(fmt.Sprint(*position))
+		b.WriteString(fmt.Sprint(position))
 	}
 	return b.String()
 }

--- a/dispatch/route.go
+++ b/dispatch/route.go
@@ -180,8 +180,7 @@ func (r *Route) Key() string {
 	return b.String()
 }
 
-// ID returns a unique identifier for the route, unlike Key(). This need to be called after full route tree
-// finish generated as it need to know the position of this route in the whole tree
+// ID returns a unique identifier for the route.
 func (r *Route) ID() string {
 	b := strings.Builder{}
 

--- a/dispatch/route.go
+++ b/dispatch/route.go
@@ -180,6 +180,29 @@ func (r *Route) Key() string {
 	return b.String()
 }
 
+// ID returns a key for the route. It should uniquely identify the route in general.
+func (r *Route) ID() string {
+	b := strings.Builder{}
+
+	var position *int
+	if r.parent != nil {
+		// Find the position in the same level leaf.
+		for i, cr := range r.parent.Routes {
+			if cr == r {
+				position = &i
+				break
+			}
+		}
+	}
+	b.WriteString(r.Key())
+
+	if position != nil {
+		b.WriteRune('/')
+		b.WriteString(fmt.Sprint(*position))
+	}
+	return b.String()
+}
+
 // Walk traverses the route tree in depth-first order.
 func (r *Route) Walk(visit func(*Route)) {
 	visit(r)

--- a/dispatch/route_test.go
+++ b/dispatch/route_test.go
@@ -907,9 +907,7 @@ routes:
 	if err := yaml.UnmarshalStrict([]byte(in), &ctree); err != nil {
 		t.Fatal(err)
 	}
-	var (
-		tree = NewRoute(&ctree, nil)
-	)
+	tree := NewRoute(&ctree, nil)
 
 	tests := []struct {
 		id string

--- a/dispatch/route_test.go
+++ b/dispatch/route_test.go
@@ -853,3 +853,80 @@ routes:
 		}
 	}
 }
+
+func TestRouteID(t *testing.T) {
+	in := `
+receiver: 'notify-def'
+
+routes:
+- matchers: ['{owner="team-A"}', '{level!="critical"}']
+
+  receiver: 'notify-A'
+
+  routes:
+  - matchers: ['{env="testing"}', '{baz!~".*quux"}']
+
+    receiver: 'notify-testing'
+    group_by: [...]
+
+  - match:
+      env: "production"
+
+    receiver: 'notify-productionA'
+    group_wait: 1m
+
+    continue: true
+
+  - matchers: [ env=~"produ.*", job=~".*"]
+
+    receiver: 'notify-productionB'
+    group_wait: 30s
+    group_interval: 5m
+    repeat_interval: 1h
+    group_by: ['job']
+
+- match_re:
+    owner: 'team-(B|C)'
+
+  group_by: ['foo', 'bar']
+  group_wait: 2m
+  receiver: 'notify-BC'
+
+- matchers: [group_by="role"]
+  group_by: ['role']
+
+  routes:
+  - matchers: ['{env="testing"}']
+    receiver: 'notify-testing'
+    routes:
+    - matchers: [wait="long"]
+      group_wait: 2m
+`
+
+	var ctree config.Route
+	if err := yaml.UnmarshalStrict([]byte(in), &ctree); err != nil {
+		t.Fatal(err)
+	}
+	var (
+		tree = NewRoute(&ctree, nil)
+	)
+
+	tests := []struct {
+		id string
+	}{
+		{
+			id: "{}/{level!=\"critical\",owner=\"team-A\"}/0",
+		},
+		{
+			id: "{}/{owner=~\"^(?:team-(B|C))$\"}/1",
+		},
+		{
+			id: "{}/{group_by=\"role\"}/2",
+		},
+	}
+
+	for i, test := range tests {
+		id := tree.Routes[i].ID()
+		require.Equal(t, test.id, id)
+	}
+}

--- a/dispatch/route_test.go
+++ b/dispatch/route_test.go
@@ -909,22 +909,24 @@ routes:
 	}
 	tree := NewRoute(&ctree, nil)
 
-	tests := []struct {
-		id string
-	}{
-		{
-			id: "{}/{level!=\"critical\",owner=\"team-A\"}/0",
-		},
-		{
-			id: "{}/{owner=~\"^(?:team-(B|C))$\"}/1",
-		},
-		{
-			id: "{}/{group_by=\"role\"}/2",
-		},
+	expected := []string{
+		"{}",
+		"{}/{level!=\"critical\",owner=\"team-A\"}/0",
+		"{}/{level!=\"critical\",owner=\"team-A\"}/{baz!~\".*quux\",env=\"testing\"}/0",
+		"{}/{level!=\"critical\",owner=\"team-A\"}/{env=\"production\"}/1",
+		"{}/{level!=\"critical\",owner=\"team-A\"}/{env=~\"produ.*\",job=~\".*\"}/2",
+		"{}/{owner=~\"^(?:team-(B|C))$\"}/1",
+		"{}/{group_by=\"role\"}/2",
+		"{}/{group_by=\"role\"}/{env=\"testing\"}/0",
+		"{}/{group_by=\"role\"}/{env=\"testing\"}/{wait=\"long\"}/0",
 	}
 
-	for i, test := range tests {
-		id := tree.Routes[i].ID()
-		require.Equal(t, test.id, id)
+	var got []string
+	tree.Walk(func(r *Route) {
+		got = append(got, r.ID())
+	})
+
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("\nexpected:\n%v\ngot:\n%v", expected, got)
 	}
 }


### PR DESCRIPTION
Adding a UUID to identify the route in general 
The route can be UUID by itself matchers+parents matchers + itself position 

```
                                                                         route1(matcher="1")
         
                    route2(matcher="1")                   route3(matcher="1")           route4(matcher="1")

route5(matcher="1")      route6(matcher="1")            

```

For example to UUID route 6, it will be (matcher="1")/(matcher="1")/(matcher="1")/1 


