### PR TITLE
Add discord message fields

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -220,8 +220,10 @@ type DiscordConfig struct {
 	WebhookURL     *SecretURL                  `yaml:"webhook_url,omitempty" json:"webhook_url,omitempty"`
 	WebhookURLFile string                      `yaml:"webhook_url_file,omitempty" json:"webhook_url_file,omitempty"`
 
-	Title   string `yaml:"title,omitempty" json:"title,omitempty"`
-	Message string `yaml:"message,omitempty" json:"message,omitempty"`
+	Title     string `yaml:"title,omitempty" json:"title,omitempty"`
+	Message   string `yaml:"message,omitempty" json:"message,omitempty"`
+	Content   string `yaml:"content,omitempty" json:"content,omitempty"`
+	AvatarURL string `yaml:"avatar_url,omitempty" json:"avatar_url,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -224,6 +224,7 @@ type DiscordConfig struct {
 	Message   string `yaml:"message,omitempty" json:"message,omitempty"`
 	Content   string `yaml:"content,omitempty" json:"content,omitempty"`
 	AvatarURL string `yaml:"avatar_url,omitempty" json:"avatar_url,omitempty"`
+	Username  string `yaml:"username,omitempty" json:"username,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/notify/discord/discord.go
+++ b/notify/discord/discord.go
@@ -159,6 +159,10 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		w.Content = content
 	}
 
+	if len(n.conf.Username) != 0 {
+		w.Username = n.conf.Username
+	}
+
 	if len(n.conf.AvatarURL) != 0 {
 		if _, err := url.Parse(n.conf.AvatarURL); err == nil {
 			w.AvatarURL = n.conf.AvatarURL


### PR DESCRIPTION
This PR adds some fields to Discord message like Content which is already mentioned in issue #3667.


Being able to set _Content_ is really important to have since at this moment, there is no way to tag users in alerts. Default Discord 
template embeds alerts and in Discord, ATM, tagging someone in embedded fields, does not tag them. It will just include user/role name without sending notification like when you get tagged in normal message.


Discord code [already](https://github.com/prometheus/alertmanager/blob/main/notify/discord/discord.go#L77) had `content` field but it's not used in the code nor config.

I added other fields like avatar url and username.

Below content are example configs and result:
Alertmanager receiver config:
```yaml

receivers:
  - name: 'discord'
    discord_configs:
    - webhook_url: 'https://discord.com/api/webhooks/1153054938155450368/kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkEwc3KouoUWE4'
      content: '{{ template "my.content" . }}'
      avatar_url: 'https://www.tbstat.com/wp/uploads/2023/05/Fvz9hOIXwAEaIR8-669x675.jpeg'
      username: GOFW
```

Template:
```
{{- define "my.content" }}
tags: {{- range .Alerts }}
{{- if .Annotations.tags }}
{{- reReplaceAll "," " " .Annotations.tags }}
{{- end }}
{{- end }}
{{- end }}
```

Prometheus alert:
```yaml
---
groups:
- name: watchdogs
  rules:
  - alert: WatchDog-1
    expr: vector(1)
    labels:
      severity: info
    annotations:
      summary: "WatchDog1"
      description: "FAKE"
      tags: '<@5132333333333336177>,<@5132333333333336177>'
        
  - alert: WatchDog-2
    expr: vector(2)
    labels:
      severity: critical
    annotations:
      summary: "WatchDog2"
      description: "FAKE"
      tags: '<@5132333333333336177>,<@5132333333333336177>'

```


![Screenshot from 2024-04-26 20-04-24](https://github.com/prometheus/alertmanager/assets/85274632/c49b61cf-92fc-4e48-819d-316cdb4550c4)
