### PR TITLE
Send a slice of values to callback function instead of references

### DIFF
--- a/provider/mem/mem.go
+++ b/provider/mem/mem.go
@@ -100,13 +100,13 @@ func NewAlerts(ctx context.Context, m types.Marker, intervalGC time.Duration, al
 		logger:    log.With(l, "component", "provider"),
 		callback:  alertCallback,
 	}
-	a.alerts.SetGCCallback(func(alerts []*types.Alert) {
+	a.alerts.SetGCCallback(func(alerts []types.Alert) {
 		for _, alert := range alerts {
 			// As we don't persist alerts, we no longer consider them after
 			// they are resolved. Alerts waiting for resolved notifications are
 			// held in memory in aggregation groups redundantly.
 			m.Delete(alert.Fingerprint())
-			a.callback.PostDelete(alert)
+			a.callback.PostDelete(&alert)
 		}
 
 		a.mtx.Lock()

--- a/store/store.go
+++ b/store/store.go
@@ -34,21 +34,21 @@ var ErrNotFound = errors.New("alert not found")
 type Alerts struct {
 	sync.Mutex
 	c  map[model.Fingerprint]*types.Alert
-	cb func([]*types.Alert)
+	cb func([]types.Alert)
 }
 
 // NewAlerts returns a new Alerts struct.
 func NewAlerts() *Alerts {
 	a := &Alerts{
 		c:  make(map[model.Fingerprint]*types.Alert),
-		cb: func(_ []*types.Alert) {},
+		cb: func(_ []types.Alert) {},
 	}
 
 	return a
 }
 
 // SetGCCallback sets a GC callback to be executed after each GC.
-func (a *Alerts) SetGCCallback(cb func([]*types.Alert)) {
+func (a *Alerts) SetGCCallback(cb func([]types.Alert)) {
 	a.Lock()
 	defer a.Unlock()
 
@@ -71,11 +71,21 @@ func (a *Alerts) Run(ctx context.Context, interval time.Duration) {
 
 func (a *Alerts) gc() {
 	a.Lock()
-	var resolved []*types.Alert
+	var resolved []types.Alert
 	for fp, alert := range a.c {
 		if alert.Resolved() {
 			delete(a.c, fp)
-			resolved = append(resolved, alert)
+			resolved = append(resolved, types.Alert{
+				Alert: model.Alert{
+					Labels:       alert.Labels.Clone(),
+					Annotations:  alert.Annotations.Clone(),
+					StartsAt:     alert.StartsAt,
+					EndsAt:       alert.EndsAt,
+					GeneratorURL: alert.GeneratorURL,
+				},
+				UpdatedAt: alert.UpdatedAt,
+				Timeout:   alert.Timeout,
+			})
 		}
 	}
 	a.Unlock()

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -79,7 +79,7 @@ func TestGC(t *testing.T) {
 		done        = make(chan struct{})
 		ctx, cancel = context.WithCancel(context.Background())
 	)
-	s.SetGCCallback(func(a []*types.Alert) {
+	s.SetGCCallback(func(a []types.Alert) {
 		n += len(a)
 		if n >= len(resolved) {
 			cancel()


### PR DESCRIPTION
This PR addresses this [comment](https://github.com/prometheus/alertmanager/pull/3715#discussion_r1507309879) 

I did not want to change `type AlertStoreCallback interface` as this might be a breaking change



