### PR TITLE
Mark the fingerprints of all inhibiting rules

### DIFF
--- a/inhibit/inhibit.go
+++ b/inhibit/inhibit.go
@@ -126,8 +126,10 @@ func (ih *Inhibitor) Stop() {
 // Mutes returns true iff the given label set is muted. It implements the Muter
 // interface.
 func (ih *Inhibitor) Mutes(lset model.LabelSet) bool {
-	fp := lset.Fingerprint()
-
+	var (
+		alert        = lset.Fingerprint()
+		fingerprints []string
+	)
 	for _, r := range ih.rules {
 		if !r.TargetMatchers.Matches(lset) {
 			// If target side of rule doesn't match, we don't need to look any further.
@@ -135,14 +137,12 @@ func (ih *Inhibitor) Mutes(lset model.LabelSet) bool {
 		}
 		// If we are here, the target side matches. If the source side matches, too, we
 		// need to exclude inhibiting alerts for which the same is true.
-		if inhibitedByFP, eq := r.hasEqual(lset, r.SourceMatchers.Matches(lset)); eq {
-			ih.marker.SetInhibited(fp, inhibitedByFP.String())
-			return true
+		if fp, eq := r.hasEqual(lset, r.SourceMatchers.Matches(lset)); eq {
+			fingerprints = append(fingerprints, fp.String())
 		}
 	}
-	ih.marker.SetInhibited(fp)
-
-	return false
+	ih.marker.SetInhibited(alert, fingerprints...)
+	return len(fingerprints) > 0
 }
 
 // An InhibitRule specifies that a class of (source) alerts should inhibit

--- a/pkg/labels/matcher.go
+++ b/pkg/labels/matcher.go
@@ -75,6 +75,16 @@ func NewMatcher(t MatchType, n, v string) (*Matcher, error) {
 	return m, nil
 }
 
+// MustNewMatcher returns a matcher object. It is equivalent to
+// NewMatcher, but panics on error. It is useful for tests.
+func MustNewMatcher(t MatchType, n, v string) *Matcher {
+	m, err := NewMatcher(t, n, v)
+	if err != nil {
+		panic(err)
+	}
+	return m
+}
+
 func (m *Matcher) String() string {
 	if strings.ContainsFunc(m.Name, isReserved) {
 		return fmt.Sprintf(`%s%s%s`, strconv.Quote(m.Name), m.Type, strconv.Quote(m.Value))

--- a/types/types.go
+++ b/types/types.go
@@ -36,12 +36,8 @@ const (
 	AlertStateSuppressed  AlertState = "suppressed"
 )
 
-// AlertStatus stores the state of an alert and, as applicable, the IDs of
-// silences silencing the alert and of other alerts inhibiting the alert. Note
-// that currently, SilencedBy is supposed to be the complete set of the relevant
-// silences while InhibitedBy may contain only a subset of the inhibiting alerts
-// – in practice exactly one ID. (This somewhat confusing semantics might change
-// in the future.)
+// AlertStatus contains the state of an alert, including IDs of all silences
+// and fingerprints of all alerts suppressing the alert.
 type AlertStatus struct {
 	State       AlertState `json:"state"`
 	SilencedBy  []string   `json:"silencedBy"`
@@ -63,13 +59,9 @@ type Marker interface {
 	// Otherwise, it sets the provided alert to AlertStateSuppressed.
 	SetActiveOrSilenced(alert model.Fingerprint, version int, activeSilenceIDs, pendingSilenceIDs []string)
 	// SetInhibited replaces the previous InhibitedBy by the provided IDs of
-	// alerts. In contrast to SetActiveOrSilenced, the set of provided IDs is not
-	// expected to represent the complete set of inhibiting alerts. (In
-	// practice, this method is only called with one or zero IDs. However,
-	// this expectation might change in the future. If no IDs are provided
-	// and InhibitedBy is already empty, it sets the provided alert to
-	// AlertStateActive. Otherwise, it sets the provided alert to
-	// AlertStateSuppressed.
+	// alerts. If no IDs are provided and InhibitedBy is already empty,
+	// it sets the provided alert to AlertStateActive. Otherwise, it sets the
+	// provided alert to AlertStateSuppressed.
 	SetInhibited(alert model.Fingerprint, alertIDs ...string)
 
 	// Count alerts of the given state(s). With no state provided, count all


### PR DESCRIPTION
Before this change, Alertmanager would mark just the fingerprint of the first inhibition rule to inhibit an alert, rather than the fingerprints of all inhibition rules that inhibit the alert. This is different from silences which mark the IDs of all silences that silence an alert, not just the first silence.

This commit changes how inhibition rules work to match the behavior of silences, such that the fingerprints of all inhibition rules that inhibit the alert are marked.

This change is expected to increase CPU usage as the inhibiter has to do more work, matching the label set against all inhibition rules instead of stopping at the first match. However, this is no different from how silences mute alerts.