### PR TITLE
Remove immediate flush on reload/restart

### DIFF
--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -381,8 +381,6 @@ type aggrGroup struct {
 	done    chan struct{}
 	next    *time.Timer
 	timeout func(time.Duration) time.Duration
-
-	mtx sync.RWMutex
 }
 
 // newAggrGroup returns a new aggregation group.
@@ -447,9 +445,7 @@ func (ag *aggrGroup) run(nf notifyFunc) {
 			ctx = notify.WithActiveTimeIntervals(ctx, ag.opts.ActiveTimeIntervals)
 
 			// Wait the configured interval before calling flush again.
-			ag.mtx.Lock()
 			ag.next.Reset(ag.opts.GroupInterval)
-			ag.mtx.Unlock()
 
 			ag.flush(func(alerts ...*types.Alert) bool {
 				return nf(ctx, alerts...)

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -382,7 +382,7 @@ type aggrGroup struct {
 	next    *time.Timer
 	timeout func(time.Duration) time.Duration
 
-	mtx        sync.RWMutex
+	mtx sync.RWMutex
 }
 
 // newAggrGroup returns a new aggregation group.

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -195,14 +195,12 @@ func TestAggrGroup(t *testing.T) {
 	ag.insert(a1)
 	ag.insert(a2)
 
-	select {
-	case batch := <-alertsCh:
-		exp := removeEndsAt(types.AlertSlice{a1, a2})
-		sort.Sort(batch)
+	batch := <-alertsCh
+	exp := removeEndsAt(types.AlertSlice{a1, a2})
+	sort.Sort(batch)
 
-		if !reflect.DeepEqual(batch, exp) {
-			t.Fatalf("expected alerts %v but got %v", exp, batch)
-		}
+	if !reflect.DeepEqual(batch, exp) {
+		t.Fatalf("expected alerts %v but got %v", exp, batch)
 	}
 
 	for i := 0; i < 3; i++ {

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -188,21 +188,14 @@ func TestAggrGroup(t *testing.T) {
 
 	ag.stop()
 
-	// Add an alert that started more than group_interval in the past. We expect
-	// immediate flushing.
-	// Finally, set all alerts to be resolved. After successful notify the aggregation group
+	// Set all alerts to be resolved. After successful notify the aggregation group
 	// should empty itself.
 	ag = newAggrGroup(context.Background(), lset, route, nil, log.NewNopLogger())
 	go ag.run(ntfy)
-
 	ag.insert(a1)
 	ag.insert(a2)
 
-	// a2 lies way in the past so the initial group_wait should be skipped.
 	select {
-	case <-time.After(opts.GroupWait / 2):
-		t.Fatalf("expected immediate alert but received none")
-
 	case batch := <-alertsCh:
 		exp := removeEndsAt(types.AlertSlice{a1, a2})
 		sort.Sort(batch)

--- a/test/with_api_v1/acceptance/send_test.go
+++ b/test/with_api_v1/acceptance/send_test.go
@@ -432,8 +432,8 @@ receivers:
 	am.Push(At(4), Alert("alertname", "test2"))
 
 	co.Want(Between(2, 2.5), Alert("alertname", "test1").Active(1))
-	// Timers are reset on reload regardless, so we count the 6 second group
-	// interval from 3 onwards.
+	// Timers are reset on reload, so if the reload happens at 3 seconds
+	// then the first flush will happen at reload + group_wait seconds.
 	co.Want(Between(4, 4.5),
 		Alert("alertname", "test1").Active(1),
 		Alert("alertname", "test2").Active(4),

--- a/test/with_api_v1/acceptance/send_test.go
+++ b/test/with_api_v1/acceptance/send_test.go
@@ -434,7 +434,7 @@ receivers:
 	co.Want(Between(2, 2.5), Alert("alertname", "test1").Active(1))
 	// Timers are reset on reload regardless, so we count the 6 second group
 	// interval from 3 onwards.
-	co.Want(Between(9, 9.5),
+	co.Want(Between(4, 4.5),
 		Alert("alertname", "test1").Active(1),
 		Alert("alertname", "test2").Active(4),
 	)

--- a/test/with_api_v2/acceptance/send_test.go
+++ b/test/with_api_v2/acceptance/send_test.go
@@ -455,7 +455,7 @@ receivers:
 	co.Want(Between(2, 2.5), Alert("alertname", "test1").Active(1))
 	// Timers are reset on reload regardless, so we count the 6 second group
 	// interval from 3 onwards.
-	co.Want(Between(9, 9.5),
+	co.Want(Between(4, 4.5),
 		Alert("alertname", "test1").Active(1),
 		Alert("alertname", "test2").Active(4),
 	)

--- a/test/with_api_v2/acceptance/send_test.go
+++ b/test/with_api_v2/acceptance/send_test.go
@@ -453,8 +453,8 @@ receivers:
 	amc.Push(At(4), Alert("alertname", "test2"))
 
 	co.Want(Between(2, 2.5), Alert("alertname", "test1").Active(1))
-	// Timers are reset on reload regardless, so we count the 6 second group
-	// interval from 3 onwards.
+	// Timers are reset on reload, so if the reload happens at 3 seconds
+	// then the first flush will happen at reload + group_wait seconds.
 	co.Want(Between(4, 4.5),
 		Alert("alertname", "test1").Active(1),
 		Alert("alertname", "test2").Active(4),


### PR DESCRIPTION
### What this PR does

This pull request changes Alertmanager so it no longer flushes aggregation groups on configuration reload or restart of Alertmanager as this behavior causes a number of issues:

1. Alertmanager will send notifications for inhibited alerts if the inhibited alert is sent to Alertmanager before the inhibiting alert following a restart (https://www.grobinson.net/best-practices-for-avoiding-race-conditions-in-inhibition-rules.html)

2. Reloading Alertmanager via /-/reload can cause incomplete flushes of aggregation groups (https://github.com/prometheus/alertmanager/issues/3407)

3. Reloading or restarting an Alertmanager while sending a notification can cause a race between the reloaded/restarted Alertmanager and the next peer in the Alertmanager cluster. This can, in some cases, cause firing and resolved notifications to be sent out of order. For example, resolved, firing, resolved.

A potential issue with this change is that following a reload or restart of Alertmanager, alerts that were waiting for group_wait will have to wait from the beginning of group_wait again. If group_wait is large then notifications could take longer to send then expected. Frequent reloads in combination with a large group_wait could even prevent alerts from being flushed at all.