### PR TITLE
Pass color as template var for discord notifier

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -48,6 +48,7 @@ var (
 		},
 		Title:   `{{ template "discord.default.title" . }}`,
 		Message: `{{ template "discord.default.message" . }}`,
+		Color:   `{{ template "discord.default.color" . }}`,
 	}
 
 	// DefaultEmailConfig defines default values for Email configurations.
@@ -221,6 +222,7 @@ type DiscordConfig struct {
 
 	Title   string `yaml:"title,omitempty" json:"title,omitempty"`
 	Message string `yaml:"message,omitempty" json:"message,omitempty"`
+	Color   string `yaml:"color,omitempty" json:"color,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -678,6 +678,9 @@ webhook_url: <secret>
 # Message body template.
 [ message: <tmpl_string> | default = '{{ template "discord.default.message" . }}' ]
 
+# Color of message frame.
+[ color: <tmpl_string> | default = '{{ template "discord.default.color" . }}' ]
+
 # The HTTP client's configuration.
 [ http_config: <http_config> | default = global.http_config ]
 ```

--- a/template/default.tmpl
+++ b/template/default.tmpl
@@ -134,6 +134,15 @@ Alerts Resolved:
 {{ template "__text_alert_list" .Alerts.Resolved }}
 {{ end }}
 {{ end }}
+{{ define "discord.default.color" }}
+{{ if gt (len .Alerts.Firing) 0 }}
+10038562
+{{ else if gt (len .Alerts.Resolved) 0 }}
+3066993
+{{ else }}
+9807270
+{{ end }}
+{{ end }}
 
 {{ define "webex.default.message" }}{{ .CommonAnnotations.SortedPairs.Values | join " " }}
 {{ if gt (len .Alerts.Firing) 0 }}


### PR DESCRIPTION
I've upgraded Discord notifier to accept `color` in template. It's the color of the embed frame, and right now there are only three options: red, green and grey. By passing the color via template, we allow developers to make better integrations. For example, one can choose different colors based on severity, or project, or any other logic that is useful to a team.

https://discord.com/developers/docs/resources/channel#embed-object-embed-structure

1. Documentation says that `color` must be of type integer, but in reality Discord accepts untrimmed strings as well, as long as they contain a 10-base integer.
2. I've moved default colors to the template, for two reasons: (a) Slack defines default color values outside of slack/slack.go, so I used it as example; (b) it makes it easier to find everything default in one place, be it default title or default color.
3. The type is now `string` instead of `int`, and it has its own pros and cons, I'm hoping someone will advise me on the best approach. I haven't found a super easy way to get int out of template without some sort of string-to-int conversion. And with parsing, we need to know if its 10-base int inside a string or `0x`. And it seems like doing parsing on our side just adds more places where something might go wrong, and it doesn't feel worth it. Discord API works okay with parsing on their end as long as colors are 10-base. It's a simpler and safer approach in my opinion, so I did that.

This is my first PR to alertmanager, so if there are any other requirements for the PR, i'll be happy to update it.
Also, I will be happy to add support for the whole `embed` struct based on current Discord API if this change is welcome, I believe this will give more freedom to developers to setup their integrations.

Screenshot of the alert with custom color, and thumbnail (thumbnail is not part of this PR):
<img width="473" alt="Screenshot 2024-01-19 at 11 07 45" src="https://github.com/prometheus/alertmanager/assets/872004/5015f1dc-516f-4d6c-8d47-34b4f1f3964c">

