### PR TITLE
Refactor: Move `inTimeIntervals` from `notify` to `timeinterval`

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -478,6 +478,8 @@ func run() int {
 			timeIntervals[ti.Name] = ti.TimeIntervals
 		}
 
+		intervener := timeinterval.NewIntervener(timeIntervals)
+
 		inhibitor.Stop()
 		disp.Stop()
 
@@ -497,7 +499,7 @@ func run() int {
 			waitFunc,
 			inhibitor,
 			silencer,
-			timeIntervals,
+			intervener,
 			notificationLog,
 			pipelinePeer,
 		)

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -894,7 +894,6 @@ func (tms TimeMuteStage) Exec(ctx context.Context, l log.Logger, alerts ...*type
 		return ctx, alerts, nil
 	}
 
-	//muted, err := inTimeIntervals(now, tms.Times, muteTimeIntervalNames)
 	muted, err := tms.muter.Mutes(muteTimeIntervalNames, now)
 	if err != nil {
 		return ctx, alerts, err

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -869,7 +869,6 @@ func (n SetNotifiesStage) Exec(ctx context.Context, l log.Logger, alerts ...*typ
 
 type timeStage struct {
 	muter types.TimeMuter
-	//Times map[string][]timeinterval.TimeInterval
 }
 
 type TimeMuteStage timeStage

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -374,7 +374,7 @@ func (pb *PipelineBuilder) New(
 	wait func() time.Duration,
 	inhibitor *inhibit.Inhibitor,
 	silencer *silence.Silencer,
-	times map[string][]timeinterval.TimeInterval,
+	intervener *timeinterval.Intervener,
 	notificationLog NotificationLog,
 	peer Peer,
 ) RoutingStage {
@@ -382,8 +382,8 @@ func (pb *PipelineBuilder) New(
 
 	ms := NewGossipSettleStage(peer)
 	is := NewMuteStage(inhibitor)
-	tas := NewTimeActiveStage(times)
-	tms := NewTimeMuteStage(times)
+	tas := NewTimeActiveStage(intervener)
+	tms := NewTimeMuteStage(intervener)
 	ss := NewMuteStage(silencer)
 
 	for name := range receivers {
@@ -868,13 +868,14 @@ func (n SetNotifiesStage) Exec(ctx context.Context, l log.Logger, alerts ...*typ
 }
 
 type timeStage struct {
-	Times map[string][]timeinterval.TimeInterval
+	muter types.TimeMuter
+	//Times map[string][]timeinterval.TimeInterval
 }
 
 type TimeMuteStage timeStage
 
-func NewTimeMuteStage(ti map[string][]timeinterval.TimeInterval) *TimeMuteStage {
-	return &TimeMuteStage{ti}
+func NewTimeMuteStage(m types.TimeMuter) *TimeMuteStage {
+	return &TimeMuteStage{m}
 }
 
 // Exec implements the stage interface for TimeMuteStage.
@@ -889,7 +890,13 @@ func (tms TimeMuteStage) Exec(ctx context.Context, l log.Logger, alerts ...*type
 		return ctx, alerts, errors.New("missing now timestamp")
 	}
 
-	muted, err := inTimeIntervals(now, tms.Times, muteTimeIntervalNames)
+	// Skip this stage if there are no mute timings.
+	if len(muteTimeIntervalNames) == 0 {
+		return ctx, alerts, nil
+	}
+
+	//muted, err := inTimeIntervals(now, tms.Times, muteTimeIntervalNames)
+	muted, err := tms.muter.Mutes(muteTimeIntervalNames, now)
 	if err != nil {
 		return ctx, alerts, err
 	}
@@ -904,8 +911,9 @@ func (tms TimeMuteStage) Exec(ctx context.Context, l log.Logger, alerts ...*type
 
 type TimeActiveStage timeStage
 
-func NewTimeActiveStage(ti map[string][]timeinterval.TimeInterval) *TimeActiveStage {
-	return &TimeActiveStage{ti}
+// func NewTimeActiveStage(ti map[string][]timeinterval.TimeInterval) *TimeActiveStage {
+func NewTimeActiveStage(m types.TimeMuter) *TimeActiveStage {
+	return &TimeActiveStage{m}
 }
 
 // Exec implements the stage interface for TimeActiveStage.
@@ -926,32 +934,16 @@ func (tas TimeActiveStage) Exec(ctx context.Context, l log.Logger, alerts ...*ty
 		return ctx, alerts, errors.New("missing now timestamp")
 	}
 
-	active, err := inTimeIntervals(now, tas.Times, activeTimeIntervalNames)
+	muted, err := tas.muter.Mutes(activeTimeIntervalNames, now)
 	if err != nil {
 		return ctx, alerts, err
 	}
 
 	// If the current time is not inside an active time, all alerts are removed from the pipeline
-	if !active {
+	if !muted {
 		level.Debug(l).Log("msg", "Notifications not sent, route is not within active time")
 		return ctx, nil, nil
 	}
 
 	return ctx, alerts, nil
-}
-
-// inTimeIntervals returns true if the current time is contained in one of the given time intervals.
-func inTimeIntervals(now time.Time, intervals map[string][]timeinterval.TimeInterval, intervalNames []string) (bool, error) {
-	for _, name := range intervalNames {
-		interval, ok := intervals[name]
-		if !ok {
-			return false, errors.Errorf("time interval %s doesn't exist in config", name)
-		}
-		for _, ti := range interval {
-			if ti.ContainsTime(now.UTC()) {
-				return true, nil
-			}
-		}
-	}
-	return false, nil
 }

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -909,7 +909,6 @@ func (tms TimeMuteStage) Exec(ctx context.Context, l log.Logger, alerts ...*type
 
 type TimeActiveStage timeStage
 
-// func NewTimeActiveStage(ti map[string][]timeinterval.TimeInterval) *TimeActiveStage {
 func NewTimeActiveStage(m types.TimeMuter) *TimeActiveStage {
 	return &TimeActiveStage{m}
 }

--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -840,7 +840,8 @@ func TestTimeMuteStage(t *testing.T) {
 		t.Fatalf("Couldn't unmarshal time interval %s", err)
 	}
 	m := map[string][]timeinterval.TimeInterval{"test": intervals}
-	stage := NewTimeMuteStage(m)
+	intervener := timeinterval.NewIntervener(m)
+	stage := NewTimeMuteStage(intervener)
 
 	outAlerts := []*types.Alert{}
 	nonMuteCount := 0
@@ -924,7 +925,8 @@ func TestTimeActiveStage(t *testing.T) {
 		t.Fatalf("Couldn't unmarshal time interval %s", err)
 	}
 	m := map[string][]timeinterval.TimeInterval{"test": intervals}
-	stage := NewTimeActiveStage(m)
+	intervener := timeinterval.NewIntervener(m)
+	stage := NewTimeActiveStage(intervener)
 
 	outAlerts := []*types.Alert{}
 	nonMuteCount := 0

--- a/timeinterval/timeinterval.go
+++ b/timeinterval/timeinterval.go
@@ -27,6 +27,8 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+// Intervener determines whether a given time and active route time interval should mute outgoing notifications.
+// It implements the TimeMuter interface.
 type Intervener struct {
 	intervals map[string][]TimeInterval
 }

--- a/timeinterval/timeinterval.go
+++ b/timeinterval/timeinterval.go
@@ -27,6 +27,33 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+type Intervener struct {
+	intervals map[string][]TimeInterval
+}
+
+func (i *Intervener) Mutes(names []string, now time.Time) (bool, error) {
+	for _, name := range names {
+		interval, ok := i.intervals[name]
+		if !ok {
+			return false, fmt.Errorf("time interval %s doesn't exist in config", name)
+		}
+
+		for _, ti := range interval {
+			if ti.ContainsTime(now.UTC()) {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}
+
+func NewIntervener(ti map[string][]TimeInterval) *Intervener {
+	return &Intervener{
+		intervals: ti,
+	}
+}
+
 // TimeInterval describes intervals of time. ContainsTime will tell you if a golang time is contained
 // within the interval.
 type TimeInterval struct {
@@ -435,9 +462,6 @@ func (ir InclusiveRange) MarshalYAML() (interface{}, error) {
 	bytes, err := ir.MarshalText()
 	return string(bytes), err
 }
-
-// TimeLayout specifies the layout to be used in time.Parse() calls for time intervals.
-const TimeLayout = "15:04"
 
 var (
 	validTime   = "^((([01][0-9])|(2[0-3])):[0-5][0-9])$|(^24:00$)"

--- a/types/types.go
+++ b/types/types.go
@@ -381,6 +381,12 @@ type Muter interface {
 	Mutes(model.LabelSet) bool
 }
 
+// TODO
+type TimeMuter interface {
+	//TODO: I don't think this should return an error but let's keep it consistent for now.
+	Mutes(timeIntervalName []string, now time.Time) (bool, error)
+}
+
 // A MuteFunc is a function that implements the Muter interface.
 type MuteFunc func(model.LabelSet) bool
 

--- a/types/types.go
+++ b/types/types.go
@@ -381,9 +381,8 @@ type Muter interface {
 	Mutes(model.LabelSet) bool
 }
 
-// TODO
+// TimeMuter determines if alerts should be muted based on the specified current time and active time interval on the route.
 type TimeMuter interface {
-	//TODO: I don't think this should return an error but let's keep it consistent for now.
 	Mutes(timeIntervalName []string, now time.Time) (bool, error)
 }
 


### PR DESCRIPTION
This should make implementing #3520 a bit cleaner given that we shouldn't need to introduce a direct dependency on marker in `notify`.

There's absolutely no change of functionality here and I've expanded coverage for similar logic in both places.