### PR TITLE
Isolate react-app package

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -57,6 +57,7 @@ import (
 	"github.com/prometheus/alertmanager/timeinterval"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/alertmanager/ui"
+	reactApp "github.com/prometheus/alertmanager/ui/react-app"
 )
 
 var (
@@ -495,6 +496,7 @@ func run() int {
 	webReload := make(chan chan error)
 
 	ui.Register(router, webReload, logger)
+	reactApp.Register(router, logger)
 
 	mux := api.Register(router, *routePrefix)
 

--- a/ui/react-app/web.go
+++ b/ui/react-app/web.go
@@ -1,0 +1,51 @@
+package reactApp
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"path"
+
+	"github.com/go-kit/log"
+
+	"github.com/prometheus/common/route"
+	"github.com/prometheus/common/server"
+)
+
+var reactRouterPaths = []string{
+	"/",
+	"/status",
+}
+
+func Register(r *route.Router, logger log.Logger) {
+	serveReactApp := func(w http.ResponseWriter, r *http.Request) {
+		f, err := Assets.Open("/dist/index.html")
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprintf(w, "Error opening React index.html: %v", err)
+			return
+		}
+		defer func() { _ = f.Close() }()
+		idx, err := io.ReadAll(f)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprintf(w, "Error reading React index.html: %v", err)
+			return
+		}
+		w.Write(idx)
+	}
+
+	// Static files required by the React app.
+	r.Get("/react-app/*filepath", func(w http.ResponseWriter, r *http.Request) {
+		for _, rt := range reactRouterPaths {
+			if r.URL.Path != "/react-app"+rt {
+				continue
+			}
+			serveReactApp(w, r)
+			return
+		}
+		r.URL.Path = path.Join("/dist", route.Param(r.Context(), "filepath"))
+		fs := server.StaticFileServer(Assets)
+		fs.ServeHTTP(w, r)
+	})
+}

--- a/ui/web.go
+++ b/ui/web.go
@@ -15,7 +15,6 @@ package ui
 
 import (
 	"fmt"
-	"io"
 	"net/http"
 	_ "net/http/pprof" // Comment this line to disable pprof endpoint.
 	"path"
@@ -23,16 +22,9 @@ import (
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/route"
-	"github.com/prometheus/common/server"
 
 	"github.com/prometheus/alertmanager/asset"
-	reactApp "github.com/prometheus/alertmanager/ui/react-app"
 )
-
-var reactRouterPaths = []string{
-	"/",
-	"/status",
-}
 
 // Register registers handlers to serve files for the web interface.
 func Register(r *route.Router, reloadCh chan<- chan error, logger log.Logger) {
@@ -68,37 +60,6 @@ func Register(r *route.Router, reloadCh chan<- chan error, logger log.Logger) {
 		req.URL.Path = path.Join("/static/lib", route.Param(req.Context(), "path"))
 		fs := http.FileServer(asset.Assets)
 		fs.ServeHTTP(w, req)
-	})
-
-	serveReactApp := func(w http.ResponseWriter, r *http.Request) {
-		f, err := reactApp.Assets.Open("/dist/index.html")
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			fmt.Fprintf(w, "Error opening React index.html: %v", err)
-			return
-		}
-		defer func() { _ = f.Close() }()
-		idx, err := io.ReadAll(f)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			fmt.Fprintf(w, "Error reading React index.html: %v", err)
-			return
-		}
-		w.Write(idx)
-	}
-
-	// Static files required by the React app.
-	r.Get("/react-app/*filepath", func(w http.ResponseWriter, r *http.Request) {
-		for _, rt := range reactRouterPaths {
-			if r.URL.Path != "/react-app"+rt {
-				continue
-			}
-			serveReactApp(w, r)
-			return
-		}
-		r.URL.Path = path.Join("/dist", route.Param(r.Context(), "filepath"))
-		fs := server.StaticFileServer(reactApp.Assets)
-		fs.ServeHTTP(w, r)
 	})
 
 	r.Post("/-/reload", func(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
This PR changes the package dependency hierarchy such that `ui` no longer depends on `ui/react-app`:

What was once this:
```
└── cmd/alertmanager/
    └── ui/
        ├── app
        └── react-app
```
Now becomes:
```
└── cmd/alertmanager/
    ├── ui/
    │   └── app
    └── react-app
```
i.e. the `react-app` endpoints are now registered separately.

This has a few benefits:
- Isolates the problem described in https://github.com/prometheus/alertmanager/issues/3588. reactApp has custom build tooling, downstream projects of alertmanager can choose to independently omit this if they don't wish to run that toolchain to compile.
-  Due to Go's package tree-shaking, downstream projects can selectively choose which UI they want to include (or both, or neither). This makes the alertmanager dependency lighter.
- Downstream projects like Mimir or Thanos which don't want to serve the react app quite yet can choose to register the routes independently.