### PR TITLE
`amtool template render` improve default data

### DIFF
--- a/cli/template_render.go
+++ b/cli/template_render.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/prometheus/common/model"
 
 	"github.com/prometheus/alertmanager/template"
 )
@@ -31,7 +32,7 @@ var defaultData = template.Data{
 	Status:   "alertstatus",
 	Alerts: template.Alerts{
 		template.Alert{
-			Status: "alertstatus",
+			Status: string(model.AlertFiring),
 			Labels: template.KV{
 				"label1":          "value1",
 				"label2":          "value2",
@@ -51,7 +52,7 @@ var defaultData = template.Data{
 			Fingerprint:  "fingerprint1",
 		},
 		template.Alert{
-			Status: "alertstatus",
+			Status: string(model.AlertResolved),
 			Labels: template.KV{
 				"foo":             "bar",
 				"baz":             "qux",


### PR DESCRIPTION
Currently, the default example alerts of the `amtool template render` command contain an invalid status, leading to `.Alerts.Firing` and `.Alerts.Resolved` returning empty arrays.

This PR changes one of the two examples to `firing` the other to `resolved`.