### PR TITLE
Reflect Discord's max length message limits

### DIFF
--- a/notify/discord/discord.go
+++ b/notify/discord/discord.go
@@ -102,14 +102,14 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		return false, err
 	}
 	if truncated {
-		level.Warn(n.logger).Log("msg", "Truncated title", "incident", key, "max_runes", maxTitleLenRunes)
+		level.Warn(n.logger).Log("msg", "Truncated title", "key", key, "max_runes", maxTitleLenRunes)
 	}
 	description, truncated := notify.TruncateInRunes(tmpl(n.conf.Message), maxDescriptionLenRunes)
 	if err != nil {
 		return false, err
 	}
 	if truncated {
-		level.Warn(n.logger).Log("msg", "Truncated message", "incident", key, "max_runes", maxDescriptionLenRunes)
+		level.Warn(n.logger).Log("msg", "Truncated message", "key", key, "max_runes", maxDescriptionLenRunes)
 	}
 
 	color := colorGrey


### PR DESCRIPTION
Discord is limiting the length of the message (title, description). In this PR, I propose truncating the strings like AM does for pushover or opsgenie.

Doc: https://discord.com/developers/docs/resources/channel#embed-object-embed-limits

Closes: #3310