### PR TITLE
feat: add counter to track alerts dropped outside of time_intervals

### DIFF
--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -876,7 +876,7 @@ func TestTimeMuteStage(t *testing.T) {
 	if len(outAlerts) != nonMuteCount {
 		t.Fatalf("Expected %d alerts after time mute stage but got %d", nonMuteCount, len(outAlerts))
 	}
-	suppressed := int(prom_testutil.ToFloat64(metrics.numAlertsSuppressedTotal))
+	suppressed := int(prom_testutil.ToFloat64(metrics.numNotificationSuppressedTotal))
 	if (len(cases) - nonMuteCount) != suppressed {
 		t.Fatalf("Expected %d alerts counted in suppressed metric but got %d", (len(cases) - nonMuteCount), suppressed)
 	}
@@ -971,7 +971,7 @@ func TestTimeActiveStage(t *testing.T) {
 	if len(outAlerts) != nonMuteCount {
 		t.Fatalf("Expected %d alerts after time mute stage but got %d", nonMuteCount, len(outAlerts))
 	}
-	suppressed := int(prom_testutil.ToFloat64(metrics.numAlertsSuppressedTotal))
+	suppressed := int(prom_testutil.ToFloat64(metrics.numNotificationSuppressedTotal))
 	if (len(cases) - nonMuteCount) != suppressed {
 		t.Fatalf("Expected %d alerts counted in suppressed metric but got %d", (len(cases) - nonMuteCount), suppressed)
 	}

--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -878,7 +878,7 @@ func TestTimeMuteStage(t *testing.T) {
 	}
 	suppressed := int(prom_testutil.ToFloat64(metrics.numAlertsSuppressedTotal))
 	if (len(cases) - nonMuteCount) != suppressed {
-		t.Fatalf("Expected %d alerts counted in suppressed metric but got %d", len(outAlerts), suppressed)
+		t.Fatalf("Expected %d alerts counted in suppressed metric but got %d", (len(cases) - nonMuteCount), suppressed)
 	}
 }
 
@@ -973,7 +973,7 @@ func TestTimeActiveStage(t *testing.T) {
 	}
 	suppressed := int(prom_testutil.ToFloat64(metrics.numAlertsSuppressedTotal))
 	if (len(cases) - nonMuteCount) != suppressed {
-		t.Fatalf("Expected %d alerts counted in suppressed metric but got %d", len(outAlerts), suppressed)
+		t.Fatalf("Expected %d alerts counted in suppressed metric but got %d", (len(cases) - nonMuteCount), suppressed)
 	}
 }
 


### PR DESCRIPTION
Addresses: #3512

This adds a new counter metric `alertmanager_alerts_supressed_total` that is incremented by `len(alerts)` when an alert is suppressed for being outside of a time_interval, ie inside of a mute_time_intervals or outside of an active_time_intervals.