### PR TITLE
Support http.Headers in util functions

### DIFF
--- a/notify/discord/discord.go
+++ b/notify/discord/discord.go
@@ -147,7 +147,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		return false, err
 	}
 
-	resp, err := notify.PostJSON(ctx, n.client, url, &payload)
+	resp, err := notify.PostJSON(ctx, n.client, url, nil, &payload)
 	if err != nil {
 		return true, notify.RedactURL(err)
 	}

--- a/notify/msteams/msteams.go
+++ b/notify/msteams/msteams.go
@@ -47,7 +47,7 @@ type Notifier struct {
 	client       *http.Client
 	retrier      *notify.Retrier
 	webhookURL   *config.SecretURL
-	postJSONFunc func(ctx context.Context, client *http.Client, url string, body io.Reader) (*http.Response, error)
+	postJSONFunc func(ctx context.Context, client *http.Client, url string, headers http.Header, body io.Reader) (*http.Response, error)
 }
 
 // Message card reference can be found at https://learn.microsoft.com/en-us/outlook/actionable-messages/message-card-reference.
@@ -141,7 +141,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		return false, err
 	}
 
-	resp, err := n.postJSONFunc(ctx, n.client, url, &payload)
+	resp, err := n.postJSONFunc(ctx, n.client, url, nil, &payload)
 	if err != nil {
 		return true, notify.RedactURL(err)
 	}

