### PR TITLE
Add date and tz functions to templates

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -95,5 +95,5 @@ templating.
 | join | sep string, s []string | [strings.Join](http://golang.org/pkg/strings/#Join), concatenates the elements of s to create a single string. The separator string sep is placed between elements in the resulting string. (note: argument order inverted for easier pipelining in templates.) |
 | safeHtml | text string | [html/template.HTML](https://golang.org/pkg/html/template/#HTML), Marks string as HTML not requiring auto-escaping. |
 | stringSlice | ...string | Returns the passed strings as a slice of strings. |
-| date | fmt, time.Time | Returns the text representation of the time in the specified format. For documentation on formats refer to [pkg.go.dev/time](https://pkg.go.dev/time#pkg-constants). |
-| tz | name, time.Time | Returns the time in the timezone. For example, Europe/Paris. |
+| date | string, time.Time | Returns the text representation of the time in the specified format. For documentation on formats refer to [pkg.go.dev/time](https://pkg.go.dev/time#pkg-constants). |
+| tz | string, time.Time | Returns the time in the timezone. For example, Europe/Paris. |

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -95,3 +95,5 @@ templating.
 | join | sep string, s []string | [strings.Join](http://golang.org/pkg/strings/#Join), concatenates the elements of s to create a single string. The separator string sep is placed between elements in the resulting string. (note: argument order inverted for easier pipelining in templates.) |
 | safeHtml | text string | [html/template.HTML](https://golang.org/pkg/html/template/#HTML), Marks string as HTML not requiring auto-escaping. |
 | stringSlice | ...string | Returns the passed strings as a slice of strings. |
+| date | fmt, time.Time | Returns the text representation of the time in the specified format. For documentation on formats refer to [pkg.go.dev/time](https://pkg.go.dev/time#pkg-constants). |
+| tz | name, time.Time | Returns the time in the timezone. For example, Europe/Paris. |

--- a/template/template.go
+++ b/template/template.go
@@ -192,6 +192,18 @@ var DefaultFuncs = FuncMap{
 	"stringSlice": func(s ...string) []string {
 		return s
 	},
+	// date returns the text representation of the time in the specified format.
+	"date": func(fmt string, t time.Time) string {
+		return t.Format(fmt)
+	},
+	// tz returns the time in the timezone.
+	"tz": func(name string, t time.Time) (time.Time, error) {
+		loc, err := time.LoadLocation(name)
+		if err != nil {
+			return time.Time{}, err
+		}
+		return t.In(loc), nil
+	},
 }
 
 // Pair is a key/value string pair.

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -519,9 +519,9 @@ func TestTemplateFuncs(t *testing.T) {
 		exp:   "2024-01-01 09:15:30 +0100 CET",
 	}, {
 		title:  "Template using invalid tz",
-		in:     `{{ . | tz "Bad/Timezone" }}`,
+		in:     `{{ . | tz "Invalid/Timezone" }}`,
 		data:   time.Date(2024, 1, 1, 8, 15, 30, 0, time.UTC),
-		expErr: "template: :1:7: executing \"\" at <tz \"Bad/Timezone\">: error calling tz: unknown time zone Bad/Timezone",
+		expErr: "template: :1:7: executing \"\" at <tz \"Invalid/Timezone\">: error calling tz: unknown time zone Invalid/Timezone",
 	}} {
 		tc := tc
 		t.Run(tc.title, func(t *testing.T) {

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -506,6 +506,16 @@ func TestTemplateFuncs(t *testing.T) {
 		title: "Template using reReplaceAll",
 		in:    `{{ reReplaceAll "ab" "AB" "abc" }}`,
 		exp:   "ABc",
+	}, {
+		title: "Template using date",
+		in:    `{{ . | date "2006-01-02" }}`,
+		data:  time.Date(2024, 1, 1, 8, 15, 30, 0, time.UTC),
+		exp:   "2024-01-01",
+	}, {
+		title: "Template using tz",
+		in:    `{{ . | tz "Europe/Paris" }}`,
+		data:  time.Date(2024, 1, 1, 8, 15, 30, 0, time.UTC),
+		exp:   "2024-01-01 09:15:30 +0100 CET",
 	}} {
 		tc := tc
 		t.Run(tc.title, func(t *testing.T) {

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -538,7 +538,6 @@ func TestTemplateFuncs(t *testing.T) {
 						require.EqualError(t, err, tc.expErr)
 						require.Empty(t, got)
 					}
-
 				}()
 			}
 			wg.Wait()


### PR DESCRIPTION
This commit adds the date and tz functions to templates. This means users can now format time in a specified format and also change the timezone to their specific locale.

An example of how these functions work, and can be composed together, can be seen here:

	{{ .StartsAt | tz "Europe/Paris" | date "15:04:05 MST" }}