### PR TITLE
Release: fix the version formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.26.0.rc-0 / 2022-08-17
+## 0.26.0-rc.0 / 2022-08-17
 
 * [CHANGE] Telegram Integration: `api_url` is now optional. #2981
 * [CHANGE] Telegram Integration: `ParseMode` default is now `HTML` instead of `MarkdownV2`. #2981


### PR DESCRIPTION
It should be `<major>.<minor>.<patch>-rc.<candidate>` both the `VERSION` file and the `CHANGELOG` header must match.