### PR TITLE
feat: add time helpers

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -95,3 +95,5 @@ templating.
 | join | sep string, s []string | [strings.Join](http://golang.org/pkg/strings/#Join), concatenates the elements of s to create a single string. The separator string sep is placed between elements in the resulting string. (note: argument order inverted for easier pipelining in templates.) |
 | safeHtml | text string | [html/template.HTML](https://golang.org/pkg/html/template/#HTML), Marks string as HTML not requiring auto-escaping. |
 | stringSlice | ...string | Returns the passed strings as a slice of strings. |
+| since | time.Time | [time.Duration](https://pkg.go.dev/time#Since), returns the duration of how much time passed from the provided time till the current system time. |
+| humanizeDuration | number or string | Returns a human-readable string representing the duration, and the error if it happened. |

--- a/template/template.go
+++ b/template/template.go
@@ -15,13 +15,16 @@ package template
 
 import (
 	"bytes"
+	"fmt"
 	tmplhtml "html/template"
 	"io"
+	"math"
 	"net/url"
 	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	tmpltext "text/template"
 	"time"
@@ -192,6 +195,74 @@ var DefaultFuncs = FuncMap{
 	"stringSlice": func(s ...string) []string {
 		return s
 	},
+	"since": time.Since,
+	"humanizeDuration": func(i interface{}) (string, error) {
+		v, err := convertToFloat(i)
+		if err != nil {
+			return "", err
+		}
+
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			return fmt.Sprintf("%.4g", v), nil
+		}
+		if v == 0 {
+			return fmt.Sprintf("%.4gs", v), nil
+		}
+		if math.Abs(v) >= 1 {
+			sign := ""
+			if v < 0 {
+				sign = "-"
+				v = -v
+			}
+			duration := int64(v)
+			seconds := duration % 60
+			minutes := (duration / 60) % 60
+			hours := (duration / 60 / 60) % 24
+			days := duration / 60 / 60 / 24
+			// For days to minutes, we display seconds as an integer.
+			if days != 0 {
+				return fmt.Sprintf("%s%dd %dh %dm %ds", sign, days, hours, minutes, seconds), nil
+			}
+			if hours != 0 {
+				return fmt.Sprintf("%s%dh %dm %ds", sign, hours, minutes, seconds), nil
+			}
+			if minutes != 0 {
+				return fmt.Sprintf("%s%dm %ds", sign, minutes, seconds), nil
+			}
+			// For seconds, we display 4 significant digits.
+			return fmt.Sprintf("%s%.4gs", sign, v), nil
+		}
+		prefix := ""
+		for _, p := range []string{"m", "u", "n", "p", "f", "a", "z", "y"} {
+			if math.Abs(v) >= 1 {
+				break
+			}
+			prefix = p
+			v *= 1000
+		}
+		return fmt.Sprintf("%.4g%ss", v, prefix), nil
+	},
+}
+
+func convertToFloat(i interface{}) (float64, error) {
+	switch v := i.(type) {
+	case float64:
+		return v, nil
+	case string:
+		return strconv.ParseFloat(v, 64)
+	case int:
+		return float64(v), nil
+	case uint:
+		return float64(v), nil
+	case int64:
+		return float64(v), nil
+	case uint64:
+		return float64(v), nil
+	case time.Duration:
+		return v.Seconds(), nil
+	default:
+		return 0, fmt.Errorf("can't convert %T to float", v)
+	}
 }
 
 // Pair is a key/value string pair.

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -385,6 +385,53 @@ func TestTemplateExpansion(t *testing.T) {
 			},
 			exp: "[key2 key4]",
 		},
+		{
+			title: "Template using HumanizeDuration - seconds - float64",
+			in:    "{{ range . }}{{ humanizeDuration . }}:{{ end }}",
+			data:  []float64{0, 1, 60, 3600, 86400, 86400 + 3600, -(86400*2 + 3600*3 + 60*4 + 5), 899.99},
+			exp:   "0s:1s:1m 0s:1h 0m 0s:1d 0h 0m 0s:1d 1h 0m 0s:-2d 3h 4m 5s:14m 59s:",
+		},
+		{
+			title: "Template using HumanizeDuration - seconds - string.",
+			in:    "{{ range . }}{{ humanizeDuration . }}:{{ end }}",
+			data:  []string{"0", "1", "60", "3600", "86400"},
+			exp:   "0s:1s:1m 0s:1h 0m 0s:1d 0h 0m 0s:",
+		},
+		{
+			title: "Template using HumanizeDuration - subsecond and fractional seconds - float64.",
+			in:    "{{ range . }}{{ humanizeDuration . }}:{{ end }}",
+			data:  []float64{.1, .0001, .12345, 60.1, 60.5, 1.2345, 12.345},
+			exp:   "100ms:100us:123.5ms:1m 0s:1m 0s:1.234s:12.35s:",
+		},
+		{
+			title: "Template using HumanizeDuration - subsecond and fractional seconds - string.",
+			in:    "{{ range . }}{{ humanizeDuration . }}:{{ end }}",
+			data:  []string{".1", ".0001", ".12345", "60.1", "60.5", "1.2345", "12.345"},
+			exp:   "100ms:100us:123.5ms:1m 0s:1m 0s:1.234s:12.35s:",
+		},
+		{
+			title: "Template using HumanizeDuration - string with error.",
+			in:    `{{ humanizeDuration "one" }}`,
+			fail:  true,
+		},
+		{
+			title: "Template using HumanizeDuration - int.",
+			in:    "{{ range . }}{{ humanizeDuration . }}:{{ end }}",
+			data:  []int{0, -1, 1, 1234567},
+			exp:   "0s:-1s:1s:14d 6h 56m 7s:",
+		},
+		{
+			title: "Template using HumanizeDuration - uint.",
+			in:    "{{ range . }}{{ humanizeDuration . }}:{{ end }}",
+			data:  []uint{0, 1, 1234567},
+			exp:   "0s:1s:14d 6h 56m 7s:",
+		},
+		{
+			title: "Template using since",
+			in:    "{{ . | since | humanizeDuration }}",
+			data:  time.Now().Add(-1 * time.Hour),
+			exp:   "1h 0m 0s",
+		},
 	} {
 		tc := tc
 		t.Run(tc.title, func(t *testing.T) {


### PR DESCRIPTION
Fixes #3717.

The `humanizeDirection` helper is 100% copied from Prometheus, the `since` is added by me.
The tests are also copied from Prometheus and adapted, plus I added my own `since` test.

Tested it locally: creating an alert like this one:
```
./amtool alert add --alertmanager.url http://localhost:9093 alertname=aaa host=test instance=test3
```

with a template like this one
```
{{ define "alerts_list" }}
{{ range . }}{{ if index .Labels "host" -}}
🖥️ Host: {{ index .Labels "host" }} ({{ index .Labels "instance" }})
{{- else -}}
🖥️ Host: {{ index .Labels "instance" }}
{{- end }}
{{ if eq (index .Labels "severity") "critical" -}}
🔴 Severity: critical
{{- else -}}
🟠 Severity: warning
{{- end }}
📖 Alert: {{ index .Labels "alertname" }}
ℹ️ Details: {{ index .Annotations "summary" }}
⌛ Firing since: {{ .StartsAt }} (for {{ .StartsAt | since | humanizeDuration }})
📝 Description: {{ index .Annotations "description" }}

Labels:
{{ range .Labels.SortedPairs }} - {{ .Name }} = {{ .Value }}
{{ end }}
<a href="{{ .GeneratorURL }}">Source</a>

{{ end }}
{{ end }}
```

produces the following output:
```
🔥 Alerts Firing

🖥️ Host: test (test3)
🟠 Severity: warning
📖 Alert: aaa
ℹ️ Details: 
⌛ Firing since: 2024-02-13 22:22:49.535404 +0300 MSK m=+4.535759668 (for 10.01s)
📝 Description: 

Labels:
 - alertname = aaa
 - host = test
 - instance = test3

Source
```