### PR TITLE
Remove duplicate integration from metrics

### DIFF
--- a/notify/notify.go
+++ b/notify/notify.go
@@ -332,7 +332,6 @@ func (m *Metrics) InitializeFor(receiver map[string][]Integration) {
 	// When the feature flag is not enabled, we just carry on registering _all_ the integrations.
 	for _, integration := range []string{
 		"email",
-		"msteams",
 		"pagerduty",
 		"wechat",
 		"pushover",


### PR DESCRIPTION
This is harmless as the vector won't be duplicated but let's remove it anyways.