### PR TITLE
[AMTOOL] Add support for env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,10 @@ Example of usage:
 ```
 # View routing tree of remote Alertmanager
 $ amtool config routes --alertmanager.url=http://localhost:9090
+# View routing tree of remote Alertmanager using environment variable
+# AMTOOL_ALERTMANAGER_URL=http://localhost:9090  amtool config routes
+# export AMTOOL_ALERTMANAGER_URL=http://localhost:9090
+# amtool config routes
 
 # Test if alert matches expected receiver
 $ amtool config routes test --config.file=doc/examples/simple.yml --tree --verify.receivers=team-X-pager service=database owner=team-X

--- a/cli/root.go
+++ b/cli/root.go
@@ -147,7 +147,7 @@ func NewAlertmanagerClient(amURL *url.URL) *client.AlertmanagerAPI {
 
 // Execute is the main function for the amtool command
 func Execute() {
-	app := kingpin.New("amtool", helpRoot).UsageWriter(os.Stdout)
+	app := kingpin.New("amtool", helpRoot).UsageWriter(os.Stdout).DefaultEnvars()
 
 	format.InitFormatFlags(app)
 


### PR DESCRIPTION
Hello,

The idea is to add support for env variable so we can set env variable that's going to be used when calling amtool. 

I did it globaly maybe it could be changed  to some specific flag  if the idea seem's to be legit

I am using amtool in different cluster so each time , i need to setup the command with the new url. I have already some shell alias configured that i am currently using when switching between cluster but  i would like to be able to use the env variable so when switching to a new cluster  the `AMTOOL_ALERTMANAGER_URL` will be updated.

Here the usage that i got 

```sh
./amtool
usage: amtool [<flags>] <command> [<args> ...]

View and modify the current Alertmanager state.

Config File: The alertmanager tool will read a config file in YAML format from one of two default config locations: $HOME/.config/amtool/config.yml or /etc/amtool/config.yml

All flags can be given in the config file, but the following are the suited for static configuration:

  alertmanager.url
        Set a default alertmanager url for each request

  author
        Set a default author value for new silences. If this argument is not
        specified then the username will be used

  require-comment
        Bool, whether to require a comment on silence creation. Defaults to true

  output
        Set a default output type. Options are (simple, extended, json)

  date.format
        Sets the output format for dates. Defaults to "2006-01-02 15:04:05 MST"

  http.config.file
        HTTP client configuration file for amtool to connect to Alertmanager.
        The format is https://prometheus.io/docs/alerting/latest/configuration/#http_config.

Flags:
  -h, --[no-]help           Show context-sensitive help (also try --help-long and --help-man). ($AMTOOL_HELP)
      --date.format="2006-01-02 15:04:05 MST"
                            Format of date output ($AMTOOL_DATE_FORMAT)
  -v, --[no-]verbose        Verbose running information ($AMTOOL_VERBOSE)
      --alertmanager.url=ALERTMANAGER.URL
                            Alertmanager to talk to ($AMTOOL_ALERTMANAGER_URL)
  -o, --output=simple       Output formatter (simple, extended, json) ($AMTOOL_OUTPUT)
      --timeout=30s         Timeout for the executed command ($AMTOOL_TIMEOUT)
      --http.config.file=<filename>
                            HTTP client configuration file for amtool to connect to Alertmanager. ($AMTOOL_HTTP_CONFIG_FILE)
      --[no-]version-check  Check alertmanager version. Use --no-version-check to disable. ($AMTOOL_VERSION_CHECK)
      --enable-feature=""   Experimental features to enable. The flag can be repeated to enable multiple features. Valid options: receiver-name-in-metrics, classic-mode, utf8-strict-mode
                            ($AMTOOL_ENABLE_FEATURE)
      --[no-]version        Show application version. ($AMTOOL_VERSION)

Commands:
  help [<command>...]
  alert
    query* [<flags>] [<matcher-groups>...]
    add [<flags>] [<labels>...]
  silence
    add [<flags>] [<matcher-groups>...]
    expire [<silence-ids>...]
    import [<flags>] [<input-file>]
    query* [<flags>] [<matcher-groups>...]
    update [<flags>] [<update-ids>...]
  check-config [<check-files>...]
  cluster
    show*
  config
    show*
    routes [<flags>]
      show*
      test [<flags>] [<labels>...]
  template
    render --template.glob=TEMPLATE.GLOB --template.text=TEMPLATE.TEXT [<flags>]
```