### PR TITLE
Newlines in smtp password file are now ignored

### DIFF
--- a/notify/email/email.go
+++ b/notify/email/email.go
@@ -368,7 +368,7 @@ func (n *Email) getPassword() (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("could not read %s: %w", n.conf.AuthPasswordFile, err)
 		}
-		return string(content), nil
+		return strings.TrimSpace(string(content)), nil
 	}
 	return string(n.conf.AuthPassword), nil
 }


### PR DESCRIPTION
This should ignore any newlines in the smtp password file (actually, the file contents are trimmed).

fixed #3549 

**BEWARE** I did not test or even build the project after this single-line change (sorry: I don't know how to do it and honestly can't be bothered to learn how to for a drive-by contribution)
