### PR TITLE
chore: Fix react linting error resulting in local `make build` failure

### DIFF
--- a/ui/react-app/src/views/ViewStatus.tsx
+++ b/ui/react-app/src/views/ViewStatus.tsx
@@ -13,7 +13,7 @@ import {
   Theme,
   Typography,
 } from '@mui/material';
-import { useAMStatus } from '../client/am-client';
+import { useAMStatus, AMStatusClusterPeersInfo } from '../client/am-client';
 
 const tableStyle: SxProps<Theme> = {
   [`& .${tableCellClasses.root}`]: {
@@ -73,7 +73,7 @@ export default function ViewStatus() {
           </TableCell>
           <TableCell>
             <List>
-              {data.cluster.peers.map((peer, i) => {
+              {data.cluster.peers.map((peer: AMStatusClusterPeersInfo, i: number) => {
                 return (
                   <ListItem disablePadding sx={{ display: 'list-item' }} key={i}>
                     <p>


### PR DESCRIPTION
Currently, running `make build` from the tip of main fails on my environment.

Unclear if this something specific to my environment or not.
Node version: v16.20.0
NPM version: 8.19.4

The error seems to stem from a lint failure in the react frontend:
```
ERROR in ./src/views/ViewStatus.tsx:76:40
TS7006: Parameter 'peer' implicitly has an 'any' type.
    74 |           <TableCell>
    75 |             <List>
  > 76 |               {data.cluster.peers.map((peer, i) => {
       |                                        ^^^^
    77 |                 return (
    78 |                   <ListItem disablePadding sx={{ display: 'list-item' }} key={i}>
    79 |                     <p>

ERROR in ./src/views/ViewStatus.tsx:76:46
TS7006: Parameter 'i' implicitly has an 'any' type.
    74 |           <TableCell>
    75 |             <List>
  > 76 |               {data.cluster.peers.map((peer, i) => {
       |                                              ^
    77 |                 return (
    78 |                   <ListItem disablePadding sx={{ display: 'list-item' }} key={i}>
    79 |                     <p>

webpack 5.75.0 compiled with 2 errors in 5263 ms
make: *** [Makefile:37: build-react-app] Error 1
```
This PR fixes the lint failure. Now, `make build` succeeds locally for me.
