### PR TITLE
Support UTF-8 label matchers: Add metrics to matchers compat package

### DIFF
--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -684,7 +684,7 @@ func (api *API) postSilencesHandler(params silence_ops.PostSilencesParams) middl
 func parseFilter(filter []string) ([]*labels.Matcher, error) {
 	matchers := make([]*labels.Matcher, 0, len(filter))
 	for _, matcherString := range filter {
-		matcher, err := compat.Matcher(matcherString)
+		matcher, err := compat.Matcher(matcherString, "api")
 		if err != nil {
 			return nil, err
 		}

--- a/cli/alert_add.go
+++ b/cli/alert_add.go
@@ -77,14 +77,14 @@ func (a *alertAddCmd) addAlert(ctx context.Context, _ *kingpin.ParseContext) err
 	if len(a.labels) > 0 {
 		// Allow the alertname label to be defined implicitly as the first argument rather
 		// than explicitly as a key=value pair.
-		if _, err := compat.Matcher(a.labels[0]); err != nil {
+		if _, err := compat.Matcher(a.labels[0], "cli"); err != nil {
 			a.labels[0] = fmt.Sprintf("alertname=%s", strconv.Quote(a.labels[0]))
 		}
 	}
 
 	ls := make(models.LabelSet, len(a.labels))
 	for _, l := range a.labels {
-		matcher, err := compat.Matcher(l)
+		matcher, err := compat.Matcher(l, "cli")
 		if err != nil {
 			return err
 		}
@@ -96,7 +96,7 @@ func (a *alertAddCmd) addAlert(ctx context.Context, _ *kingpin.ParseContext) err
 
 	annotations := make(models.LabelSet, len(a.annotations))
 	for _, a := range a.annotations {
-		matcher, err := compat.Matcher(a)
+		matcher, err := compat.Matcher(a, "cli")
 		if err != nil {
 			return err
 		}

--- a/cli/alert_query.go
+++ b/cli/alert_query.go
@@ -81,7 +81,7 @@ func (a *alertQueryCmd) queryAlerts(ctx context.Context, _ *kingpin.ParseContext
 		// the user wants alertname=<arg> and prepend `alertname=` to
 		// the front.
 		m := a.matcherGroups[0]
-		_, err := compat.Matcher(m)
+		_, err := compat.Matcher(m, "cli")
 		if err != nil {
 			a.matcherGroups[0] = fmt.Sprintf("alertname=%s", strconv.Quote(m))
 		}

--- a/cli/root.go
+++ b/cli/root.go
@@ -61,7 +61,7 @@ func initMatchersCompat(_ *kingpin.ParseContext) error {
 	if err != nil {
 		kingpin.Fatalf("error parsing the feature flag list: %v\n", err)
 	}
-	compat.InitFromFlags(logger, featureConfig)
+	compat.InitFromFlags(logger, compat.RegisteredMetrics, featureConfig)
 	return nil
 }
 

--- a/cli/silence_add.go
+++ b/cli/silence_add.go
@@ -95,7 +95,7 @@ func (c *silenceAddCmd) add(ctx context.Context, _ *kingpin.ParseContext) error 
 		// If the parser fails then we likely don't have a (=|=~|!=|!~) so lets
 		// assume that the user wants alertname=<arg> and prepend `alertname=`
 		// to the front.
-		_, err := compat.Matcher(c.matchers[0])
+		_, err := compat.Matcher(c.matchers[0], "cli")
 		if err != nil {
 			c.matchers[0] = fmt.Sprintf("alertname=%s", strconv.Quote(c.matchers[0]))
 		}
@@ -103,7 +103,7 @@ func (c *silenceAddCmd) add(ctx context.Context, _ *kingpin.ParseContext) error 
 
 	matchers := make([]labels.Matcher, 0, len(c.matchers))
 	for _, s := range c.matchers {
-		m, err := compat.Matcher(s)
+		m, err := compat.Matcher(s, "cli")
 		if err != nil {
 			return err
 		}

--- a/cli/silence_query.go
+++ b/cli/silence_query.go
@@ -99,7 +99,7 @@ func (c *silenceQueryCmd) query(ctx context.Context, _ *kingpin.ParseContext) er
 		// If the parser fails then we likely don't have a (=|=~|!=|!~) so lets
 		// assume that the user wants alertname=<arg> and prepend `alertname=`
 		// to the front.
-		_, err := compat.Matcher(c.matchers[0])
+		_, err := compat.Matcher(c.matchers[0], "cli")
 		if err != nil {
 			c.matchers[0] = fmt.Sprintf("alertname=%s", strconv.Quote(c.matchers[0]))
 		}

--- a/cli/test_routing.go
+++ b/cli/test_routing.go
@@ -84,7 +84,7 @@ func (c *routingShow) routingTestAction(ctx context.Context, _ *kingpin.ParseCon
 	// Parse labels to LabelSet.
 	ls := make(models.LabelSet, len(c.labels))
 	for _, l := range c.labels {
-		matcher, err := compat.Matcher(l)
+		matcher, err := compat.Matcher(l, "cli")
 		if err != nil {
 			kingpin.Fatalf("Failed to parse labels: %v\n", err)
 		}

--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -180,7 +180,7 @@ func run() int {
 		level.Error(logger).Log("msg", "error parsing the feature flag list", "err", err)
 		return 1
 	}
-	compat.InitFromFlags(logger, ff)
+	compat.InitFromFlags(logger, compat.RegisteredMetrics, ff)
 
 	err = os.MkdirAll(*dataDir, 0o777)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -1006,7 +1006,7 @@ func (m *Matchers) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 	for _, line := range lines {
-		pm, err := compat.Matchers(line)
+		pm, err := compat.Matchers(line, "config")
 		if err != nil {
 			return err
 		}
@@ -1032,7 +1032,7 @@ func (m *Matchers) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	for _, line := range lines {
-		pm, err := compat.Matchers(line)
+		pm, err := compat.Matchers(line, "config")
 		if err != nil {
 			return err
 		}

--- a/matchers/compat/metrics.go
+++ b/matchers/compat/metrics.go
@@ -40,7 +40,7 @@ type Metrics struct {
 func NewMetrics(r prometheus.Registerer) *Metrics {
 	m := &Metrics{
 		Total: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
-			Name: "alertmanager_matchers_parsed",
+			Name: "alertmanager_matchers_parse",
 			Help: "Total number of matcher inputs parsed, including invalid inputs.",
 		}, []string{"origin"}),
 		DisagreeTotal: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{

--- a/matchers/compat/metrics.go
+++ b/matchers/compat/metrics.go
@@ -1,3 +1,16 @@
+// Copyright 2023 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package compat
 
 import (

--- a/matchers/compat/metrics.go
+++ b/matchers/compat/metrics.go
@@ -40,19 +40,19 @@ type Metrics struct {
 func NewMetrics(r prometheus.Registerer) *Metrics {
 	m := &Metrics{
 		Total: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
-			Name: "alertmanager_matchers_parse_total",
+			Name: "alertmanager_matchers_parsed",
 			Help: "Total number of matcher inputs parsed, including invalid inputs.",
 		}, []string{"origin"}),
 		DisagreeTotal: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
-			Name: "alertmanager_matchers_disagree_total",
+			Name: "alertmanager_matchers_disagree",
 			Help: "Total number of matcher inputs which produce different parsings (disagreement).",
 		}, []string{"origin"}),
 		IncompatibleTotal: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
-			Name: "alertmanager_matchers_incompatible_total",
+			Name: "alertmanager_matchers_incompatible",
 			Help: "Total number of matcher inputs that are incompatible with the UTF-8 parser.",
 		}, []string{"origin"}),
 		InvalidTotal: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
-			Name: "alertmanager_matchers_invalid_total",
+			Name: "alertmanager_matchers_invalid",
 			Help: "Total number of matcher inputs that could not be parsed.",
 		}, []string{"origin"}),
 	}

--- a/matchers/compat/metrics.go
+++ b/matchers/compat/metrics.go
@@ -1,0 +1,51 @@
+package compat
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	RegisteredMetrics = NewMetrics(prometheus.DefaultRegisterer)
+)
+
+const (
+	OriginAPI    = "api"
+	OriginConfig = "config"
+)
+
+var (
+	DefaultOrigins = []string{
+		OriginAPI,
+		OriginConfig,
+	}
+)
+
+type Metrics struct {
+	Total             *prometheus.GaugeVec
+	DisagreeTotal     *prometheus.GaugeVec
+	IncompatibleTotal *prometheus.GaugeVec
+	InvalidTotal      *prometheus.GaugeVec
+}
+
+func NewMetrics(r prometheus.Registerer) *Metrics {
+	m := &Metrics{
+		Total: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "alertmanager_matchers_parse_total",
+			Help: "Total number of matcher inputs parsed, including invalid inputs.",
+		}, []string{"origin"}),
+		DisagreeTotal: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "alertmanager_matchers_disagree_total",
+			Help: "Total number of matcher inputs which produce different parsings (disagreement).",
+		}, []string{"origin"}),
+		IncompatibleTotal: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "alertmanager_matchers_incompatible_total",
+			Help: "Total number of matcher inputs that are incompatible with the UTF-8 parser.",
+		}, []string{"origin"}),
+		InvalidTotal: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "alertmanager_matchers_invalid_total",
+			Help: "Total number of matcher inputs that could not be parsed.",
+		}, []string{"origin"}),
+	}
+	return m
+}

