### PR TITLE
Fix race conditions in the memory alerts store

### DIFF
--- a/provider/mem/mem.go
+++ b/provider/mem/mem.go
@@ -134,7 +134,7 @@ func (a *Alerts) gc() {
 		// they are resolved. Alerts waiting for resolved notifications are
 		// held in memory in aggregation groups redundantly.
 		a.marker.Delete(alert.Fingerprint())
-		a.callback.PostDelete(alert)
+		a.callback.PostDelete(&alert)
 	}
 
 	for i, l := range a.listeners {

--- a/provider/mem/mem.go
+++ b/provider/mem/mem.go
@@ -34,7 +34,7 @@ const alertChannelLength = 200
 type Alerts struct {
 	cancel context.CancelFunc
 
-	mtx sync.RWMutex
+	mtx sync.Mutex
 
 	alerts *store.Alerts
 	marker types.AlertMarker
@@ -191,8 +191,8 @@ func (a *Alerts) GetPending() provider.AlertIterator {
 		ch   = make(chan *types.Alert, alertChannelLength)
 		done = make(chan struct{})
 	)
-	a.mtx.RLock()
-	defer a.mtx.RUnlock()
+	a.mtx.Lock()
+	defer a.mtx.Unlock()
 	alerts := a.alerts.List()
 
 	go func() {
@@ -211,8 +211,8 @@ func (a *Alerts) GetPending() provider.AlertIterator {
 
 // Get returns the alert for a given fingerprint.
 func (a *Alerts) Get(fp model.Fingerprint) (*types.Alert, error) {
-	a.mtx.RLock()
-	defer a.mtx.RUnlock()
+	a.mtx.Lock()
+	defer a.mtx.Unlock()
 	return a.alerts.Get(fp)
 }
 
@@ -263,8 +263,8 @@ func (a *Alerts) Put(alerts ...*types.Alert) error {
 
 // count returns the number of non-resolved alerts we currently have stored filtered by the provided state.
 func (a *Alerts) count(state types.AlertState) int {
-	a.mtx.RLock()
-	defer a.mtx.RUnlock()
+	a.mtx.Lock()
+	defer a.mtx.Unlock()
 
 	var count int
 	for _, alert := range a.alerts.List() {

--- a/provider/mem/mem.go
+++ b/provider/mem/mem.go
@@ -34,7 +34,7 @@ const alertChannelLength = 200
 type Alerts struct {
 	cancel context.CancelFunc
 
-	mtx sync.Mutex
+	mtx sync.RWMutex
 
 	alerts *store.Alerts
 	marker types.AlertMarker
@@ -194,9 +194,9 @@ func (a *Alerts) GetPending() provider.AlertIterator {
 
 	go func() {
 		defer close(ch)
-		a.mtx.Lock()
+		a.mtx.RLock()
 		alerts := a.alerts.List()
-		a.mtx.Unlock()
+		a.mtx.RUnlock()
 
 		for _, a := range alerts {
 			select {
@@ -212,8 +212,8 @@ func (a *Alerts) GetPending() provider.AlertIterator {
 
 // Get returns the alert for a given fingerprint.
 func (a *Alerts) Get(fp model.Fingerprint) (*types.Alert, error) {
-	a.mtx.Lock()
-	defer a.mtx.Unlock()
+	a.mtx.RLock()
+	defer a.mtx.RUnlock()
 	return a.alerts.Get(fp)
 }
 
@@ -265,8 +265,8 @@ func (a *Alerts) Put(alerts ...*types.Alert) error {
 
 // count returns the number of non-resolved alerts we currently have stored filtered by the provided state.
 func (a *Alerts) count(state types.AlertState) int {
-	a.mtx.Lock()
-	defer a.mtx.Unlock()
+	a.mtx.RLock()
+	defer a.mtx.RUnlock()
 
 	var count int
 	for _, alert := range a.alerts.List() {

--- a/store/store.go
+++ b/store/store.go
@@ -70,7 +70,7 @@ func (a *Alerts) Run(ctx context.Context, interval time.Duration) {
 }
 
 // GC deletes resolved alerts and returns them.
-func (a *Alerts) GC() []*types.Alert {
+func (a *Alerts) GC() []types.Alert {
 	a.Lock()
 	var resolved []types.Alert
 	for fp, alert := range a.c {

--- a/store/store.go
+++ b/store/store.go
@@ -64,12 +64,13 @@ func (a *Alerts) Run(ctx context.Context, interval time.Duration) {
 		case <-ctx.Done():
 			return
 		case <-t.C:
-			a.gc()
+			a.GC()
 		}
 	}
 }
 
-func (a *Alerts) gc() {
+// GC deletes resolved alerts and returns them.
+func (a *Alerts) GC() []*types.Alert {
 	a.Lock()
 	var resolved []types.Alert
 	for fp, alert := range a.c {
@@ -90,6 +91,7 @@ func (a *Alerts) gc() {
 	}
 	a.Unlock()
 	a.cb(resolved)
+	return resolved
 }
 
 // Get returns the Alert with the matching fingerprint, or an error if it is


### PR DESCRIPTION
The main branch will easily fail the newly added test case:
```
=== RUN   TestAlertsConcurrently
    mem_test.go:565:
                Error Trace:    /prometheus-io/alertmanager/provider/mem/mem_test.go:565
                Error:          Not equal:
                                expected: 0
                                actual  : -171
                Test:           TestAlertsConcurrently
```

There are multiple race conditions in the provider/mem:
1. Any Put or GC operation that occurs concurrently with this code block will introduce a race condition https://github.com/prometheus/alertmanager/blob/c920b605b647f2548e23a3dc2fea014b9c9dbf43/provider/mem/mem.go#L204-L228
2. A race condition between Put() and Subscribe() can cause some newly added Alerts to be missed.

@simonpasquier @w0rm @gotjosh please take a look
