### PR TITLE
Add support for Block Kit

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -470,6 +470,7 @@ type SlackConfig struct {
 	LinkNames   bool           `yaml:"link_names" json:"link_names,omitempty"`
 	MrkdwnIn    []string       `yaml:"mrkdwn_in,omitempty" json:"mrkdwn_in,omitempty"`
 	Actions     []*SlackAction `yaml:"actions,omitempty" json:"actions,omitempty"`
+	Blocks      []*SlackBlock  `yaml:"blocks,omitempty" json:"blocks,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
@@ -485,6 +486,47 @@ func (c *SlackConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 
 	return nil
+}
+
+type SlackBlock struct {
+	Context *SlackBlockContext `yaml:"context,omitempty" json:"context,omitempty"`
+	Divider *SlackBlockDivider `yaml:"divider,omitempty" json:"divider,omitempty"`
+	Header  *SlackBlockHeader  `yaml:"header,omitempty" json:"header,omitempty"`
+	Image   *SlackBlockImage   `yaml:"image,omitempty" json:"image,omitempty"`
+	Section *SlackBlockSection `yaml:"section,omitempty" json:"section,omitempty"`
+}
+
+type SlackBlockContext struct {
+	Elements []SlackBlockContextElement `yaml:"elements,omitempty" json:"elements,omitempty"`
+}
+
+type SlackBlockContextElement struct {
+	Image *SlackBlockImage `yaml:"image,omitempty" json:"image,omitempty"`
+	Text  *SlackBlockText  `yaml:"text,omitempty" json:"text,omitempty"`
+}
+
+type SlackBlockDivider struct{}
+
+type SlackBlockHeader struct {
+	Text SlackBlockText `yaml:"text,omitempty" json:"text,omitempty"`
+}
+
+type SlackBlockImage struct {
+	ImageURL string `yaml:"image_url,omitempty" json:"image_url,omitempty"`
+	AltText  string `yaml:"alt_text,omitempty" json:"alt_text,omitempty"`
+	Title    string `yaml:"title,omitempty" json:"title,omitempty"`
+}
+
+type SlackBlockSection struct {
+	Type   string           `yaml:"type,omitempty" json:"type,omitempty"`
+	Text   *SlackBlockText  `yaml:"text,omitempty" json:"text,omitempty"`
+	Fields []SlackBlockText `yaml:"fields,omitempty" json:"fields,omitempty"`
+}
+
+type SlackBlockText struct {
+	Text     string `yaml:"text,omitempty" json:"text,omitempty"`
+	Emoji    bool   `yaml:"emoji,omitempty" json:"emoji,omitempty"`
+	Markdown bool   `yaml:"markdown,omitempty" json:"markdown,omitempty"`
 }
 
 // WebhookConfig configures notifications via a generic webhook.

--- a/notify/slack/block.go
+++ b/notify/slack/block.go
@@ -1,0 +1,143 @@
+package slack
+
+import (
+	"encoding/json"
+)
+
+type SlackBlock struct {
+	Context *SlackBlockContext
+	Divider *SlackBlockDivider
+	Header  *SlackBlockHeader
+	Image   *SlackBlockImage
+	Section *SlackBlockSection
+}
+
+func (b *SlackBlock) MarshalJSON() ([]byte, error) {
+	var v any
+	if b.Context != nil {
+		v = b.Context
+	} else if b.Divider != nil {
+		v = b.Divider
+	} else if b.Header != nil {
+		v = b.Header
+	} else if b.Image != nil {
+		v = b.Image
+	} else {
+		v = b.Section
+	}
+	return json.Marshal(v)
+}
+
+type SlackBlockContext struct {
+	Elements []SlackBlockContextElement
+}
+
+func (b *SlackBlockContext) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type     string                     `json:"type"`
+		Elements []SlackBlockContextElement `json:"elements"`
+	}{
+		Type:     "context",
+		Elements: b.Elements,
+	})
+}
+
+type SlackBlockContextElement struct {
+	Image *SlackBlockImage
+	Text  *SlackBlockText
+}
+
+func (b *SlackBlockContextElement) MarshalJSON() ([]byte, error) {
+	var v any
+	if b.Image != nil {
+		v = b.Image
+	} else {
+		v = b.Text
+	}
+	return json.Marshal(v)
+}
+
+type SlackBlockDivider struct{}
+
+func (b *SlackBlockDivider) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type string `json:"type"`
+	}{
+		Type: "divider",
+	})
+}
+
+type SlackBlockHeader struct {
+	Text *SlackBlockText `json:"-"`
+}
+
+func (b *SlackBlockHeader) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type string          `json:"type"`
+		Text *SlackBlockText `json:"text"`
+	}{
+		Type: "header",
+		Text: b.Text,
+	})
+}
+
+type SlackBlockImage struct {
+	ImageURL string
+	AltText  string
+	Title    string
+}
+
+func (b *SlackBlockImage) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type     string `json:"type"`
+		ImageURL string `json:"image_url"`
+		AltText  string `json:"alt_text"`
+		Title    string `json:"title,omitempty"`
+	}{
+		Type:     "image",
+		ImageURL: b.ImageURL,
+		AltText:  b.AltText,
+		Title:    b.Title,
+	})
+}
+
+type SlackBlockSection struct {
+	Text   *SlackBlockText
+	Fields []*SlackBlockText
+}
+
+func (b *SlackBlockSection) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type   string            `json:"type"`
+		Text   *SlackBlockText   `json:"text,omitempty"`
+		Fields []*SlackBlockText `json:"fields,omitempty"`
+	}{
+		Type:   "section",
+		Text:   b.Text,
+		Fields: b.Fields,
+	})
+}
+
+type SlackBlockText struct {
+	Text     string
+	Emoji    bool
+	Markdown bool
+}
+
+func (b *SlackBlockText) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type  string `json:"type"`
+		Text  string `json:"text"`
+		Emoji bool   `json:"emoji,omitempty"`
+	}{
+		Type: func() string {
+			if b.Markdown {
+				return "mrkdwn"
+			} else {
+				return "plain_text"
+			}
+		}(),
+		Text:  b.Text,
+		Emoji: b.Emoji,
+	})
+}

--- a/notify/slack/block_test.go
+++ b/notify/slack/block_test.go
@@ -1,0 +1,1 @@
+package slack


### PR DESCRIPTION
### Background

In #2217 @mambax and others proposed a number of options for supporting Slack's Block Kit UI framework in Alertmanager. This feature seems to have gained some traction with 88 👍 , 9 🎉 , 12 ❤️ and 5 👀 at the time of opening this pull request.

### What this pull request does

This pull request is a draft of how I think support for Slack's Block Kit UI framework could be added to Alertmanager. You will find in this pull request the most simple implementation of Block Kit, missing validation of user configuration and a number of blocks such as the `Actions` block, and almost all Element blocks.

### How it works

The configuration file is structured as follows:

```yml
receivers:
- name: test
  slack_configs:
    - api_url: https://example.com/hooks/test
      blocks:
        - header:
            text:
              text: "{{ len .Alerts.Firing }} :fire: alerts, {{ len .Alerts.Resolved }} :white_check_mark: alerts"
              emoji: true
        - context:
            elements:
              - text:
                  text: "You have {{ len .Alerts.Firing }} firing alert(s), and {{ len .Alerts.Resolved }} alert(s) for *{{ .CommonLabels }}*"
                  markdown: true
        - section:
            text:
              text: "This is the message"
              markdown: true
route:
  receiver: test
  group_by: [alertname]
  group_wait: 30s
  group_interval: 1m
  repeat_interval: 4h
```

and here is a screenshot of a notification I sent using the above configuration:

<img width="427" alt="Screenshot 2023-06-04 at 17 06 59" src="https://github.com/prometheus/alertmanager/assets/85952834/169c27aa-b56f-4fc8-a194-d723379a8514">

You'll notice that, unlike a number of the other proposals in #2217, I have put the type of each block as the name of the object rather than using `type: header`:

```yml
blocks:
  - type: header
    text:
      type: plain_text
      text: "{{ len .Alerts.Firing }} :fire: alerts, {{ len .Alerts.Resolved }} :white_check_mark: alerts"
```

The reason for this is so we can decode the Yaml into Go structs such as the following:

```go
type SlackBlock struct {
	Context *SlackBlockContext `yaml:"context,omitempty" json:"context,omitempty"`
	Divider *SlackBlockDivider `yaml:"divider,omitempty" json:"divider,omitempty"`
	Header  *SlackBlockHeader  `yaml:"header,omitempty" json:"header,omitempty"`
	Image   *SlackBlockImage   `yaml:"image,omitempty" json:"image,omitempty"`
	Section *SlackBlockSection `yaml:"section,omitempty" json:"section,omitempty"`
}
```

This is not just consistent with how all other configuration is represented in Alertmanager, but it also doesn't break strict Yaml decoding which complains when using a generic struct such as the following:

```go
type SlackBlock struct {
	Type string `yaml:"type,omitempty" json:"type,omitempty"`
	// Config contains the configuration for the block. For example, if this
	// is a header block then Config is a *SlackBlockHeader.
	Config interface{} `yaml:"-" json:"-"`
}
```

### Mockups

Here is a mockup of what notifications from Alertmanager could look like with full support of Slack's Block Kit UI framework:

<img width="468" alt="Screenshot 2023-06-04 at 17 27 51" src="https://github.com/prometheus/alertmanager/assets/85952834/3c5c0408-d43e-4d9d-8a3f-783b81805f1d">
