### PR TITLE
Feature/expose opsgenie alias config

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -555,6 +555,7 @@ type OpsGenieConfig struct {
 	APIKey       Secret                    `yaml:"api_key,omitempty" json:"api_key,omitempty"`
 	APIKeyFile   string                    `yaml:"api_key_file,omitempty" json:"api_key_file,omitempty"`
 	APIURL       *URL                      `yaml:"api_url,omitempty" json:"api_url,omitempty"`
+	Alias        string                    `yaml:"alias,omitempty" json:"alias,omitempty"`
 	Message      string                    `yaml:"message,omitempty" json:"message,omitempty"`
 	Description  string                    `yaml:"description,omitempty" json:"description,omitempty"`
 	Source       string                    `yaml:"source,omitempty" json:"source,omitempty"`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -767,6 +767,11 @@ OpsGenie notifications are sent via the [OpsGenie API](https://docs.opsgenie.com
 # The host to send OpsGenie API requests to.
 [ api_url: <string> | default = global.opsgenie_api_url ]
 
+# Alias used by Opsgenie to deduplicate alerts. Limit 512 characters.
+# Custom alias is particularly usefull in situations you have multiple teams to receive the same alert and
+# each one has its own integration instead of global integration.
+[ alias: <string> | default = route.group_by ]
+
 # Alert text limited to 130 characters.
 [ message: <tmpl_string> | default = '{{ template "opsgenie.default.message" . }}' ]
 

--- a/notify/opsgenie/opsgenie.go
+++ b/notify/opsgenie/opsgenie.go
@@ -132,7 +132,8 @@ func (n *Notifier) createRequests(ctx context.Context, as ...*types.Alert) ([]*h
 	var key notify.Key
 	var err error
 	// Use custom alias if provided, otherwise use group key.
-	// Custom alias will help to deduplicate opsgenie alerts in cases you are not using global integration and have multiple receivers or teams
+	// Custom alias will be used by Opsgenie to deduplicate alerts in situations you are not using global integration and you have to deliver the same alert
+	// to multiple teams and each team has its own integration.
 	if n.conf.Alias != "" {
 		key = notify.Key(n.conf.Alias)
 	} else {


### PR DESCRIPTION
This change will help Opsgenie to deduplicate Alerts when it is necessary to send the same alert to multiple teams and each team is using its own integration instead of a global integration.