### PR TITLE
ui: Force using linux/amd64 when using docker

### DIFF
--- a/ui/app/Makefile
+++ b/ui/app/Makefile
@@ -16,7 +16,7 @@ all: script.js test
 elm-env:
 	@(if [ "$(NO_DOCKER)" != "true" ] ; then \
 		echo ">> building elm-env docker image"; \
-		docker build -t $(DOCKER_IMG) ../. > /dev/null; \
+		docker build --platform=linux/amd64 -t $(DOCKER_IMG) ../. > /dev/null; \
 	fi; )
 
 format: elm-env $(ELM_FILES)


### PR DESCRIPTION
The elm npm package doesn't support linux/arm64. The easiest option is to force docker to run this as a AMD64 container.

Upstream issue:
https://github.com/elm/compiler/issues/2283