### PR TITLE
actions: cross build in ci and fix publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,21 @@ jobs:
       - run: make apiv2
       - run: git diff --exit-code
 
+  build:
+    name: Build Alertmanager for common architectures
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        thread: [ 0, 1, 2 ]
+    steps:
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+      - uses: prometheus/promci@3cb0c3871f223bd5ce1226995bd52ffb314798b6 # v0.1.0
+      - uses: ./.github/promci/actions/build
+        with:
+          promu_opts: "-p linux/amd64 -p windows/amd64 -p linux/arm64 -p darwin/amd64 -p darwin/arm64 -p linux/386"
+          parallelism: 3
+          thread: ${{ matrix.thread }}
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,13 +9,27 @@ jobs:
     name: Run ci
     uses: ./.github/workflows/ci.yml
 
-  publish_main:
-    name: Publish main branch artefacts
+  build:
+    name: Build Alertmanager for all architectures
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        thread: [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 ]
     needs: ci
     steps:
       - uses: actions/checkout@v3
-      - uses: prometheus/promci@v0.0.2
+      - uses: prometheus/promci@3cb0c3871f223bd5ce1226995bd52ffb314798b6 # v0.1.0
+      - uses: ./.github/promci/actions/build
+        with:
+          parallelism: 12
+          thread: ${{ matrix.thread }}
+  publish_main:
+    name: Publish main branch artefacts
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+      - uses: prometheus/promci@3cb0c3871f223bd5ce1226995bd52ffb314798b6 # v0.1.0
       - uses: ./.github/promci/actions/publish_main
         with:
           docker_hub_login: ${{ secrets.docker_hub_login }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,17 +9,30 @@ jobs:
     name: Run ci
     uses: ./.github/workflows/ci.yml
 
-  publish_release:
-    name: Publish release arfefacts
+  build:
+    name: Build Alertmanager for all architectures
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        thread: [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 ]
     needs: ci
     steps:
       - uses: actions/checkout@v3
-      - uses: prometheus/promci@v0.0.2
+      - uses: prometheus/promci@3cb0c3871f223bd5ce1226995bd52ffb314798b6 # v0.1.0
+      - uses: ./.github/promci/actions/build
+        with:
+          parallelism: 12
+          thread: ${{ matrix.thread }}
+  publish_release:
+    name: Publish release artefacts
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+      - uses: prometheus/promci@3cb0c3871f223bd5ce1226995bd52ffb314798b6 # v0.1.0
       - uses: ./.github/promci/actions/publish_release
         with:
           docker_hub_login: ${{ secrets.docker_hub_login }}
           docker_hub_password: ${{ secrets.docker_hub_password }}
           quay_io_login: ${{ secrets.quay_io_login }}
           quay_io_password: ${{ secrets.quay_io_password }}
-          github_token: ${{ secrets.PROMBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
This add

- a job to build on 3 architectures in the CI action
- Fixes the publish action to cross build all architectures first

~TODO: add a release action and discuss and add appropriate trigger filters for release and publish.~