### PR TITLE
Log a warning when repeat_interval is less than group_interval

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -515,6 +515,19 @@ func run() int {
 					r.Key(),
 				)
 			}
+
+			if r.RouteOpts.RepeatInterval < r.RouteOpts.GroupInterval {
+				level.Warn(configLogger).Log(
+					"msg",
+					"repeat_interval is less than group_interval. Notifications will not repeat until the next group_interval.",
+					"repeat_interval",
+					r.RouteOpts.RepeatInterval,
+					"group_interval",
+					r.RouteOpts.GroupInterval,
+					"route",
+					r.Key(),
+				)
+			}
 		})
 
 		go disp.Run()

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -197,7 +197,7 @@ matchers:
 # Note that this parameter is implicitly bound by Alertmanager's
 # `--data.retention` configuration flag. Notifications will be resent after either
 # repeat_interval or the data retention period have passed, whichever
-# occurs first.
+# occurs first. repeat_interval should not be less than group_interval.
 [ repeat_interval: <duration> | default = 4h ]
 
 # Times when the route should be muted. These must match the name of a

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -197,7 +197,7 @@ matchers:
 # Note that this parameter is implicitly bound by Alertmanager's
 # `--data.retention` configuration flag. Notifications will be resent after either
 # repeat_interval or the data retention period have passed, whichever
-# occurs first. repeat_interval should not be less than group_interval.
+# occurs first. `repeat_interval` should not be less than `group_interval`.
 [ repeat_interval: <duration> | default = 4h ]
 
 # Times when the route should be muted. These must match the name of a


### PR DESCRIPTION
This commit updates Alertmanager to log a warning when repeat_interval is less than group_interval for an individual route.

When `repeat_interval` is less than `group_interval`, the earliest a notification can be sent again is the next time the aggregation group is flushed, and this happens at each `group_interval`.

Fixes #3370