### PR TITLE
Fix flaky test TestClusterJoinAndReconnect/TestTLSConnection

### DIFF
--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -335,6 +335,8 @@ func testTLSConnection(t *testing.T) {
 	require.NoError(t, err)
 	go p2.Settle(context.Background(), 0*time.Second)
 	p2.WaitReady(context.Background())
+	require.Equal(t, "ready", p2.Status())
+
 	require.Equal(t, 2, p1.ClusterSize())
 	p2.Leave(0 * time.Second)
 	require.Equal(t, 1, p1.ClusterSize())


### PR DESCRIPTION
wait until `p2.Status()` returns because it blocks until we're ready - that way, we're guaranteed to know that the cluster size is 2.

This keeps failing consistently now https://github.com/prometheus/alertmanager/actions/runs/7900029184/job/21561068687?pr=3721