### PR TITLE
#3513: Add GroupMarker interface

### DIFF
--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -107,7 +107,7 @@ func NewDispatcher(
 	ap provider.Alerts,
 	r *Route,
 	s notify.Stage,
-	mk types.Marker,
+	mk types.AlertMarker,
 	to func(time.Duration) time.Duration,
 	lim Limits,
 	l log.Logger,
@@ -182,6 +182,7 @@ func (d *Dispatcher) run(it provider.AlertIterator) {
 				for _, ag := range groups {
 					if ag.empty() {
 						ag.stop()
+
 						delete(groups, ag.fingerprint())
 						d.aggrGroupsNum--
 						d.metrics.aggrGroups.Dec()

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -182,7 +182,6 @@ func (d *Dispatcher) run(it provider.AlertIterator) {
 				for _, ag := range groups {
 					if ag.empty() {
 						ag.stop()
-
 						delete(groups, ag.fingerprint())
 						d.aggrGroupsNum--
 						d.metrics.aggrGroups.Dec()

--- a/inhibit/inhibit.go
+++ b/inhibit/inhibit.go
@@ -36,7 +36,7 @@ import (
 type Inhibitor struct {
 	alerts provider.Alerts
 	rules  []*InhibitRule
-	marker types.Marker
+	marker types.AlertMarker
 	logger log.Logger
 
 	mtx    sync.RWMutex
@@ -44,7 +44,7 @@ type Inhibitor struct {
 }
 
 // NewInhibitor returns a new Inhibitor.
-func NewInhibitor(ap provider.Alerts, rs []config.InhibitRule, mk types.Marker, logger log.Logger) *Inhibitor {
+func NewInhibitor(ap provider.Alerts, rs []config.InhibitRule, mk types.AlertMarker, logger log.Logger) *Inhibitor {
 	ih := &Inhibitor{
 		alerts: ap,
 		marker: mk,

--- a/provider/mem/mem.go
+++ b/provider/mem/mem.go
@@ -35,7 +35,7 @@ type Alerts struct {
 	cancel context.CancelFunc
 
 	alerts *store.Alerts
-	marker types.Marker
+	marker types.AlertMarker
 
 	mtx       sync.Mutex
 	listeners map[int]listeningAlerts
@@ -85,7 +85,7 @@ func (a *Alerts) registerMetrics(r prometheus.Registerer) {
 }
 
 // NewAlerts returns a new alert provider.
-func NewAlerts(ctx context.Context, m types.Marker, intervalGC time.Duration, alertCallback AlertStoreCallback, l log.Logger, r prometheus.Registerer) (*Alerts, error) {
+func NewAlerts(ctx context.Context, m types.AlertMarker, intervalGC time.Duration, alertCallback AlertStoreCallback, l log.Logger, r prometheus.Registerer) (*Alerts, error) {
 	if alertCallback == nil {
 		alertCallback = noopCallback{}
 	}

--- a/silence/silence.go
+++ b/silence/silence.go
@@ -92,16 +92,16 @@ func (c matcherCache) add(s *pb.Silence) (labels.Matchers, error) {
 	return ms, nil
 }
 
-// Silencer binds together a Marker and a Silences to implement the Muter
+// Silencer binds together a AlertMarker and a Silences to implement the Muter
 // interface.
 type Silencer struct {
 	silences *Silences
-	marker   types.Marker
+	marker   types.AlertMarker
 	logger   log.Logger
 }
 
 // NewSilencer returns a new Silencer.
-func NewSilencer(s *Silences, m types.Marker, l log.Logger) *Silencer {
+func NewSilencer(s *Silences, m types.AlertMarker, l log.Logger) *Silencer {
 	return &Silencer{
 		silences: s,
 		marker:   m,

--- a/types/types.go
+++ b/types/types.go
@@ -104,12 +104,12 @@ type GroupMarker interface {
 	// Muted returns true if the alert is muted, otherwise false. If the alert
 	// is muted then it also returns the names of the time intervals that muted
 	// it.
-	Muted(groupKey string, fingerprint model.Fingerprint) ([]string, bool)
+	Muted(groupKey string) ([]string, bool)
 
 	// SetMuted marks the alert as muted, and sets the names of the time
 	// intervals that mute it. If the list of names is nil or the empty slice
 	// then the muted marker is removed.
-	SetMuted(groupKey string, fingerprint model.Fingerprint, timeIntervalNames []string)
+	SetMuted(groupKey string, timeIntervalNames []string)
 }
 
 // NewMarker returns an instance of a AlertMarker implementation.

--- a/types/types.go
+++ b/types/types.go
@@ -101,12 +101,12 @@ type AlertMarker interface {
 }
 
 type GroupMarker interface {
-	// Muted returns true if the alert is muted, otherwise false. If the alert
+	// Muted returns true if the group is muted, otherwise false. If the group
 	// is muted then it also returns the names of the time intervals that muted
 	// it.
 	Muted(groupKey string) ([]string, bool)
 
-	// SetMuted marks the alert as muted, and sets the names of the time
+	// SetMuted marks the group as muted, and sets the names of the time
 	// intervals that mute it. If the list of names is nil or the empty slice
 	// then the muted marker is removed.
 	SetMuted(groupKey string, timeIntervalNames []string)

--- a/types/types.go
+++ b/types/types.go
@@ -113,7 +113,7 @@ type GroupMarker interface {
 }
 
 // NewMarker returns an instance of a AlertMarker implementation.
-func NewMarker(r prometheus.Registerer) AlertMarker {
+func NewMarker(r prometheus.Registerer) *memMarker {
 	m := &memMarker{
 		alerts: map[model.Fingerprint]*AlertStatus{},
 		groups: map[string]*GroupStatus{},

--- a/types/types.go
+++ b/types/types.go
@@ -57,7 +57,7 @@ type AlertStatus struct {
 type groupStatus struct {
 	// mutedAlerts contains the fingerprints of all muted alerts, and for each
 	// muted alert the active or mute time intervals that muted it.
-	mutedAlerts map[model.Fingerprint][]string `json:"mutedAlerts"`
+	mutedAlerts map[model.Fingerprint][]string
 }
 
 // AlertMarker helps to mark alerts as silenced and/or inhibited.

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -34,24 +34,29 @@ func TestMemMarker_Muted(t *testing.T) {
 	marker := NewMarker(r)
 
 	// No groups should be muted.
-	timeIntervalNames, isMuted := marker.Muted("group1")
+	timeIntervalNames, isMuted := marker.Muted("route1", "group1")
 	require.False(t, isMuted)
 	require.Empty(t, timeIntervalNames)
 
 	// Mark the group as muted because it's the weekend.
-	marker.SetMuted("group1", []string{"weekends"})
-	timeIntervalNames, isMuted = marker.Muted("group1")
+	marker.SetMuted("route1", "group1", []string{"weekends"})
+	timeIntervalNames, isMuted = marker.Muted("route1", "group1")
 	require.True(t, isMuted)
 	require.Equal(t, []string{"weekends"}, timeIntervalNames)
 
 	// Other groups should not be marked as muted.
-	timeIntervalNames, isMuted = marker.Muted("group2")
+	timeIntervalNames, isMuted = marker.Muted("route1", "group2")
+	require.False(t, isMuted)
+	require.Empty(t, timeIntervalNames)
+
+	// Other routes should not be marked as muted either.
+	timeIntervalNames, isMuted = marker.Muted("route2", "group1")
 	require.False(t, isMuted)
 	require.Empty(t, timeIntervalNames)
 
 	// The group is no longer muted.
-	marker.SetMuted("group1", nil)
-	timeIntervalNames, isMuted = marker.Muted("group1")
+	marker.SetMuted("route1", "group1", nil)
+	timeIntervalNames, isMuted = marker.Muted("route1", "group1")
 	require.False(t, isMuted)
 	require.Empty(t, timeIntervalNames)
 }

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -33,36 +33,25 @@ func TestMemMarker_Muted(t *testing.T) {
 	r := prometheus.NewRegistry()
 	marker := NewMarker(r)
 
-	muted := model.Alert{Labels: model.LabelSet{"bar": "baz"}}
-	active := model.Alert{Labels: model.LabelSet{"foo": "bar"}}
-
 	// No alerts should be muted.
-	timeIntervalNames, isMuted := marker.Muted("group1", muted.Fingerprint())
-	require.False(t, isMuted)
-	require.Empty(t, timeIntervalNames)
-	timeIntervalNames, isMuted = marker.Muted("group1", active.Fingerprint())
+	timeIntervalNames, isMuted := marker.Muted("group1")
 	require.False(t, isMuted)
 	require.Empty(t, timeIntervalNames)
 
-	// Mark the muted alert as muted because it's the weekend.
-	marker.SetMuted("group1", muted.Fingerprint(), []string{"weekends"})
-
-	// The muted alert should be muted, but not the active alert.
-	timeIntervalNames, isMuted = marker.Muted("group1", muted.Fingerprint())
+	// Mark the group as muted because it's the weekend.
+	marker.SetMuted("group1", []string{"weekends"})
+	timeIntervalNames, isMuted = marker.Muted("group1")
 	require.True(t, isMuted)
 	require.Equal(t, []string{"weekends"}, timeIntervalNames)
-	timeIntervalNames, isMuted = marker.Muted("group1", active.Fingerprint())
+
+	// Other groups should not be marked as muted.
+	timeIntervalNames, isMuted = marker.Muted("group2")
 	require.False(t, isMuted)
 	require.Empty(t, timeIntervalNames)
 
-	// The muted alert should not be muted in other groups.
-	timeIntervalNames, isMuted = marker.Muted("group2", muted.Fingerprint())
-	require.False(t, isMuted)
-	require.Empty(t, timeIntervalNames)
-
-	// The muted alert is no longer muted.
-	marker.SetMuted("group1", muted.Fingerprint(), nil)
-	timeIntervalNames, isMuted = marker.Muted("group1", muted.Fingerprint())
+	// The group is no longer muted.
+	marker.SetMuted("group1", nil)
+	timeIntervalNames, isMuted = marker.Muted("group1")
 	require.False(t, isMuted)
 	require.Empty(t, timeIntervalNames)
 }

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -33,7 +33,7 @@ func TestMemMarker_Muted(t *testing.T) {
 	r := prometheus.NewRegistry()
 	marker := NewMarker(r)
 
-	// No alerts should be muted.
+	// No groups should be muted.
 	timeIntervalNames, isMuted := marker.Muted("group1")
 	require.False(t, isMuted)
 	require.Empty(t, timeIntervalNames)

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -59,6 +59,12 @@ func TestMemMarker_Muted(t *testing.T) {
 	timeIntervalNames, isMuted = marker.Muted("group2", muted.Fingerprint())
 	require.False(t, isMuted)
 	require.Empty(t, timeIntervalNames)
+
+	// The muted alert is no longer muted.
+	marker.SetMuted("group1", muted.Fingerprint(), nil)
+	timeIntervalNames, isMuted = marker.Muted("group1", muted.Fingerprint())
+	require.False(t, isMuted)
+	require.Empty(t, timeIntervalNames)
 }
 
 func TestMemMarker_Count(t *testing.T) {


### PR DESCRIPTION
This commit adds a new GroupMarker interface that marks the status of groups. For example, whether a group is muted because or one or more active or mute time intervals. It renames the existing Marker interface to AlertMarker to avoid confusion.

It is based on https://github.com/prometheus/alertmanager/pull/3791.