### PR TITLE
Add summary to msteams notification

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -169,8 +169,9 @@ var (
 		NotifierConfig: NotifierConfig{
 			VSendResolved: true,
 		},
-		Title: `{{ template "msteams.default.title" . }}`,
-		Text:  `{{ template "msteams.default.text" . }}`,
+		Title:   `{{ template "msteams.default.title" . }}`,
+		Summary: `{{ template "msteams.default.summary" . }}`,
+		Text:    `{{ template "msteams.default.text" . }}`,
 	}
 )
 
@@ -788,8 +789,9 @@ type MSTeamsConfig struct {
 	HTTPConfig     *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 	WebhookURL     *SecretURL                  `yaml:"webhook_url,omitempty" json:"webhook_url,omitempty"`
 
-	Title string `yaml:"title,omitempty" json:"title,omitempty"`
-	Text  string `yaml:"text,omitempty" json:"text,omitempty"`
+	Title   string `yaml:"title,omitempty" json:"title,omitempty"`
+	Summary string `yaml:"summary,omitempty" json:"summary,omitempty"`
+	Text    string `yaml:"text,omitempty" json:"text,omitempty"`
 }
 
 func (c *MSTeamsConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -736,6 +736,9 @@ Microsoft Teams notifications are sent via the [Incoming Webhooks](https://learn
 # Message title template.
 [ title: <tmpl_string> | default = '{{ template "msteams.default.title" . }}' ]
 
+# Message title template.
+[ summary: <tmpl_string> | default = '{{ template "msteams.default.summary" . }}' ]
+
 # Message body template.
 [ text: <tmpl_string> | default = '{{ template "msteams.default.text" . }}' ]
 

--- a/notify/msteams/msteams.go
+++ b/notify/msteams/msteams.go
@@ -52,6 +52,7 @@ type teamsMessage struct {
 	Context    string `json:"@context"`
 	Type       string `json:"type"`
 	Title      string `json:"title"`
+	Summary    string `json:"summary"`
 	Text       string `json:"text"`
 	ThemeColor string `json:"themeColor"`
 }
@@ -98,6 +99,10 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	if err != nil {
 		return false, err
 	}
+	summary := tmpl(n.conf.Summary)
+	if err != nil {
+		return false, err
+	}
 
 	alerts := types.Alerts(as...)
 	color := colorGrey
@@ -112,6 +117,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		Context:    "http://schema.org/extensions",
 		Type:       "MessageCard",
 		Title:      title,
+		Summary:    summary,
 		Text:       text,
 		ThemeColor: color,
 	}

--- a/notify/msteams/msteams_test.go
+++ b/notify/msteams/msteams_test.go
@@ -77,8 +77,9 @@ func TestMSTeamsTemplating(t *testing.T) {
 		{
 			title: "full-blown message",
 			cfg: &config.MSTeamsConfig{
-				Title: `{{ template "msteams.default.title" . }}`,
-				Text:  `{{ template "msteams.default.text" . }}`,
+				Title:   `{{ template "msteams.default.title" . }}`,
+				Summary: `{{ template "msteams.default.summary" . }}`,
+				Text:    `{{ template "msteams.default.text" . }}`,
 			},
 			retry: false,
 		},
@@ -90,10 +91,19 @@ func TestMSTeamsTemplating(t *testing.T) {
 			errMsg: "template: :1: unclosed action",
 		},
 		{
+			title: "summary with templating errors",
+			cfg: &config.MSTeamsConfig{
+				Title:   `{{ template "msteams.default.title" . }}`,
+				Summary: "{{ ",
+			},
+			errMsg: "template: :1: unclosed action",
+		},
+		{
 			title: "message with templating errors",
 			cfg: &config.MSTeamsConfig{
-				Title: `{{ template "msteams.default.title" . }}`,
-				Text:  "{{ ",
+				Title:   `{{ template "msteams.default.title" . }}`,
+				Summary: `{{ template "msteams.default.summary" . }}`,
+				Text:    "{{ ",
 			},
 			errMsg: "template: :1: unclosed action",
 		},

--- a/template/default.tmpl
+++ b/template/default.tmpl
@@ -146,6 +146,7 @@ Alerts Resolved:
 {{ end }}
 {{ end }}
 
+{{ define "msteams.default.summary" }}{{ template "__subject" . }}{{ end }}
 {{ define "msteams.default.title" }}{{ template "__subject" . }}{{ end }}
 {{ define "msteams.default.text" }}
 {{ if gt (len .Alerts.Firing) 0 }}


### PR DESCRIPTION
Hi,
currently msteams notification does not support summary atribute from Message card. Result is that in Activity (inside MS Teams) you don't know what kind of alert you received and you need to klik on it. It is same for notification on phone etc.

Example (bottom one is without pull request, top one is with pull request): 
<img width="352" alt="image" src="https://github.com/prometheus/alertmanager/assets/112698283/93d73c87-2aa1-49de-aa3e-919e885f9077">
