### PR TITLE
golangci-lint: enable testifylint linter

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         with:
-          version: v1.54.2
+          version: v1.55.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,8 +13,9 @@ linters:
     - errorlint
     - gofumpt
     - goimports
-    - revive
     - misspell
+    - revive
+    - testifylint
 
 issues:
   max-issues-per-linter: 0
@@ -74,3 +75,18 @@ linters-settings:
       - name: unexported-return
       - name: indent-error-flow
       - name: errorf
+  testifylint:
+    disable:
+      - float-compare
+      - go-require
+    enable:
+      - bool-compare
+      - compares
+      - empty
+      - error-is-as
+      - error-nil
+      - expected-actual
+      - len
+      - require-error
+      - suite-dont-use-pkg
+      - suite-extra-assert-call

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -69,10 +69,10 @@ func testJoinLeave(t *testing.T) {
 		cancel()
 		require.Equal(t, context.Canceled, p.WaitReady(ctx))
 	}
-	require.Equal(t, p.Status(), "settling")
+	require.Equal(t, "settling", p.Status())
 	go p.Settle(context.Background(), 0*time.Second)
 	require.NoError(t, p.WaitReady(context.Background()))
-	require.Equal(t, p.Status(), "ready")
+	require.Equal(t, "ready", p.Status())
 
 	// Create the peer who joins the first.
 	p2, err := Create(
@@ -104,7 +104,7 @@ func testJoinLeave(t *testing.T) {
 	require.Equal(t, 2, p.ClusterSize())
 	p2.Leave(0 * time.Second)
 	require.Equal(t, 1, p.ClusterSize())
-	require.Equal(t, 1, len(p.failedPeers))
+	require.Len(t, p.failedPeers, 1)
 	require.Equal(t, p2.Self().Address(), p.peers[p2.Self().Address()].Node.Address())
 	require.Equal(t, p2.Name(), p.failedPeers[0].Name)
 }
@@ -167,12 +167,12 @@ func testReconnect(t *testing.T) {
 	p.peerLeave(p2.Self())
 
 	require.Equal(t, 1, p.ClusterSize())
-	require.Equal(t, 1, len(p.failedPeers))
+	require.Len(t, p.failedPeers, 1)
 
 	p.reconnect()
 
 	require.Equal(t, 2, p.ClusterSize())
-	require.Equal(t, 0, len(p.failedPeers))
+	require.Empty(t, p.failedPeers)
 	require.Equal(t, StatusAlive, p.peers[p2.Self().Address()].status)
 }
 
@@ -222,7 +222,7 @@ func testRemoveFailedPeers(t *testing.T) {
 	p.failedPeers = []peer{p1, p2, p3}
 
 	p.removeFailedPeers(30 * time.Minute)
-	require.Equal(t, 1, len(p.failedPeers))
+	require.Len(t, p.failedPeers, 1)
 	require.Equal(t, p1, p.failedPeers[0])
 }
 
@@ -258,7 +258,7 @@ func testInitiallyFailingPeers(t *testing.T) {
 
 	// We shouldn't have added "our" bind addr and the FQDN address to the
 	// failed peers list.
-	require.Equal(t, len(peerAddrs)-2, len(p.failedPeers))
+	require.Len(t, p.failedPeers, len(peerAddrs)-2)
 	for _, addr := range peerAddrs {
 		if addr == myAddr || addr == "foo.example.com:5000" {
 			continue
@@ -270,7 +270,7 @@ func testInitiallyFailingPeers(t *testing.T) {
 		require.Equal(t, addr, pr.Address())
 		expectedLen := len(p.failedPeers) - 1
 		p.peerJoin(pr.Node)
-		require.Equal(t, expectedLen, len(p.failedPeers))
+		require.Len(t, p.failedPeers, expectedLen)
 	}
 }
 
@@ -302,10 +302,10 @@ func testTLSConnection(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.False(t, p1.Ready())
-	require.Equal(t, p1.Status(), "settling")
+	require.Equal(t, "settling", p1.Status())
 	go p1.Settle(context.Background(), 0*time.Second)
 	p1.WaitReady(context.Background())
-	require.Equal(t, p1.Status(), "ready")
+	require.Equal(t, "ready", p1.Status())
 
 	// Create the peer who joins the first.
 	tlsTransportConfig2, err := GetTLSTransportConfig("./testdata/tls_config_node2.yml")
@@ -338,7 +338,7 @@ func testTLSConnection(t *testing.T) {
 	require.Equal(t, 2, p1.ClusterSize())
 	p2.Leave(0 * time.Second)
 	require.Equal(t, 1, p1.ClusterSize())
-	require.Equal(t, 1, len(p1.failedPeers))
+	require.Len(t, p1.failedPeers, 1)
 	require.Equal(t, p2.Self().Address(), p1.peers[p2.Self().Address()].Node.Address())
 	require.Equal(t, p2.Name(), p1.failedPeers[0].Name)
 }

--- a/cluster/tls_connection_test.go
+++ b/cluster/tls_connection_test.go
@@ -33,7 +33,7 @@ func TestWriteStream(t *testing.T) {
 		w.Close()
 	}()
 	packet, err := rcvTLSConn(r).read()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Nil(t, packet)
 }
 
@@ -55,7 +55,7 @@ func TestWritePacket(t *testing.T) {
 			w.Close()
 		}()
 		packet, err := rcvTLSConn(r).read()
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, tc.msg, string(packet.Buf))
 		require.Equal(t, tc.fromAddr, packet.From.String())
 
@@ -65,7 +65,7 @@ func TestWritePacket(t *testing.T) {
 func TestRead_Nil(t *testing.T) {
 	packet, err := (&tlsConn{}).read()
 	require.Nil(t, packet)
-	require.NotNil(t, err)
+	require.Error(t, err)
 }
 
 func TestTLSConn_Close(t *testing.T) {

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -398,7 +398,7 @@ route:
 	for i := 0; len(recorder.Alerts()) != 7 && i < 10; i++ {
 		time.Sleep(200 * time.Millisecond)
 	}
-	require.Equal(t, 7, len(recorder.Alerts()))
+	require.Len(t, recorder.Alerts(), 7)
 
 	alertGroups, receivers := dispatcher.Groups(
 		func(*Route) bool {
@@ -541,7 +541,7 @@ route:
 	for i := 0; len(recorder.Alerts()) != 7 && i < 10; i++ {
 		time.Sleep(200 * time.Millisecond)
 	}
-	require.Equal(t, 7, len(recorder.Alerts()))
+	require.Len(t, recorder.Alerts(), 7)
 
 	routeFilter := func(*Route) bool { return true }
 	alertFilter := func(*types.Alert, time.Time) bool { return true }
@@ -681,7 +681,7 @@ func TestDispatcherRaceOnFirstAlertNotDeliveredWhenGroupWaitIsZero(t *testing.T)
 	}
 
 	// We expect all alerts to be notified immediately, since they all belong to different groups.
-	require.Equal(t, numAlerts, len(recorder.Alerts()))
+	require.Len(t, recorder.Alerts(), numAlerts)
 }
 
 type limits struct {

--- a/dispatch/route_test.go
+++ b/dispatch/route_test.go
@@ -378,9 +378,9 @@ routes:
 	parent := tree.Routes[0]
 	child1 := parent.Routes[0]
 	child2 := parent.Routes[1]
-	require.Equal(t, parent.RouteOpts.GroupByAll, true)
-	require.Equal(t, child1.RouteOpts.GroupByAll, true)
-	require.Equal(t, child2.RouteOpts.GroupByAll, false)
+	require.True(t, parent.RouteOpts.GroupByAll)
+	require.True(t, child1.RouteOpts.GroupByAll)
+	require.False(t, child2.RouteOpts.GroupByAll)
 }
 
 func TestRouteMatchers(t *testing.T) {

--- a/matchers/compat/parse_test.go
+++ b/matchers/compat/parse_test.go
@@ -53,7 +53,7 @@ func TestFallbackMatcherParser(t *testing.T) {
 			if test.err != "" {
 				require.EqualError(t, err, test.err)
 			} else {
-				require.Nil(t, err)
+				require.NoError(t, err)
 				require.EqualValues(t, test.expected, matcher)
 			}
 		})
@@ -99,7 +99,7 @@ func TestFallbackMatchersParser(t *testing.T) {
 			if test.err != "" {
 				require.EqualError(t, err, test.err)
 			} else {
-				require.Nil(t, err)
+				require.NoError(t, err)
 				require.EqualValues(t, test.expected, matchers)
 			}
 		})

--- a/matchers/parse/parse_test.go
+++ b/matchers/parse/parse_test.go
@@ -219,7 +219,7 @@ func TestMatchers(t *testing.T) {
 			if test.error != "" {
 				require.EqualError(t, err, test.error)
 			} else {
-				require.Nil(t, err)
+				require.NoError(t, err)
 				require.EqualValues(t, test.expected, matchers)
 			}
 		})
@@ -363,7 +363,7 @@ func TestMatcher(t *testing.T) {
 			if test.error != "" {
 				require.EqualError(t, err, test.error)
 			} else {
-				require.Nil(t, err)
+				require.NoError(t, err)
 				require.EqualValues(t, test.expected, matcher)
 			}
 		})

--- a/nflog/nflog_test.go
+++ b/nflog/nflog_test.go
@@ -57,7 +57,7 @@ func TestLogGC(t *testing.T) {
 	expected := state{
 		"a2": newEntry(now.Add(time.Second)),
 	}
-	require.Equal(t, l.st, expected, "unexpected state after garbage collection")
+	require.Equal(t, expected, l.st, "unexpected state after garbage collection")
 }
 
 func TestLogSnapshot(t *testing.T) {

--- a/notify/email/email_test.go
+++ b/notify/email/email_test.go
@@ -300,7 +300,7 @@ func TestEmailNotifyWithErrors(t *testing.T) {
 			_, retry, err := notifyEmail(emailCfg, c.Server)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), tc.errMsg)
-			require.Equal(t, false, retry)
+			require.False(t, retry)
 
 			e, err := c.Server.getLastEmail()
 			require.NoError(t, err)
@@ -610,7 +610,7 @@ func TestEmailConfigNoAuthMechs(t *testing.T) {
 	}
 	_, err := email.auth("")
 	require.Error(t, err)
-	require.Equal(t, err.Error(), "unknown auth mechanism: ")
+	require.Equal(t, "unknown auth mechanism: ", err.Error())
 }
 
 func TestEmailConfigMissingAuthParam(t *testing.T) {
@@ -620,19 +620,19 @@ func TestEmailConfigMissingAuthParam(t *testing.T) {
 	}
 	_, err := email.auth("CRAM-MD5")
 	require.Error(t, err)
-	require.Equal(t, err.Error(), "missing secret for CRAM-MD5 auth mechanism")
+	require.Equal(t, "missing secret for CRAM-MD5 auth mechanism", err.Error())
 
 	_, err = email.auth("PLAIN")
 	require.Error(t, err)
-	require.Equal(t, err.Error(), "missing password for PLAIN auth mechanism")
+	require.Equal(t, "missing password for PLAIN auth mechanism", err.Error())
 
 	_, err = email.auth("LOGIN")
 	require.Error(t, err)
-	require.Equal(t, err.Error(), "missing password for LOGIN auth mechanism")
+	require.Equal(t, "missing password for LOGIN auth mechanism", err.Error())
 
 	_, err = email.auth("PLAIN LOGIN")
 	require.Error(t, err)
-	require.Equal(t, err.Error(), "missing password for PLAIN auth mechanism; missing password for LOGIN auth mechanism")
+	require.Equal(t, "missing password for PLAIN auth mechanism; missing password for LOGIN auth mechanism", err.Error())
 }
 
 func TestEmailNoUsernameStillOk(t *testing.T) {

--- a/notify/msteams/msteams_test.go
+++ b/notify/msteams/msteams_test.go
@@ -16,7 +16,6 @@ package msteams
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -187,7 +186,7 @@ func TestNotifier_Notify_WithReason(t *testing.T) {
 				require.NoError(t, err)
 			} else {
 				var reasonError *notify.ErrorWithReason
-				require.True(t, errors.As(err, &reasonError))
+				require.ErrorAs(t, err, &reasonError)
 				require.Equal(t, tt.expectedReason, reasonError.Reason)
 			}
 		})

