### PR TITLE
fix: label mismatch for alertmanager_notifications_failed_total

### DIFF
--- a/doc/alertmanager-mixin/alerts.libsonnet
+++ b/doc/alertmanager-mixin/alerts.libsonnet
@@ -44,7 +44,7 @@
               (
                 rate(alertmanager_notifications_failed_total{%(alertmanagerSelector)s}[5m])
               /
-                rate(alertmanager_notifications_total{%(alertmanagerSelector)s}[5m])
+                ignoring (reason) group_left rate(alertmanager_notifications_total{%(alertmanagerSelector)s}[5m])
               )
               > 0.01
             ||| % $._config,
@@ -63,7 +63,7 @@
               min by (%(alertmanagerClusterLabels)s, integration) (
                 rate(alertmanager_notifications_failed_total{%(alertmanagerSelector)s, integration=~`%(alertmanagerCriticalIntegrationsRegEx)s`}[5m])
               /
-                rate(alertmanager_notifications_total{%(alertmanagerSelector)s, integration=~`%(alertmanagerCriticalIntegrationsRegEx)s`}[5m])
+                ignoring (reason) group_left rate(alertmanager_notifications_total{%(alertmanagerSelector)s, integration=~`%(alertmanagerCriticalIntegrationsRegEx)s`}[5m])
               )
               > 0.01
             ||| % $._config,
@@ -82,7 +82,7 @@
               min by (%(alertmanagerClusterLabels)s, integration) (
                 rate(alertmanager_notifications_failed_total{%(alertmanagerSelector)s, integration!~`%(alertmanagerCriticalIntegrationsRegEx)s`}[5m])
               /
-                rate(alertmanager_notifications_total{%(alertmanagerSelector)s, integration!~`%(alertmanagerCriticalIntegrationsRegEx)s`}[5m])
+                ignoring (reason) group_left rate(alertmanager_notifications_total{%(alertmanagerSelector)s, integration!~`%(alertmanagerCriticalIntegrationsRegEx)s`}[5m])
               )
               > 0.01
             ||| % $._config,


### PR DESCRIPTION
Since [Alertmanager 0.26.0 version](https://github.com/prometheus/alertmanager/blob/ce6efba023b0397cb522d64e910684e48d12455f/CHANGELOG.md#0260--2023-08-23), a new label `reason` was added in the `alertmanager_notifications_failed_total` metric to indicate the type of error of the alert delivery. 

As a result, the original alert rules are broken because labels are mismatched between `alertmanager_notifications_failed_total` and `alertmanager_notifications_total metrics`.
Prometheus requires samples with exactly the same labels to get matched together when performing calculations. [docs](https://prometheus.io/docs/prometheus/latest/querying/operators/#one-to-one-vector-matches)

Use the `on` vector matching keyword to match only the `integration` label to allow for matching between series with different labels.
