### PR TITLE
Fix missing check for len(name) == 0

### DIFF
--- a/matchers/compat/parse.go
+++ b/matchers/compat/parse.go
@@ -244,6 +244,9 @@ func isValidClassicLabelName(_ log.Logger) func(model.LabelName) bool {
 // isValidUTF8LabelName returns true if the string is a valid UTF-8 label name.
 func isValidUTF8LabelName(_ log.Logger) func(model.LabelName) bool {
 	return func(name model.LabelName) bool {
+		if len(name) == 0 {
+			return false
+		}
 		return utf8.ValidString(string(name))
 	}
 }

--- a/matchers/compat/parse_test.go
+++ b/matchers/compat/parse_test.go
@@ -172,19 +172,23 @@ func TestIsValidClassicLabelName(t *testing.T) {
 		input    model.LabelName
 		expected bool
 	}{{
-		name:     "is accepted",
+		name:     "foo is accepted",
 		input:    "foo",
 		expected: true,
 	}, {
-		name:     "is also accepted",
+		name:     "starts with underscore and ends with number is accepted",
 		input:    "_foo1",
 		expected: true,
 	}, {
-		name:     "is not accepted",
+		name:     "empty is not accepted",
+		input:    "",
+		expected: false,
+	}, {
+		name:     "starts with number is not accepted",
 		input:    "0foo",
 		expected: false,
 	}, {
-		name:     "is also not accepted",
+		name:     "contains emoji is not accepted",
 		input:    "foo🙂",
 		expected: false,
 	}}
@@ -203,21 +207,25 @@ func TestIsValidUTF8LabelName(t *testing.T) {
 		input    model.LabelName
 		expected bool
 	}{{
-		name:     "is accepted",
+		name:     "foo is accepted",
 		input:    "foo",
 		expected: true,
 	}, {
-		name:     "is also accepted",
+		name:     "starts with underscore and ends with number is accepted",
 		input:    "_foo1",
 		expected: true,
 	}, {
-		name:     "is accepted in UTF-8",
+		name:     "starts with number is accepted",
 		input:    "0foo",
 		expected: true,
 	}, {
-		name:     "is also accepted with UTF-8",
+		name:     "contains emoji is accepted",
 		input:    "foo🙂",
 		expected: true,
+	}, {
+		name:     "empty is not accepted",
+		input:    "",
+		expected: false,
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
This pull request fixes a missing check when validating UTF-8 label names that is present in `prometheus/common`.