### PR TITLE
fix: discord & msteams webhook_url_file configuration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -516,8 +516,8 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			if discord.HTTPConfig == nil {
 				discord.HTTPConfig = c.Global.HTTPConfig
 			}
-			if discord.WebhookURL == nil {
-				return fmt.Errorf("no discord webhook URL provided")
+			if discord.WebhookURL == nil && len(discord.WebhookURLFile) == 0 {
+				return fmt.Errorf("no discord webhook URL or URLFile provided")
 			}
 		}
 		for _, webex := range rcv.WebexConfigs {
@@ -536,8 +536,8 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			if msteams.HTTPConfig == nil {
 				msteams.HTTPConfig = c.Global.HTTPConfig
 			}
-			if msteams.WebhookURL == nil {
-				return fmt.Errorf("no msteams webhook URL provided")
+			if msteams.WebhookURL == nil && len(msteams.WebhookURLFile) == 0 {
+				return fmt.Errorf("no msteams webhook URL or URLFile provided")
 			}
 		}
 


### PR DESCRIPTION
This PR fixes the discord & msteams webhook_url_file config option introduced in #3555

There was a missing check for the WebhookURLFile causing this error:
msg="Loading configuration file failed" file=alertmanager.yml err="no discord webhook URL provided"