### PR TITLE
Rename silence limit to max-silence-size-bytes

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -147,7 +147,7 @@ func run() int {
 		retention           = kingpin.Flag("data.retention", "How long to keep data for.").Default("120h").Duration()
 		maintenanceInterval = kingpin.Flag("data.maintenance-interval", "Interval between garbage collection and snapshotting to disk of the silences and the notification logs.").Default("15m").Duration()
 		maxSilences         = kingpin.Flag("silences.max-silences", "Maximum number of silences, including expired silences. If negative or zero, no limit is set.").Default("0").Int()
-		maxPerSilenceBytes  = kingpin.Flag("silences.max-per-silence-bytes", "Maximum per silence size in bytes. If negative or zero, no limit is set.").Default("0").Int()
+		maxSilenceSizeBytes = kingpin.Flag("silences.max-silence-size-bytes", "Maximum per silence size in bytes. If negative or zero, no limit is set.").Default("0").Int()
 		alertGCInterval     = kingpin.Flag("alerts.gc-interval", "Interval between alert GC.").Default("30m").Duration()
 
 		webConfig      = webflag.AddFlags(kingpin.CommandLine, ":9093")
@@ -262,8 +262,8 @@ func run() int {
 		SnapshotFile: filepath.Join(*dataDir, "silences"),
 		Retention:    *retention,
 		Limits: silence.Limits{
-			MaxSilences:        func() int { return *maxSilences },
-			MaxPerSilenceBytes: func() int { return *maxPerSilenceBytes },
+			MaxSilences:         func() int { return *maxSilences },
+			MaxSilenceSizeBytes: func() int { return *maxSilenceSizeBytes },
 		},
 		Logger:  log.With(logger, "component", "silences"),
 		Metrics: prometheus.DefaultRegisterer,

--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -147,7 +147,7 @@ func run() int {
 		retention           = kingpin.Flag("data.retention", "How long to keep data for.").Default("120h").Duration()
 		maintenanceInterval = kingpin.Flag("data.maintenance-interval", "Interval between garbage collection and snapshotting to disk of the silences and the notification logs.").Default("15m").Duration()
 		maxSilences         = kingpin.Flag("silences.max-silences", "Maximum number of silences, including expired silences. If negative or zero, no limit is set.").Default("0").Int()
-		maxSilenceSizeBytes = kingpin.Flag("silences.max-silence-size-bytes", "Maximum per silence size in bytes. If negative or zero, no limit is set.").Default("0").Int()
+		maxSilenceSizeBytes = kingpin.Flag("silences.max-silence-size-bytes", "Maximum silence size in bytes. If negative or zero, no limit is set.").Default("0").Int()
 		alertGCInterval     = kingpin.Flag("alerts.gc-interval", "Interval between alert GC.").Default("30m").Duration()
 
 		webConfig      = webflag.AddFlags(kingpin.CommandLine, ":9093")

--- a/silence/silence.go
+++ b/silence/silence.go
@@ -207,9 +207,9 @@ type Limits struct {
 	// MaxSilences limits the maximum number of silences, including expired
 	// silences.
 	MaxSilences func() int
-	// MaxPerSilenceBytes is the maximum size of an individual silence as
+	// MaxSilenceSizeBytes is the maximum size of an individual silence as
 	// stored on disk.
-	MaxPerSilenceBytes func() int
+	MaxSilenceSizeBytes func() int
 }
 
 // MaintenanceFunc represents the function to run as part of the periodic maintenance for silences.
@@ -585,9 +585,9 @@ func (s *Silences) setSilence(sil *pb.Silence, now time.Time, skipValidate bool)
 	// Check the limit unless the silence has been expired. This is to avoid
 	// situations where silences cannot be expired after the limit has been
 	// reduced.
-	if s.limits.MaxPerSilenceBytes != nil {
+	if s.limits.MaxSilenceSizeBytes != nil {
 		n := msil.Size()
-		if m := s.limits.MaxPerSilenceBytes(); m > 0 && n > m && sil.EndsAt.After(now) {
+		if m := s.limits.MaxSilenceSizeBytes(); m > 0 && n > m && sil.EndsAt.After(now) {
 			return fmt.Errorf("silence exceeded maximum size: %d bytes (limit: %d bytes)", n, m)
 		}
 	}

--- a/silence/silence_test.go
+++ b/silence/silence_test.go
@@ -462,8 +462,8 @@ func TestSilenceSet(t *testing.T) {
 func TestSilenceLimits(t *testing.T) {
 	s, err := New(Options{
 		Limits: Limits{
-			MaxSilences:        func() int { return 1 },
-			MaxPerSilenceBytes: func() int { return 2 << 11 }, // 4KB
+			MaxSilences:         func() int { return 1 },
+			MaxSilenceSizeBytes: func() int { return 2 << 11 }, // 4KB
 		},
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
This commit renames an existing (unreleased) limit from `max-per-silence-bytes` to `max-silence-size-bytes`.

Based on #3885.