### PR TITLE
Bump: go-swagger to latest stable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ SWAGGER = docker run \
 	--user=$(shell id -u $(USER)):$(shell id -g $(USER)) \
 	--rm \
 	-v $(shell pwd):/go/src/github.com/prometheus/alertmanager \
-	-w /go/src/github.com/prometheus/alertmanager quay.io/goswagger/swagger:v0.30.3
+	-w /go/src/github.com/prometheus/alertmanager quay.io/goswagger/swagger:v0.30.5
 
 api/v2/models api/v2/restapi api/v2/client: api/v2/openapi.yaml
 	-rm -r api/v2/{client,models,restapi}

--- a/api/v2/client/alert/get_alerts_responses.go
+++ b/api/v2/client/alert/get_alerts_responses.go
@@ -56,7 +56,7 @@ func (o *GetAlertsReader) ReadResponse(response runtime.ClientResponse, consumer
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /alerts] getAlerts", response, response.Code())
 	}
 }
 
@@ -97,6 +97,11 @@ func (o *GetAlertsOK) IsServerError() bool {
 // IsCode returns true when this get alerts o k response a status code equal to that given
 func (o *GetAlertsOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get alerts o k response
+func (o *GetAlertsOK) Code() int {
+	return 200
 }
 
 func (o *GetAlertsOK) Error() string {
@@ -160,6 +165,11 @@ func (o *GetAlertsBadRequest) IsCode(code int) bool {
 	return code == 400
 }
 
+// Code gets the status code for the get alerts bad request response
+func (o *GetAlertsBadRequest) Code() int {
+	return 400
+}
+
 func (o *GetAlertsBadRequest) Error() string {
 	return fmt.Sprintf("[GET /alerts][%d] getAlertsBadRequest  %+v", 400, o.Payload)
 }
@@ -219,6 +229,11 @@ func (o *GetAlertsInternalServerError) IsServerError() bool {
 // IsCode returns true when this get alerts internal server error response a status code equal to that given
 func (o *GetAlertsInternalServerError) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the get alerts internal server error response
+func (o *GetAlertsInternalServerError) Code() int {
+	return 500
 }
 
 func (o *GetAlertsInternalServerError) Error() string {

--- a/api/v2/client/alert/post_alerts_responses.go
+++ b/api/v2/client/alert/post_alerts_responses.go
@@ -54,7 +54,7 @@ func (o *PostAlertsReader) ReadResponse(response runtime.ClientResponse, consume
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[POST /alerts] postAlerts", response, response.Code())
 	}
 }
 
@@ -94,6 +94,11 @@ func (o *PostAlertsOK) IsServerError() bool {
 // IsCode returns true when this post alerts o k response a status code equal to that given
 func (o *PostAlertsOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the post alerts o k response
+func (o *PostAlertsOK) Code() int {
+	return 200
 }
 
 func (o *PostAlertsOK) Error() string {
@@ -146,6 +151,11 @@ func (o *PostAlertsBadRequest) IsServerError() bool {
 // IsCode returns true when this post alerts bad request response a status code equal to that given
 func (o *PostAlertsBadRequest) IsCode(code int) bool {
 	return code == 400
+}
+
+// Code gets the status code for the post alerts bad request response
+func (o *PostAlertsBadRequest) Code() int {
+	return 400
 }
 
 func (o *PostAlertsBadRequest) Error() string {
@@ -207,6 +217,11 @@ func (o *PostAlertsInternalServerError) IsServerError() bool {
 // IsCode returns true when this post alerts internal server error response a status code equal to that given
 func (o *PostAlertsInternalServerError) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the post alerts internal server error response
+func (o *PostAlertsInternalServerError) Code() int {
+	return 500
 }
 
 func (o *PostAlertsInternalServerError) Error() string {

--- a/api/v2/client/alertgroup/get_alert_groups_responses.go
+++ b/api/v2/client/alertgroup/get_alert_groups_responses.go
@@ -56,7 +56,7 @@ func (o *GetAlertGroupsReader) ReadResponse(response runtime.ClientResponse, con
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /alerts/groups] getAlertGroups", response, response.Code())
 	}
 }
 
@@ -97,6 +97,11 @@ func (o *GetAlertGroupsOK) IsServerError() bool {
 // IsCode returns true when this get alert groups o k response a status code equal to that given
 func (o *GetAlertGroupsOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get alert groups o k response
+func (o *GetAlertGroupsOK) Code() int {
+	return 200
 }
 
 func (o *GetAlertGroupsOK) Error() string {
@@ -160,6 +165,11 @@ func (o *GetAlertGroupsBadRequest) IsCode(code int) bool {
 	return code == 400
 }
 
+// Code gets the status code for the get alert groups bad request response
+func (o *GetAlertGroupsBadRequest) Code() int {
+	return 400
+}
+
 func (o *GetAlertGroupsBadRequest) Error() string {
 	return fmt.Sprintf("[GET /alerts/groups][%d] getAlertGroupsBadRequest  %+v", 400, o.Payload)
 }
@@ -219,6 +229,11 @@ func (o *GetAlertGroupsInternalServerError) IsServerError() bool {
 // IsCode returns true when this get alert groups internal server error response a status code equal to that given
 func (o *GetAlertGroupsInternalServerError) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the get alert groups internal server error response
+func (o *GetAlertGroupsInternalServerError) Code() int {
+	return 500
 }
 
 func (o *GetAlertGroupsInternalServerError) Error() string {

--- a/api/v2/client/general/get_status_responses.go
+++ b/api/v2/client/general/get_status_responses.go
@@ -44,7 +44,7 @@ func (o *GetStatusReader) ReadResponse(response runtime.ClientResponse, consumer
 		}
 		return result, nil
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /status] getStatus", response, response.Code())
 	}
 }
 
@@ -85,6 +85,11 @@ func (o *GetStatusOK) IsServerError() bool {
 // IsCode returns true when this get status o k response a status code equal to that given
 func (o *GetStatusOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get status o k response
+func (o *GetStatusOK) Code() int {
+	return 200
 }
 
 func (o *GetStatusOK) Error() string {

--- a/api/v2/client/receiver/get_receivers_responses.go
+++ b/api/v2/client/receiver/get_receivers_responses.go
@@ -44,7 +44,7 @@ func (o *GetReceiversReader) ReadResponse(response runtime.ClientResponse, consu
 		}
 		return result, nil
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /receivers] getReceivers", response, response.Code())
 	}
 }
 
@@ -85,6 +85,11 @@ func (o *GetReceiversOK) IsServerError() bool {
 // IsCode returns true when this get receivers o k response a status code equal to that given
 func (o *GetReceiversOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get receivers o k response
+func (o *GetReceiversOK) Code() int {
+	return 200
 }
 
 func (o *GetReceiversOK) Error() string {

--- a/api/v2/client/silence/delete_silence_responses.go
+++ b/api/v2/client/silence/delete_silence_responses.go
@@ -54,7 +54,7 @@ func (o *DeleteSilenceReader) ReadResponse(response runtime.ClientResponse, cons
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[DELETE /silence/{silenceID}] deleteSilence", response, response.Code())
 	}
 }
 
@@ -94,6 +94,11 @@ func (o *DeleteSilenceOK) IsServerError() bool {
 // IsCode returns true when this delete silence o k response a status code equal to that given
 func (o *DeleteSilenceOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the delete silence o k response
+func (o *DeleteSilenceOK) Code() int {
+	return 200
 }
 
 func (o *DeleteSilenceOK) Error() string {
@@ -147,6 +152,11 @@ func (o *DeleteSilenceNotFound) IsCode(code int) bool {
 	return code == 404
 }
 
+// Code gets the status code for the delete silence not found response
+func (o *DeleteSilenceNotFound) Code() int {
+	return 404
+}
+
 func (o *DeleteSilenceNotFound) Error() string {
 	return fmt.Sprintf("[DELETE /silence/{silenceID}][%d] deleteSilenceNotFound ", 404)
 }
@@ -197,6 +207,11 @@ func (o *DeleteSilenceInternalServerError) IsServerError() bool {
 // IsCode returns true when this delete silence internal server error response a status code equal to that given
 func (o *DeleteSilenceInternalServerError) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the delete silence internal server error response
+func (o *DeleteSilenceInternalServerError) Code() int {
+	return 500
 }
 
 func (o *DeleteSilenceInternalServerError) Error() string {

--- a/api/v2/client/silence/get_silence_responses.go
+++ b/api/v2/client/silence/get_silence_responses.go
@@ -56,7 +56,7 @@ func (o *GetSilenceReader) ReadResponse(response runtime.ClientResponse, consume
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /silence/{silenceID}] getSilence", response, response.Code())
 	}
 }
 
@@ -97,6 +97,11 @@ func (o *GetSilenceOK) IsServerError() bool {
 // IsCode returns true when this get silence o k response a status code equal to that given
 func (o *GetSilenceOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get silence o k response
+func (o *GetSilenceOK) Code() int {
+	return 200
 }
 
 func (o *GetSilenceOK) Error() string {
@@ -161,6 +166,11 @@ func (o *GetSilenceNotFound) IsCode(code int) bool {
 	return code == 404
 }
 
+// Code gets the status code for the get silence not found response
+func (o *GetSilenceNotFound) Code() int {
+	return 404
+}
+
 func (o *GetSilenceNotFound) Error() string {
 	return fmt.Sprintf("[GET /silence/{silenceID}][%d] getSilenceNotFound ", 404)
 }
@@ -211,6 +221,11 @@ func (o *GetSilenceInternalServerError) IsServerError() bool {
 // IsCode returns true when this get silence internal server error response a status code equal to that given
 func (o *GetSilenceInternalServerError) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the get silence internal server error response
+func (o *GetSilenceInternalServerError) Code() int {
+	return 500
 }
 
 func (o *GetSilenceInternalServerError) Error() string {

--- a/api/v2/client/silence/get_silences_responses.go
+++ b/api/v2/client/silence/get_silences_responses.go
@@ -50,7 +50,7 @@ func (o *GetSilencesReader) ReadResponse(response runtime.ClientResponse, consum
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /silences] getSilences", response, response.Code())
 	}
 }
 
@@ -91,6 +91,11 @@ func (o *GetSilencesOK) IsServerError() bool {
 // IsCode returns true when this get silences o k response a status code equal to that given
 func (o *GetSilencesOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the get silences o k response
+func (o *GetSilencesOK) Code() int {
+	return 200
 }
 
 func (o *GetSilencesOK) Error() string {
@@ -152,6 +157,11 @@ func (o *GetSilencesInternalServerError) IsServerError() bool {
 // IsCode returns true when this get silences internal server error response a status code equal to that given
 func (o *GetSilencesInternalServerError) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the get silences internal server error response
+func (o *GetSilencesInternalServerError) Code() int {
+	return 500
 }
 
 func (o *GetSilencesInternalServerError) Error() string {

--- a/api/v2/client/silence/post_silences_responses.go
+++ b/api/v2/client/silence/post_silences_responses.go
@@ -56,7 +56,7 @@ func (o *PostSilencesReader) ReadResponse(response runtime.ClientResponse, consu
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[POST /silences] postSilences", response, response.Code())
 	}
 }
 
@@ -97,6 +97,11 @@ func (o *PostSilencesOK) IsServerError() bool {
 // IsCode returns true when this post silences o k response a status code equal to that given
 func (o *PostSilencesOK) IsCode(code int) bool {
 	return code == 200
+}
+
+// Code gets the status code for the post silences o k response
+func (o *PostSilencesOK) Code() int {
+	return 200
 }
 
 func (o *PostSilencesOK) Error() string {
@@ -162,6 +167,11 @@ func (o *PostSilencesBadRequest) IsCode(code int) bool {
 	return code == 400
 }
 
+// Code gets the status code for the post silences bad request response
+func (o *PostSilencesBadRequest) Code() int {
+	return 400
+}
+
 func (o *PostSilencesBadRequest) Error() string {
 	return fmt.Sprintf("[POST /silences][%d] postSilencesBadRequest  %+v", 400, o.Payload)
 }
@@ -221,6 +231,11 @@ func (o *PostSilencesNotFound) IsServerError() bool {
 // IsCode returns true when this post silences not found response a status code equal to that given
 func (o *PostSilencesNotFound) IsCode(code int) bool {
 	return code == 404
+}
+
+// Code gets the status code for the post silences not found response
+func (o *PostSilencesNotFound) Code() int {
+	return 404
 }
 
 func (o *PostSilencesNotFound) Error() string {

--- a/api/v2/models/alert_group.go
+++ b/api/v2/models/alert_group.go
@@ -163,6 +163,11 @@ func (m *AlertGroup) contextValidateAlerts(ctx context.Context, formats strfmt.R
 	for i := 0; i < len(m.Alerts); i++ {
 
 		if m.Alerts[i] != nil {
+
+			if swag.IsZero(m.Alerts[i]) { // not required
+				return nil
+			}
+
 			if err := m.Alerts[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("alerts" + "." + strconv.Itoa(i))
@@ -195,6 +200,7 @@ func (m *AlertGroup) contextValidateLabels(ctx context.Context, formats strfmt.R
 func (m *AlertGroup) contextValidateReceiver(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Receiver != nil {
+
 		if err := m.Receiver.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("receiver")

--- a/api/v2/models/alert_groups.go
+++ b/api/v2/models/alert_groups.go
@@ -68,6 +68,11 @@ func (m AlertGroups) ContextValidate(ctx context.Context, formats strfmt.Registr
 	for i := 0; i < len(m); i++ {
 
 		if m[i] != nil {
+
+			if swag.IsZero(m[i]) { // not required
+				return nil
+			}
+
 			if err := m[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName(strconv.Itoa(i))

--- a/api/v2/models/alertmanager_status.go
+++ b/api/v2/models/alertmanager_status.go
@@ -175,6 +175,7 @@ func (m *AlertmanagerStatus) ContextValidate(ctx context.Context, formats strfmt
 func (m *AlertmanagerStatus) contextValidateCluster(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Cluster != nil {
+
 		if err := m.Cluster.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cluster")
@@ -191,6 +192,7 @@ func (m *AlertmanagerStatus) contextValidateCluster(ctx context.Context, formats
 func (m *AlertmanagerStatus) contextValidateConfig(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Config != nil {
+
 		if err := m.Config.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("config")
@@ -207,6 +209,7 @@ func (m *AlertmanagerStatus) contextValidateConfig(ctx context.Context, formats 
 func (m *AlertmanagerStatus) contextValidateVersionInfo(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.VersionInfo != nil {
+
 		if err := m.VersionInfo.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("versionInfo")

--- a/api/v2/models/cluster_status.go
+++ b/api/v2/models/cluster_status.go
@@ -156,6 +156,11 @@ func (m *ClusterStatus) contextValidatePeers(ctx context.Context, formats strfmt
 	for i := 0; i < len(m.Peers); i++ {
 
 		if m.Peers[i] != nil {
+
+			if swag.IsZero(m.Peers[i]) { // not required
+				return nil
+			}
+
 			if err := m.Peers[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("peers" + "." + strconv.Itoa(i))

--- a/api/v2/models/gettable_alert.go
+++ b/api/v2/models/gettable_alert.go
@@ -366,6 +366,11 @@ func (m *GettableAlert) contextValidateReceivers(ctx context.Context, formats st
 	for i := 0; i < len(m.Receivers); i++ {
 
 		if m.Receivers[i] != nil {
+
+			if swag.IsZero(m.Receivers[i]) { // not required
+				return nil
+			}
+
 			if err := m.Receivers[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("receivers" + "." + strconv.Itoa(i))
@@ -384,6 +389,7 @@ func (m *GettableAlert) contextValidateReceivers(ctx context.Context, formats st
 func (m *GettableAlert) contextValidateStatus(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Status != nil {
+
 		if err := m.Status.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")

--- a/api/v2/models/gettable_alerts.go
+++ b/api/v2/models/gettable_alerts.go
@@ -68,6 +68,11 @@ func (m GettableAlerts) ContextValidate(ctx context.Context, formats strfmt.Regi
 	for i := 0; i < len(m); i++ {
 
 		if m[i] != nil {
+
+			if swag.IsZero(m[i]) { // not required
+				return nil
+			}
+
 			if err := m[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName(strconv.Itoa(i))

--- a/api/v2/models/gettable_silence.go
+++ b/api/v2/models/gettable_silence.go
@@ -202,6 +202,7 @@ func (m *GettableSilence) ContextValidate(ctx context.Context, formats strfmt.Re
 func (m *GettableSilence) contextValidateStatus(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Status != nil {
+
 		if err := m.Status.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")

--- a/api/v2/models/gettable_silences.go
+++ b/api/v2/models/gettable_silences.go
@@ -68,6 +68,11 @@ func (m GettableSilences) ContextValidate(ctx context.Context, formats strfmt.Re
 	for i := 0; i < len(m); i++ {
 
 		if m[i] != nil {
+
+			if swag.IsZero(m[i]) { // not required
+				return nil
+			}
+
 			if err := m[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName(strconv.Itoa(i))

--- a/api/v2/models/matchers.go
+++ b/api/v2/models/matchers.go
@@ -75,6 +75,11 @@ func (m Matchers) ContextValidate(ctx context.Context, formats strfmt.Registry) 
 	for i := 0; i < len(m); i++ {
 
 		if m[i] != nil {
+
+			if swag.IsZero(m[i]) { // not required
+				return nil
+			}
+
 			if err := m[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName(strconv.Itoa(i))

--- a/api/v2/models/postable_alert.go
+++ b/api/v2/models/postable_alert.go
@@ -203,6 +203,10 @@ func (m *PostableAlert) ContextValidate(ctx context.Context, formats strfmt.Regi
 
 func (m *PostableAlert) contextValidateAnnotations(ctx context.Context, formats strfmt.Registry) error {
 
+	if swag.IsZero(m.Annotations) { // not required
+		return nil
+	}
+
 	if err := m.Annotations.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("annotations")

--- a/api/v2/models/postable_alerts.go
+++ b/api/v2/models/postable_alerts.go
@@ -68,6 +68,11 @@ func (m PostableAlerts) ContextValidate(ctx context.Context, formats strfmt.Regi
 	for i := 0; i < len(m); i++ {
 
 		if m[i] != nil {
+
+			if swag.IsZero(m[i]) { // not required
+				return nil
+			}
+
 			if err := m[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName(strconv.Itoa(i))

--- a/api/v2/restapi/operations/alertmanager_api.go
+++ b/api/v2/restapi/operations/alertmanager_api.go
@@ -412,6 +412,6 @@ func (o *AlertmanagerAPI) AddMiddlewareFor(method, path string, builder middlewa
 	}
 	o.Init()
 	if h, ok := o.handlers[um][path]; ok {
-		o.handlers[method][path] = builder(h)
+		o.handlers[um][path] = builder(h)
 	}
 }


### PR DESCRIPTION
Bumps the API spec/client generation util of `go-swagger` from 0.30.2 to 0.30.5 which is the latest stable.

Signed-off-by: gotjosh <josue.abreu@gmail.com>
