### PR TITLE
Docs: Update docs on inheritance for time intervals

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -185,15 +185,18 @@ matchers:
 # How long to initially wait to send a notification for a group
 # of alerts. Allows to wait for an inhibiting alert to arrive or collect
 # more initial alerts for the same group. (Usually ~0s to few minutes.)
+# If omitted, child routes inherit the group_wait of the parent route.
 [ group_wait: <duration> | default = 30s ]
 
 # How long to wait before sending a notification about new alerts that
 # are added to a group of alerts for which an initial notification has
-# already been sent. (Usually ~5m or more.)
+# already been sent. (Usually ~5m or more.) If omitted, child routes
+# inherit the group_interval of the parent route.
 [ group_interval: <duration> | default = 5m ]
 
 # How long to wait before sending a notification again if it has already
-# been sent successfully for an alert. (Usually ~3h or more).
+# been sent successfully for an alert. (Usually ~3h or more). If omitted,
+# child routes inherit the repeat_interval of the parent route.
 # Note that this parameter is implicitly bound by Alertmanager's
 # `--data.retention` configuration flag. Notifications will be resent after either
 # repeat_interval or the data retention period have passed, whichever


### PR DESCRIPTION
This commit updates the docs on inheritance for group_wait, group_interval and repeat_interval.