### PR TITLE
Support UTF-8 label matchers: Remove braces from suggestion

### DIFF
--- a/matchers/compat/parse.go
+++ b/matchers/compat/parse.go
@@ -152,14 +152,12 @@ func fallbackMatchersParser(l log.Logger) matchersParser {
 				return nil, invalidErr
 			}
 			var sb strings.Builder
-			sb.WriteRune('{')
 			for i, n := range m {
 				sb.WriteString(n.String())
 				if i < len(m)-1 {
 					sb.WriteRune(',')
 				}
 			}
-			sb.WriteRune('}')
 			suggestion := sb.String()
 			// The input is valid in the old pkg/labels parser, but not the
 			// new matchers/parse parser.


### PR DESCRIPTION
This commit removes the open and close braces from the suggestion as braces do not make sense in the configuration file. This does not change the behavior of the suggestion whatsoever as these are optional.