### PR TITLE
Fix incorrect use of fmt.Errorf with no args

### DIFF
--- a/api/v2/restapi/server.go
+++ b/api/v2/restapi/server.go
@@ -21,7 +21,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
-	"fmt"
 	"log"
 	"net"
 	"net/http"

--- a/api/v2/restapi/server.go
+++ b/api/v2/restapi/server.go
@@ -294,7 +294,7 @@ func (s *Server) Serve() (err error) {
 			caCertPool := x509.NewCertPool()
 			ok := caCertPool.AppendCertsFromPEM(caCert)
 			if !ok {
-				return fmt.Errorf("cannot parse CA certificate")
+				return errors.New("cannot parse CA certificate")
 			}
 			httpsServer.TLSConfig.ClientCAs = caCertPool
 			httpsServer.TLSConfig.ClientAuth = tls.RequireAndVerifyClientCert

--- a/cli/silence_add.go
+++ b/cli/silence_add.go
@@ -110,7 +110,7 @@ func (c *silenceAddCmd) add(ctx context.Context, _ *kingpin.ParseContext) error 
 		matchers = append(matchers, *m)
 	}
 	if len(matchers) < 1 {
-		return fmt.Errorf("no matchers specified")
+		return errors.New("no matchers specified")
 	}
 
 	var startsAt time.Time
@@ -136,7 +136,7 @@ func (c *silenceAddCmd) add(ctx context.Context, _ *kingpin.ParseContext) error 
 			return err
 		}
 		if d == 0 {
-			return fmt.Errorf("silence duration must be greater than 0")
+			return errors.New("silence duration must be greater than 0")
 		}
 		endsAt = startsAt.UTC().Add(time.Duration(d))
 	}

--- a/cli/silence_update.go
+++ b/cli/silence_update.go
@@ -54,7 +54,7 @@ func configureSilenceUpdateCmd(cc *kingpin.CmdClause) {
 
 func (c *silenceUpdateCmd) update(ctx context.Context, _ *kingpin.ParseContext) error {
 	if len(c.ids) < 1 {
-		return fmt.Errorf("no silence IDs specified")
+		return errors.New("no silence IDs specified")
 	}
 
 	amclient := NewAlertmanagerClient(alertmanagerURL)
@@ -90,7 +90,7 @@ func (c *silenceUpdateCmd) update(ctx context.Context, _ *kingpin.ParseContext) 
 				return err
 			}
 			if d == 0 {
-				return fmt.Errorf("silence duration must be greater than 0")
+				return errors.New("silence duration must be greater than 0")
 			}
 			endsAt := strfmt.DateTime(time.Time(*sil.StartsAt).UTC().Add(time.Duration(d)))
 			sil.EndsAt = &endsAt
@@ -128,7 +128,7 @@ func (c *silenceUpdateCmd) update(ctx context.Context, _ *kingpin.ParseContext) 
 	} else {
 		formatter, found := format.Formatters[output]
 		if !found {
-			return fmt.Errorf("unknown output formatter")
+			return errors.New("unknown output formatter")
 		}
 		if err := formatter.FormatSilences(updatedSilences); err != nil {
 			return fmt.Errorf("error formatting silences: %w", err)

--- a/cluster/tls_config.go
+++ b/cluster/tls_config.go
@@ -14,7 +14,7 @@
 package cluster
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"path/filepath"
 
@@ -46,7 +46,7 @@ func GetTLSTransportConfig(configPath string) (*TLSTransportConfig, error) {
 	}
 
 	if cfg.TLSServerConfig == nil {
-		return nil, fmt.Errorf("missing 'tls_server_config' entry in the TLS configuration")
+		return nil, errors.New("missing 'tls_server_config' entry in the TLS configuration")
 	}
 
 	cfg.TLSServerConfig.SetDirectory(filepath.Dir(configPath))

--- a/cmd/alertmanager/main_test.go
+++ b/cmd/alertmanager/main_test.go
@@ -14,6 +14,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -67,7 +68,7 @@ func TestExternalURL(t *testing.T) {
 			err: true,
 		},
 		{
-			hostnameResolver: func() (string, error) { return "", fmt.Errorf("some error") },
+			hostnameResolver: func() (string, error) { return "", errors.New("some error") },
 			err:              true,
 		},
 		{

--- a/config/config.go
+++ b/config/config.go
@@ -274,7 +274,7 @@ func (mt *MuteTimeInterval) UnmarshalYAML(unmarshal func(interface{}) error) err
 		return err
 	}
 	if mt.Name == "" {
-		return fmt.Errorf("missing name in mute time interval")
+		return errors.New("missing name in mute time interval")
 	}
 	return nil
 }
@@ -292,7 +292,7 @@ func (ti *TimeInterval) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 	if ti.Name == "" {
-		return fmt.Errorf("missing name in time interval")
+		return errors.New("missing name in time interval")
 	}
 	return nil
 }
