### PR TITLE
Muted alerts are supressed and add "mutedBy" to APIv2

### DIFF
--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -288,7 +288,7 @@ func (api *API) getAlertsHandler(params alert_ops.GetAlertsParams) middleware.Re
 			continue
 		}
 
-		alert := AlertToOpenAPIAlert(a, api.getAlertStatus(a.Fingerprint()), receivers)
+		alert := AlertToOpenAPIAlert(a, api.getAlertStatus(a.Fingerprint()), receivers, nil)
 
 		res = append(res, alert)
 	}
@@ -415,7 +415,7 @@ func (api *API) getAlertGroupsHandler(params alertgroup_ops.GetAlertGroupsParams
 			fp := alert.Fingerprint()
 			receivers := allReceivers[fp]
 			status := api.getAlertStatus(fp)
-			apiAlert := AlertToOpenAPIAlert(alert, status, receivers)
+			apiAlert := AlertToOpenAPIAlert(alert, status, receivers, alertGroup)
 			ag.Alerts = append(ag.Alerts, apiAlert)
 		}
 		res = append(res, ag)

--- a/api/v2/api_test.go
+++ b/api/v2/api_test.go
@@ -420,6 +420,7 @@ func TestAlertToOpenAPIAlert(t *testing.T) {
 			State:       &active,
 			InhibitedBy: []string{},
 			SilencedBy:  []string{},
+			MutedBy:     []string{},
 		},
 		StartsAt:    convertDateTime(start),
 		EndsAt:      convertDateTime(time.Time{}),

--- a/api/v2/api_test.go
+++ b/api/v2/api_test.go
@@ -410,7 +410,7 @@ func TestAlertToOpenAPIAlert(t *testing.T) {
 			UpdatedAt: updated,
 		}
 	)
