### PR TITLE
Cluster: Add `GetStates` to `Peer`

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -40,6 +40,8 @@ type ClusterPeer interface {
 	Status() string
 	// Peers returns the peer nodes in the cluster.
 	Peers() []ClusterMember
+	// GetStates returns the States associated with the given keys and a slice of keys not found.
+	GetStates(...string) (map[string]State, []string)
 }
 
 // ClusterMember interface that represents node peers in a cluster
@@ -543,6 +545,24 @@ func (p *Peer) peerUpdate(n *memberlist.Node) {
 
 	p.peerUpdateCounter.Inc()
 	level.Debug(p.logger).Log("msg", "peer updated", "peer", pr.Node)
+}
+
+// GetStates returns the States associated with the given keys and a slice of keys not found.
+func (p *Peer) GetStates(keys ...string) (map[string]State, []string) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	result := make(map[string]State, len(keys))
+	notFound := make([]string, 0)
+	for _, key := range keys {
+		if v, ok := p.states[key]; ok {
+			result[key] = v
+		} else {
+			notFound = append(notFound, key)
+		}
+	}
+
+	return result, notFound
 }
 
 // AddState adds a new state that will be gossiped. It returns a channel to which


### PR DESCRIPTION
This adds support for retrieving the states from the cluster Peer.

This is useful for moving around the states from replica to replica when deem neccesary - while not stricily useful for the Alertmanager itself at the moment, we have a need to support migrations between different types of Alertmanager and this helps the cause.

Signed-off-by: gotjosh <josue.abreu@gmail.com>
