### PR TITLE
Document difference between tab and newline in tests

### DIFF
--- a/pkg/labels/parse_test.go
+++ b/pkg/labels/parse_test.go
@@ -283,6 +283,22 @@ func TestMatchers(t *testing.T) {
 			}(),
 		},
 		{
+			input: `{foo=bar\t}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "bar\\t")
+				return append(ms, m)
+			}(),
+		},
+		{
+			input: `{foo=bar\n}`,
+			want: func() []*Matcher {
+				ms := []*Matcher{}
+				m, _ := NewMatcher(MatchEqual, "foo", "bar\n")
+				return append(ms, m)
+			}(),
+		},
+		{
 			input: `job=`,
 			want: func() []*Matcher {
 				m, _ := NewMatcher(MatchEqual, "job", "")


### PR DESCRIPTION
I found a possible bug (unexpected behaviour?) in the current parser for label matchers where `\n` is interpolated and `\t` is not. I've chosen to document this with a test while I figure out if this is intentional or not.

Related: https://github.com/prometheus/alertmanager/pull/3353