### PR TITLE
Support UTF-8 label matchers: Update Stringer for non-Prometheus compliant label names

### DIFF
--- a/pkg/labels/matcher.go
+++ b/pkg/labels/matcher.go
@@ -76,7 +76,7 @@ func NewMatcher(t MatchType, n, v string) (*Matcher, error) {
 }
 
 func (m *Matcher) String() string {
-	if strings.ContainsFunc(m.Name, isReserved) {
+	if strings.IndexFunc(m.Name, isReserved) >= 0 {
 		return fmt.Sprintf(`%s%s%s`, strconv.Quote(m.Name), m.Type, strconv.Quote(m.Value))
 	}
 	return fmt.Sprintf(`%s%s"%s"`, m.Name, m.Type, openMetricsEscape(m.Value))

--- a/pkg/labels/matcher.go
+++ b/pkg/labels/matcher.go
@@ -76,7 +76,7 @@ func NewMatcher(t MatchType, n, v string) (*Matcher, error) {
 }
 
 func (m *Matcher) String() string {
-	if strings.IndexFunc(m.Name, isReserved) >= 0 {
+	if strings.ContainsFunc(m.Name, isReserved) {
 		return fmt.Sprintf(`%s%s%s`, strconv.Quote(m.Name), m.Type, strconv.Quote(m.Value))
 	}
 	return fmt.Sprintf(`%s%s"%s"`, m.Name, m.Type, openMetricsEscape(m.Value))

--- a/pkg/labels/matcher_test.go
+++ b/pkg/labels/matcher_test.go
@@ -182,6 +182,30 @@ line`,
 			value: `tab	stop`,
 			want:  `foo="tab	stop"`,
 		},
+		{
+			name:  `foo`,
+			op:    MatchEqual,
+			value: `🙂`,
+			want:  `foo="🙂"`,
+		},
+		{
+			name:  `foo!`,
+			op:    MatchNotEqual,
+			value: `bar`,
+			want:  `"foo!"!="bar"`,
+		},
+		{
+			name:  `foo🙂`,
+			op:    MatchEqual,
+			value: `bar`,
+			want:  `foo🙂="bar"`,
+		},
+		{
+			name:  `foo bar`,
+			op:    MatchEqual,
+			value: `baz`,
+			want:  `"foo bar"="baz"`,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This commit updates the String method to print non-Prometheus compliant label names in a format that can be parsed in the UTF-8 parser. Such inputs are never valid in the classic parser. If the label name is Prometheus compliant, it is still printed unquoted.