@@ -367,13 +367,13 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		for _, ec := range rcv.EmailConfigs {
 			if ec.Smarthost.String() == "" {
 				if c.Global.SMTPSmarthost.String() == "" {
-					return fmt.Errorf("no global SMTP smarthost set")
+					return errors.New("no global SMTP smarthost set")
 				}
 				ec.Smarthost = c.Global.SMTPSmarthost
 			}
 			if ec.From == "" {
 				if c.Global.SMTPFrom == "" {
-					return fmt.Errorf("no global SMTP from set")
+					return errors.New("no global SMTP from set")
 				}
 				ec.From = c.Global.SMTPFrom
 			}
@@ -404,7 +404,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			}
 			if sc.APIURL == nil && len(sc.APIURLFile) == 0 {
 				if c.Global.SlackAPIURL == nil && len(c.Global.SlackAPIURLFile) == 0 {
-					return fmt.Errorf("no global Slack API URL set either inline or in a file")
+					return errors.New("no global Slack API URL set either inline or in a file")
 				}
 				sc.APIURL = c.Global.SlackAPIURL
 				sc.APIURLFile = c.Global.SlackAPIURLFile
@@ -421,7 +421,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			}
 			if pdc.URL == nil {
 				if c.Global.PagerdutyURL == nil {
-					return fmt.Errorf("no global PagerDuty URL set")
+					return errors.New("no global PagerDuty URL set")
 				}
 				pdc.URL = c.Global.PagerdutyURL
 			}
@@ -432,7 +432,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			}
 			if ogc.APIURL == nil {
 				if c.Global.OpsGenieAPIURL == nil {
-					return fmt.Errorf("no global OpsGenie URL set")
+					return errors.New("no global OpsGenie URL set")
 				}
 				ogc.APIURL = c.Global.OpsGenieAPIURL
 			}
@@ -441,7 +441,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			}
 			if ogc.APIKey == "" && len(ogc.APIKeyFile) == 0 {
 				if c.Global.OpsGenieAPIKey == "" && len(c.Global.OpsGenieAPIKeyFile) == 0 {
-					return fmt.Errorf("no global OpsGenie API Key set either inline or in a file")
+					return errors.New("no global OpsGenie API Key set either inline or in a file")
 				}
 				ogc.APIKey = c.Global.OpsGenieAPIKey
 				ogc.APIKeyFile = c.Global.OpsGenieAPIKeyFile
@@ -454,21 +454,21 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 			if wcc.APIURL == nil {
 				if c.Global.WeChatAPIURL == nil {
-					return fmt.Errorf("no global Wechat URL set")
+					return errors.New("no global Wechat URL set")
 				}
 				wcc.APIURL = c.Global.WeChatAPIURL
 			}
 
 			if wcc.APISecret == "" {
 				if c.Global.WeChatAPISecret == "" {
-					return fmt.Errorf("no global Wechat ApiSecret set")
+					return errors.New("no global Wechat ApiSecret set")
 				}
 				wcc.APISecret = c.Global.WeChatAPISecret
 			}
 
 			if wcc.CorpID == "" {
 				if c.Global.WeChatAPICorpID == "" {
-					return fmt.Errorf("no global Wechat CorpID set")
+					return errors.New("no global Wechat CorpID set")
 				}
 				wcc.CorpID = c.Global.WeChatAPICorpID
 			}
@@ -483,7 +483,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			}
 			if voc.APIURL == nil {
 				if c.Global.VictorOpsAPIURL == nil {
-					return fmt.Errorf("no global VictorOps URL set")
+					return errors.New("no global VictorOps URL set")
 				}
 				voc.APIURL = c.Global.VictorOpsAPIURL
 			}
