### PR TITLE
feat: add opsgenie priority template based on severity label

### DIFF
--- a/template/default.tmpl
+++ b/template/default.tmpl
@@ -52,7 +52,9 @@ Alerts Resolved:
 {{- end }}
 {{- end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanagerURL" . }}{{ end }}
-
+{{ define "opsgenie.default.priority" }}
+{{- if eq .Labels.severity "critical" }}P2{{- else if eq .Labels.severity "warn" }}P3{{- else if eq .Labels.severity "info" }}P4{{- else }}P5{{- end }}
+{{ end }}
 
 {{ define "wechat.default.message" }}{{ template "__subject" . }}
 {{ .CommonAnnotations.SortedPairs.Values | join " " }}


### PR DESCRIPTION
P1 in my opinion is reserved for actual outage, in our case if cloudflare fails the external domain health check though I'm open to updating this _default_.