### PR TITLE
Add limits for silences

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -146,8 +146,8 @@ func run() int {
 		dataDir             = kingpin.Flag("storage.path", "Base path for data storage.").Default("data/").String()
 		retention           = kingpin.Flag("data.retention", "How long to keep data for.").Default("120h").Duration()
 		maintenanceInterval = kingpin.Flag("data.maintenance-interval", "Interval between garbage collection and snapshotting to disk of the silences and the notification logs.").Default("15m").Duration()
-		maxSilences         = kingpin.Flag("silences.max-silences", "Maximum number of active and pending silences. If negative or zero, no limit is set.").Default("0").Int()
-		maxPerSilenceBytes  = kingpin.Flag("silences.max-per-silence-bytes", "Maximum per silence size. If negative or zero, no limit is set.").Default("0").Int()
+		maxSilences         = kingpin.Flag("silences.max-silences", "Maximum number of active and pending silences, excluding expired silences. If negative or zero, no limit is set.").Default("0").Int()
+		maxPerSilenceBytes  = kingpin.Flag("silences.max-per-silence-bytes", "Maximum per silence size in bytes. If negative or zero, no limit is set.").Default("0").Int()
 		alertGCInterval     = kingpin.Flag("alerts.gc-interval", "Interval between alert GC.").Default("30m").Duration()
 
 		webConfig      = webflag.AddFlags(kingpin.CommandLine, ":9093")

--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -147,7 +147,7 @@ func run() int {
 		retention           = kingpin.Flag("data.retention", "How long to keep data for.").Default("120h").Duration()
 		maintenanceInterval = kingpin.Flag("data.maintenance-interval", "Interval between garbage collection and snapshotting to disk of the silences and the notification logs.").Default("15m").Duration()
 		maxSilences         = kingpin.Flag("silences.max-silences", "Maximum number of active and pending silences. If negative or zero, no limit is set.").Default("0").Int()
-		maxPerSilenceSize   = kingpin.Flag("silences.max-per-silence-size", "Maximum per silence size (in bytes). If negative or zero, no limit is set.").Default("0").Int()
+		maxPerSilenceBytes  = kingpin.Flag("silences.max-per-silence-bytes", "Maximum per silence size. If negative or zero, no limit is set.").Default("0").Int()
 		alertGCInterval     = kingpin.Flag("alerts.gc-interval", "Interval between alert GC.").Default("30m").Duration()
 
 		webConfig      = webflag.AddFlags(kingpin.CommandLine, ":9093")
@@ -262,8 +262,8 @@ func run() int {
 		SnapshotFile: filepath.Join(*dataDir, "silences"),
 		Retention:    *retention,
 		Limits: silence.Limits{
-			MaxSilences:       *maxSilences,
-			MaxPerSilenceSize: *maxPerSilenceSize,
+			MaxSilences:        *maxSilences,
+			MaxPerSilenceBytes: *maxPerSilenceBytes,
 		},
 		Logger:  log.With(logger, "component", "silences"),
 		Metrics: prometheus.DefaultRegisterer,

--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -146,8 +146,8 @@ func run() int {
 		dataDir             = kingpin.Flag("storage.path", "Base path for data storage.").Default("data/").String()
 		retention           = kingpin.Flag("data.retention", "How long to keep data for.").Default("120h").Duration()
 		maintenanceInterval = kingpin.Flag("data.maintenance-interval", "Interval between garbage collection and snapshotting to disk of the silences and the notification logs.").Default("15m").Duration()
-		maxSilences         = kingpin.Flag("silences.max-silences", "Maximum number of active and pending silences.").Default("1000").Int()
-		maxSilenceSize      = kingpin.Flag("silences.max-size", "Maximum per silence size (in bytes).").Default("4096").Int()
+		maxSilences         = kingpin.Flag("silences.max-silences", "Maximum number of active and pending silences. If negative or zero, no limit is set.").Default("0").Int()
+		maxSilenceSize      = kingpin.Flag("silences.max-size", "Maximum per silence size (in bytes). If negative or zero, no limit is set.").Default("0").Int()
 		alertGCInterval     = kingpin.Flag("alerts.gc-interval", "Interval between alert GC.").Default("30m").Duration()
 
 		webConfig      = webflag.AddFlags(kingpin.CommandLine, ":9093")

--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -146,6 +146,8 @@ func run() int {
 		dataDir             = kingpin.Flag("storage.path", "Base path for data storage.").Default("data/").String()
 		retention           = kingpin.Flag("data.retention", "How long to keep data for.").Default("120h").Duration()
 		maintenanceInterval = kingpin.Flag("data.maintenance-interval", "Interval between garbage collection and snapshotting to disk of the silences and the notification logs.").Default("15m").Duration()
+		maxSilences         = kingpin.Flag("silences.max-silences", "Maximum number of active and pending silences.").Default("1000").Int()
+		maxSilenceSize      = kingpin.Flag("silences.max-size", "Maximum per silence size (in bytes).").Default("4096").Int()
 		alertGCInterval     = kingpin.Flag("alerts.gc-interval", "Interval between alert GC.").Default("30m").Duration()
 
 		webConfig      = webflag.AddFlags(kingpin.CommandLine, ":9093")
@@ -259,8 +261,12 @@ func run() int {
 	silenceOpts := silence.Options{
 		SnapshotFile: filepath.Join(*dataDir, "silences"),
 		Retention:    *retention,
-		Logger:       log.With(logger, "component", "silences"),
-		Metrics:      prometheus.DefaultRegisterer,
+		Limits: silence.Limits{
+			MaxSilences:       *maxSilences,
+			MaxPerSilenceSize: *maxSilenceSize,
+		},
+		Logger:  log.With(logger, "component", "silences"),
+		Metrics: prometheus.DefaultRegisterer,
 	}
 
 	silences, err := silence.New(silenceOpts)

--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -147,7 +147,7 @@ func run() int {
 		retention           = kingpin.Flag("data.retention", "How long to keep data for.").Default("120h").Duration()
 		maintenanceInterval = kingpin.Flag("data.maintenance-interval", "Interval between garbage collection and snapshotting to disk of the silences and the notification logs.").Default("15m").Duration()
 		maxSilences         = kingpin.Flag("silences.max-silences", "Maximum number of active and pending silences. If negative or zero, no limit is set.").Default("0").Int()
-		maxSilenceSize      = kingpin.Flag("silences.max-size", "Maximum per silence size (in bytes). If negative or zero, no limit is set.").Default("0").Int()
+		maxPerSilenceSize   = kingpin.Flag("silences.max-per-silence-size", "Maximum per silence size (in bytes). If negative or zero, no limit is set.").Default("0").Int()
 		alertGCInterval     = kingpin.Flag("alerts.gc-interval", "Interval between alert GC.").Default("30m").Duration()
 
 		webConfig      = webflag.AddFlags(kingpin.CommandLine, ":9093")
@@ -263,7 +263,7 @@ func run() int {
 		Retention:    *retention,
 		Limits: silence.Limits{
 			MaxSilences:       *maxSilences,
-			MaxPerSilenceSize: *maxSilenceSize,
+			MaxPerSilenceSize: *maxPerSilenceSize,
 		},
 		Logger:  log.With(logger, "component", "silences"),
 		Metrics: prometheus.DefaultRegisterer,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,7 +28,7 @@ Alertmanager supports a number of configurable limits via command-line flags.
 
 To limit the maximum number of active and pending silences, excluding expired ones,
 use the `--silences.max-silences` flag.
-You can limit the maximum size of individual silences with `--silences.max-per-silence-size`,
+You can limit the maximum size of individual silences with `--silences.max-per-silence-bytes`,
 where the unit is in bytes.
 
 Both limits are disabled by default.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,6 +22,14 @@ is not well-formed, the changes will not be applied and an error is logged.
 A configuration reload is triggered by sending a `SIGHUP` to the process or
 sending an HTTP POST request to the `/-/reload` endpoint.
 
+## Limits
+
+Alertmanager supports a number of configurable limits via command-line flags.
+
+To limit the maximum number of active and pending silences, use the `--silences.max-silences` flag.
+You can limit the maximum size of individual silences with `--silences.max-per-silence-size`,
+where the unit is in bytes.
+
 ## Configuration file introduction
 
 To specify which configuration file to load, use the `--config.file` flag.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,9 +26,12 @@ sending an HTTP POST request to the `/-/reload` endpoint.
 
 Alertmanager supports a number of configurable limits via command-line flags.
 
-To limit the maximum number of active and pending silences, use the `--silences.max-silences` flag.
+To limit the maximum number of active and pending silences, excluding expired ones,
+use the `--silences.max-silences` flag.
 You can limit the maximum size of individual silences with `--silences.max-per-silence-size`,
 where the unit is in bytes.
+
+Both limits are disabled by default.
 
 ## Configuration file introduction
 

--- a/silence/silence.go
+++ b/silence/silence.go
@@ -207,9 +207,9 @@ type Limits struct {
 	// MaxSilences limits the maximum number active and pending silences.
 	// It does not include expired silences.
 	MaxSilences int
-	// MaxPerSilenceSize is the maximum size of an individual silence as
+	// MaxPerSilenceBytes is the maximum size of an individual silence as
 	// stored on disk.
-	MaxPerSilenceSize int
+	MaxPerSilenceBytes int
 }
 
 // MaintenanceFunc represents the function to run as part of the periodic maintenance for silences.
@@ -585,8 +585,8 @@ func (s *Silences) setSilence(sil *pb.Silence, now time.Time, skipValidate bool)
 	// Check the limit unless the silence has been expired. This is to avoid
 	// situations where silences cannot be expired after the limit has been
 	// reduced.
-	if n := msil.Size(); s.limits.MaxPerSilenceSize > 0 && n > s.limits.MaxPerSilenceSize && sil.EndsAt.After(now) {
-		return fmt.Errorf("silence exceeded maximum size: %d bytes (limit: %d bytes)", n, s.limits.MaxPerSilenceSize)
+	if n := msil.Size(); s.limits.MaxPerSilenceBytes > 0 && n > s.limits.MaxPerSilenceBytes && sil.EndsAt.After(now) {
+		return fmt.Errorf("silence exceeded maximum size: %d bytes (limit: %d bytes)", n, s.limits.MaxPerSilenceBytes)
 	}
 
 	if s.st.merge(msil, now) {

--- a/silence/silence.go
+++ b/silence/silence.go
@@ -352,14 +352,11 @@ func New(o Options) (*Silences, error) {
 		mc:        matcherCache{},
 		logger:    log.NewNopLogger(),
 		retention: o.Retention,
+		limits:    o.Limits,
 		broadcast: func([]byte) {},
 		st:        state{},
 	}
 	s.metrics = newMetrics(o.Metrics, s)
-
-	if o.Limits != (Limits{}) {
-		s.limits = o.Limits
-	}
 
 	if o.Logger != nil {
 		s.logger = o.Logger

--- a/silence/silence.go
+++ b/silence/silence.go
@@ -583,7 +583,7 @@ func (s *Silences) setSilence(sil *pb.Silence, now time.Time, skipValidate bool)
 		return err
 	}
 
-	if n := msil.Size(); s.limits.MaxPerSilenceSize > 0 && n > s.limits.MaxPerSilenceSize {
+	if n := msil.Size(); s.limits.MaxPerSilenceSize > 0 && n > s.limits.MaxPerSilenceSize && sil.EndsAt.After(now) {
 		return fmt.Errorf("silence exceeded maximum size: %d", s.limits.MaxPerSilenceSize)
 	}
 

--- a/silence/silence.go
+++ b/silence/silence.go
@@ -619,6 +619,7 @@ func (s *Silences) Set(sil *pb.Silence) (string, error) {
 		}
 	}
 
+	// If we got here it's either a new silence or a replacing one.
 	if s.limits.MaxSilences > 0 {
 		// Get the number of active and pending silences to enforce limits.
 		q := &query{}
@@ -635,7 +636,6 @@ func (s *Silences) Set(sil *pb.Silence) (string, error) {
 		}
 	}
 
-	// If we got here it's either a new silence or a replacing one.
 	uid, err := uuid.NewV4()
 	if err != nil {
 		return "", fmt.Errorf("generate uuid: %w", err)

--- a/silence/silence.go
+++ b/silence/silence.go
@@ -580,6 +580,9 @@ func (s *Silences) setSilence(sil *pb.Silence, now time.Time, skipValidate bool)
 		return err
 	}
 
+	// Check the limit unless the silence has been expired. This is to avoid
+	// situations where silences cannot be expired after the limit has been
+	// reduced.
 	if n := msil.Size(); s.limits.MaxPerSilenceSize > 0 && n > s.limits.MaxPerSilenceSize && sil.EndsAt.After(now) {
 		return fmt.Errorf("silence exceeded maximum size: %d", s.limits.MaxPerSilenceSize)
 	}

--- a/silence/silence_test.go
+++ b/silence/silence_test.go
@@ -486,7 +486,7 @@ func TestSilenceLimits(t *testing.T) {
 		EndsAt:   time.Now().Add(5 * time.Minute),
 	}
 	id2, err := s.Set(sil2)
-	require.EqualError(t, err, "exceeded maximum number of silences: 1")
+	require.EqualError(t, err, "exceeded maximum number of silences: 1 (limit: 1)")
 	require.Equal(t, "", id2)
 
 	// Expire sil1. This should allow sil2 to be inserted.
@@ -520,7 +520,10 @@ func TestSilenceLimits(t *testing.T) {
 		EndsAt:    time.Now().Add(5 * time.Minute),
 	}
 	id3, err := s.Set(sil3)
-	require.EqualError(t, err, "silence exceeded maximum size: 4096")
+	require.NotNil(t, err)
+	// Do not check the exact size as it can change between consecutive runs
+	// due to padding.
+	require.Contains(t, err.Error(), "silence exceeded maximum size")
 	require.Equal(t, "", id3)
 }
 

--- a/silence/silence_test.go
+++ b/silence/silence_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"runtime"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -456,6 +457,67 @@ func TestSilenceSet(t *testing.T) {
 		},
 	}
 	require.Equal(t, want, s.st, "unexpected state after silence creation")
+}
+
+func TestSilenceLimits(t *testing.T) {
+	s, err := New(Options{
+		Limits: Limits{
+			MaxSilences:       1,
+			MaxPerSilenceSize: 2 << 11, // 4KB
+		},
+	})
+	require.NoError(t, err)
+
+	// Insert sil1 should succeed without error.
+	sil1 := &pb.Silence{
+		Matchers: []*pb.Matcher{{Name: "a", Pattern: "b"}},
+		StartsAt: time.Now(),
+		EndsAt:   time.Now().Add(5 * time.Minute),
+	}
+	id1, err := s.Set(sil1)
+	require.NoError(t, err)
+	require.NotEqual(t, "", id1)
+
+	// Insert sil2 should fail because maximum number of silences
+	// has been exceeded.
+	sil2 := &pb.Silence{
+		Matchers: []*pb.Matcher{{Name: "a", Pattern: "b"}},
+		StartsAt: time.Now(),
+		EndsAt:   time.Now().Add(5 * time.Minute),
+	}
+	id2, err := s.Set(sil2)
+	require.EqualError(t, err, "exceeded maximum number of silences: 1")
+	require.Equal(t, "", id2)
+
+	// Expire sil1. This should allow sil2 to be inserted.
+	require.NoError(t, s.Expire(id1))
+	id2, err = s.Set(sil2)
+	require.NoError(t, err)
+	require.NotEqual(t, "", id2)
+
+	// Expire sil2.
+	require.NoError(t, s.Expire(id2))
+
+	// Insert sil3 should fail because it exceeds maximum size.
+	sil3 := &pb.Silence{
+		Matchers: []*pb.Matcher{
+			{
+				Name:    strings.Repeat("a", 2<<9),
+				Pattern: strings.Repeat("b", 2<<9),
+			},
+			{
+				Name:    strings.Repeat("c", 2<<9),
+				Pattern: strings.Repeat("d", 2<<9),
+			},
+		},
+		CreatedBy: strings.Repeat("e", 2<<9),
+		Comment:   strings.Repeat("f", 2<<9),
+		StartsAt:  time.Now(),
+		EndsAt:    time.Now().Add(5 * time.Minute),
+	}
+	id3, err := s.Set(sil3)
+	require.EqualError(t, err, "silence exceeded maximum size: 4096")
+	require.Equal(t, "", id3)
 }
 
 func TestSetActiveSilence(t *testing.T) {

--- a/silence/silence_test.go
+++ b/silence/silence_test.go
@@ -462,8 +462,8 @@ func TestSilenceSet(t *testing.T) {
 func TestSilenceLimits(t *testing.T) {
 	s, err := New(Options{
 		Limits: Limits{
-			MaxSilences:       1,
-			MaxPerSilenceSize: 2 << 11, // 4KB
+			MaxSilences:        1,
+			MaxPerSilenceBytes: 2 << 11, // 4KB
 		},
 	})
 	require.NoError(t, err)

--- a/silence/silence_test.go
+++ b/silence/silence_test.go
@@ -495,6 +495,10 @@ func TestSilenceLimits(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEqual(t, "", id2)
 
+	// Should be able to update sil2 without hitting the limit.
+	_, err = s.Set(sil2)
+	require.NoError(t, err)
+
 	// Expire sil2.
 	require.NoError(t, s.Expire(id2))
 

--- a/silence/silence_test.go
+++ b/silence/silence_test.go
@@ -520,7 +520,7 @@ func TestSilenceLimits(t *testing.T) {
 		EndsAt:    time.Now().Add(5 * time.Minute),
 	}
 	id3, err := s.Set(sil3)
-	require.NotNil(t, err)
+	require.Error(t, err)
 	// Do not check the exact size as it can change between consecutive runs
 	// due to padding.
 	require.Contains(t, err.Error(), "silence exceeded maximum size")


### PR DESCRIPTION
This commit adds limits for silences including the maximum number of active and pending silences, and the maximum size per silence (in bytes).