@@ -492,7 +492,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			}
 			if voc.APIKey == "" && len(voc.APIKeyFile) == 0 {
 				if c.Global.VictorOpsAPIKey == "" && len(c.Global.VictorOpsAPIKeyFile) == 0 {
-					return fmt.Errorf("no global VictorOps API Key set")
+					return errors.New("no global VictorOps API Key set")
 				}
 				voc.APIKey = c.Global.VictorOpsAPIKey
 				voc.APIKeyFile = c.Global.VictorOpsAPIKeyFile
@@ -517,7 +517,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 				discord.HTTPConfig = c.Global.HTTPConfig
 			}
 			if discord.WebhookURL == nil && len(discord.WebhookURLFile) == 0 {
-				return fmt.Errorf("no discord webhook URL or URLFile provided")
+				return errors.New("no discord webhook URL or URLFile provided")
 			}
 		}
 		for _, webex := range rcv.WebexConfigs {
@@ -526,7 +526,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			}
 			if webex.APIURL == nil {
 				if c.Global.WebexAPIURL == nil {
-					return fmt.Errorf("no global Webex URL set")
+					return errors.New("no global Webex URL set")
 				}
 
 				webex.APIURL = c.Global.WebexAPIURL
@@ -537,7 +537,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 				msteams.HTTPConfig = c.Global.HTTPConfig
 			}
 			if msteams.WebhookURL == nil && len(msteams.WebhookURLFile) == 0 {
-				return fmt.Errorf("no msteams webhook URL or URLFile provided")
+				return errors.New("no msteams webhook URL or URLFile provided")
 			}
 		}
 
@@ -547,20 +547,20 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	// The root route must not have any matchers as it is the fallback node
 	// for all alerts.
 	if c.Route == nil {
-		return fmt.Errorf("no routes provided")
+		return errors.New("no routes provided")
 	}
 	if len(c.Route.Receiver) == 0 {
-		return fmt.Errorf("root route must specify a default receiver")
+		return errors.New("root route must specify a default receiver")
 	}
 	if len(c.Route.Match) > 0 || len(c.Route.MatchRE) > 0 || len(c.Route.Matchers) > 0 {
-		return fmt.Errorf("root route must not have any matchers")
+		return errors.New("root route must not have any matchers")
 	}
 	if len(c.Route.MuteTimeIntervals) > 0 {
-		return fmt.Errorf("root route must not have any mute time intervals")
+		return errors.New("root route must not have any mute time intervals")
 	}
 
 	if len(c.Route.ActiveTimeIntervals) > 0 {
-		return fmt.Errorf("root route must not have any active time intervals")
+		return errors.New("root route must not have any active time intervals")
 	}
 
 	// Validate that all receivers used in the routing tree are defined.
@@ -661,7 +661,7 @@ func parseURL(s string) (*URL, error) {
 		return nil, fmt.Errorf("unsupported scheme %q for URL", u.Scheme)
 	}
 	if u.Host == "" {
-		return nil, fmt.Errorf("missing host for URL")
+		return nil, errors.New("missing host for URL")
 	}
 	return &URL{u}, nil
 }
@@ -918,7 +918,7 @@ func (c *Receiver) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 	if c.Name == "" {
-		return fmt.Errorf("missing name in receiver")
+		return errors.New("missing name in receiver")
 	}
 	return nil
 }

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -14,6 +14,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"net/textproto"
 	"regexp"