--- a/matchers/compat/metrics.go
+++ b/matchers/compat/metrics.go
@@ -18,21 +18,17 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-var (
-	RegisteredMetrics = NewMetrics(prometheus.DefaultRegisterer)
-)
-
 const (
 	OriginAPI    = "api"
 	OriginConfig = "config"
 )
 
-var (
-	DefaultOrigins = []string{
-		OriginAPI,
-		OriginConfig,
-	}
-)
+var DefaultOrigins = []string{
+	OriginAPI,
+	OriginConfig,
+}
+
+var RegisteredMetrics = NewMetrics(prometheus.DefaultRegisterer)
 
 type Metrics struct {
 	Total             *prometheus.GaugeVec

--- a/matchers/compat/parse.go
+++ b/matchers/compat/parse.go
@@ -15,11 +15,13 @@ package compat
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 	"unicode/utf8"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 
 	"github.com/prometheus/alertmanager/featurecontrol"
@@ -29,8 +31,8 @@ import (
 
 var (
 	isValidLabelName = isValidClassicLabelName(log.NewNopLogger())
-	parseMatcher     = ClassicMatcherParser(log.NewNopLogger())
-	parseMatchers    = ClassicMatchersParser(log.NewNopLogger())
+	parseMatcher     = ClassicMatcherParser(log.NewNopLogger(), RegisteredMetrics)
+	parseMatchers    = ClassicMatchersParser(log.NewNopLogger(), RegisteredMetrics)
 )
 
 // IsValidLabelName returns true if the string is a valid label name.
@@ -38,143 +40,195 @@ func IsValidLabelName(name model.LabelName) bool {
 	return isValidLabelName(name)
 }
 
-type ParseMatcher func(s string) (*labels.Matcher, error)
+type ParseMatcher func(input, origin string) (*labels.Matcher, error)
 
-type ParseMatchers func(s string) (labels.Matchers, error)
+type ParseMatchers func(input, origin string) (labels.Matchers, error)
 
 // Matcher parses the matcher in the input string. It returns an error
 // if the input is invalid or contains two or more matchers.
-func Matcher(s string) (*labels.Matcher, error) {
-	return parseMatcher(s)
+func Matcher(input, origin string) (*labels.Matcher, error) {
+	return parseMatcher(input, origin)
 }
 
 // Matchers parses one or more matchers in the input string. It returns
 // an error if the input is invalid.
-func Matchers(s string) (labels.Matchers, error) {
-	return parseMatchers(s)
+func Matchers(input, origin string) (labels.Matchers, error) {
+	return parseMatchers(input, origin)
 }
 
 // InitFromFlags initializes the compat package from the flagger.
-func InitFromFlags(l log.Logger, f featurecontrol.Flagger) {
+func InitFromFlags(l log.Logger, m *Metrics, f featurecontrol.Flagger) {
 	if f.ClassicMode() {
 		isValidLabelName = isValidClassicLabelName(l)
-		parseMatcher = ClassicMatcherParser(l)
-		parseMatchers = ClassicMatchersParser(l)
+		parseMatcher = ClassicMatcherParser(l, m)
+		parseMatchers = ClassicMatchersParser(l, m)
 	} else if f.UTF8StrictMode() {
 		isValidLabelName = isValidUTF8LabelName(l)
-		parseMatcher = UTF8MatcherParser(l)
-		parseMatchers = UTF8MatchersParser(l)
+		parseMatcher = UTF8MatcherParser(l, m)
+		parseMatchers = UTF8MatchersParser(l, m)
 	} else {
 		isValidLabelName = isValidUTF8LabelName(l)
-		parseMatcher = FallbackMatcherParser(l)
-		parseMatchers = FallbackMatchersParser(l)
+		parseMatcher = FallbackMatcherParser(l, m)
+		parseMatchers = FallbackMatchersParser(l, m)
 	}
 }
 
-// ClassicMatcherParser uses the old pkg/labels parser to parse the matcher in
+// ClassicMatcherParser uses the pkg/labels parser to parse the matcher in
 // the input string.
-func ClassicMatcherParser(l log.Logger) ParseMatcher {
-	return func(s string) (*labels.Matcher, error) {
-		level.Debug(l).Log("msg", "Parsing with classic matchers parser", "input", s)
-		return labels.ParseMatcher(s)
-	}
-}
-
-// ClassicMatchersParser uses the old pkg/labels parser to parse zero or more
-// matchers in the input string. It returns an error if the input is invalid.
-func ClassicMatchersParser(l log.Logger) ParseMatchers {
-	return func(s string) (labels.Matchers, error) {
-		level.Debug(l).Log("msg", "Parsing with classic matchers parser", "input", s)
-		return labels.ParseMatchers(s)
-	}
-}
-
-// UTF8MatcherParser uses the new matchers/parse parser to parse
-// the matcher in the input string. If this fails it does not fallback
-// to the old pkg/labels parser.
-func UTF8MatcherParser(l log.Logger) ParseMatcher {
-	return func(s string) (*labels.Matcher, error) {
-		level.Debug(l).Log("msg", "Parsing with UTF-8 matchers parser", "input", s)
-		if strings.HasPrefix(s, "{") || strings.HasSuffix(s, "}") {
-			return nil, fmt.Errorf("unexpected open or close brace: %s", s)
-		}
-		return parse.Matcher(s)
-	}
-}
-
-// UTF8MatchersParser uses the new matchers/parse parser to parse
-// zero or more matchers in the input string. If this fails it
-// does not fallback to the old pkg/labels parser.
-func UTF8MatchersParser(l log.Logger) ParseMatchers {
-	return func(s string) (labels.Matchers, error) {
-		level.Debug(l).Log("msg", "Parsing with UTF-8 matchers parser", "input", s)
-		return parse.Matchers(s)
-	}
-}
-
-// FallbackMatcherParser uses the new matchers/parse parser to parse
-// zero or more matchers in the string. If this fails it falls back to
-// the old pkg/labels parser and emits a warning log line.
-func FallbackMatcherParser(l log.Logger) ParseMatcher {
-	return func(s string) (*labels.Matcher, error) {
-		var (
-			m          *labels.Matcher
-			err        error
-			invalidErr error
-		)
-		level.Debug(l).Log("msg", "Parsing with UTF-8 matchers parser, with fallback to classic matchers parser", "input", s)
-		if strings.HasPrefix(s, "{") || strings.HasSuffix(s, "}") {
-			return nil, fmt.Errorf("unexpected open or close brace: %s", s)
-		}
-		m, err = parse.Matcher(s)
-		if err != nil {
-			m, invalidErr = labels.ParseMatcher(s)
-			if invalidErr != nil {
-				// The input is not valid in the old pkg/labels parser either,
-				// it cannot be valid input.
-				return nil, invalidErr
+func ClassicMatcherParser(l log.Logger, m *Metrics) ParseMatcher {
+	return func(input, origin string) (matcher *labels.Matcher, err error) {
+		defer func() {
+			lbs := prometheus.Labels{"origin": origin}
+			m.Total.With(lbs).Inc()
+			if err != nil {
+				m.InvalidTotal.With(lbs).Inc()
 			}
-			// The input is valid in the old pkg/labels parser, but not the
-			// new matchers/parse parser.
-			suggestion := m.String()
-			level.Warn(l).Log("msg", "Alertmanager is moving to a new parser for labels and matchers, and this input is incompatible. Alertmanager has instead parsed the input using the old matchers parser as a fallback. To make this input compatible with the new parser please make sure all regular expressions and values are double-quoted. If you are still seeing this message please open an issue.", "input", s, "err", err, "suggestion", suggestion)
+		}()
+		level.Debug(l).Log("msg", "Parsing with classic matchers parser", "input", input)
+		return labels.ParseMatcher(input)
+	}
+}
+
+// ClassicMatchersParser uses the pkg/labels parser to parse zero or more
+// matchers in the input string. It returns an error if the input is invalid.
+func ClassicMatchersParser(l log.Logger, m *Metrics) ParseMatchers {
+	return func(input, origin string) (matchers labels.Matchers, err error) {
+		defer func() {
+			lbs := prometheus.Labels{"origin": origin}
+			m.Total.With(lbs).Inc()
+			if err != nil {
+				m.InvalidTotal.With(lbs).Inc()
+			}
+		}()
+		level.Debug(l).Log("msg", "Parsing with classic matchers parser", "input", input)
+		return labels.ParseMatchers(input)
+	}
+}
+
+// UTF8MatcherParser uses the new matchers/parse parser to parse the matcher
+// in the input string. If this fails it does not revert to the pkg/labels parser.
+func UTF8MatcherParser(l log.Logger, m *Metrics) ParseMatcher {
+	return func(input, origin string) (matcher *labels.Matcher, err error) {
+		defer func() {
+			lbs := prometheus.Labels{"origin": origin}
+			m.Total.With(lbs).Inc()
+			if err != nil {
+				m.InvalidTotal.With(lbs).Inc()
+			}
+		}()
+		level.Debug(l).Log("msg", "Parsing with UTF-8 matchers parser", "input", input)
+		if strings.HasPrefix(input, "{") || strings.HasSuffix(input, "}") {
+			return nil, fmt.Errorf("unexpected open or close brace: %s", input)
 		}
-		return m, nil
+		return parse.Matcher(input)
+	}
+}
+
+// UTF8MatchersParser uses the new matchers/parse parser to parse zero or more
+// matchers in the input string. If this fails it does not revert to the
+// pkg/labels parser.
+func UTF8MatchersParser(l log.Logger, m *Metrics) ParseMatchers {
+	return func(input, origin string) (matchers labels.Matchers, err error) {
+		defer func() {
+			lbs := prometheus.Labels{"origin": origin}
+			m.Total.With(lbs).Inc()
+			if err != nil {
+				m.InvalidTotal.With(lbs).Inc()
+			}
+		}()
+		level.Debug(l).Log("msg", "Parsing with UTF-8 matchers parser", "input", input)
+		return parse.Matchers(input)
+	}
+}
+
+// FallbackMatcherParser uses the new matchers/parse parser to parse zero or more
+// matchers in the string. If this fails it reverts to the pkg/labels parser and
+// emits a warning log line.
+func FallbackMatcherParser(l log.Logger, m *Metrics) ParseMatcher {
+	return func(input, origin string) (matcher *labels.Matcher, err error) {
+		lbs := prometheus.Labels{"origin": origin}
+		defer func() {
+			m.Total.With(lbs).Inc()
+			if err != nil {
+				m.InvalidTotal.With(lbs).Inc()
+			}
+		}()
+		level.Debug(l).Log("msg", "Parsing with UTF-8 matchers parser, with fallback to classic matchers parser", "input", input)
+		if strings.HasPrefix(input, "{") || strings.HasSuffix(input, "}") {
+			return nil, fmt.Errorf("unexpected open or close brace: %s", input)
+		}
+		// Parse the input in both parsers to look for disagreement and incompatible
+		// inputs.
+		nMatcher, nErr := parse.Matcher(input)
+		cMatcher, cErr := labels.ParseMatcher(input)
+		if nErr != nil {
+			// If the input is invalid in both parsers, return the error.
+			if cErr != nil {
+				return nil, cErr
+			}
+			// The input is valid in the pkg/labels parser, but not the matchers/parse
+			// parser. This means the input is not forwards compatible.
+			m.IncompatibleTotal.With(lbs).Inc()
+			suggestion := cMatcher.String()
+			level.Warn(l).Log("msg", "Alertmanager is moving to a new parser for labels and matchers, and this input is incompatible. Alertmanager has instead parsed the input using the old matchers parser as a fallback. To make this input compatible with the new parser please make sure all regular expressions and values are double-quoted. If you are still seeing this message please open an issue.", "input", input, "err", err, "suggestion", suggestion)
+			return cMatcher, nil
+		}
+		// If the input is valid in both parsers, but produces different results,
+		// then there is disagreement.
+		if nErr == nil && cErr == nil && !reflect.DeepEqual(nMatcher, cMatcher) {
+			m.DisagreeTotal.With(lbs).Inc()
+			level.Warn(l).Log("msg", "Matchers input has disagreement", "input", input)
+		}
+		return nMatcher, nil
 	}
 }
 
 // FallbackMatchersParser uses the new matchers/parse parser to parse the
-// matcher in the input string. If this fails it falls back to the old
-// pkg/labels parser and emits a warning log line.
-func FallbackMatchersParser(l log.Logger) ParseMatchers {
-	return func(s string) (labels.Matchers, error) {
-		var (
-			m          []*labels.Matcher
-			err        error
-			invalidErr error
-		)
-		level.Debug(l).Log("msg", "Parsing with UTF-8 matchers parser, with fallback to classic matchers parser", "input", s)
-		m, err = parse.Matchers(s)
-		if err != nil {
-			m, invalidErr = labels.ParseMatchers(s)
-			if invalidErr != nil {
-				// The input is not valid in the old pkg/labels parser either,
-				// it cannot be valid input.
-				return nil, invalidErr
+// matcher in the input string. If this fails it falls back to the pkg/labels
+// parser and emits a warning log line.
+func FallbackMatchersParser(l log.Logger, m *Metrics) ParseMatchers {
+	return func(input, origin string) (matchers labels.Matchers, err error) {
+		lbs := prometheus.Labels{"origin": origin}
+		defer func() {
+			m.Total.With(lbs).Inc()
+			if err != nil {
+				m.InvalidTotal.With(lbs).Inc()
 			}
+		}()
+		level.Debug(l).Log("msg", "Parsing with UTF-8 matchers parser, with fallback to classic matchers parser", "input", input)
+		// Parse the input in both parsers to look for disagreement and incompatible
+		// inputs.
+		nMatchers, nErr := parse.Matchers(input)
+		cMatchers, cErr := labels.ParseMatchers(input)
+		if nErr != nil {
+			// If the input is invalid in both parsers, return the error.
+			if cErr != nil {
+				return nil, cErr
+			}
+			// The input is valid in the pkg/labels parser, but not the matchers/parse
+			// parser. This means the input is not forwards compatible.
+			m.IncompatibleTotal.With(lbs).Inc()
 			var sb strings.Builder
-			for i, n := range m {
+			for i, n := range cMatchers {
 				sb.WriteString(n.String())
-				if i < len(m)-1 {
+				if i < len(cMatchers)-1 {
 					sb.WriteRune(',')
 				}
 			}
 			suggestion := sb.String()
-			// The input is valid in the old pkg/labels parser, but not the
+			// The input is valid in the pkg/labels parser, but not the
 			// new matchers/parse parser.
-			level.Warn(l).Log("msg", "Alertmanager is moving to a new parser for labels and matchers, and this input is incompatible. Alertmanager has instead parsed the input using the old matchers parser as a fallback. To make this input compatible with the new parser please make sure all regular expressions and values are double-quoted. If you are still seeing this message please open an issue.", "input", s, "err", err, "suggestion", suggestion)
+			level.Warn(l).Log("msg", "Alertmanager is moving to a new parser for labels and matchers, and this input is incompatible. Alertmanager has instead parsed the input using the old matchers parser as a fallback. To make this input compatible with the new parser please make sure all regular expressions and values are double-quoted. If you are still seeing this message please open an issue.", "input", input, "err", err, "suggestion", suggestion)
+			return cMatchers, nil
 		}
-		return m, nil
+		// If the input is valid in both parsers, but produces different results,
+		// then there is disagreement. We need to compare to labels.Matchers(cMatchers)
+		// as cMatchers is a []*labels.Matcher not labels.Matchers.
+		if nErr == nil && cErr == nil && !reflect.DeepEqual(nMatchers, labels.Matchers(cMatchers)) {
+			m.DisagreeTotal.With(lbs).Inc()
+			level.Warn(l).Log("msg", "Matchers input has disagreement", "input", input)
+		}
+		return nMatchers, nil
 	}
 }
 

--- a/matchers/compat/parse.go
+++ b/matchers/compat/parse.go
@@ -178,6 +178,7 @@ func FallbackMatcherParser(l log.Logger, m *Metrics) ParseMatcher {
 		if nErr == nil && cErr == nil && !reflect.DeepEqual(nMatcher, cMatcher) {
 			m.DisagreeTotal.With(lbs).Inc()
 			level.Warn(l).Log("msg", "Matchers input has disagreement", "input", input)
+			return cMatcher, nil
 		}
 		return nMatcher, nil
 	}
@@ -227,6 +228,7 @@ func FallbackMatchersParser(l log.Logger, m *Metrics) ParseMatchers {
 		if nErr == nil && cErr == nil && !reflect.DeepEqual(nMatchers, labels.Matchers(cMatchers)) {
 			m.DisagreeTotal.With(lbs).Inc()
 			level.Warn(l).Log("msg", "Matchers input has disagreement", "input", input)
+			return cMatchers, nil
 		}
 		return nMatchers, nil
 	}

--- a/matchers/compat/parse_test.go
+++ b/matchers/compat/parse_test.go
@@ -17,6 +17,8 @@ import (
 	"testing"
 
 	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
@@ -25,47 +27,67 @@ import (
 
 func TestFallbackMatcherParser(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    string
-		expected *labels.Matcher
-		err      string
+		name              string
+		input             string
+		expected          *labels.Matcher
+		err               string
+		total             int
+		disagreeTotal     int
+		incompatibleTotal int
+		invalidTotal      int
 	}{{
 		name:     "is accepted in both",
 		input:    "foo=bar",
 		expected: mustNewMatcher(t, labels.MatchEqual, "foo", "bar"),
+		total:    1,
 	}, {
 		name:     "is accepted in new parser but not old",
 		input:    "foo🙂=bar",
 		expected: mustNewMatcher(t, labels.MatchEqual, "foo🙂", "bar"),
+		total:    1,
 	}, {
-		name:     "is accepted in old parser but not new",
-		input:    "foo=!bar\\n",
-		expected: mustNewMatcher(t, labels.MatchEqual, "foo", "!bar\n"),
+		name:              "is accepted in old parser but not new",
+		input:             "foo=!bar\\n",
+		expected:          mustNewMatcher(t, labels.MatchEqual, "foo", "!bar\n"),
+		total:             1,
+		incompatibleTotal: 1,
 	}, {
-		name:  "is accepted in neither",
-		input: "foo!bar",
-		err:   "bad matcher format: foo!bar",
+		name:         "is accepted in neither",
+		input:        "foo!bar",
+		err:          "bad matcher format: foo!bar",
+		total:        1,
+		invalidTotal: 1,
 	}}
-	f := FallbackMatcherParser(log.NewNopLogger())
+
 	for _, test := range tests {
+		m := NewMetrics(prometheus.NewRegistry())
+		f := FallbackMatcherParser(log.NewNopLogger(), m)
 		t.Run(test.name, func(t *testing.T) {
-			matcher, err := f(test.input)
+			matcher, err := f(test.input, "test")
 			if test.err != "" {
 				require.EqualError(t, err, test.err)
 			} else {
 				require.NoError(t, err)
 				require.EqualValues(t, test.expected, matcher)
 			}
+			require.Equal(t, test.total, testutil.CollectAndCount(m.Total))
+			require.Equal(t, test.disagreeTotal, testutil.CollectAndCount(m.DisagreeTotal))
+			require.Equal(t, test.incompatibleTotal, testutil.CollectAndCount(m.IncompatibleTotal))
+			require.Equal(t, test.invalidTotal, testutil.CollectAndCount(m.InvalidTotal))
 		})
 	}
 }
 
 func TestFallbackMatchersParser(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    string
-		expected labels.Matchers
-		err      string
+		name              string
+		input             string
+		expected          labels.Matchers
+		err               string
+		total             int
+		disagreeTotal     int
+		incompatibleTotal int
+		invalidTotal      int
 	}{{
 		name:  "is accepted in both",
 		input: "{foo=bar,bar=baz}",
@@ -73,6 +95,7 @@ func TestFallbackMatchersParser(t *testing.T) {
 			mustNewMatcher(t, labels.MatchEqual, "foo", "bar"),
 			mustNewMatcher(t, labels.MatchEqual, "bar", "baz"),
 		},
+		total: 1,
 	}, {
 		name:  "is accepted in new parser but not old",
 		input: "{foo🙂=bar,bar=baz🙂}",
@@ -80,6 +103,7 @@ func TestFallbackMatchersParser(t *testing.T) {
 			mustNewMatcher(t, labels.MatchEqual, "foo🙂", "bar"),
 			mustNewMatcher(t, labels.MatchEqual, "bar", "baz🙂"),
 		},
+		total: 1,
 	}, {
 		name:  "is accepted in old parser but not new",
 		input: "{foo=!bar,bar=$baz\\n}",
@@ -87,21 +111,31 @@ func TestFallbackMatchersParser(t *testing.T) {
 			mustNewMatcher(t, labels.MatchEqual, "foo", "!bar"),
 			mustNewMatcher(t, labels.MatchEqual, "bar", "$baz\n"),
 		},
+		total:             1,
+		incompatibleTotal: 1,
 	}, {
-		name:  "is accepted in neither",
-		input: "{foo!bar}",
-		err:   "bad matcher format: foo!bar",
+		name:         "is accepted in neither",
+		input:        "{foo!bar}",
+		err:          "bad matcher format: foo!bar",
+		total:        1,
+		invalidTotal: 1,
 	}}
-	f := FallbackMatchersParser(log.NewNopLogger())
+
 	for _, test := range tests {
+		m := NewMetrics(prometheus.NewRegistry())
+		f := FallbackMatchersParser(log.NewNopLogger(), m)
 		t.Run(test.name, func(t *testing.T) {
-			matchers, err := f(test.input)
+			matchers, err := f(test.input, "test")
 			if test.err != "" {
 				require.EqualError(t, err, test.err)
 			} else {
 				require.NoError(t, err)
 				require.EqualValues(t, test.expected, matchers)
 			}
+			require.Equal(t, test.total, testutil.CollectAndCount(m.Total))
+			require.Equal(t, test.disagreeTotal, testutil.CollectAndCount(m.DisagreeTotal))
+			require.Equal(t, test.incompatibleTotal, testutil.CollectAndCount(m.IncompatibleTotal))
+			require.Equal(t, test.invalidTotal, testutil.CollectAndCount(m.InvalidTotal))
 		})
 	}
 }


### PR DESCRIPTION
This commit adds the following metrics to the compat package:

- `alertmanager_matchers_parse`
- `alertmanager_matchers_disagree`
- `alertmanager_matchers_incompatible`
- `alertmanager_matchers_invalid`

With a label called origin to differentiate the different sources of inputs: the configuration file, the API, and amtool.

The disagree_total metric is incremented when an input is invalid in both parsers, but results in different parsed representations, then there is disagreement. This should not happen, and suggests their is either a bug in one of the parsers or a mistake in the backwards compatible guarantees of the matchers/parse parser.

The incompatible_total metric is incremented when an input is valid in pkg/labels, but not the UTF-8 parser in matchers/parse. In such case, the matcher should be updated to be compatible. This often means adding double quotes around the right hand side of the matcher. For example, foo="bar".

The invalid_total metric is incremented when an input is invalid in both parsers. This was never a valid input.

The tests have been updated to check the metrics are incremented as expected.