### PR TITLE
Fix example matchers in docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -463,7 +463,7 @@ Here are some examples of valid string matchers:
     As shown below, in the short-form, it's generally better to quote the list elements to avoid problems with special characters like commas:
 
     ```yaml
-    matchers: [ "foo = bar,baz", "dings != bums" ]
+    matchers: [ "foo = \"bar,baz\"", "dings != bums" ]
     ```
 
 3. You can also put both matchers into one PromQL-like string. Single quotes for the whole string work best here.


### PR DESCRIPTION
This pull request fixes an incorrect example in the docs:

```
matchers: [ "foo = bar,baz", "dings != bums" ]
```

Is not valid and will throw the following error:

```
ts=2023-06-22T09:51:29.199Z caller=coordinator.go:118 level=error component=configuration msg="Loading configuration file failed" file=config.yml err="bad matcher format: baz"
```

The example should be:

```
matchers: [ "foo = \"bar,baz\"", "dings != bums" ]
```

Fixes #3400