### PR TITLE
Support UTF-8 label matchers: Use DI for matchers compat instead of package-level variables

### DIFF
--- a/cli/alert_query.go
+++ b/cli/alert_query.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/prometheus/alertmanager/api/v2/client/alert"
 	"github.com/prometheus/alertmanager/cli/format"
-	"github.com/prometheus/alertmanager/matchers/compat"
 )
 
 type alertQueryCmd struct {
@@ -74,13 +73,15 @@ func configureQueryAlertsCmd(cc *kingpin.CmdClause) {
 }
 
 func (a *alertQueryCmd) queryAlerts(ctx context.Context, _ *kingpin.ParseContext) error {
+	parseMatcher, _ := matchersFromFeatureFlags()
+
 	if len(a.matcherGroups) > 0 {
 		// Attempt to parse the first argument. If the parser fails
 		// then we likely don't have a (=|=~|!=|!~) so lets assume that
 		// the user wants alertname=<arg> and prepend `alertname=` to
 		// the front.
 		m := a.matcherGroups[0]
-		_, err := compat.Matcher(m)
+		_, err := parseMatcher(m)
 		if err != nil {
 			a.matcherGroups[0] = fmt.Sprintf("alertname=%s", m)
 		}

--- a/cli/root.go
+++ b/cli/root.go
@@ -50,7 +50,7 @@ var (
 	legacyFlags = map[string]string{"comment_required": "require-comment"}
 )
 
-func initMatchersCompat(_ *kingpin.ParseContext) error {
+func matchersFromFeatureFlags() (compat.Matcher, compat.Matchers) {
 	logger := log.NewLogfmtLogger(os.Stdout)
 	if verbose {
 		logger = level.NewFilter(logger, level.AllowDebug())
@@ -61,8 +61,7 @@ func initMatchersCompat(_ *kingpin.ParseContext) error {
 	if err != nil {
 		kingpin.Fatalf("error parsing the feature flag list: %v\n", err)
 	}
-	compat.InitFromFlags(logger, featureConfig)
-	return nil
+	return compat.NewFromFlags(logger, featureConfig)
 }
 
 func requireAlertManagerURL(pc *kingpin.ParseContext) error {
@@ -174,8 +173,6 @@ func Execute() {
 	configureClusterCmd(app)
 	configureConfigCmd(app)
 	configureTemplateCmd(app)
-
-	app.Action(initMatchersCompat)
 
 	err = resolver.Bind(app, os.Args[1:])
 	if err != nil {

--- a/cli/silence_query.go
+++ b/cli/silence_query.go
@@ -25,7 +25,6 @@ import (
 	"github.com/prometheus/alertmanager/api/v2/client/silence"
 	"github.com/prometheus/alertmanager/api/v2/models"
 	"github.com/prometheus/alertmanager/cli/format"
-	"github.com/prometheus/alertmanager/matchers/compat"
 )
 
 type silenceQueryCmd struct {
@@ -95,11 +94,13 @@ func configureSilenceQueryCmd(cc *kingpin.CmdClause) {
 }
 
 func (c *silenceQueryCmd) query(ctx context.Context, _ *kingpin.ParseContext) error {
+	parseMatcher, _ := matchersFromFeatureFlags()
+
 	if len(c.matchers) > 0 {
 		// If the parser fails then we likely don't have a (=|=~|!=|!~) so lets
 		// assume that the user wants alertname=<arg> and prepend `alertname=`
 		// to the front.
-		_, err := compat.Matcher(c.matchers[0])
+		_, err := parseMatcher(c.matchers[0])
 		if err != nil {
 			c.matchers[0] = fmt.Sprintf("alertname=%s", strconv.Quote(c.matchers[0]))
 		}

--- a/cli/test_routing.go
+++ b/cli/test_routing.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/prometheus/alertmanager/api/v2/models"
 	"github.com/prometheus/alertmanager/dispatch"
-	"github.com/prometheus/alertmanager/matchers/compat"
 	"github.com/prometheus/alertmanager/pkg/labels"
 )
 
@@ -73,6 +72,8 @@ func printMatchingTree(mainRoute *dispatch.Route, ls models.LabelSet) {
 }
 
 func (c *routingShow) routingTestAction(ctx context.Context, _ *kingpin.ParseContext) error {
+	parseMatcher, _ := matchersFromFeatureFlags()
+
 	cfg, err := loadAlertmanagerConfig(ctx, alertmanagerURL, c.configFile)
 	if err != nil {
 		kingpin.Fatalf("%v\n", err)
@@ -84,7 +85,7 @@ func (c *routingShow) routingTestAction(ctx context.Context, _ *kingpin.ParseCon
 	// Parse labels to LabelSet.
 	ls := make(models.LabelSet, len(c.labels))
 	for _, l := range c.labels {
-		matcher, err := compat.Matcher(l)
+		matcher, err := parseMatcher(l)
 		if err != nil {
 			kingpin.Fatalf("Failed to parse labels: %v\n", err)
 		}

--- a/matchers/compat/parse_test.go
+++ b/matchers/compat/parse_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/prometheus/alertmanager/pkg/labels"
 )
 
-func TestFallbackMatcherParser(t *testing.T) {
+func TestFallbackMatcher(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
@@ -45,7 +45,7 @@ func TestFallbackMatcherParser(t *testing.T) {
 		input: "foo!bar",
 		err:   "bad matcher format: foo!bar",
 	}}
-	f := fallbackMatcherParser(log.NewNopLogger())
+	f := fallbackMatcher(log.NewNopLogger())
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			matcher, err := f(test.input)
@@ -59,7 +59,7 @@ func TestFallbackMatcherParser(t *testing.T) {
 	}
 }
 
-func TestFallbackMatchersParser(t *testing.T) {
+func TestFallbackMatchers(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
@@ -91,7 +91,7 @@ func TestFallbackMatchersParser(t *testing.T) {
 		input: "{foo!bar}",
 		err:   "bad matcher format: foo!bar",
 	}}
-	f := fallbackMatchersParser(log.NewNopLogger())
+	f := fallbackMatchers(log.NewNopLogger())
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			matchers, err := f(test.input)


### PR DESCRIPTION
This commit changes amtool and the matchers/compat package to support DI instead of package-level variables. The purpose of this change to allow multi-tenant Alertmanagers, such as those used in Cortex and Mimir to configure the feature flags per tenant and not just process-wide.