### PR TITLE
Fix: Hide config.SecretURL when the URL is incorrect.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -165,7 +165,12 @@ func (s *SecretURL) UnmarshalJSON(data []byte) error {
 		s.URL = &url.URL{}
 		return nil
 	}
-	return json.Unmarshal(data, (*URL)(s))
+	// Redact the secret URL in case of errors
+	if err := json.Unmarshal(data, (*URL)(s)); err != nil {
+		return errors.New(strings.ReplaceAll(err.Error(), string(data), "[REDACTED]"))
+	}
+
+	return nil
 }
 
 // Load parses the YAML input s into a Config.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -607,12 +607,8 @@ func TestHideSecretURL(t *testing.T) {
 	var u SecretURL
 
 	err := json.Unmarshal(b, &u)
-	if err != nil {
-		errStr := err.Error()
-		if strings.Contains(errStr, "://wrongurl/") {
-			t.Fatal("config's String method reveals authentication credentials.")
-		}
-	}
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "wrongurl")
 }
 
 func TestMarshalURL(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -602,6 +602,19 @@ func TestUnmarshalSecretURL(t *testing.T) {
 	require.Equal(t, "http://example.com/se%20cret", u.String(), "SecretURL not properly unmarshaled in YAML.")
 }
 
+func TestHideSecretURL(t *testing.T) {
+	b := []byte(`"://wrongurl/"`)
+	var u SecretURL
+
+	err := json.Unmarshal(b, &u)
+	if err != nil {
+		errStr := err.Error()
+		if strings.Contains(errStr, "://wrongurl/") {
+			t.Fatal("config's String method reveals authentication credentials.")
+		}
+	}
+}
+
 func TestMarshalURL(t *testing.T) {
 	for name, tc := range map[string]struct {
 		input        *URL


### PR DESCRIPTION
### Issue 
Fixes https://github.com/prometheus/alertmanager/issues/3884

### Changes Made
Updated the config.go to redact the URL.
Added test cases to check URL stays hidden.

### Testing Performed 
- [x] Unit Tests 
- [x] Manual tested sending a mal-formatted url. 
