### PR TITLE
Support UTF-8 label matchers: Add Init method to support custom parse functions

### DIFF
--- a/matchers/compat/parse.go
+++ b/matchers/compat/parse.go
@@ -46,6 +46,14 @@ func Matchers(s string) (labels.Matchers, error) {
 	return parseMatchers(s)
 }
 
+// Init can be used to set the functions for parsing matchers. This is
+// useful for downstream users of which might want to add custom behaviour
+// and/or instrumentation.
+func Init(matcherFn matcherParser, matchersFn matchersParser) {
+	parseMatcher = matcherFn
+	parseMatchers = matchersFn
+}
+
 // InitFromFlags initializes the compat package from the flagger.
 func InitFromFlags(l log.Logger, f featurecontrol.Flagger) {
 	if f.ClassicMatchersParsing() {


### PR DESCRIPTION
In Mimir, I'm thinking we run custom parser functions for the first couple of weeks that instrument the number of backwards compatible matchers and also collect possible matchers that are valid in both parsers but result in different parsings. This function would let us register our own functions to achieve this.