### PR TITLE
Fix GCCallback was not invoked upon deletion in the alerts store

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -110,7 +110,10 @@ func (a *Alerts) Delete(fp model.Fingerprint) error {
 	a.Lock()
 	defer a.Unlock()
 
-	delete(a.c, fp)
+	if alert, ok := a.c[fp]; ok {
+		delete(a.c, fp)
+		a.cb([]*types.Alert{alert})
+	}
 	return nil
 }
 


### PR DESCRIPTION
This will result in [AlertStoreCallback.PostDelete](https://github.com/prometheus/alertmanager/blob/c920b605b647f2548e23a3dc2fea014b9c9dbf43/provider/mem/mem.go#L60) being called less frequently than AlertStoreCallback.PreStore/PostStore.


Additionally, race conditions may create inconsistencies outside the store. However, potential race conditions will not be addressed in this PR.
@simonpasquier 