-	openAPIAlert := AlertToOpenAPIAlert(alert, types.AlertStatus{State: types.AlertStateActive}, receivers)
+	openAPIAlert := AlertToOpenAPIAlert(alert, types.AlertStatus{State: types.AlertStateActive}, receivers, nil)
 	require.Equal(t, &open_api_models.GettableAlert{
 		Annotations: open_api_models.LabelSet{},
 		Alert: open_api_models.Alert{

--- a/api/v2/client/alert/get_alerts_parameters.go
+++ b/api/v2/client/alert/get_alerts_parameters.go
@@ -98,6 +98,14 @@ type GetAlertsParams struct {
 	*/
 	Inhibited *bool
 
+	/* Muted.
+
+	   Show muted alerts
+
+	   Default: true
+	*/
+	Muted *bool
+
 	/* Receiver.
 
 	   A regex matching receivers to filter alerts by
@@ -142,6 +150,8 @@ func (o *GetAlertsParams) SetDefaults() {
 
 		inhibitedDefault = bool(true)
 
+		mutedDefault = bool(true)
+
 		silencedDefault = bool(true)
 
 		unprocessedDefault = bool(true)
@@ -150,6 +160,7 @@ func (o *GetAlertsParams) SetDefaults() {
 	val := GetAlertsParams{
 		Active:      &activeDefault,
 		Inhibited:   &inhibitedDefault,
+		Muted:       &mutedDefault,
 		Silenced:    &silencedDefault,
 		Unprocessed: &unprocessedDefault,
 	}
@@ -224,6 +235,17 @@ func (o *GetAlertsParams) WithInhibited(inhibited *bool) *GetAlertsParams {
 // SetInhibited adds the inhibited to the get alerts params
 func (o *GetAlertsParams) SetInhibited(inhibited *bool) {
 	o.Inhibited = inhibited
+}
+
+// WithMuted adds the muted to the get alerts params
+func (o *GetAlertsParams) WithMuted(muted *bool) *GetAlertsParams {
+	o.SetMuted(muted)
+	return o
+}
+
+// SetMuted adds the muted to the get alerts params
+func (o *GetAlertsParams) SetMuted(muted *bool) {
+	o.Muted = muted
 }
 
 // WithReceiver adds the receiver to the get alerts params
@@ -307,6 +329,23 @@ func (o *GetAlertsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Reg
 		if qInhibited != "" {
 
 			if err := r.SetQueryParam("inhibited", qInhibited); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.Muted != nil {
+
+		// query param muted
+		var qrMuted bool
+
+		if o.Muted != nil {
+			qrMuted = *o.Muted
+		}
+		qMuted := swag.FormatBool(qrMuted)
+		if qMuted != "" {
+
+			if err := r.SetQueryParam("muted", qMuted); err != nil {
 				return err
 			}
 		}

--- a/api/v2/client/alertgroup/get_alert_groups_parameters.go
+++ b/api/v2/client/alertgroup/get_alert_groups_parameters.go
@@ -98,6 +98,14 @@ type GetAlertGroupsParams struct {
 	*/
 	Inhibited *bool
 
+	/* Muted.
+
+	   Show muted alerts
+
+	   Default: true
+	*/
+	Muted *bool
+
 	/* Receiver.
 
 	   A regex matching receivers to filter alerts by
@@ -134,12 +142,15 @@ func (o *GetAlertGroupsParams) SetDefaults() {
 
 		inhibitedDefault = bool(true)
 
+		mutedDefault = bool(true)
+
 		silencedDefault = bool(true)
 	)
 
 	val := GetAlertGroupsParams{
 		Active:    &activeDefault,
 		Inhibited: &inhibitedDefault,
+		Muted:     &mutedDefault,
 		Silenced:  &silencedDefault,
 	}
 
@@ -215,6 +226,17 @@ func (o *GetAlertGroupsParams) SetInhibited(inhibited *bool) {
 	o.Inhibited = inhibited
 }
 
+// WithMuted adds the muted to the get alert groups params
+func (o *GetAlertGroupsParams) WithMuted(muted *bool) *GetAlertGroupsParams {
+	o.SetMuted(muted)
+	return o
+}
+
+// SetMuted adds the muted to the get alert groups params
+func (o *GetAlertGroupsParams) SetMuted(muted *bool) {
+	o.Muted = muted
+}
+
 // WithReceiver adds the receiver to the get alert groups params
 func (o *GetAlertGroupsParams) WithReceiver(receiver *string) *GetAlertGroupsParams {
 	o.SetReceiver(receiver)
@@ -285,6 +307,23 @@ func (o *GetAlertGroupsParams) WriteToRequest(r runtime.ClientRequest, reg strfm
 		if qInhibited != "" {
 
 			if err := r.SetQueryParam("inhibited", qInhibited); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.Muted != nil {
+
+		// query param muted
+		var qrMuted bool
+
+		if o.Muted != nil {
+			qrMuted = *o.Muted
+		}
+		qMuted := swag.FormatBool(qrMuted)
+		if qMuted != "" {
+
+			if err := r.SetQueryParam("muted", qMuted); err != nil {
 				return err
 			}
 		}

--- a/api/v2/compat.go
+++ b/api/v2/compat.go
@@ -144,6 +144,7 @@ func AlertToOpenAPIAlert(alert *types.Alert, status types.AlertStatus, receivers
 			State:       &state,
 			SilencedBy:  status.SilencedBy,
 			InhibitedBy: status.InhibitedBy,
+			MutedBy:     status.MutedBy,
 		},
 	}
 
@@ -153,6 +154,10 @@ func AlertToOpenAPIAlert(alert *types.Alert, status types.AlertStatus, receivers
 
 	if aa.Status.InhibitedBy == nil {
 		aa.Status.InhibitedBy = []string{}
+	}
+
+	if aa.Status.MutedBy == nil {
+		aa.Status.MutedBy = []string{}
 	}
 
 	return aa

--- a/api/v2/models/alert_status.go
+++ b/api/v2/models/alert_status.go
@@ -38,6 +38,10 @@ type AlertStatus struct {
 	// Required: true
 	InhibitedBy []string `json:"inhibitedBy"`
 
+	// muted by
+	// Required: true
+	MutedBy []string `json:"mutedBy"`
+
 	// silenced by
 	// Required: true
 	SilencedBy []string `json:"silencedBy"`
@@ -53,6 +57,10 @@ func (m *AlertStatus) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateInhibitedBy(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateMutedBy(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -73,6 +81,15 @@ func (m *AlertStatus) Validate(formats strfmt.Registry) error {
 func (m *AlertStatus) validateInhibitedBy(formats strfmt.Registry) error {
 
 	if err := validate.Required("inhibitedBy", "body", m.InhibitedBy); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *AlertStatus) validateMutedBy(formats strfmt.Registry) error {
+
+	if err := validate.Required("mutedBy", "body", m.MutedBy); err != nil {
 		return err
 	}
 

--- a/api/v2/openapi.yaml
+++ b/api/v2/openapi.yaml
@@ -154,6 +154,11 @@ paths:
           description: Show inhibited alerts
           default: true
         - in: query
+          name: muted
+          type: boolean
+          description: Show muted alerts
+          default: true
+        - in: query
           name: unprocessed
           type: boolean
           description: Show unprocessed alerts
@@ -220,6 +225,11 @@ paths:
           name: inhibited
           type: boolean
           description: Show inhibited alerts
+          default: true
+        - in: query
+          name: muted
+          type: boolean
+          description: Show muted alerts
           default: true
         - name: filter
           in: query
@@ -499,10 +509,15 @@ definitions:
         type: array
         items:
           type: string
+      mutedBy:
+        type: array
+        items:
+          type: string
     required:
       - state
       - silencedBy
       - inhibitedBy
+      - mutedBy
   receiver:
     type: object
     properties:

--- a/api/v2/restapi/embedded_spec.go
+++ b/api/v2/restapi/embedded_spec.go
@@ -82,6 +82,13 @@ func init() {
           {
             "type": "boolean",
             "default": true,
+            "description": "Show muted alerts",
+            "name": "muted",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "default": true,
             "description": "Show unprocessed alerts",
             "name": "unprocessed",
             "in": "query"
@@ -175,6 +182,13 @@ func init() {
             "default": true,
             "description": "Show inhibited alerts",
             "name": "inhibited",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "default": true,
+            "description": "Show muted alerts",
+            "name": "muted",
             "in": "query"
           },
           {
@@ -430,10 +444,17 @@ func init() {
       "required": [
         "state",
         "silencedBy",
-        "inhibitedBy"
+        "inhibitedBy",
+        "mutedBy"
       ],
       "properties": {
         "inhibitedBy": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "mutedBy": {
           "type": "array",
           "items": {
             "type": "string"
@@ -869,6 +890,13 @@ func init() {
           {
             "type": "boolean",
             "default": true,
+            "description": "Show muted alerts",
+            "name": "muted",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "default": true,
             "description": "Show unprocessed alerts",
             "name": "unprocessed",
             "in": "query"
@@ -974,6 +1002,13 @@ func init() {
             "default": true,
             "description": "Show inhibited alerts",
             "name": "inhibited",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "default": true,
+            "description": "Show muted alerts",
+            "name": "muted",
             "in": "query"
           },
           {
@@ -1247,10 +1282,17 @@ func init() {
       "required": [
         "state",
         "silencedBy",
-        "inhibitedBy"
+        "inhibitedBy",
+        "mutedBy"
       ],
       "properties": {
         "inhibitedBy": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "mutedBy": {
           "type": "array",
           "items": {
             "type": "string"

--- a/api/v2/restapi/operations/alert/get_alerts_parameters.go
+++ b/api/v2/restapi/operations/alert/get_alerts_parameters.go
@@ -39,6 +39,7 @@ func NewGetAlertsParams() GetAlertsParams {
 		activeDefault = bool(true)
 
 		inhibitedDefault = bool(true)
+		mutedDefault     = bool(true)
 
 		silencedDefault    = bool(true)
 		unprocessedDefault = bool(true)
@@ -48,6 +49,8 @@ func NewGetAlertsParams() GetAlertsParams {
 		Active: &activeDefault,
 
 		Inhibited: &inhibitedDefault,
+
+		Muted: &mutedDefault,
 
 		Silenced: &silencedDefault,
 
@@ -79,6 +82,11 @@ type GetAlertsParams struct {
 	  Default: true
 	*/
 	Inhibited *bool
+	/*Show muted alerts
+	  In: query
+	  Default: true
+	*/
+	Muted *bool
 	/*A regex matching receivers to filter alerts by
 	  In: query
 	*/
@@ -118,6 +126,11 @@ func (o *GetAlertsParams) BindRequest(r *http.Request, route *middleware.Matched
 
 	qInhibited, qhkInhibited, _ := qs.GetOK("inhibited")
 	if err := o.bindInhibited(qInhibited, qhkInhibited, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qMuted, qhkMuted, _ := qs.GetOK("muted")
+	if err := o.bindMuted(qMuted, qhkMuted, route.Formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -207,6 +220,30 @@ func (o *GetAlertsParams) bindInhibited(rawData []string, hasKey bool, formats s
 		return errors.InvalidType("inhibited", "query", "bool", raw)
 	}
 	o.Inhibited = &value
+
+	return nil
+}
+
+// bindMuted binds and validates parameter Muted from query.
+func (o *GetAlertsParams) bindMuted(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		// Default values have been previously initialized by NewGetAlertsParams()
+		return nil
+	}
+
+	value, err := swag.ConvertBool(raw)
+	if err != nil {
+		return errors.InvalidType("muted", "query", "bool", raw)
+	}
+	o.Muted = &value
 
 	return nil
 }

--- a/api/v2/restapi/operations/alert/get_alerts_urlbuilder.go
+++ b/api/v2/restapi/operations/alert/get_alerts_urlbuilder.go
@@ -32,6 +32,7 @@ type GetAlertsURL struct {
 	Active      *bool
 	Filter      []string
 	Inhibited   *bool
+	Muted       *bool
 	Receiver    *string
 	Silenced    *bool
 	Unprocessed *bool
@@ -98,6 +99,14 @@ func (o *GetAlertsURL) Build() (*url.URL, error) {
 	}
 	if inhibitedQ != "" {
 		qs.Set("inhibited", inhibitedQ)
+	}
+
+	var mutedQ string
+	if o.Muted != nil {
+		mutedQ = swag.FormatBool(*o.Muted)
+	}
+	if mutedQ != "" {
+		qs.Set("muted", mutedQ)
 	}
 
 	var receiverQ string

--- a/api/v2/restapi/operations/alertgroup/get_alert_groups_parameters.go
+++ b/api/v2/restapi/operations/alertgroup/get_alert_groups_parameters.go
@@ -39,6 +39,7 @@ func NewGetAlertGroupsParams() GetAlertGroupsParams {
 		activeDefault = bool(true)
 
 		inhibitedDefault = bool(true)
+		mutedDefault     = bool(true)
 
 		silencedDefault = bool(true)
 	)
@@ -47,6 +48,8 @@ func NewGetAlertGroupsParams() GetAlertGroupsParams {
 		Active: &activeDefault,
 
 		Inhibited: &inhibitedDefault,
+
+		Muted: &mutedDefault,
 
 		Silenced: &silencedDefault,
 	}
@@ -76,6 +79,11 @@ type GetAlertGroupsParams struct {
 	  Default: true
 	*/
 	Inhibited *bool
+	/*Show muted alerts
+	  In: query
+	  Default: true
+	*/
+	Muted *bool
 	/*A regex matching receivers to filter alerts by
 	  In: query
 	*/
@@ -110,6 +118,11 @@ func (o *GetAlertGroupsParams) BindRequest(r *http.Request, route *middleware.Ma
 
 	qInhibited, qhkInhibited, _ := qs.GetOK("inhibited")
 	if err := o.bindInhibited(qInhibited, qhkInhibited, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qMuted, qhkMuted, _ := qs.GetOK("muted")
+	if err := o.bindMuted(qMuted, qhkMuted, route.Formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -194,6 +207,30 @@ func (o *GetAlertGroupsParams) bindInhibited(rawData []string, hasKey bool, form
 		return errors.InvalidType("inhibited", "query", "bool", raw)
 	}
 	o.Inhibited = &value
+
+	return nil
+}
+
+// bindMuted binds and validates parameter Muted from query.
+func (o *GetAlertGroupsParams) bindMuted(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		// Default values have been previously initialized by NewGetAlertGroupsParams()
+		return nil
+	}
+
+	value, err := swag.ConvertBool(raw)
+	if err != nil {
+		return errors.InvalidType("muted", "query", "bool", raw)
+	}
+	o.Muted = &value
 
 	return nil
 }

--- a/api/v2/restapi/operations/alertgroup/get_alert_groups_urlbuilder.go
+++ b/api/v2/restapi/operations/alertgroup/get_alert_groups_urlbuilder.go
@@ -32,6 +32,7 @@ type GetAlertGroupsURL struct {
 	Active    *bool
 	Filter    []string
 	Inhibited *bool
+	Muted     *bool
 	Receiver  *string
 	Silenced  *bool
 
@@ -97,6 +98,14 @@ func (o *GetAlertGroupsURL) Build() (*url.URL, error) {
 	}
 	if inhibitedQ != "" {
 		qs.Set("inhibited", inhibitedQ)
+	}
+
+	var mutedQ string
+	if o.Muted != nil {
+		mutedQ = swag.FormatBool(*o.Muted)
+	}
+	if mutedQ != "" {
+		qs.Set("muted", mutedQ)
 	}
 
 	var receiverQ string

--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -404,7 +404,7 @@ func run() int {
 			timeIntervals[ti.Name] = ti.TimeIntervals
 		}
 
-		intervener := timeinterval.NewIntervener(timeIntervals)
+		intervener := timeinterval.NewIntervener(timeIntervals, marker)
 
 		inhibitor.Stop()
 		disp.Stop()

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -201,6 +201,7 @@ type AlertGroup struct {
 	Alerts   types.AlertSlice
 	Labels   model.LabelSet
 	Receiver string
+	Key      string
 }
 
 type AlertGroups []*AlertGroup
@@ -237,6 +238,7 @@ func (d *Dispatcher) Groups(routeFilter func(*Route) bool, alertFilter func(*typ
 			alertGroup := &AlertGroup{
 				Labels:   ag.labels,
 				Receiver: receiver,
+				Key:      ag.GroupKey(),
 			}
 
 			alerts := ag.alerts.List()

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -415,6 +415,7 @@ route:
 				"alertname": "OtherAlert",
 			},
 			Receiver: "prod",
+			Key:      "{}:{alertname=\"OtherAlert\"}",
 		},
 		&AlertGroup{
 			Alerts: []*types.Alert{inputAlerts[1]},
@@ -423,6 +424,7 @@ route:
 				"service":   "api",
 			},
 			Receiver: "testing",
+			Key:      "{}/{env=\"testing\"}:{alertname=\"TestingAlert\", service=\"api\"}",
 		},
 		&AlertGroup{
 			Alerts: []*types.Alert{inputAlerts[2], inputAlerts[3]},
@@ -432,6 +434,7 @@ route:
 				"cluster":   "aa",
 			},
 			Receiver: "prod",
+			Key:      "{}/{env=\"prod\"}:{alertname=\"HighErrorRate\", cluster=\"aa\", service=\"api\"}",
 		},
 		&AlertGroup{
 			Alerts: []*types.Alert{inputAlerts[4]},
@@ -441,6 +444,7 @@ route:
 				"cluster":   "bb",
 			},
 			Receiver: "prod",
+			Key:      "{}/{env=\"prod\"}:{alertname=\"HighErrorRate\", cluster=\"bb\", service=\"api\"}",
 		},
 		&AlertGroup{
 			Alerts: []*types.Alert{inputAlerts[5]},
@@ -450,6 +454,7 @@ route:
 				"cluster":   "bb",
 			},
 			Receiver: "kafka",
+			Key:      "{}/{kafka=\"yes\"}:{alertname=\"HighLatency\", cluster=\"bb\", service=\"db\"}",
 		},
 		&AlertGroup{
 			Alerts: []*types.Alert{inputAlerts[5]},
@@ -459,6 +464,7 @@ route:
 				"cluster":   "bb",
 			},
 			Receiver: "prod",
+			Key:      "{}/{env=\"prod\"}:{alertname=\"HighLatency\", cluster=\"bb\", service=\"db\"}",
 		},
 	}, alertGroups)
 	require.Equal(t, map[model.Fingerprint][]string{

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -947,20 +947,3 @@ func (tas TimeActiveStage) Exec(ctx context.Context, l log.Logger, alerts ...*ty
 
 	return ctx, alerts, nil
 }
-
-// inTimeIntervals returns true if the current time is contained in one of the given time intervals.
-func inTimeIntervals(now time.Time, intervals map[string][]timeinterval.TimeInterval, intervalNames []string) (bool, []string, error) {
-	var in []string
-	for _, name := range intervalNames {
-		interval, ok := intervals[name]
-		if !ok {
-			return false, nil, errors.Errorf("time interval %s doesn't exist in config", name)
-		}
-		for _, ti := range interval {
-			if ti.ContainsTime(now.UTC()) {
-				in = append(in, name)
-			}
-		}
-	}
-	return len(in) > 0, in, nil
-}

--- a/types/types.go
+++ b/types/types.go
@@ -54,23 +54,29 @@ type AlertStatus struct {
 // Marker helps to mark alerts as silenced and/or inhibited.
 // All methods are goroutine-safe.
 type Marker interface {
-	// SetActiveOrSilenced replaces the previous SilencedBy by the provided IDs of
-	// active and pending silences, including the version number of the
-	// silences state. The set of provided IDs is supposed to represent the
-	// complete set of relevant silences. If no active silence IDs are provided and
-	// InhibitedBy is already empty, it sets the provided alert to AlertStateActive.
-	// Otherwise, it sets the provided alert to AlertStateSuppressed.
+	// SetActiveOrSilenced replaces the previous SilencedBy by the provided
+	// IDs of active and pending silences, including the version number of
+	// the silences state. The set of provided IDs is supposed to represent
+	// the complete set of relevant silences. If no active silence IDs are
+	// provided and both InhibitedBy and MutedBy are empty, it sets the
+	// provided alert to AlertStateActive. Otherwise, it sets the provided
+	// alert to AlertStateSuppressed.
 	SetActiveOrSilenced(alert model.Fingerprint, version int, activeSilenceIDs, pendingSilenceIDs []string)
-	// SetInhibited replaces the previous InhibitedBy by the provided IDs of
-	// alerts. In contrast to SetActiveOrSilenced, the set of provided IDs is not
-	// expected to represent the complete set of inhibiting alerts. (In
-	// practice, this method is only called with one or zero IDs. However,
+	// SetInhibited replaces the previous InhibitedBy by the provided IDs
+	// of alerts. In contrast to SetActiveOrSilenced, the set of provided
+	// IDs is not expected to represent the complete set of inhibiting alerts.
+	// In practice, this method is only called with one or zero IDs. However,
 	// this expectation might change in the future. If no IDs are provided
-	// and InhibitedBy is already empty, it sets the provided alert to
+	// and InhibitedBy and SilencedBy are empty, it sets the provided alert to
 	// AlertStateActive. Otherwise, it sets the provided alert to
 	// AlertStateSuppressed.
 	SetInhibited(alert model.Fingerprint, alertIDs ...string)
-	// SetMuted
+	// SetMuted replaces the previous MutedBy by the provided time intervals.
+	// Unlike SetInhibited, the set of provided time intervals is expected
+	// to represent the complete set of relevant time intervals. If no time
+	// intervals are provided and both InhibitedBy and SilencedBy are empty,
+	// it sets the provided alert to AlertStateActive. Otherwise, it sets the
+	// provided alert to AlertStateSuppressed.
 	SetMuted(alert model.Fingerprint, alertIDs ...string)
 
 	// Count alerts of the given state(s). With no state provided, count all


### PR DESCRIPTION
This commit updates TimeMuteStage to mark muted alerts as suppressed, and adds the names of all mutes that mute the alert to a field called mutedBy. This field is also returned in APIv2.

Fixes #3513