### PR TITLE
Fix scheme required for webhook url in amtool

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -503,11 +503,6 @@ func (c *WebhookConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if c.URL != nil && c.URLFile != "" {
 		return fmt.Errorf("at most one of url & url_file must be configured")
 	}
-	if c.URL != nil {
-		if c.URL.Scheme != "https" && c.URL.Scheme != "http" {
-			return fmt.Errorf("scheme required for webhook url")
-		}
-	}
 	return nil
 }
 

--- a/test/cli/acceptance.go
+++ b/test/cli/acceptance.go
@@ -658,6 +658,17 @@ func (am *Alertmanager) UpdateConfig(conf string) {
 	}
 }
 
+func (am *Alertmanager) ShowRoute() ([]byte, error) {
+	return am.showRouteCommand()
+}
+
+func (am *Alertmanager) showRouteCommand() ([]byte, error) {
+	amURLFlag := "--alertmanager.url=" + am.getURL("/")
+	args := []string{amURLFlag, "config", "routes", "show"}
+	cmd := exec.Command(amtool, args...)
+	return cmd.CombinedOutput()
+}
+
 func (am *Alertmanager) getURL(path string) string {
 	return fmt.Sprintf("http://%s%s%s", am.apiAddr, am.opts.RoutePrefix, path)
 }

--- a/test/cli/acceptance.go
+++ b/test/cli/acceptance.go
@@ -669,6 +669,17 @@ func (am *Alertmanager) showRouteCommand() ([]byte, error) {
 	return cmd.CombinedOutput()
 }
 
+func (am *Alertmanager) TestRoute() ([]byte, error) {
+	return am.testRouteCommand()
+}
+
+func (am *Alertmanager) testRouteCommand() ([]byte, error) {
+	amURLFlag := "--alertmanager.url=" + am.getURL("/")
+	args := []string{amURLFlag, "config", "routes", "test"}
+	cmd := exec.Command(amtool, args...)
+	return cmd.CombinedOutput()
+}
+
 func (am *Alertmanager) getURL(path string) string {
 	return fmt.Sprintf("http://%s%s%s", am.apiAddr, am.opts.RoutePrefix, path)
 }

--- a/test/cli/acceptance/cli_test.go
+++ b/test/cli/acceptance/cli_test.go
@@ -201,3 +201,36 @@ receivers:
 	_, err := am.ShowRoute()
 	require.NoError(t, err)
 }
+
+func TestRoutesTest(t *testing.T) {
+	t.Parallel()
+
+	conf := `
+route:
+  receiver: "default"
+  group_by: [alertname]
+  group_wait:      1s
+  group_interval:  1s
+  repeat_interval: 1ms
+
+receivers:
+- name: "default"
+  webhook_configs:
+  - url: 'http://%s'
+    send_resolved: true
+`
+
+	at := NewAcceptanceTest(t, &AcceptanceOpts{
+		Tolerance: 1 * time.Second,
+	})
+	co := at.Collector("webhook")
+	wh := NewWebhook(co)
+
+	amc := at.AlertmanagerCluster(fmt.Sprintf(conf, wh.Address()), 1)
+	require.NoError(t, amc.Start())
+	defer amc.Terminate()
+
+	am := amc.Members()[0]
+	_, err := am.TestRoute()
+	require.NoError(t, err)
+}


### PR DESCRIPTION
This commit fixes issue #3505 where amtool would fail with `error: scheme required for webhook url` when using amtool with `--alertmanager.url`.

The issue here is that `UnmarshalYaml` for `WebhookConfig` checks if the scheme is present when `c.URL` is non-nil. However, `UnmarshalYam`l for `SecretURL` returns a non-nil, default value `url.URL{}` if the response from `api/v2/status` contains `<secret>` as the webhook URL.