### PR TITLE
API: Allow the Silences API to use their own 400 response

### DIFF
--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -511,7 +511,7 @@ func (api *API) getSilencesHandler(params silence_ops.GetSilencesParams) middlew
 			matcher, err := labels.ParseMatcher(matcherString)
 			if err != nil {
 				level.Debug(logger).Log("msg", "Failed to parse matchers", "err", err)
-				return alert_ops.NewGetAlertsBadRequest().WithPayload(err.Error())
+				return silence_ops.NewGetSilencesBadRequest().WithPayload(err.Error())
 			}
 
 			matchers = append(matchers, matcher)

--- a/api/v2/client/silence/get_silences_responses.go
+++ b/api/v2/client/silence/get_silences_responses.go
@@ -43,6 +43,12 @@ func (o *GetSilencesReader) ReadResponse(response runtime.ClientResponse, consum
 			return nil, err
 		}
 		return result, nil
+	case 400:
+		result := NewGetSilencesBadRequest()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 500:
 		result := NewGetSilencesInternalServerError()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -111,6 +117,72 @@ func (o *GetSilencesOK) GetPayload() models.GettableSilences {
 }
 
 func (o *GetSilencesOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	// response payload
+	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewGetSilencesBadRequest creates a GetSilencesBadRequest with default headers values
+func NewGetSilencesBadRequest() *GetSilencesBadRequest {
+	return &GetSilencesBadRequest{}
+}
+
+/*
+GetSilencesBadRequest describes a response with status code 400, with default header values.
+
+Bad request
+*/
+type GetSilencesBadRequest struct {
+	Payload string
+}
+
+// IsSuccess returns true when this get silences bad request response has a 2xx status code
+func (o *GetSilencesBadRequest) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get silences bad request response has a 3xx status code
+func (o *GetSilencesBadRequest) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get silences bad request response has a 4xx status code
+func (o *GetSilencesBadRequest) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this get silences bad request response has a 5xx status code
+func (o *GetSilencesBadRequest) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this get silences bad request response a status code equal to that given
+func (o *GetSilencesBadRequest) IsCode(code int) bool {
+	return code == 400
+}
+
+// Code gets the status code for the get silences bad request response
+func (o *GetSilencesBadRequest) Code() int {
+	return 400
+}
+
+func (o *GetSilencesBadRequest) Error() string {
+	return fmt.Sprintf("[GET /silences][%d] getSilencesBadRequest  %+v", 400, o.Payload)
+}
+
+func (o *GetSilencesBadRequest) String() string {
+	return fmt.Sprintf("[GET /silences][%d] getSilencesBadRequest  %+v", 400, o.Payload)
+}
+
+func (o *GetSilencesBadRequest) GetPayload() string {
+	return o.Payload
+}
+
+func (o *GetSilencesBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	// response payload
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {

--- a/api/v2/openapi.yaml
+++ b/api/v2/openapi.yaml
@@ -53,6 +53,8 @@ paths:
           description: Get silences response
           schema:
             $ref: '#/definitions/gettableSilences'
+        '400':
+          $ref: '#/responses/BadRequest'
         '500':
           $ref: '#/responses/InternalServerError'
       parameters:

--- a/api/v2/restapi/embedded_spec.go
+++ b/api/v2/restapi/embedded_spec.go
@@ -317,6 +317,9 @@ func init() {
               "$ref": "#/definitions/gettableSilences"
             }
           },
+          "400": {
+            "$ref": "#/responses/BadRequest"
+          },
           "500": {
             "$ref": "#/responses/InternalServerError"
           }
@@ -1126,6 +1129,12 @@ func init() {
             "description": "Get silences response",
             "schema": {
               "$ref": "#/definitions/gettableSilences"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "type": "string"
             }
           },
           "500": {

--- a/api/v2/restapi/operations/silence/get_silences_responses.go
+++ b/api/v2/restapi/operations/silence/get_silences_responses.go
@@ -75,6 +75,49 @@ func (o *GetSilencesOK) WriteResponse(rw http.ResponseWriter, producer runtime.P
 	}
 }
 
+// GetSilencesBadRequestCode is the HTTP code returned for type GetSilencesBadRequest
+const GetSilencesBadRequestCode int = 400
+
+/*
+GetSilencesBadRequest Bad request
+
+swagger:response getSilencesBadRequest
+*/
+type GetSilencesBadRequest struct {
+
+	/*
+	  In: Body
+	*/
+	Payload string `json:"body,omitempty"`
+}
+
+// NewGetSilencesBadRequest creates GetSilencesBadRequest with default headers values
+func NewGetSilencesBadRequest() *GetSilencesBadRequest {
+
+	return &GetSilencesBadRequest{}
+}
+
+// WithPayload adds the payload to the get silences bad request response
+func (o *GetSilencesBadRequest) WithPayload(payload string) *GetSilencesBadRequest {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the get silences bad request response
+func (o *GetSilencesBadRequest) SetPayload(payload string) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *GetSilencesBadRequest) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(400)
+	payload := o.Payload
+	if err := producer.Produce(rw, payload); err != nil {
+		panic(err) // let the recovery middleware deal with this
+	}
+}
+
 // GetSilencesInternalServerErrorCode is the HTTP code returned for type GetSilencesInternalServerError
 const GetSilencesInternalServerErrorCode int = 500
 


### PR DESCRIPTION
There's no change to the logic here - it just struck me as odd that we were reusing the response from alerting groups in the silences call when it's pretty simple to add a new one in the API description.

This is more accurate as well, as this will be used to power the documentation.