### PR TITLE
Limits should include expired silences

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -146,7 +146,7 @@ func run() int {
 		dataDir             = kingpin.Flag("storage.path", "Base path for data storage.").Default("data/").String()
 		retention           = kingpin.Flag("data.retention", "How long to keep data for.").Default("120h").Duration()
 		maintenanceInterval = kingpin.Flag("data.maintenance-interval", "Interval between garbage collection and snapshotting to disk of the silences and the notification logs.").Default("15m").Duration()
-		maxSilences         = kingpin.Flag("silences.max-silences", "Maximum number of active and pending silences, excluding expired silences. If negative or zero, no limit is set.").Default("0").Int()
+		maxSilences         = kingpin.Flag("silences.max-silences", "Maximum number of silences, including expired silences. If negative or zero, no limit is set.").Default("0").Int()
 		maxPerSilenceBytes  = kingpin.Flag("silences.max-per-silence-bytes", "Maximum per silence size in bytes. If negative or zero, no limit is set.").Default("0").Int()
 		alertGCInterval     = kingpin.Flag("alerts.gc-interval", "Interval between alert GC.").Default("30m").Duration()
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,7 +26,7 @@ sending an HTTP POST request to the `/-/reload` endpoint.
 
 Alertmanager supports a number of configurable limits via command-line flags.
 
-To limit the maximum number of active and pending silences, excluding expired ones,
+To limit the maximum number of silences, including expired ones,
 use the `--silences.max-silences` flag.
 You can limit the maximum size of individual silences with `--silences.max-per-silence-bytes`,
 where the unit is in bytes.

--- a/silence/silence.go
+++ b/silence/silence.go
@@ -204,8 +204,8 @@ type Silences struct {
 
 // Limits contains the limits for silences.
 type Limits struct {
-	// MaxSilences limits the maximum number active and pending silences.
-	// It does not include expired silences.
+	// MaxSilences limits the maximum number of silences, including expired
+	// silences.
 	MaxSilences int
 	// MaxPerSilenceBytes is the maximum size of an individual silence as
 	// stored on disk.
@@ -623,18 +623,8 @@ func (s *Silences) Set(sil *pb.Silence) (string, error) {
 
 	// If we got here it's either a new silence or a replacing one.
 	if s.limits.MaxSilences > 0 {
-		// Get the number of active and pending silences to enforce limits.
-		q := &query{}
-		err := QState(types.SilenceStateActive, types.SilenceStatePending)(q)
-		if err != nil {
-			return "", fmt.Errorf("unable to query silences while checking limits: %w", err)
-		}
-		sils, _, err := s.query(q, s.nowUTC())
-		if err != nil {
-			return "", fmt.Errorf("unable to query silences while checking limits: %w", err)
-		}
-		if len(sils)+1 > s.limits.MaxSilences {
-			return "", fmt.Errorf("exceeded maximum number of silences: %d (limit: %d)", len(sils), s.limits.MaxSilences)
+		if len(s.st)+1 > s.limits.MaxSilences {
+			return "", fmt.Errorf("exceeded maximum number of silences: %d (limit: %d)", len(s.st), s.limits.MaxSilences)
 		}
 	}
 


### PR DESCRIPTION
The limits we added in #3852 should include expired silences.