--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -407,7 +407,7 @@ func TestRetryStageWithError(t *testing.T) {
 
 	// Notify with a recoverable error should retry and succeed.
 	resctx, res, err := r.Exec(ctx, log.NewNopLogger(), alerts...)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, alerts, res)
 	require.Equal(t, alerts, sent)
 	require.NotNil(t, resctx)
@@ -417,7 +417,7 @@ func TestRetryStageWithError(t *testing.T) {
 	fail = true
 	retry = false
 	resctx, _, err = r.Exec(ctx, log.NewNopLogger(), alerts...)
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.NotNil(t, resctx)
 }
 
@@ -464,7 +464,7 @@ func TestRetryStageWithErrorCode(t *testing.T) {
 
 		require.Equal(t, testData.expectedCount, int(prom_testutil.ToFloat64(counter.WithLabelValues(r.integration.Name(), testData.reasonlabel))))
 
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.NotNil(t, resctx)
 	}
 }
@@ -498,7 +498,7 @@ func TestRetryStageWithContextCanceled(t *testing.T) {
 
 	require.Equal(t, 1, int(prom_testutil.ToFloat64(counter.WithLabelValues(r.integration.Name(), ContextCanceledReason.String()))))
 
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.NotNil(t, resctx)
 }
 
@@ -536,7 +536,7 @@ func TestRetryStageNoResolved(t *testing.T) {
 	ctx = WithFiringAlerts(ctx, []uint64{0})
 
 	resctx, res, err = r.Exec(ctx, log.NewNopLogger(), alerts...)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, alerts, res)
 	require.Equal(t, []*types.Alert{alerts[1]}, sent)
 	require.NotNil(t, resctx)
