### PR TITLE
Add Severities to template data and hasString to template function

### DIFF
--- a/docs/notification_examples.md
+++ b/docs/notification_examples.md
@@ -73,6 +73,16 @@ Receiver
     text: "{{ range .Alerts }}{{ .Annotations.description }}\n{{ end }}"
 ```
 
+## Checking for specific severity levels
+
+
+```
+- name: 'default-receiver'
+  slack_configs:
+  - channel: '#alerts'
+    icon_emoji: ":{{ if hasString "critical" .Severities }}fire{{ else if hasString "warning" .Severities }}ghost{{ else }}ship{{ end }}:"
+```
+
 ## Defining reusable templates
 
 Going back to our first example, we can also provide a file containing named templates which are then loaded by Alertmanager in order to avoid complex templates that span many lines.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -29,6 +29,7 @@ Note that some fields are evaluated as text, and others as HTML which will affec
 | CommonLabels | [KV](#kv) | The labels common to all of the alerts. |
 | CommonAnnotations | [KV](#kv) | Set of common annotations to all of the alerts. Used for longer additional strings of information about the alert. |
 | ExternalURL | string | Backlink to the Alertmanager that sent the notification. |
+| Severities | []string | A list of string contains all severity label values. |
 
 The `Alerts` type exposes functions for filtering alerts:
 
@@ -93,6 +94,7 @@ templating.
 | match | pattern, string | [Regexp.MatchString](https://golang.org/pkg/regexp/#MatchString). Match a string using Regexp. |
 | reReplaceAll | pattern, replacement, text | [Regexp.ReplaceAllString](http://golang.org/pkg/regexp/#Regexp.ReplaceAllString) Regexp substitution, unanchored. |
 | join | sep string, s []string | [strings.Join](http://golang.org/pkg/strings/#Join), concatenates the elements of s to create a single string. The separator string sep is placed between elements in the resulting string. (note: argument order inverted for easier pipelining in templates.) |
+| hasString | search string, s []string | [slices.Contains](http://golang.org/pkg/slices/#Contains), return true, if list contains search string |
 | safeHtml | text string | [html/template.HTML](https://golang.org/pkg/html/template/#HTML), Marks string as HTML not requiring auto-escaping. |
 | stringSlice | ...string | Returns the passed strings as a slice of strings. |
 | date | string, time.Time | Returns the text representation of the time in the specified format. For documentation on formats refer to [pkg.go.dev/time](https://pkg.go.dev/time#pkg-constants). |

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -157,6 +157,7 @@ func TestData(t *testing.T) {
 				CommonLabels:      KV{},
 				CommonAnnotations: KV{},
 				ExternalURL:       u.String(),
+				Severities:        []string{},
 			},
 		},
 		{
@@ -217,6 +218,7 @@ func TestData(t *testing.T) {
 				CommonLabels:      KV{"job": "foo"},
 				CommonAnnotations: KV{"runbook": "foo"},
 				ExternalURL:       u.String(),
+				Severities:        []string{"critical", "warning"},
 			},
 		},
 		{
@@ -275,6 +277,7 @@ func TestData(t *testing.T) {
 				CommonLabels:      KV{},
 				CommonAnnotations: KV{},
 				ExternalURL:       u.String(),
+				Severities:        []string{"critical", "warning"},
 			},
 		},
 	} {
@@ -522,6 +525,16 @@ func TestTemplateFuncs(t *testing.T) {
 		in:     `{{ . | tz "Invalid/Timezone" }}`,
 		data:   time.Date(2024, 1, 1, 8, 15, 30, 0, time.UTC),
 		expErr: "template: :1:7: executing \"\" at <tz \"Invalid/Timezone\">: error calling tz: unknown time zone Invalid/Timezone",
+	}, {
+		title: "Template using hasString",
+		in:    `{{ . | hasString "a" }}`,
+		data:  []string{"a", "b", "c"},
+		exp:   "true",
+	}, {
+		title:  "Template using invalid hasString",
+		in:     `{{ . | hasString "a" }}`,
+		data:   []KV{{"a": "b"}, {"b": "c"}},
+		expErr: "template: :1:17: executing \"\" at <\"a\">: wrong type for value; expected []string; got []template.KV",
 	}} {
 		tc := tc
 		t.Run(tc.title, func(t *testing.T) {


### PR DESCRIPTION
# Motivation of this PR

Some receiver of Alertmanager handling a persistent state of alerts.

Looking at OpsGenie, it can be setup one alert with group of alerts.

However, currently its not really possible to get the highest severity of the alert group. One potential solution is having severity as part of the group_labels, but this results into distinct alerts, because the HashKey of an alert group changes and grouped alerts may get splited.

In conclusion, I added a new template data field `severities` which hold a list of string contains all values of the label severity. In addition, I added a new template func `hasString` that maps to `slices.Contains`.

The result would be a template that could be used to define a OpsGenie priority:

```mustache
{{ if hasString "critical" .Severities }}P1{{ else if hasString "warning" .Severities }}P3{{ else }}P5{{ end }}
```

It's also useful for #3590, since the receiver has the capability to update existing issues and it would be great if the priority can be updated as well. 