### PR TITLE
Fix MaxSilences limit causes incomplete updates of existing silences

### DIFF
--- a/silence/silence_test.go
+++ b/silence/silence_test.go
@@ -535,7 +535,7 @@ func TestSilenceLimits(t *testing.T) {
 	require.Equal(t, sil5.Id, sil6.Id)
 
 	// Should not be able to update the start and end time as this requires
-	// sil5 to be expired and a new silence to be created. However, this would
+	// sil6 to be expired and a new silence to be created. However, this would
 	// exceed the maximum number of silences, which counts both active and
 	// expired silences.
 	sil7 := cloneSilence(sil6)


### PR DESCRIPTION
This commit fixes a bug where the MaxSilences limit can cause an incomplete update of existing silences, where the old silence can be expired but the new silence cannot be created because it would exceeded the maximum number of silences.