### PR TITLE
Add metric for inhibit rules

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -96,6 +96,11 @@ var (
 			Help: "Number of configured integrations.",
 		},
 	)
+	configuredInhibitRules = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "alertmanager_inhibit_rules",
+			Help: "Number of configured inhibit rules.",
+		})
 	promlogConfig = promlog.Config{}
 )
 
@@ -105,6 +110,7 @@ func init() {
 	prometheus.MustRegister(clusterEnabled)
 	prometheus.MustRegister(configuredReceivers)
 	prometheus.MustRegister(configuredIntegrations)
+	prometheus.MustRegister(configuredInhibitRules)
 	prometheus.MustRegister(version.NewCollector("alertmanager"))
 }
 
@@ -435,6 +441,7 @@ func run() int {
 
 		configuredReceivers.Set(float64(len(activeReceivers)))
 		configuredIntegrations.Set(float64(integrationsNum))
+		configuredInhibitRules.Set(float64(len(conf.InhibitRules)))
 
 		api.Update(conf, func(labels model.LabelSet) {
 			inhibitor.Mutes(labels)

--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -96,10 +96,10 @@ var (
 			Help: "Number of configured integrations.",
 		},
 	)
-	configuredInhibitRules = prometheus.NewGauge(
+	configuredInhibitionRules = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name: "alertmanager_inhibit_rules",
-			Help: "Number of configured inhibit rules.",
+			Name: "alertmanager_inhibition_rules",
+			Help: "Number of configured inhibition rules.",
 		})
 	promlogConfig = promlog.Config{}
 )
@@ -110,7 +110,7 @@ func init() {
 	prometheus.MustRegister(clusterEnabled)
 	prometheus.MustRegister(configuredReceivers)
 	prometheus.MustRegister(configuredIntegrations)
-	prometheus.MustRegister(configuredInhibitRules)
+	prometheus.MustRegister(configuredInhibitionRules)
 	prometheus.MustRegister(version.NewCollector("alertmanager"))
 }
 
@@ -441,7 +441,7 @@ func run() int {
 
 		configuredReceivers.Set(float64(len(activeReceivers)))
 		configuredIntegrations.Set(float64(integrationsNum))
-		configuredInhibitRules.Set(float64(len(conf.InhibitRules)))
+		configuredInhibitionRules.Set(float64(len(conf.InhibitRules)))
 
 		api.Update(conf, func(labels model.LabelSet) {
 			inhibitor.Mutes(labels)


### PR DESCRIPTION
This commit adds a new metric called `alertmanager_inhibit_rules`. It is identical to the `alertmanager_integrations` and `alertmanager_receivers` metrics that are present in the current and previous versions.

Some examples of this at `/metrics`:

```
# HELP alertmanager_inhibit_rules Number of configured inhibit rules.
# TYPE alertmanager_inhibit_rules gauge
alertmanager_inhibit_rules 0
```

```
# HELP alertmanager_inhibit_rules Number of configured inhibit rules.
# TYPE alertmanager_inhibit_rules gauge
alertmanager_inhibit_rules 1
```

```
# HELP alertmanager_inhibit_rules Number of configured inhibit rules.
# TYPE alertmanager_inhibit_rules gauge
alertmanager_inhibit_rules 2
```