@@ -547,7 +547,7 @@ func TestRetryStageNoResolved(t *testing.T) {
 	alerts[1].Alert.EndsAt = time.Now().Add(-time.Hour)
 
 	resctx, res, err = r.Exec(ctx, log.NewNopLogger(), alerts...)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, alerts, res)
 	require.Equal(t, []*types.Alert{}, sent)
 	require.NotNil(t, resctx)
@@ -581,7 +581,7 @@ func TestRetryStageSendResolved(t *testing.T) {
 	ctx = WithFiringAlerts(ctx, []uint64{0})
 
 	resctx, res, err := r.Exec(ctx, log.NewNopLogger(), alerts...)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, alerts, res)
 	require.Equal(t, alerts, sent)
 	require.NotNil(t, resctx)
@@ -592,7 +592,7 @@ func TestRetryStageSendResolved(t *testing.T) {
 	alerts[1].Alert.EndsAt = time.Now().Add(-time.Hour)
 
 	resctx, res, err = r.Exec(ctx, log.NewNopLogger(), alerts...)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, alerts, res)
 	require.Equal(t, alerts, sent)
 	require.NotNil(t, resctx)
@@ -638,7 +638,7 @@ func TestSetNotifiesStage(t *testing.T) {
 		return nil
 	}
 	resctx, res, err = s.Exec(ctx, log.NewNopLogger(), alerts...)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, alerts, res)
 	require.NotNil(t, resctx)
 
