### PR TITLE
Fix race condition in dispatch.go

### DIFF
--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -499,14 +499,17 @@ func (ag *aggrGroup) flush(notify func(...*types.Alert) bool) {
 	}
 
 	var (
-		alerts      = ag.alerts.List()
-		alertsSlice = make(types.AlertSlice, 0, len(alerts))
-		now         = time.Now()
+		alerts        = ag.alerts.List()
+		alertsSlice   = make(types.AlertSlice, 0, len(alerts))
+		resolvedSlice = make(types.AlertSlice, 0, len(alerts))
+		now           = time.Now()
 	)
 	for _, alert := range alerts {
 		a := *alert
 		// Ensure that alerts don't resolve as time move forwards.
-		if !a.ResolvedAt(now) {
+		if a.ResolvedAt(now) {
+			resolvedSlice = append(resolvedSlice, &a)
+		} else {
 			a.EndsAt = time.Time{}
 		}
 		alertsSlice = append(alertsSlice, &a)
@@ -516,13 +519,12 @@ func (ag *aggrGroup) flush(notify func(...*types.Alert) bool) {
 	level.Debug(ag.logger).Log("msg", "flushing", "alerts", fmt.Sprintf("%v", alertsSlice))
 
 	if notify(alertsSlice...) {
-		for _, a := range alertsSlice {
-			// Only delete if the fingerprint has not been inserted again since we notified about it.
-			if err := ag.alerts.DeleteIf(a.Fingerprint(), func(b *types.Alert) bool {
-				return a.Resolved() && a.UpdatedAt == b.UpdatedAt
-			}); err != nil {
-				level.Error(ag.logger).Log("msg", "error on delete alert", "err", err, "alert", a.String())
-			}
+		// Delete all resolved alerts as we just sent a notification for them,
+		// and we don't want to send another one. However, we need to make sure
+		// that each resolved alert has not fired again during the flush as then
+		// we would delete an active alert thinking it was resolved.
+		if err := ag.alerts.DeleteIfNotModified(resolvedSlice); err != nil {
+			level.Error(ag.logger).Log("msg", "error on delete alerts", "err", err)
 		}
 	}
 }

--- a/store/store.go
+++ b/store/store.go
@@ -123,6 +123,17 @@ func (a *Alerts) Delete(fp model.Fingerprint) error {
 	return nil
 }
 
+// DeleteIf removes the Alert with hte matching fingerprint from the store
+// if fn returns true.
+func (a *Alerts) DeleteIf(fp model.Fingerprint, fn func(*types.Alert) bool) error {
+	a.Lock()
+	defer a.Unlock()
+	if alert, ok := a.c[fp]; ok && fn(alert) {
+		delete(a.c, fp)
+	}
+	return nil
+}
+
 // List returns a slice of Alerts currently held in memory.
 func (a *Alerts) List() []*types.Alert {
 	a.Lock()

--- a/store/store.go
+++ b/store/store.go
@@ -123,7 +123,7 @@ func (a *Alerts) Delete(fp model.Fingerprint) error {
 	return nil
 }
 
-// DeleteIf removes the Alert with hte matching fingerprint from the store
+// DeleteIf removes the Alert with the matching fingerprint from the store
 // if fn returns true.
 func (a *Alerts) DeleteIf(fp model.Fingerprint, fn func(*types.Alert) bool) error {
 	a.Lock()

--- a/store/store.go
+++ b/store/store.go
@@ -114,22 +114,16 @@ func (a *Alerts) Set(alert *types.Alert) error {
 	return nil
 }
 
-// Delete removes the Alert with the matching fingerprint from the store.
-func (a *Alerts) Delete(fp model.Fingerprint) error {
+// DeleteIfNotModified deletes the slice of Alerts from the store if not
+// modified.
+func (a *Alerts) DeleteIfNotModified(alerts types.AlertSlice) error {
 	a.Lock()
 	defer a.Unlock()
-
-	delete(a.c, fp)
-	return nil
-}
-
-// DeleteIf removes the Alert with the matching fingerprint from the store
-// if fn returns true.
-func (a *Alerts) DeleteIf(fp model.Fingerprint, fn func(*types.Alert) bool) error {
-	a.Lock()
-	defer a.Unlock()
-	if alert, ok := a.c[fp]; ok && fn(alert) {
-		delete(a.c, fp)
+	for _, alert := range alerts {
+		fp := alert.Fingerprint()
+		if other, ok := a.c[fp]; ok && alert.UpdatedAt == other.UpdatedAt {
+			delete(a.c, fp)
+		}
 	}
 	return nil
 }

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -54,6 +54,32 @@ func TestDelete(t *testing.T) {
 	require.Equal(t, ErrNotFound, err)
 }
 
+func TestDeleteIf(t *testing.T) {
+	a := NewAlerts()
+	alert := &types.Alert{
+		UpdatedAt: time.Now(),
+	}
+	require.NoError(t, a.Set(alert))
+
+	fp := alert.Fingerprint()
+
+	// Should not delete the alert because func returns false.
+	require.NoError(t, a.DeleteIf(fp, func(a *types.Alert) bool {
+		return false
+	}))
+	got, err := a.Get(fp)
+	require.Nil(t, err)
+	require.Equal(t, alert, got)
+
+	// Should delete the alert because func returns true.
+	require.NoError(t, a.DeleteIf(fp, func(a *types.Alert) bool {
+		return true
+	}))
+	got, err = a.Get(fp)
+	require.Nil(t, got)
+	require.Equal(t, ErrNotFound, err)
+}
+
 func TestGC(t *testing.T) {
 	now := time.Now()
 	newAlert := func(key string, start, end time.Duration) *types.Alert {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -68,7 +68,7 @@ func TestDeleteIf(t *testing.T) {
 		return false
 	}))
 	got, err := a.Get(fp)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, alert, got)
 
 	// Should delete the alert because func returns true.


### PR DESCRIPTION
This commit fixes a race condition in dispatch.go that would cause a firing alert to be deleted from the aggregation group when instead it should have been flushed.

The root cause is a race condition that can occur when dispatch.go deletes resolved alerts from the aggregation group following a successful notification. If a firing alert with the same fingerprint is added back to the aggregation group at the same time then the firing alert can be deleted.

The issue was first reported in #3006.

#### How to observe the race condition

1. `git checkout v0.27.0`
2. Add the following sleep to `dispatch.go`. This makes it easier to observe the race condition because the scheduler can resume the test between `ag.alerts.Get(fp)` and `ag.alerts.Delete(fp)`, during which it should replace the resolved alert with a firing alert.

```go
diff --git a/dispatch/dispatch.go b/dispatch/dispatch.go
index 640b22ab..1eafa054 100644
--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -521,6 +521,7 @@ func (ag *aggrGroup) flush(notify func(...*types.Alert) bool) {
                        // again since we notified about it.
                        fp := a.Fingerprint()
                        got, err := ag.alerts.Get(fp)
+                       <-time.After(time.Millisecond)
                        if err != nil {
                                // This should never happen.
                                level.Error(ag.logger).Log("msg", "failed to get alert", "err", err, "alert", a.String())
```

3. Add and run the following test to `dispatch_test.go`. It should fail:

```go
type bufferedStage struct {
	c chan struct{}
}

func (s *bufferedStage) Exec(ctx context.Context, _ log.Logger, _ ...*types.Alert) (context.Context, []*types.Alert, error) {
	s.c <- struct{}{}
	return ctx, nil, nil
}

func TestDispatcherRaceFiringAlertDeleted(t *testing.T) {
	r := Route{RouteOpts: RouteOpts{GroupWait: 0, GroupInterval: time.Second}}
	s := bufferedStage{c: make(chan struct{}, 1)}
	logger := log.NewLogfmtLogger(os.Stdout)
	marker := types.NewMarker(prometheus.NewRegistry())
	alerts, err := mem.NewAlerts(context.Background(), marker, time.Hour, nil, logger, nil)
	require.NoError(t, err)
	defer alerts.Close()
	timeout := func(d time.Duration) time.Duration { return time.Duration(0) }
	dispatcher := NewDispatcher(alerts, &r, &s, marker, timeout, nil, logger, NewDispatcherMetrics(false, prometheus.NewRegistry()))
	go dispatcher.Run()
	defer dispatcher.Stop()

	// Add a new firing alert and wait for it to be flushed.
	a1 := newAlert(model.LabelSet{"foo": "bar"})
	a1.StartsAt = time.Now().Add(-time.Second)
	a1.UpdatedAt = a1.StartsAt
	require.NoError(t, alerts.Put(a1))
	<-s.c

	// Change the firing alert to resolved and wait for it to be flushed too.
	a2 := newAlert(model.LabelSet{"foo": "bar"})
	a2.StartsAt = a1.StartsAt
	a2.UpdatedAt = a1.UpdatedAt
	a2.EndsAt = time.Now()
	require.NoError(t, alerts.Put(a2))
	<-s.c

	// Change the resolved alert back to firing. If the race condition is still
	// present, it will be deleted instead of flushed.
	a3 := newAlert(model.LabelSet{"foo": "bar"})
	a3.StartsAt = time.Now()
	a3.UpdatedAt = time.Now()
	require.NoError(t, alerts.Put(a3))
	select {
	case <-s.c:
	case <-time.After(2 * time.Second):
		t.Fatal()
	}
}
```

#### How to observe the fix

1. Check out this branch, add the sleep and re-run the same test. It should pass.

```go
diff --git a/dispatch/dispatch.go b/dispatch/dispatch.go
index d78fbf68..efb0c246 100644
--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -517,6 +517,7 @@ func (ag *aggrGroup) flush(notify func(...*types.Alert) bool) {

        if notify(alertsSlice...) {
                for _, a := range alertsSlice {
+                       <-time.After(time.Millisecond)
                        // Only delete if the fingerprint has not been inserted again since we notified about it.
                        if err := ag.alerts.DeleteIf(a.Fingerprint(), func(b *types.Alert) bool {
                                return a.Resolved() && a.UpdatedAt == b.UpdatedAt
```