### PR TITLE
Remove unused feature flags

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -251,7 +251,6 @@ func run() int {
 		Retention:    *retention,
 		Logger:       log.With(logger, "component", "silences"),
 		Metrics:      prometheus.DefaultRegisterer,
-		FeatureFlags: ff,
 	}
 
 	silences, err := silence.New(silenceOpts)

--- a/silence/silence.go
+++ b/silence/silence.go
@@ -37,7 +37,6 @@ import (
 	"github.com/prometheus/common/model"
 
 	"github.com/prometheus/alertmanager/cluster"
-	"github.com/prometheus/alertmanager/featurecontrol"
 	"github.com/prometheus/alertmanager/matchers/compat"
 	"github.com/prometheus/alertmanager/pkg/labels"
 	pb "github.com/prometheus/alertmanager/silence/silencepb"
@@ -317,9 +316,8 @@ type Options struct {
 	Retention time.Duration
 
 	// A logger used by background processing.
-	Logger       log.Logger
-	Metrics      prometheus.Registerer
-	FeatureFlags featurecontrol.Flagger
+	Logger  log.Logger
+	Metrics prometheus.Registerer
 }
 
 func (o *Options) validate() error {


### PR DESCRIPTION
This commit removes some code that should have been removed in #3668. The FeatureFlags in silence.Options are no longer used but were still initialized. These had a no-op effect.