### PR TITLE
Do not register compat metrics in amtool

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -61,7 +61,7 @@ func initMatchersCompat(_ *kingpin.ParseContext) error {
 	if err != nil {
 		kingpin.Fatalf("error parsing the feature flag list: %v\n", err)
 	}
-	compat.InitFromFlags(logger, compat.RegisteredMetrics, featureConfig)
+	compat.InitFromFlags(logger, compat.NewMetrics(nil), featureConfig)
 	return nil
 }
 


### PR DESCRIPTION
There is no need to register these metrics in amtool, so use `compat.NewMetrics(nil)` instead of `compat.RegisteredMetrics`.