### PR TITLE
Support UTF-8 label matchers: Update the docs on how to use UTF-8 in label matchers and parse mode feature flags

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -486,9 +486,9 @@ A UTF-8 matcher consists of three tokens:
 - One of  `=`, `!=`, `=~`, or `!~`. `=` means equals, `!=` means not equal, `=~` means matches the regular expression and `!~` means doesn't match the regular expression.
 - An unquoted literal or a double-quoted string for the regular expression or label value.
 
-Unquoted literals can contain all UTF-8 characters other than the reserved characters. These are whitespace, curly braces, exclamation marks, equals, tilda, commas, backslashes, double quotes, single quotes and backticks. For example, `foo`, `[a-zA-Z]+`, and `Προμηθεύς` (Prometheus in Ancient Greek) are all examples of valid unquoted literals. However, `foo!` is not a valid literal as `!` is a reserved character.
+Unquoted literals can contain all UTF-8 characters other than the reserved characters. These are whitespace, and all characters in ``` { } ! = ~ , \ " ' ` ```. For example, `foo`, `[a-zA-Z]+`, and `Προμηθεύς` (Prometheus in Greek) are all examples of valid unquoted literals. However, `foo!` is not a valid literal as `!` is a reserved character.
 
-Double-quoted strings can contain all UTF-8 characters. Unlike unquoted literals, there are no reserved characters. You can even use UTF-8 code points. For example, `"foo!"`, `"bar,baz"` and `"baz qux\"` are valid double-quoted strings.
+Double-quoted strings can contain all UTF-8 characters. Unlike unquoted literals, there are no reserved characters. You can even use UTF-8 code points. For example, `"foo!"`, `"bar,baz"`, `"\"baz qux\""` and `"\xf0\x9f\x99\x82"` are valid double-quoted strings.
 
 #### Classic matchers
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -427,7 +427,7 @@ Label matchers match alerts to routes, silences, and inhibition rules.
 
 If this is a new Alertmanager installation, we recommend enabling UTF-8 strict mode before creating an Alertmanager configuration file. You can find instructions on how to enable UTF-8 strict mode [here](#utf-8-strict-mode).
 
-If this is an existing Alertmanager installation, we recommend running the Alertmanager in the default mode called fallback mode before enabling UTF-8 strict mode. In this mode, Alertmanager will tell you if you need to make any changes to your configuration file before UTF-8 strict mode can be enabled. Alertmanager will make UTF-8 strict mode the default in the next two versions, so it's important to transition as soon as possible.
+If this is an existing Alertmanager installation, we recommend running the Alertmanager in the default mode called fallback mode before enabling UTF-8 strict mode. In this mode, Alertmanager will log warnings if you need to make any changes to your configuration file before UTF-8 strict mode can be enabled. Alertmanager will make UTF-8 strict mode the default in the next two versions, so it's important to transition as soon as possible.
 
 Irrespective of whether an Alertmanager installation is a new or existing installation, you can also use `amtool` to validate that an Alertmanager configuration file is compatible with UTF-8 strict mode before enabling it in Alertmanager server. You do not need a running Alertmanager server to do this. You can find instructions on how to validate an Alertmanager configuration file using `amtool` [here](#verification).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -427,7 +427,7 @@ Label matchers match alerts to routes, silences, and inhibition rules.
 
 If this is a new Alertmanager installation, we recommend enabling UTF-8 strict mode before creating an Alertmanager configuration file. You can find instructions on how to enable UTF-8 strict mode [here](#utf-8-strict-mode).
 
-If this is an existing Alertmanager installation, we recommend running the Alertmanager in the default mode called fallback mode before enabling UTF-8 strict mode. In this mode, Alertmanager will log warnings if you need to make any changes to your configuration file before UTF-8 strict mode can be enabled. Alertmanager will make UTF-8 strict mode the default in the next two versions, so it's important to transition as soon as possible.
+If this is an existing Alertmanager installation, we recommend running the Alertmanager in the default mode called fallback mode before enabling UTF-8 strict mode. In this mode, Alertmanager will log a warning if you need to make any changes to your configuration file before UTF-8 strict mode can be enabled. Alertmanager will make UTF-8 strict mode the default in the next two versions, so it's important to transition as soon as possible.
 
 Irrespective of whether an Alertmanager installation is a new or existing installation, you can also use `amtool` to validate that an Alertmanager configuration file is compatible with UTF-8 strict mode before enabling it in Alertmanager server. You do not need a running Alertmanager server to do this. You can find instructions on how to validate an Alertmanager configuration file using `amtool` [here](#verification).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -432,13 +432,13 @@ By default, Alertmanager runs with support for both UTF-8 and classic matchers. 
 If you need to disable the new parser you can do so with the following feature flag:
 
 ```
-./alertmanager --config.file=config.yml --enable-feature="classic-matchers-parsing"
+./alertmanager --config.file=config.yml --enable-feature="classic-mode"
 ```
 
 Likewise, if you would like to disable the classic parser and use just the UTF-8 parser then you can do so too:
 
 ```
-./alertmanager --config.file=config.yml --enable-feature="utf8-matchers-parsing"
+./alertmanager --config.file=config.yml --enable-feature="utf8-strict-mode"
 ```
 
 ### `<matcher>`


### PR DESCRIPTION
This pull request updates the docs to:

1. Explain that there is a new parser for label matchers, the transition period, and how Alertmanager reverts to the classic parser.
2. How to use the feature flags to switch between fallback, UTF-8, and classic parse modes.
3. The difference between UTF-8 matchers and classic matchers.
4. Improved the documentation on composing matchers to make more complex expressions.