### PR TITLE
Fix unexpected behavior interpreting matchers in amtool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,7 @@ require (
 	github.com/go-openapi/jsonreference v0.20.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/btree v1.0.0 // indirect
+	github.com/grobinson-grafana/matchers v0.0.0-20230528130227-07c6c200d343 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-msgpack v0.5.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -313,6 +313,8 @@ github.com/googleapis/gax-go/v2 v2.2.0/go.mod h1:as02EH8zWkzwUoLbBaFeQ+arQaj/Oth
 github.com/googleapis/gax-go/v2 v2.3.0/go.mod h1:b8LNqSzNabLiUpXKkY7HAR5jr6bIT99EXz9pXxye9YM=
 github.com/googleapis/gax-go/v2 v2.4.0/go.mod h1:XOTVJ59hdnfJLIP/dh8n5CGryZR2LxK9wbMD5+iXC6c=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
+github.com/grobinson-grafana/matchers v0.0.0-20230528130227-07c6c200d343 h1:Y006/19n+TelWvpodfqVwLYI9+HpC0BD+izsuDbdDWY=
+github.com/grobinson-grafana/matchers v0.0.0-20230528130227-07c6c200d343/go.mod h1:HE5p32VRCQh3pch31pHTuVxkvd/efaTDr/ggt2qtoxE=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/consul/api v1.12.0/go.mod h1:6pVBMo0ebnYdt2S3H87XhekM/HHrUoTD2XXb/VrZVy0=


### PR DESCRIPTION
This commit fixes some of the unexpected behavior when interpreting matchers in amtool.

Before this commit, `<matcher-groups>` that looked like a valid matcher such as `{foo=bar}` would have `"alertname"` prefixed as amtool considered it to be a label value. However, this would create a silence for `alertname="{foo=bar}"` which is almost never want the user intended.

Instead, this commit updates the heuristic to be more accurate in determining whether the input is a label value without a label name and operator or if it is a complete matcher that should be parsed from start to end.

Fixes #3385