@@ -654,7 +654,7 @@ func TestSetNotifiesStage(t *testing.T) {
 		return nil
 	}
 	resctx, res, err = s.Exec(ctx, log.NewNopLogger(), alerts...)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, alerts, res)
 	require.NotNil(t, resctx)
 }

--- a/notify/opsgenie/opsgenie_test.go
+++ b/notify/opsgenie/opsgenie_test.go
@@ -230,7 +230,7 @@ func TestOpsGenie(t *testing.T) {
 			req, retry, err := notifier.createRequests(ctx, alert1)
 			require.NoError(t, err)
 			require.Len(t, req, 1)
-			require.Equal(t, true, retry)
+			require.True(t, retry)
 			require.Equal(t, expectedURL, req[0].URL)
 			require.Equal(t, "GenieKey http://am", req[0].Header.Get("Authorization"))
 			require.Equal(t, tc.expectedEmptyAlertBody, readBody(t, req[0]))
@@ -260,7 +260,7 @@ func TestOpsGenie(t *testing.T) {
 			}
 			req, retry, err = notifier.createRequests(ctx, alert2)
 			require.NoError(t, err)
-			require.Equal(t, true, retry)
+			require.True(t, retry)
 			require.Len(t, req, 1)
 			require.Equal(t, tc.expectedBody, readBody(t, req[0]))
 
@@ -268,7 +268,7 @@ func TestOpsGenie(t *testing.T) {
 			tc.cfg.APIKey = "{{ kaput "
 			_, _, err = notifier.createRequests(ctx, alert2)
 			require.Error(t, err)
-			require.Equal(t, err.Error(), "templating error: template: :1: function \"kaput\" not defined")
+			require.Equal(t, "templating error: template: :1: function \"kaput\" not defined", err.Error())
 		})
 	}
 }