--- a/notify/msteams/msteams_test.go
+++ b/notify/msteams/msteams_test.go
@@ -167,7 +167,7 @@ func TestNotifier_Notify_WithReason(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			notifier.postJSONFunc = func(ctx context.Context, client *http.Client, url string, body io.Reader) (*http.Response, error) {
+			notifier.postJSONFunc = func(ctx context.Context, client *http.Client, url string, headers http.Header, body io.Reader) (*http.Response, error) {
 				resp := httptest.NewRecorder()
 				resp.WriteString(tt.responseContent)
 				resp.WriteHeader(tt.statusCode)

--- a/notify/pagerduty/pagerduty.go
+++ b/notify/pagerduty/pagerduty.go
@@ -196,7 +196,7 @@ func (n *Notifier) notifyV1(
 		return false, err
 	}
 
-	resp, err := notify.PostJSON(ctx, n.client, n.apiV1, &encodedMsg)
+	resp, err := notify.PostJSON(ctx, n.client, n.apiV1, nil, &encodedMsg)
 	if err != nil {
 		return true, fmt.Errorf("failed to post message to PagerDuty v1: %w", err)
 	}
@@ -290,7 +290,7 @@ func (n *Notifier) notifyV2(
 		return false, err
 	}
 
-	resp, err := notify.PostJSON(ctx, n.client, n.conf.URL.String(), &encodedMsg)
+	resp, err := notify.PostJSON(ctx, n.client, n.conf.URL.String(), nil, &encodedMsg)
 	if err != nil {
 		return true, fmt.Errorf("failed to post message to PagerDuty: %w", err)
 	}

--- a/notify/pushover/pushover.go
+++ b/notify/pushover/pushover.go
@@ -164,7 +164,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	u.RawQuery = parameters.Encode()
 	// Don't log the URL as it contains secret data (see #1825).
 	level.Debug(n.logger).Log("msg", "Sending message", "incident", key)
-	resp, err := notify.PostText(ctx, n.client, u.String(), nil)
+	resp, err := notify.PostText(ctx, n.client, u.String(), nil, nil)
 	if err != nil {
 		return true, notify.RedactURL(err)
 	}

--- a/notify/slack/slack.go
+++ b/notify/slack/slack.go
@@ -44,7 +44,7 @@ type Notifier struct {
 	client  *http.Client
 	retrier *notify.Retrier
 
-	postJSONFunc func(ctx context.Context, client *http.Client, url string, body io.Reader) (*http.Response, error)
+	postJSONFunc func(ctx context.Context, client *http.Client, url string, headers http.Header, body io.Reader) (*http.Response, error)
 }
 
 // New returns a new Slack notification handler.
@@ -205,7 +205,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		u = strings.TrimSpace(string(content))
 	}
 
-	resp, err := n.postJSONFunc(ctx, n.client, u, &buf)
+	resp, err := n.postJSONFunc(ctx, n.client, u, nil, &buf)
 	if err != nil {
 		return true, notify.RedactURL(err)
 	}

--- a/notify/slack/slack_test.go
+++ b/notify/slack/slack_test.go
@@ -203,7 +203,7 @@ func TestNotifier_Notify_WithReason(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			notifier.postJSONFunc = func(ctx context.Context, client *http.Client, url string, body io.Reader) (*http.Response, error) {
+			notifier.postJSONFunc = func(ctx context.Context, client *http.Client, url string, headers http.Header, body io.Reader) (*http.Response, error) {
 				resp := httptest.NewRecorder()
 				if strings.HasPrefix(tt.responseBody, "{") {
 					resp.Header().Add("Content-Type", "application/json; charset=utf-8")

--- a/notify/util_test.go
+++ b/notify/util_test.go
@@ -16,14 +16,13 @@ package notify
 import (
 	"bytes"
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"io"
 	"net/http"
 	"path"
 	"reflect"
 	"runtime"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
 
 func TestTruncate(t *testing.T) {
@@ -216,3 +215,64 @@ func TestRetrierCheck(t *testing.T) {
 		})
 	}
 }
+
+//func TestPostJSON(t *testing.T) {
+//	tests := []struct {
+//		name            string
+//		headers         http.Header
+//		expectedHeaders http.Header
+//		data            io.Reader
+//	}{{
+//		name:    "No headers",
+//		headers: nil,
+//		expectedHeaders: http.Header{
+//			"Accept-Encoding": []string{"gzip"},
+//			"Content-Length":  []string{"13"},
+//			"Content-Type":    []string{"application/json"},
+//			"User-Agent":      []string{"Alertmanager/"},
+//		},
+//		data: strings.NewReader("Hello, world!"),
+//	}, {
+//		name: "With headers",
+//		headers: http.Header{
+//			"X-Test-PostJSON": []string{"true"},
+//		},
+//		expectedHeaders: http.Header{
+//			"Accept-Encoding": []string{"gzip"},
+//			"Content-Length":  []string{"13"},
+//			"Content-Type":    []string{"application/json"},
+//			"User-Agent":      []string{"Alertmanager/"},
+//			"X-Test-PostJSON": []string{"true"},
+//		},
+//		data: strings.NewReader("Hello, world!"),
+//	}}
+//	for _, test := range tests {
+//		t.Run(test.name, func(t *testing.T) {
+//			var (
+//				receivedHeaders http.Header
+//				receivedData    []byte
+//			)
+//			// Start an HTTP test server to record the headers and data from the request.
+//			s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+//				receivedHeaders = r.Header
+//				receivedData, _ = io.ReadAll(r.Body)
+//			}))
+//			defer s.Close()
+//
+//			ctx, cancelFunc := context.WithTimeout(context.Background(), 5*time.Second)
+//			defer cancelFunc()
+//
+//			resp, err := PostJSON(ctx, http.DefaultClient, s.URL, test.headers, test.data)
+//			require.NoError(t, err)
+//			require.NoError(t, resp.Body.Close())
+//			require.Equal(t, http.StatusOK, resp.StatusCode)
+//
+//			require.Equal(t, test.expectedHeaders, receivedHeaders)
+//
+//			b, err := io.ReadAll(test.data)
+//			require.NoError(t, err)
+//			require.Equal(t, b, receivedData)
+//		})
+//	}
+//
+//}

--- a/notify/util_test.go
+++ b/notify/util_test.go
@@ -15,13 +15,16 @@ package notify
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"path"
 	"reflect"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -217,63 +220,59 @@ func TestRetrierCheck(t *testing.T) {
 	}
 }
 
-//func TestPostJSON(t *testing.T) {
-//	tests := []struct {
-//		name            string
-//		headers         http.Header
-//		expectedHeaders http.Header
-//		data            io.Reader
-//	}{{
-//		name:    "No headers",
-//		headers: nil,
-//		expectedHeaders: http.Header{
-//			"Accept-Encoding": []string{"gzip"},
-//			"Content-Length":  []string{"13"},
-//			"Content-Type":    []string{"application/json"},
-//			"User-Agent":      []string{"Alertmanager/"},
-//		},
-//		data: strings.NewReader("Hello, world!"),
-//	}, {
-//		name: "With headers",
-//		headers: http.Header{
-//			"X-Test-PostJSON": []string{"true"},
-//		},
-//		expectedHeaders: http.Header{
-//			"Accept-Encoding": []string{"gzip"},
-//			"Content-Length":  []string{"13"},
-//			"Content-Type":    []string{"application/json"},
-//			"User-Agent":      []string{"Alertmanager/"},
-//			"X-Test-PostJSON": []string{"true"},
-//		},
-//		data: strings.NewReader("Hello, world!"),
-//	}}
-//	for _, test := range tests {
-//		t.Run(test.name, func(t *testing.T) {
-//			var (
-//				receivedHeaders http.Header
-//				receivedData    []byte
-//			)
-//			// Start an HTTP test server to record the headers and data from the request.
-//			s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-//				receivedHeaders = r.Header
-//				receivedData, _ = io.ReadAll(r.Body)
-//			}))
-//			defer s.Close()
-//
-//			ctx, cancelFunc := context.WithTimeout(context.Background(), 5*time.Second)
-//			defer cancelFunc()
-//
-//			resp, err := PostJSON(ctx, http.DefaultClient, s.URL, test.headers, test.data)
-//			require.NoError(t, err)
-//			require.NoError(t, resp.Body.Close())
-//			require.Equal(t, http.StatusOK, resp.StatusCode)
-//
-//			require.Equal(t, test.expectedHeaders, receivedHeaders)
-//
-//			b, err := io.ReadAll(test.data)
-//			require.NoError(t, err)
-//			require.Equal(t, b, receivedData)
-//		})
-//	}
-//
-//}
+func TestPostJSON(t *testing.T) {
+	tests := []struct {
+		name            string
+		headers         http.Header
+		expectedHeaders http.Header
+		data            []byte
+	}{{
+		name:    "No headers",
+		headers: nil,
+		expectedHeaders: http.Header{
+			"Accept-Encoding": []string{"gzip"},
+			"Content-Length":  []string{"13"},
+			"Content-Type":    []string{"application/json"},
+			"User-Agent":      []string{"Alertmanager/"},
+		},
+		data: []byte("Hello, world!"),
+	}, {
+		name: "With headers",
+		headers: http.Header{
+			"X-Test-PostJSON": []string{"true"},
+		},
+		expectedHeaders: http.Header{
+			"Accept-Encoding": []string{"gzip"},
+			"Content-Length":  []string{"13"},
+			"Content-Type":    []string{"application/json"},
+			"User-Agent":      []string{"Alertmanager/"},
+			"X-Test-Postjson": []string{"true"},
+		},
+		data: []byte("Hello, world!"),
+	}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var (
+				receivedHeaders http.Header
+				receivedData    []byte
+			)
+			// Start an HTTP test server to record the headers and data from the request.
+			s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				receivedHeaders = r.Header
+				receivedData, _ = io.ReadAll(r.Body)
+			}))
+			defer s.Close()
+
+			ctx, cancelFunc := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancelFunc()
+
+			resp, err := PostJSON(ctx, http.DefaultClient, s.URL, test.headers, bytes.NewReader(test.data))
+			require.NoError(t, err)
+			require.NoError(t, resp.Body.Close())
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			require.Equal(t, test.expectedHeaders, receivedHeaders)
+			require.Equal(t, test.data, receivedData)
+		})
+	}
+}

