### PR TITLE
[FEAT] Add missing integrations to notify metrics

### DIFF
--- a/notify/notify.go
+++ b/notify/notify.go
@@ -292,6 +292,9 @@ func NewMetrics(r prometheus.Registerer) *Metrics {
 		"victorops",
 		"sns",
 		"telegram",
+		"discord",
+		"webex",
+		"msteams",
 	} {
 		m.numNotifications.WithLabelValues(integration)
 		m.numNotificationRequestsTotal.WithLabelValues(integration)


### PR DESCRIPTION
Implementing notify metrics for missing integrations, following https://github.com/prometheus/alertmanager/issues/3237