### PR TITLE
Add s390x Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,7 @@ workflows:
       - prometheus/build:
           name: build
           parallelism: 3
-          promu_opts: "-p linux/amd64 -p windows/amd64 -p linux/arm64 -p darwin/amd64 -p darwin/arm64 -p linux/386"
+          promu_opts: "-p linux/amd64 -p windows/amd64 -p linux/arm64 -p darwin/amd64 -p darwin/arm64 -p linux/386 -p linux/s390x"
           filters:
             tags:
               ignore: /^v2(\.[0-9]+){2}(-.+|[^-.]*)$/


### PR DESCRIPTION
To be honest, I have no idea how circleci works.
I hope this does it.
Everything else seems to already build for s390x.