### PR TITLE
Make `route.Key()` unique and remove `route.ID()`

### DIFF
--- a/dispatch/route.go
+++ b/dispatch/route.go
@@ -169,24 +169,12 @@ func (r *Route) Match(lset model.LabelSet) []*Route {
 	return all
 }
 
-// Key returns a key for the route. It does not uniquely identify the route in general.
+// Key returns a key for the route. It uniquely identifies the route.
 func (r *Route) Key() string {
 	b := strings.Builder{}
 
 	if r.parent != nil {
 		b.WriteString(r.parent.Key())
-		b.WriteRune('/')
-	}
-	b.WriteString(r.Matchers.String())
-	return b.String()
-}
-
-// ID returns a unique identifier for the route.
-func (r *Route) ID() string {
-	b := strings.Builder{}
-
-	if r.parent != nil {
-		b.WriteString(r.parent.ID())
 		b.WriteRune('/')
 	}
 


### PR DESCRIPTION
This pull request replaces the code in `route.Key()` with that of `route.ID()`, and removes `route.ID()`. The motivation behind this change is to fix a number of bugs caused by conflicting group keys such as "Different aggregation groups can share the same nflog" (#3808) and also prevent an issue where groups are incorrectly marked as muted when they are not.