### PR TITLE
Update email.html to use "https://schema.org" instead of "https://schema.org"

### DIFF
--- a/template/email.html
+++ b/template/email.html
@@ -314,7 +314,7 @@ a {
 </style>
 </head>
 
-<body itemscope itemtype="http://schema.org/EmailMessage">
+<body itemscope itemtype="https://schema.org/EmailMessage">
 
 <table class="body-wrap">
   <tr>


### PR DESCRIPTION
According to schema.org's faq both https and http are fine, but https is preferred going forward: https://schema.org/docs/faq.html#19

Why am I making this change? To make some security code scanner happy :)