@@ -272,7 +273,7 @@ func (c *EmailConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 	if c.To == "" {
-		return fmt.Errorf("missing to address in email config")
+		return errors.New("missing to address in email config")
 	}
 	// Header names are case-insensitive, check for collisions.
 	normalizedHeaders := map[string]string{}
@@ -333,13 +334,13 @@ func (c *PagerdutyConfig) UnmarshalYAML(unmarshal func(interface{}) error) error
 		return err
 	}
 	if c.RoutingKey == "" && c.ServiceKey == "" && c.RoutingKeyFile == "" && c.ServiceKeyFile == "" {
-		return fmt.Errorf("missing service or routing key in PagerDuty config")
+		return errors.New("missing service or routing key in PagerDuty config")
 	}
 	if len(c.RoutingKey) > 0 && len(c.RoutingKeyFile) > 0 {
-		return fmt.Errorf("at most one of routing_key & routing_key_file must be configured")
+		return errors.New("at most one of routing_key & routing_key_file must be configured")
 	}
 	if len(c.ServiceKey) > 0 && len(c.ServiceKeyFile) > 0 {
-		return fmt.Errorf("at most one of service_key & service_key_file must be configured")
+		return errors.New("at most one of service_key & service_key_file must be configured")
 	}
 	if c.Details == nil {
 		c.Details = make(map[string]string)
@@ -375,10 +376,10 @@ func (c *SlackAction) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 	if c.Type == "" {
-		return fmt.Errorf("missing type in Slack action configuration")
+		return errors.New("missing type in Slack action configuration")
 	}
 	if c.Text == "" {
-		return fmt.Errorf("missing text in Slack action configuration")
+		return errors.New("missing text in Slack action configuration")
 	}
 	if c.URL != "" {
 		// Clear all message action fields.
@@ -388,7 +389,7 @@ func (c *SlackAction) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	} else if c.Name != "" {
 		c.URL = ""
 	} else {
-		return fmt.Errorf("missing name or url in Slack action configuration")
+		return errors.New("missing name or url in Slack action configuration")
 	}
 	return nil
 }
@@ -410,7 +411,7 @@ func (c *SlackConfirmationField) UnmarshalYAML(unmarshal func(interface{}) error
 		return err
 	}
 	if c.Text == "" {
-		return fmt.Errorf("missing text in Slack confirmation configuration")
+		return errors.New("missing text in Slack confirmation configuration")
 	}
 	return nil
 }
@@ -432,10 +433,10 @@ func (c *SlackField) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 	if c.Title == "" {
-		return fmt.Errorf("missing title in Slack field configuration")
+		return errors.New("missing title in Slack field configuration")
 	}
 	if c.Value == "" {
-		return fmt.Errorf("missing value in Slack field configuration")
+		return errors.New("missing value in Slack field configuration")
 	}
 	return nil
 }
@@ -653,10 +654,10 @@ func (c *VictorOpsConfig) UnmarshalYAML(unmarshal func(interface{}) error) error
 		return err
 	}
 	if c.RoutingKey == "" {
-		return fmt.Errorf("missing Routing key in VictorOps config")
+		return errors.New("missing Routing key in VictorOps config")
 	}
 	if c.APIKey != "" && len(c.APIKeyFile) > 0 {
-		return fmt.Errorf("at most one of api_key & api_key_file must be configured")
+		return errors.New("at most one of api_key & api_key_file must be configured")
 	}
 
 	reservedFields := []string{"routing_key", "message_type", "state_message", "entity_display_name", "monitoring_tool", "entity_id", "entity_state"}

--- a/matchers/parse/parse.go
+++ b/matchers/parse/parse.go
@@ -59,7 +59,7 @@ func Matcher(input string) (*labels.Matcher, error) {
 	case 1:
 		return m[0], nil
 	case 0:
-		return nil, fmt.Errorf("no matchers")
+		return nil, errors.New("no matchers")
 	default:
 		return nil, fmt.Errorf("expected 1 matcher, found %d", len(m))
 	}

--- a/notify/email/email_test.go
+++ b/notify/email/email_test.go
@@ -30,6 +30,7 @@ package email
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -199,7 +200,7 @@ func notifyEmailWithContext(ctx context.Context, cfg *config.EmailConfig, server
 	if err != nil {
 		return nil, retry, err
 	} else if e == nil {
-		return nil, retry, fmt.Errorf("email not found")
+		return nil, retry, errors.New("email not found")
 	}
 	return e, retry, nil
 }

