### PR TITLE
Update configuration docs for Repeat interval

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -200,7 +200,7 @@ matchers:
 # Note that this parameter is implicitly bound by Alertmanager's
 # `--data.retention` configuration flag. Notifications will be resent after either
 # repeat_interval or the data retention period have passed, whichever
-# occurs first. `repeat_interval` should not be less than `group_interval`.
+# occurs first. `repeat_interval` should be a multiple of `group_interval`.
 [ repeat_interval: <duration> | default = 4h ]
 
 # Times when the route should be muted. These must match the name of a


### PR DESCRIPTION
Although it is true that Repeat interval should be greater than or equal to the Group interval, it should also be a multiple of it too. If the Repeat interval is not a multiple, then because of how aggregation groups are flushed, it will be made into one implicitly. This commit documents this behavior.