### PR TITLE
README: Use new matchers syntax in config examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ route:
 
   # The child route trees.
   routes:
-  # This routes performs a regular expression match on alert labels to
+  # This route performs a regular expression match on alert labels to
   # catch alerts that are related to a list of services.
   - matchers:
     - service=~"^(foo1|foo2|baz)$"

--- a/README.md
+++ b/README.md
@@ -104,43 +104,43 @@ route:
   routes:
   # This routes performs a regular expression match on alert labels to
   # catch alerts that are related to a list of services.
-  - match_re:
-      service: ^(foo1|foo2|baz)$
+  - matchers:
+    - service=~"^(foo1|foo2|baz)$"
     receiver: team-X-mails
 
     # The service has a sub-route for critical alerts, any alerts
     # that do not match, i.e. severity != critical, fall-back to the
     # parent node and are sent to 'team-X-mails'
     routes:
-    - match:
-        severity: critical
+    - matchers:
+      - severity="critical"
       receiver: team-X-pager
 
-  - match:
-      service: files
+  - matchers:
+    - service="files"
     receiver: team-Y-mails
 
     routes:
-    - match:
-        severity: critical
+    - matchers:
+      - severity="critical"
       receiver: team-Y-pager
 
   # This route handles all alerts coming from a database service. If there's
   # no team to handle it, it defaults to the DB team.
-  - match:
-      service: database
+  - matchers:
+    - service="database"
 
     receiver: team-DB-pager
     # Also group alerts by affected database.
     group_by: [alertname, cluster, database]
 
     routes:
-    - match:
-        owner: team-X
+    - matchers:
+      - owner="team-X"
       receiver: team-X-pager
 
-    - match:
-        owner: team-Y
+    - matchers:
+      - owner="team-Y"
       receiver: team-Y-pager
 
 


### PR DESCRIPTION
#1023 (0.22+?) introduced a new, now preferred matchers syntax for routes and inhibitions. The README still uses the old, deprecated syntax. This PR updates those examples (and fixes a very minor example config comment typo).

:heavy_check_mark: I've checked that the new config still parses with alertmanager v0.26.
:heavy_check_mark: The quoting is consistent with the style used in the already updated inhibitions example.