### PR TITLE
Build with Go 1.20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           command: sudo rm -rf /usr/local/go
       # Whenever the Go version is updated here, .promu.yml should also be updated.
       - go/install:
-          version: "1.19"
+          version: "1.20"
       - run:
           name: Remove generated code
           command: make clean
@@ -47,7 +47,7 @@ jobs:
   test:
     docker:
       # Whenever the Go version is updated here, .promu.yml should also be updated.
-      - image: quay.io/prometheus/golang-builder:1.19-base
+      - image: quay.io/prometheus/golang-builder:1.20-base
       # maildev containers are for running the email tests against a "real" SMTP server.
       # See notify/email_test.go for details.
       - image: maildev/maildev:1.1.0
@@ -104,7 +104,7 @@ jobs:
   mixin:
     docker:
       # Whenever the Go version is updated here, .promu.yml should also be updated.
-      - image: quay.io/prometheus/golang-builder:1.19-base
+      - image: quay.io/prometheus/golang-builder:1.20-base
     steps:
       - checkout
       - run: go install github.com/monitoring-mixins/mixtool/cmd/mixtool@latest

--- a/.promu.yml
+++ b/.promu.yml
@@ -1,7 +1,7 @@
 go:
-    # Whenever the Go version is updated here, .travis.yml and
+    # Whenever the Go version is updated here,
     # .circle/config.yml should also be updated.
-    version: 1.19
+    version: 1.20
 repository:
     path: github.com/prometheus/alertmanager
 build:


### PR DESCRIPTION
Go 1.19 will be EOL come August.

https://go.dev/doc/devel/release

Verified 1.20 tag available: https://quay.io/repository/prometheus/golang-builder?tab=tags

```
Build with Go 1.20

- Start using Go 1.20 toolchain to build
- Remove deprecated reference to updating .travis.yml
```