### PR TITLE
Replace Intervener with ActiveIntervener and MuteIntervener

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -478,7 +478,8 @@ func run() int {
 			timeIntervals[ti.Name] = ti.TimeIntervals
 		}
 
-		intervener := timeinterval.NewIntervener(timeIntervals)
+		activeIntervener := timeinterval.NewActiveIntervener(timeIntervals)
+		muteIntervener := timeinterval.NewMuteIntervener(timeIntervals)
 
 		inhibitor.Stop()
 		disp.Stop()
@@ -499,7 +500,8 @@ func run() int {
 			waitFunc,
 			inhibitor,
 			silencer,
-			intervener,
+			activeIntervener,
+			muteIntervener,
 			notificationLog,
 			pipelinePeer,
 		)

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -939,7 +939,7 @@ func (tas TimeActiveStage) Exec(ctx context.Context, l log.Logger, alerts ...*ty
 	}
 
 	// If the current time is not inside an active time, all alerts are removed from the pipeline
-	if !muted {
+	if muted {
 		level.Debug(l).Log("msg", "Notifications not sent, route is not within active time")
 		return ctx, nil, nil
 	}

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -374,7 +374,8 @@ func (pb *PipelineBuilder) New(
 	wait func() time.Duration,
 	inhibitor *inhibit.Inhibitor,
 	silencer *silence.Silencer,
-	intervener *timeinterval.Intervener,
+	activeIntervener *timeinterval.ActiveIntervener,
+	muteIntervener *timeinterval.MuteIntervener,
 	notificationLog NotificationLog,
 	peer Peer,
 ) RoutingStage {
@@ -382,8 +383,8 @@ func (pb *PipelineBuilder) New(
 
 	ms := NewGossipSettleStage(peer)
 	is := NewMuteStage(inhibitor)
-	tas := NewTimeActiveStage(intervener)
-	tms := NewTimeMuteStage(intervener)
+	tas := NewTimeActiveStage(activeIntervener)
+	tms := NewTimeMuteStage(muteIntervener)
 	ss := NewMuteStage(silencer)
 
 	for name := range receivers {

--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -879,7 +879,7 @@ func TestTimeMuteStage(t *testing.T) {
 
 func TestTimeActiveStage(t *testing.T) {
 	// Route mutes alerts inside business hours if it is an active time interval
-	muteIn := `
+	muteOut := `
 ---
 - weekdays: ['monday:friday']
   times:
@@ -920,12 +920,12 @@ func TestTimeActiveStage(t *testing.T) {
 		},
 	}
 	var intervals []timeinterval.TimeInterval
-	err := yaml.Unmarshal([]byte(muteIn), &intervals)
+	err := yaml.Unmarshal([]byte(muteOut), &intervals)
 	if err != nil {
 		t.Fatalf("Couldn't unmarshal time interval %s", err)
 	}
 	m := map[string][]timeinterval.TimeInterval{"test": intervals}
-	intervener := timeinterval.NewMuteIntervener(m)
+	intervener := timeinterval.NewActiveIntervener(m)
 	stage := NewTimeActiveStage(intervener)
 
 	outAlerts := []*types.Alert{}

--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -840,7 +840,7 @@ func TestTimeMuteStage(t *testing.T) {
 		t.Fatalf("Couldn't unmarshal time interval %s", err)
 	}
 	m := map[string][]timeinterval.TimeInterval{"test": intervals}
-	intervener := timeinterval.NewIntervener(m)
+	intervener := timeinterval.NewMuteIntervener(m)
 	stage := NewTimeMuteStage(intervener)
 
 	outAlerts := []*types.Alert{}
@@ -925,7 +925,7 @@ func TestTimeActiveStage(t *testing.T) {
 		t.Fatalf("Couldn't unmarshal time interval %s", err)
 	}
 	m := map[string][]timeinterval.TimeInterval{"test": intervals}
-	intervener := timeinterval.NewIntervener(m)
+	intervener := timeinterval.NewMuteIntervener(m)
 	stage := NewTimeActiveStage(intervener)
 
 	outAlerts := []*types.Alert{}

--- a/timeinterval/timeinterval.go
+++ b/timeinterval/timeinterval.go
@@ -27,31 +27,56 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// Intervener determines whether a given time and active route time interval should mute outgoing notifications.
+// MuteIntervener determines whether the mute time interval should mute outgoing notifications.
 // It implements the TimeMuter interface.
-type Intervener struct {
+type MuteIntervener struct {
 	intervals map[string][]TimeInterval
 }
 
-func (i *Intervener) Mutes(names []string, now time.Time) (bool, error) {
+func (i *MuteIntervener) Mutes(names []string, now time.Time) (bool, error) {
 	for _, name := range names {
 		interval, ok := i.intervals[name]
 		if !ok {
-			return false, fmt.Errorf("time interval %s doesn't exist in config", name)
+			return false, fmt.Errorf("mute time interval %s doesn't exist in config", name)
 		}
-
 		for _, ti := range interval {
 			if ti.ContainsTime(now.UTC()) {
 				return true, nil
 			}
 		}
 	}
-
 	return false, nil
 }
 
-func NewIntervener(ti map[string][]TimeInterval) *Intervener {
-	return &Intervener{
+func NewMuteIntervener(ti map[string][]TimeInterval) *MuteIntervener {
+	return &MuteIntervener{
+		intervals: ti,
+	}
+}
+
+// ActiveIntervener determines whether the active time interval should mute outgoing notifications.
+// It implements the TimeMuter interface.
+type ActiveIntervener struct {
+	intervals map[string][]TimeInterval
+}
+
+func (i *ActiveIntervener) Mutes(names []string, now time.Time) (bool, error) {
+	for _, name := range names {
+		interval, ok := i.intervals[name]
+		if !ok {
+			return false, fmt.Errorf("active time interval %s doesn't exist in config", name)
+		}
+		for _, ti := range interval {
+			if ti.ContainsTime(now.UTC()) {
+				return false, nil
+			}
+		}
+	}
+	return true, nil
+}
+
+func NewActiveIntervener(ti map[string][]TimeInterval) *ActiveIntervener {
+	return &ActiveIntervener{
 		intervals: ti,
 	}
 }

--- a/timeinterval/timeinterval_test.go
+++ b/timeinterval/timeinterval_test.go
@@ -661,7 +661,93 @@ func mustLoadLocation(name string) *time.Location {
 	return loc
 }
 
-func TestIntervener_Mutes(t *testing.T) {
+func TestActiveIntervener_Mutes(t *testing.T) {
+	// muteOut mutes alerts outside business hours, using the +1 timezone.
+	muteOut := `
+---
+- weekdays:
+    - monday:friday
+  location: Europe/Berlin
+  months:
+    - November
+  times:
+    - start_time: 09:00
+      end_time: 17:00
+`
+	intervalName := "test"
+	var intervals []TimeInterval
+	err := yaml.Unmarshal([]byte(muteOut), &intervals)
+	require.NoError(t, err)
+	m := map[string][]TimeInterval{intervalName: intervals}
+
+	tc := []struct {
+		name     string
+		firedAt  string
+		expected bool
+		err      error
+	}{
+		{
+			name:     "Should not mute on Friday during business hours",
+			firedAt:  "19 Nov 21 13:00 +0100",
+			expected: false,
+		},
+		{
+			name:     "Should not mute on a Tuesday before 5pm",
+			firedAt:  "16 Nov 21 16:59 +0100",
+			expected: false,
+		},
+		{
+			name:     "Should mute on a Saturday",
+			firedAt:  "20 Nov 21 10:00 +0100",
+			expected: true,
+		},
+		{
+			name:     "Should mute before 9am on a Wednesday",
+			firedAt:  "17 Nov 21 05:00 +0100",
+			expected: true,
+		},
+		{
+			name:     "Should mute even if we are in a different timezone (KST)",
+			firedAt:  "14 Nov 21 20:00 +0900",
+			expected: true,
+		},
+		{
+			name:     "Should mute even if the timezone is UTC",
+			firedAt:  "14 Nov 21 21:30 +0000",
+			expected: true,
+		},
+		{
+			name:     "Should not mute different timezone (EET)",
+			firedAt:  "15 Nov 22 14:30 +0200",
+			expected: false,
+		},
+		{
+			name:     "Should mute in a different timezone (PET)",
+			firedAt:  "15 Nov 21 02:00 -0500",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			now, err := time.Parse(time.RFC822Z, tt.firedAt)
+			require.NoError(t, err)
+
+			intervener := NewActiveIntervener(m)
+
+			expected, err := intervener.Mutes([]string{intervalName}, now)
+			if err != nil {
+				require.Error(t, tt.err)
+				require.False(t, tt.expected)
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, expected, tt.expected)
+		})
+	}
+}
+
+func TestMuteIntervener_Mutes(t *testing.T) {
 	// muteIn mutes alerts outside business hours in November, using the +1100 timezone.
 	muteIn := `
 ---
@@ -741,7 +827,7 @@ func TestIntervener_Mutes(t *testing.T) {
 			now, err := time.Parse(time.RFC822Z, tt.firedAt)
 			require.NoError(t, err)
 
-			intervener := NewIntervener(m)
+			intervener := NewMuteIntervener(m)
 
 			expected, err := intervener.Mutes([]string{intervalName}, now)
 			if err != nil {


### PR DESCRIPTION
This commit replaces the Intervener in timeinterval package with an ActiveIntervener and a MuteIntervener for active time intervals and mute time intervals. It avoids having a double-negative in TimeActiveStage where Mute returns true if its not muted rather than if it is muted, and will also enable us to mark alerts as muted or not within ActiveIntervener and MuteIntervener.