### PR TITLE
Added custom Tessell webhook receiver to route requests across namespaces

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -58,6 +58,7 @@ import (
 	"github.com/prometheus/alertmanager/notify/slack"
 	"github.com/prometheus/alertmanager/notify/sns"
 	"github.com/prometheus/alertmanager/notify/telegram"
+	"github.com/prometheus/alertmanager/notify/tessell"
 	"github.com/prometheus/alertmanager/notify/victorops"
 	"github.com/prometheus/alertmanager/notify/webex"
 	"github.com/prometheus/alertmanager/notify/webhook"
@@ -184,6 +185,9 @@ func buildReceiverIntegrations(nc config.Receiver, tmpl *template.Template, logg
 	}
 	for i, c := range nc.MSTeamsConfigs {
 		add("msteams", i, c, func(l log.Logger) (notify.Notifier, error) { return msteams.New(c, tmpl, l) })
+	}
+	for i, c := range nc.TessellWebhookConfigs {
+		add("tessell_webhook", i, c, func(l log.Logger) (notify.Notifier, error) { return tessell.New(c, tmpl, l) })
 	}
 
 	if errs.Len() > 0 {

--- a/config/config.go
+++ b/config/config.go
@@ -257,6 +257,9 @@ func resolveFilepaths(baseDir string, cfg *Config) {
 		for _, cfg := range receiver.MSTeamsConfigs {
 			cfg.HTTPConfig.SetDirectory(baseDir)
 		}
+		for _, cfg := range receiver.TessellWebhookConfigs {
+			cfg.HTTPConfig.SetDirectory(baseDir)
+		}
 	}
 }
 
@@ -361,6 +364,11 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		for _, wh := range rcv.WebhookConfigs {
 			if wh.HTTPConfig == nil {
 				wh.HTTPConfig = c.Global.HTTPConfig
+			}
+		}
+		for _, tc := range rcv.TessellWebhookConfigs {
+			if tc.HTTPConfig == nil {
+				tc.HTTPConfig = c.Global.HTTPConfig
 			}
 		}
 		for _, ec := range rcv.EmailConfigs {
@@ -895,19 +903,20 @@ type Receiver struct {
 	// A unique identifier for this receiver.
 	Name string `yaml:"name" json:"name"`
 
-	DiscordConfigs   []*DiscordConfig   `yaml:"discord_configs,omitempty" json:"discord_configs,omitempty"`
-	EmailConfigs     []*EmailConfig     `yaml:"email_configs,omitempty" json:"email_configs,omitempty"`
-	PagerdutyConfigs []*PagerdutyConfig `yaml:"pagerduty_configs,omitempty" json:"pagerduty_configs,omitempty"`
-	SlackConfigs     []*SlackConfig     `yaml:"slack_configs,omitempty" json:"slack_configs,omitempty"`
-	WebhookConfigs   []*WebhookConfig   `yaml:"webhook_configs,omitempty" json:"webhook_configs,omitempty"`
-	OpsGenieConfigs  []*OpsGenieConfig  `yaml:"opsgenie_configs,omitempty" json:"opsgenie_configs,omitempty"`
-	WechatConfigs    []*WechatConfig    `yaml:"wechat_configs,omitempty" json:"wechat_configs,omitempty"`
-	PushoverConfigs  []*PushoverConfig  `yaml:"pushover_configs,omitempty" json:"pushover_configs,omitempty"`
-	VictorOpsConfigs []*VictorOpsConfig `yaml:"victorops_configs,omitempty" json:"victorops_configs,omitempty"`
-	SNSConfigs       []*SNSConfig       `yaml:"sns_configs,omitempty" json:"sns_configs,omitempty"`
-	TelegramConfigs  []*TelegramConfig  `yaml:"telegram_configs,omitempty" json:"telegram_configs,omitempty"`
-	WebexConfigs     []*WebexConfig     `yaml:"webex_configs,omitempty" json:"webex_configs,omitempty"`
-	MSTeamsConfigs   []*MSTeamsConfig   `yaml:"msteams_configs,omitempty" json:"teams_configs,omitempty"`
+	DiscordConfigs        []*DiscordConfig        `yaml:"discord_configs,omitempty" json:"discord_configs,omitempty"`
+	EmailConfigs          []*EmailConfig          `yaml:"email_configs,omitempty" json:"email_configs,omitempty"`
+	PagerdutyConfigs      []*PagerdutyConfig      `yaml:"pagerduty_configs,omitempty" json:"pagerduty_configs,omitempty"`
+	SlackConfigs          []*SlackConfig          `yaml:"slack_configs,omitempty" json:"slack_configs,omitempty"`
+	WebhookConfigs        []*WebhookConfig        `yaml:"webhook_configs,omitempty" json:"webhook_configs,omitempty"`
+	OpsGenieConfigs       []*OpsGenieConfig       `yaml:"opsgenie_configs,omitempty" json:"opsgenie_configs,omitempty"`
+	WechatConfigs         []*WechatConfig         `yaml:"wechat_configs,omitempty" json:"wechat_configs,omitempty"`
+	PushoverConfigs       []*PushoverConfig       `yaml:"pushover_configs,omitempty" json:"pushover_configs,omitempty"`
+	VictorOpsConfigs      []*VictorOpsConfig      `yaml:"victorops_configs,omitempty" json:"victorops_configs,omitempty"`
+	SNSConfigs            []*SNSConfig            `yaml:"sns_configs,omitempty" json:"sns_configs,omitempty"`
+	TelegramConfigs       []*TelegramConfig       `yaml:"telegram_configs,omitempty" json:"telegram_configs,omitempty"`
+	WebexConfigs          []*WebexConfig          `yaml:"webex_configs,omitempty" json:"webex_configs,omitempty"`
+	MSTeamsConfigs        []*MSTeamsConfig        `yaml:"msteams_configs,omitempty" json:"teams_configs,omitempty"`
+	TessellWebhookConfigs []*TessellWebhookConfig `yaml:"tessell_webhook_configs,omitempty" json:"tessell_configs,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for Receiver.

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -292,6 +292,7 @@ func NewMetrics(r prometheus.Registerer) *Metrics {
 		"victorops",
 		"sns",
 		"telegram",
+		"tessell_webhook",
 	} {
 		m.numNotifications.WithLabelValues(integration)
 		m.numNotificationRequestsTotal.WithLabelValues(integration)

--- a/notify/tessell/tessell.go
+++ b/notify/tessell/tessell.go
@@ -1,0 +1,172 @@
+// Copyright 2023 Tessell Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tessell
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	commoncfg "github.com/prometheus/common/config"
+
+	"github.com/prometheus/alertmanager/config"
+	"github.com/prometheus/alertmanager/notify"
+	"github.com/prometheus/alertmanager/template"
+	"github.com/prometheus/alertmanager/types"
+)
+
+// Notifier implements a Notifier for generic webhooks.
+type Notifier struct {
+	conf    *config.TessellWebhookConfig
+	tmpl    *template.Template
+	logger  log.Logger
+	client  *http.Client
+	retrier *notify.Retrier
+}
+
+// New returns a new Webhook.
+func New(conf *config.TessellWebhookConfig, t *template.Template, l log.Logger, httpOpts ...commoncfg.HTTPClientOption) (*Notifier, error) {
+	client, err := commoncfg.NewClientFromConfig(*conf.HTTPConfig, "tessell", httpOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return &Notifier{
+		conf:   conf,
+		tmpl:   t,
+		logger: l,
+		client: client,
+		// Webhooks are assumed to respond with 2xx response codes on a successful
+		// request and 5xx response codes are assumed to be recoverable.
+		retrier: &notify.Retrier{
+			CustomDetailsFunc: func(_ int, body io.Reader) string {
+				return errDetails(body, conf.URL.String())
+			},
+		},
+	}, nil
+}
+
+func truncateAlerts(maxAlerts uint64, alerts []*types.Alert) ([]*types.Alert, uint64) {
+	if maxAlerts != 0 && uint64(len(alerts)) > maxAlerts {
+		return alerts[:maxAlerts], uint64(len(alerts)) - maxAlerts
+	}
+
+	return alerts, 0
+}
+
+type NodeStatus struct {
+	Status string `json:"status"`
+}
+
+// Notify implements the Notifier interface.
+func (n *Notifier) Notify(ctx context.Context, alerts ...*types.Alert) (bool, error) {
+	level.Info(n.logger).Log("tessellversion", "9")
+	var url string
+	if n.conf.URL != nil {
+		url = n.conf.URL.String()
+	} else {
+		content, err := os.ReadFile(n.conf.URLFile)
+		if err != nil {
+			return false, fmt.Errorf("read url_file: %w", err)
+		}
+		url = strings.TrimSpace(string(content))
+	}
+
+	alerts, numTruncated := truncateAlerts(n.conf.MaxAlerts, alerts)
+	level.Info(n.logger).Log("truncatedAlerts", numTruncated)
+
+	shouldRetry := false
+	var err error = nil
+	for _, alert := range alerts {
+		level.Info(n.logger).Log("alertLabels", alert.Labels.String())
+
+		eksNamespace, hasEksNamespace := alert.Labels["eks_namespace"]
+		serviceId, hasServiceId := alert.Labels["service_id"]
+		serviceInstanceId, hasServiceInstanceId := alert.Labels["service_instance_id"]
+
+		if hasServiceInstanceId && hasEksNamespace && hasServiceId {
+			status := "DOWN"
+			if strings.Contains(strings.ToLower(alert.Name()), "resolved") {
+				status = "UP"
+			}
+			nodeStatus := &NodeStatus{
+				Status: status,
+			}
+
+			url = strings.Replace(url, "(EKS_NAMESPACE)", string(eksNamespace), -1)
+			url = strings.Replace(url, "(SERVICE_ID)", string(serviceId), -1)
+			url = strings.Replace(url, "(SERVICE_INSTANCE_ID)", string(serviceInstanceId), -1)
+
+			var buf bytes.Buffer
+			if err := json.NewEncoder(&buf).Encode(nodeStatus); err != nil {
+				return false, err
+			}
+
+			level.Info(n.logger).Log("url", url)
+
+			retries := 5
+			resp, err := n.sendPatchRequestWithInstantRetries(ctx, url, &buf, retries)
+			if err != nil {
+				return true, notify.RedactURL(err)
+			}
+
+			level.Info(n.logger).Log("status", status)
+			level.Info(n.logger).Log("ApiStatus", resp.StatusCode)
+
+			shouldRetry, err = n.retrier.Check(resp.StatusCode, resp.Body)
+			if err != nil {
+				err = notify.NewErrorWithReason(notify.GetFailureReasonFromStatusCode(resp.StatusCode), err)
+			}
+			notify.Drain(resp)
+		}
+	}
+
+	return shouldRetry, err
+}
+
+func (n *Notifier) sendPatchRequestWithInstantRetries(ctx context.Context, url string, body io.Reader, retries int) (*http.Response, error) {
+	if retries < 0 {
+		return nil, errors.New("retries should not be less than 0")
+	}
+
+	var resp *http.Response
+	var err error
+	for i := 0; i <= retries; i++ {
+		resp, err = notify.PatchJSON(ctx, n.client, url, body)
+		// 2xx responses are considered to be always successful.
+		if resp.StatusCode/100 == 2 {
+			return resp, err
+		}
+
+	}
+	return resp, err
+}
+
+func errDetails(body io.Reader, url string) string {
+	if body == nil {
+		return url
+	}
+	bs, err := io.ReadAll(body)
+	if err != nil {
+		return url
+	}
+	return fmt.Sprintf("%s: %s", url, string(bs))
+}

--- a/notify/util.go
+++ b/notify/util.go
@@ -57,6 +57,11 @@ func PostJSON(ctx context.Context, client *http.Client, url string, body io.Read
 	return post(ctx, client, url, "application/json", body)
 }
 
+// PatchJSON sends a PATCH request with JSON payload to the given URL.
+func PatchJSON(ctx context.Context, client *http.Client, url string, body io.Reader) (*http.Response, error) {
+	return patch(ctx, client, url, "application/json", body)
+}
+
 // PostText sends a POST request with text payload to the given URL.
 func PostText(ctx context.Context, client *http.Client, url string, body io.Reader) (*http.Response, error) {
 	return post(ctx, client, url, "text/plain", body)
@@ -64,6 +69,10 @@ func PostText(ctx context.Context, client *http.Client, url string, body io.Read
 
 func post(ctx context.Context, client *http.Client, url, bodyType string, body io.Reader) (*http.Response, error) {
 	return request(ctx, client, http.MethodPost, url, bodyType, body)
+}
+
+func patch(ctx context.Context, client *http.Client, url, bodyType string, body io.Reader) (*http.Response, error) {
+	return request(ctx, client, http.MethodPatch, url, bodyType, body)
 }
 
 func request(ctx context.Context, client *http.Client, method, url, bodyType string, body io.Reader) (*http.Response, error) {


### PR DESCRIPTION
Added custom Tessell webhook receiver to route requests across namespaces.
Sample configuration:
    - name: status-test
      tessell_webhook_configs:
        - url: 'http://tessell-database-system.(EKS_NAMESPACE).svc.cluster.local:8080/tessell-ops/services/(SERVICE_ID)/service-instances/(SERVICE_INSTANCE_ID)/status'
          send_resolved: false
          
 Todo:
- Improve retry mechanism to retry only failed alerts instead of the whole batch.
- Send timestamp with the alert
- Make instant retry configurable
- Change prometheus licensing header to tessell license header
- Thorough testing