--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -54,7 +54,7 @@ func (f notifierFunc) Notify(ctx context.Context, alerts ...*types.Alert) (bool,
 type failStage struct{}
 
 func (s failStage) Exec(ctx context.Context, l log.Logger, as ...*types.Alert) (context.Context, []*types.Alert, error) {
-	return ctx, nil, fmt.Errorf("some error")
+	return ctx, nil, errors.New("some error")
 }
 
 type testNflog struct {

--- a/notify/pushover/pushover.go
+++ b/notify/pushover/pushover.go
@@ -15,6 +15,7 @@ package pushover
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"

--- a/notify/pushover/pushover.go
+++ b/notify/pushover/pushover.go
@@ -71,7 +71,7 @@ func New(c *config.PushoverConfig, t *template.Template, l log.Logger, httpOpts 
 func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 	key, ok := notify.GroupKey(ctx)
 	if !ok {
-		return false, fmt.Errorf("group key missing")
+		return false, errors.New("group key missing")
 	}
 	data := notify.GetTemplateData(ctx, n.tmpl, as, n.logger)
 

--- a/notify/telegram/telegram.go
+++ b/notify/telegram/telegram.go
@@ -15,6 +15,7 @@ package telegram
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -77,7 +78,7 @@ func (n *Notifier) Notify(ctx context.Context, alert ...*types.Alert) (bool, err
 
 	key, ok := notify.GroupKey(ctx)
 	if !ok {
-		return false, fmt.Errorf("group key missing")
+		return false, errors.New("group key missing")
 	}
 
 	messageText, truncated := notify.TruncateInRunes(tmpl(n.conf.Message), maxMessageLenRunes)

--- a/notify/util.go
+++ b/notify/util.go
@@ -160,7 +160,7 @@ type Key string
 func ExtractGroupKey(ctx context.Context) (Key, error) {
 	key, ok := GroupKey(ctx)
 	if !ok {
-		return "", fmt.Errorf("group key missing")
+		return "", errors.New("group key missing")
 	}
 	return Key(key), nil
 }

--- a/notify/util_test.go
+++ b/notify/util_test.go
@@ -15,6 +15,7 @@ package notify
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -127,7 +128,7 @@ func TestTruncate(t *testing.T) {
 type brokenReader struct{}
 
 func (b brokenReader) Read([]byte) (int, error) {
-	return 0, fmt.Errorf("some error")
+	return 0, errors.New("some error")
 }
 
 func TestRetrierCheck(t *testing.T) {

--- a/provider/mem/mem.patch
+++ b/provider/mem/mem.patch
@@ -1,0 +1,53 @@
+diff --git a/provider/mem/mem.go b/provider/mem/mem.go
+index cfc3bfc3..0dbdbd50 100644
+--- a/provider/mem/mem.go
++++ b/provider/mem/mem.go
+@@ -101,6 +101,8 @@ func NewAlerts(ctx context.Context, m types.AlertMarker, intervalGC time.Duratio
+ 		callback:  alertCallback,
+ 	}
+ 	a.alerts.SetGCCallback(func(alerts []types.Alert) {
++		a.mtx.Lock()
++		defer a.mtx.Unlock()
+ 		for _, alert := range alerts {
+ 			// As we don't persist alerts, we no longer consider them after
+ 			// they are resolved. Alerts waiting for resolved notifications are
+@@ -109,7 +111,6 @@ func NewAlerts(ctx context.Context, m types.AlertMarker, intervalGC time.Duratio
+ 			a.callback.PostDelete(&alert)
+ 		}
+ 
+-		a.mtx.Lock()
+ 		for i, l := range a.listeners {
+ 			select {
+ 			case <-l.done:
+@@ -119,7 +120,6 @@ func NewAlerts(ctx context.Context, m types.AlertMarker, intervalGC time.Duratio
+ 				// listener is not closed yet, hence proceed.
+ 			}
+ 		}
+-		a.mtx.Unlock()
+ 	})
+ 
+ 	if r != nil {
+@@ -197,6 +197,8 @@ func (a *Alerts) Get(fp model.Fingerprint) (*types.Alert, error) {
+ 
+ // Put adds the given alert to the set.
+ func (a *Alerts) Put(alerts ...*types.Alert) error {
++	a.mtx.Lock()
++	defer a.mtx.Unlock()
+ 	for _, alert := range alerts {
+ 		fp := alert.Fingerprint()
+ 
+@@ -226,14 +228,12 @@ func (a *Alerts) Put(alerts ...*types.Alert) error {
+ 
+ 		a.callback.PostStore(alert, existing)
+ 
+-		a.mtx.Lock()
+ 		for _, l := range a.listeners {
+ 			select {
+ 			case l.alerts <- alert:
+ 			case <-l.done:
+ 			}
+ 		}
+-		a.mtx.Unlock()
+ 	}
+ 
+ 	return nil

--- a/provider/mem/mem_test.go
+++ b/provider/mem/mem_test.go
@@ -539,7 +539,7 @@ type limitCountCallback struct {
 	limit  int
 }
 
-var errTooManyAlerts = fmt.Errorf("too many alerts")
+var errTooManyAlerts = errors.New("too many alerts")
 
 func (l *limitCountCallback) PreStore(_ *types.Alert, existing bool) error {
 	if existing {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -14,15 +14,14 @@
 package provider
 
 import (
-	"fmt"
-
+	"errors"
 	"github.com/prometheus/common/model"
 
 	"github.com/prometheus/alertmanager/types"
 )
 
 // ErrNotFound is returned if a provider cannot find a requested item.
-var ErrNotFound = fmt.Errorf("item not found")
+var ErrNotFound = errors.New("item not found")
 
 // Iterator provides the functions common to all iterators. To be useful, a
 // specific iterator interface (e.g. AlertIterator) has to be implemented that

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -15,6 +15,7 @@ package provider
 
 import (
 	"errors"
+
 	"github.com/prometheus/common/model"
 
 	"github.com/prometheus/alertmanager/types"

--- a/silence/silence.go
+++ b/silence/silence.go
@@ -44,10 +44,10 @@ import (
 )
 
 // ErrNotFound is returned if a silence was not found.
-var ErrNotFound = fmt.Errorf("silence not found")
+var ErrNotFound = errors.New("silence not found")
 
 // ErrInvalidState is returned if the state isn't valid.
-var ErrInvalidState = fmt.Errorf("invalid state")
+var ErrInvalidState = errors.New("invalid state")
 
 type matcherCache map[*pb.Silence]labels.Matchers
 
@@ -326,7 +326,7 @@ type Options struct {
 
 func (o *Options) validate() error {
 	if o.SnapshotFile != "" && o.SnapshotReader != nil {
-		return fmt.Errorf("only one of SnapshotFile and SnapshotReader must be set")
+		return errors.New("only one of SnapshotFile and SnapshotReader must be set")
 	}
 	return nil
 }

--- a/timeinterval/timeinterval.go
+++ b/timeinterval/timeinterval.go
@@ -279,7 +279,7 @@ func (r *DayOfMonthRange) UnmarshalYAML(unmarshal func(interface{}) error) error
 	}
 	// Restricting here prevents errors where begin > end in longer months but not shorter months.
 	if r.Begin < 0 && r.End > 0 {
-		return fmt.Errorf("end day must be negative if start day is negative")
+		return errors.New("end day must be negative if start day is negative")
 	}
 	// Check begin <= end. We can't know this for sure when using negative indices
 	// but we can prevent cases where its always invalid (using 28 day minimum length).
@@ -434,7 +434,7 @@ func (tr TimeRange) MarshalJSON() (out []byte, err error) {
 // It marshals a Location back into a string that represents a time.Location.
 func (tz Location) MarshalText() ([]byte, error) {
 	if tz.Location == nil {
-		return nil, fmt.Errorf("unable to convert nil location into string")
+		return nil, errors.New("unable to convert nil location into string")
 	}
 	return []byte(tz.Location.String()), nil
 }

--- a/types/types.go
+++ b/types/types.go
@@ -14,6 +14,7 @@
 package types
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -378,13 +379,13 @@ func validateLs(ls model.LabelSet) error {
 // This can be removed once prometheus/common has support for UTF-8.
 func (a *Alert) Validate() error {
 	if a.StartsAt.IsZero() {
-		return fmt.Errorf("start time missing")
+		return errors.New("start time missing")
 	}
 	if !a.EndsAt.IsZero() && a.EndsAt.Before(a.StartsAt) {
-		return fmt.Errorf("start time must be before end time")
+		return errors.New("start time must be before end time")
 	}
 	if len(a.Labels) == 0 {
-		return fmt.Errorf("at least one label pair required")
+		return errors.New("at least one label pair required")
 	}
 	if err := validateLs(a.Labels); err != nil {
 		return fmt.Errorf("invalid label set: %w", err)


### PR DESCRIPTION
This pull request fixes incorrect use of `fmt.Errorf` when no args are passed. It should be `errors.New`.