### PR TITLE
Add duration to the notify success message

### DIFF
--- a/notify/notify.go
+++ b/notify/notify.go
@@ -792,7 +792,8 @@ func (r RetryStage) exec(ctx context.Context, l log.Logger, alerts ...*types.Ale
 		case <-tick.C:
 			now := time.Now()
 			retry, err := r.integration.Notify(ctx, sent...)
-			r.metrics.notificationLatencySeconds.WithLabelValues(r.labelValues...).Observe(time.Since(now).Seconds())
+			dur := time.Since(now)
+			r.metrics.notificationLatencySeconds.WithLabelValues(r.labelValues...).Observe(dur.Seconds())
 			r.metrics.numNotificationRequestsTotal.WithLabelValues(r.labelValues...).Inc()
 			if err != nil {
 				r.metrics.numNotificationRequestsFailedTotal.WithLabelValues(r.labelValues...).Inc()
@@ -813,7 +814,7 @@ func (r RetryStage) exec(ctx context.Context, l log.Logger, alerts ...*types.Ale
 					lvl = level.Debug(log.With(l, "alerts", fmt.Sprintf("%v", alerts)))
 				}
 
-				lvl.Log("msg", "Notify success", "attempts", i)
+				lvl.Log("msg", "Notify success", "attempts", i, "duration", dur)
 				return ctx, alerts, nil
 			}
 		case <-ctx.Done():


### PR DESCRIPTION
This commit updates Alertmanager to add a duration to the notify success message. It complements the existing histogram to offer fine-grained information about notification attempts. This can be useful when debuggin duplicate notifications, for example, when the duration exceeds peer_timeout.

```
ts=2023-10-16T19:22:49.666Z caller=notify.go:817 level=debug component=dispatcher receiver=test integration=webhook[0] aggrGroup={}:{} alerts=[[6ad8c19][active]] msg="Notify success" attempts=1 duration=3.064417ms
```