### PR TITLE
Fix Docs: default for msteams config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -734,10 +734,10 @@ Microsoft Teams notifications are sent via the [Incoming Webhooks](https://learn
 [ webhook_url: <secret> ]
 
 # Message title template.
-[ title: <tmpl_string> | default = '{{ template "teams.default.title" . }}' ]
+[ title: <tmpl_string> | default = '{{ template "msteams.default.title" . }}' ]
 
 # Message body template.
-[ text: <tmpl_string> | default = '{{ template "teams.default.text" . }}' ]
+[ text: <tmpl_string> | default = '{{ template "msteams.default.text" . }}' ]
 
 # The HTTP client's configuration.
 [ http_config: <http_config> | default = global.http_config ]


### PR DESCRIPTION
now fits to https://github.com/prometheus/alertmanager/blob/v0.26.0/config/notifiers.go#L168-L175

similar to https://github.com/prometheus/alertmanager/pull/3495; introduced in https://github.com/prometheus/alertmanager/pull/3324