@@ -310,15 +310,15 @@ func TestOpsGenieWithUpdate(t *testing.T) {
 	key, _ := notify.ExtractGroupKey(ctx)
 	alias := key.Hash()
 
-	require.Equal(t, requests[0].URL.String(), "https://test-opsgenie-url/v2/alerts")
+	require.Equal(t, "https://test-opsgenie-url/v2/alerts", requests[0].URL.String())
 	require.NotEmpty(t, body0)
 
 	require.Equal(t, requests[1].URL.String(), fmt.Sprintf("https://test-opsgenie-url/v2/alerts/%s/message?identifierType=alias", alias))
-	require.Equal(t, body1, `{"message":"new message"}
-`)
+	require.Equal(t, `{"message":"new message"}
+`, body1)
 	require.Equal(t, requests[2].URL.String(), fmt.Sprintf("https://test-opsgenie-url/v2/alerts/%s/description?identifierType=alias", alias))
-	require.Equal(t, body2, `{"description":"new description"}
-`)
+	require.Equal(t, `{"description":"new description"}
+`, body2)
 }
 
 func readBody(t *testing.T, r *http.Request) string {

--- a/notify/slack/slack_test.go
+++ b/notify/slack/slack_test.go
@@ -15,7 +15,6 @@ package slack
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -228,7 +227,7 @@ func TestNotifier_Notify_WithReason(t *testing.T) {
 				require.NoError(t, err)
 			} else {
 				var reasonError *notify.ErrorWithReason
-				require.True(t, errors.As(err, &reasonError))
+				require.ErrorAs(t, err, &reasonError)
 				require.Equal(t, tt.expectedReason, reasonError.Reason)
 				require.Contains(t, err.Error(), tt.expectedErr)
 				require.Contains(t, err.Error(), "channelname")

--- a/notify/sns/sns_test.go
+++ b/notify/sns/sns_test.go
@@ -28,7 +28,7 @@ func TestValidateAndTruncateMessage(t *testing.T) {
 	require.True(t, isTruncated)
 	require.NoError(t, err)
 	require.NotEqual(t, sBuff, truncatedMessage)
-	require.Equal(t, len(truncatedMessage), 256*1024)
+	require.Len(t, truncatedMessage, 256*1024)
 
 	sBuff = make([]byte, 100)
 	for i := range sBuff {

--- a/notify/webhook/webhook_test.go
+++ b/notify/webhook/webhook_test.go
@@ -89,15 +89,15 @@ func TestWebhookTruncateAlerts(t *testing.T) {
 
 	truncatedAlerts, numTruncated := truncateAlerts(0, alerts)
 	require.Len(t, truncatedAlerts, 10)
-	require.EqualValues(t, numTruncated, 0)
+	require.EqualValues(t, 0, numTruncated)
 
 	truncatedAlerts, numTruncated = truncateAlerts(4, alerts)
 	require.Len(t, truncatedAlerts, 4)
-	require.EqualValues(t, numTruncated, 6)
+	require.EqualValues(t, 6, numTruncated)
 
 	truncatedAlerts, numTruncated = truncateAlerts(100, alerts)
 	require.Len(t, truncatedAlerts, 10)
-	require.EqualValues(t, numTruncated, 0)
+	require.EqualValues(t, 0, numTruncated)
 }
 
 func TestWebhookRedactedURL(t *testing.T) {

--- a/silence/silence_test.go
+++ b/silence/silence_test.go
@@ -285,7 +285,7 @@ func TestSilencesSetSilence(t *testing.T) {
 		_, err := pbutil.ReadDelimited(r, &e)
 		require.NoError(t, err)
 
-		require.Equal(t, want["some_id"], &e)
+		require.Equal(t, &e, want["some_id"])
 		close(done)
 	}
 
@@ -322,7 +322,7 @@ func TestSilenceSet(t *testing.T) {
 	}
 	id1, err := s.Set(sil1)
 	require.NoError(t, err)
-	require.NotEqual(t, id1, "")
+	require.NotEqual(t, "", id1)
 
 	want := state{
 		id1: &pb.MeshSilence{
@@ -348,7 +348,7 @@ func TestSilenceSet(t *testing.T) {
 	}
 	id2, err := s.Set(sil2)
 	require.NoError(t, err)
-	require.NotEqual(t, id2, "")
+	require.NotEqual(t, "", id2)
 
 	want = state{
 		id1: want[id1],
@@ -942,7 +942,7 @@ func TestSilenceExpire(t *testing.T) {
 	// Expiring a pending Silence should make the API return the
 	// SilenceStateExpired Silence state.
 	silenceState := types.CalcSilenceState(sil.StartsAt, sil.EndsAt)
-	require.Equal(t, silenceState, types.SilenceStateExpired)
+	require.Equal(t, types.SilenceStateExpired, silenceState)
 
 	sil, err = s.QueryOne(QIDs("active"))
 	require.NoError(t, err)
@@ -1628,7 +1628,7 @@ func benchmarkSilencesQuery(b *testing.B, numSilences int) {
 		QMatches(lset),
 	)
 	require.NoError(b, err)
-	require.Equal(b, numSilences/10, len(sils))
+	require.Len(b, sils, numSilences/10)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -1637,7 +1637,7 @@ func benchmarkSilencesQuery(b *testing.B, numSilences int) {
 			QMatches(lset),
 		)
 		require.NoError(b, err)
-		require.Equal(b, numSilences/10, len(sils))
+		require.Len(b, sils, numSilences/10)
 	}
 }
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -109,5 +109,5 @@ func TestGC(t *testing.T) {
 			t.Errorf("alert %v should have been gc'd", alert)
 		}
 	}
-	require.Equal(t, len(resolved), n)
+	require.Len(t, resolved, n)
 }

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -394,7 +394,7 @@ func TestTemplateExpansion(t *testing.T) {
 			}
 			got, err := f(tc.in, tc.data)
 			if tc.fail {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
@@ -458,7 +458,7 @@ func TestTemplateExpansionWithOptions(t *testing.T) {
 			}
 			got, err := f(tc.in, tc.data)
 			if tc.fail {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)

--- a/test/with_api_v2/acceptance/api_test.go
+++ b/test/with_api_v2/acceptance/api_test.go
@@ -174,7 +174,7 @@ receivers:
 	for _, al := range resp.Payload {
 		require.Equal(t, models.AlertStatusStateSuppressed, *al.Status.State)
 		require.Equal(t, fp.String(), *al.Fingerprint)
-		require.Equal(t, 1, len(al.Status.SilencedBy))
+		require.Len(t, al.Status.SilencedBy, 1)
 		require.Equal(t, silenceID, al.Status.SilencedBy[0])
 	}
 
@@ -189,12 +189,12 @@ receivers:
 	resp, err = am.Client().Alert.GetAlerts(nil)
 	require.NoError(t, err)
 	for _, al := range resp.Payload {
-		require.Equal(t, 1, len(al.Status.SilencedBy))
+		require.Len(t, al.Status.SilencedBy, 1)
 		require.Equal(t, silenceID, al.Status.SilencedBy[0])
 		if fp.String() == *al.Fingerprint {
 			require.Equal(t, models.AlertStatusStateSuppressed, *al.Status.State)
 			require.Equal(t, fp.String(), *al.Fingerprint)
-			require.Equal(t, 1, len(al.Status.InhibitedBy))
+			require.Len(t, al.Status.InhibitedBy, 1)
 			require.Equal(t, inhibitingFP.String(), al.Status.InhibitedBy[0])
 		}
 	}
@@ -208,7 +208,7 @@ receivers:
 	// Silence has been deleted, inhibiting alert should be active.
 	// Original alert should still be inhibited.
 	for _, al := range resp.Payload {
-		require.Equal(t, 0, len(al.Status.SilencedBy))
+		require.Empty(t, al.Status.SilencedBy)
 		if inhibitingFP.String() == *al.Fingerprint {
 			require.Equal(t, models.AlertStatusStateActive, *al.Status.State)
 		} else {
@@ -277,7 +277,7 @@ receivers:
 	filter := []string{"alertname=test1", "severity=warning"}
 	resp, err := am.Client().Alert.GetAlerts(alert.NewGetAlertsParams().WithFilter(filter))
 	require.NoError(t, err)
-	require.Equal(t, 1, len(resp.Payload))
+	require.Len(t, resp.Payload, 1)
 	for _, al := range resp.Payload {
 		require.Equal(t, models.AlertStatusStateActive, *al.Status.State)
 	}

--- a/test/with_api_v2/acceptance/utf8_test.go
+++ b/test/with_api_v2/acceptance/utf8_test.go
@@ -150,7 +150,7 @@ receivers:
 	alertParams.Alerts = models.PostableAlerts{pa}
 
 	_, err := am.Client().Alert.PostAlerts(alertParams)
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.True(t, strings.Contains(err.Error(), "invalid label set"))
 }
 
@@ -266,7 +266,7 @@ receivers:
 	silenceParams.Silence = &ps
 
 	_, err := am.Client().Silence.PostSilences(silenceParams)
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.True(t, strings.Contains(err.Error(), "silence invalid: invalid label matcher"))
 }
 


### PR DESCRIPTION
This help ensure that the the testify best practices are followed.
It requires an upgrade of golangci-lint.


Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>