### PR TITLE
expose opsgenie alias configuration to improve deduplicaiton alerts

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -555,6 +555,7 @@ type OpsGenieConfig struct {
 	APIKey       Secret                    `yaml:"api_key,omitempty" json:"api_key,omitempty"`
 	APIKeyFile   string                    `yaml:"api_key_file,omitempty" json:"api_key_file,omitempty"`
 	APIURL       *URL                      `yaml:"api_url,omitempty" json:"api_url,omitempty"`
+	Alias        string                    `yaml:"alias,omitempty" json:"alias,omitempty"`
 	Message      string                    `yaml:"message,omitempty" json:"message,omitempty"`
 	Description  string                    `yaml:"description,omitempty" json:"description,omitempty"`
 	Source       string                    `yaml:"source,omitempty" json:"source,omitempty"`


### PR DESCRIPTION
This change will help Opsgenie to deduplicate Alerts when it is necessary to send the same alert to multiple teams and each team is using its own integration instead of a global integration.