--- a/notify/util_test.go
+++ b/notify/util_test.go
@@ -16,13 +16,14 @@ package notify
 import (
 	"bytes"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"io"
 	"net/http"
 	"path"
 	"reflect"
 	"runtime"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestTruncate(t *testing.T) {

--- a/notify/victorops/victorops.go
+++ b/notify/victorops/victorops.go
@@ -97,7 +97,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		return true, err
 	}
 
-	resp, err := notify.PostJSON(ctx, n.client, apiURL.String(), buf)
+	resp, err := notify.PostJSON(ctx, n.client, apiURL.String(), nil, buf)
 	if err != nil {
 		return true, notify.RedactURL(err)
 	}

--- a/notify/webex/webex.go
+++ b/notify/webex/webex.go
@@ -101,7 +101,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		return false, err
 	}
 
-	resp, err := notify.PostJSON(ctx, n.client, n.conf.APIURL.String(), &payload)
+	resp, err := notify.PostJSON(ctx, n.client, n.conf.APIURL.String(), nil, &payload)
 	if err != nil {
 		return true, notify.RedactURL(err)
 	}

--- a/notify/webhook/webhook.go
+++ b/notify/webhook/webhook.go
@@ -114,7 +114,7 @@ func (n *Notifier) Notify(ctx context.Context, alerts ...*types.Alert) (bool, er
 		url = strings.TrimSpace(string(content))
 	}
 
-	resp, err := notify.PostJSON(ctx, n.client, url, &buf)
+	resp, err := notify.PostJSON(ctx, n.client, url, nil, &buf)
 	if err != nil {
 		return true, notify.RedactURL(err)
 	}

--- a/notify/wechat/wechat.go
+++ b/notify/wechat/wechat.go
@@ -108,7 +108,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		u.Path += "gettoken"
 		u.RawQuery = parameters.Encode()
 
-		resp, err := notify.Get(ctx, n.client, u.String())
+		resp, err := notify.Get(ctx, n.client, u.String(), nil)
 		if err != nil {
 			return true, notify.RedactURL(err)
 		}
@@ -161,7 +161,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	q.Set("access_token", n.accessToken)
 	postMessageURL.RawQuery = q.Encode()
 
-	resp, err := notify.PostJSON(ctx, n.client, postMessageURL.String(), &buf)
+	resp, err := notify.PostJSON(ctx, n.client, postMessageURL.String(), nil, &buf)
 	if err != nil {
 		return true, notify.RedactURL(err)
 	}


### PR DESCRIPTION
This commit updates the util functions such as PostJSON to support additional headers using http.Header. It will mean integrations such as RocketChat can use the notify functions instead of http.NewRequest.