### PR TITLE
CI: Pin the mixtool version in CircleCI and update the golang CircleCI orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 version: 2.1
 orbs:
   prometheus: prometheus/prometheus@0.16.0
-  go: circleci/go@1.7.0
+  go: circleci/go@1.7.3
 jobs:
   test_frontend:
     # We need to use a machine executor because the front-end validation runs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,8 @@ jobs:
       - image: quay.io/prometheus/golang-builder:1.20-base
     steps:
       - checkout
-      - run: go install github.com/monitoring-mixins/mixtool/cmd/mixtool@latest
+      # pin the mixtool version until https://github.com/monitoring-mixins/mixtool/issues/135 is merged.
+      - run: go install github.com/monitoring-mixins/mixtool/cmd/mixtool@2282201396b69055bb0f92f187049027a16d2130
       - run: go install github.com/google/go-jsonnet/cmd/jsonnetfmt@latest
       - run: go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
       - run: make -C doc/alertmanager-mixin lint

--- a/doc/alertmanager-mixin/Makefile
+++ b/doc/alertmanager-mixin/Makefile
@@ -20,7 +20,6 @@ lint: build
 
 	mixtool lint mixin.libsonnet
 
-
 dashboards_out: mixin.libsonnet config.libsonnet $(wildcard dashboards/*)
 	@mkdir -p dashboards_out
 	jsonnet -J vendor -m dashboards_out dashboards.jsonnet


### PR DESCRIPTION
In mixtool, the tip of master broke for our mixin - I have managed to trace it down and opened a PR (see https://github.com/grafana/dashboard-linter/pull/143) but for now, let's pin the version to make sure our CI is not affected.

There's also the fact that I golang circleCI orb hasn't been updated in ages - updating it solved the CI problem we hand on tests_frontend where the goland version was failing to install. I think this might have been a result of #3411 