### PR TITLE
Issue #3878: Fix bugs in silences

### DIFF
--- a/api/v2/api_test.go
+++ b/api/v2/api_test.go
@@ -240,11 +240,13 @@ func TestPostSilencesHandler(t *testing.T) {
 			expectedCode int
 		}{
 			{
-				"with an non-existent silence ID - it returns 404",
+				// This can happen when updating an expired silence that has been GC'd.
+				// Instead of failing, we can instead create a new silence.
+				"with an non-existent silence ID - it creates a new silence",
 				"unknownSid",
 				now.Add(time.Hour),
 				now.Add(time.Hour * 2),
-				404,
+				200,
 			},
 			{
 				"with no silence ID - it creates the silence",

--- a/silence/silence.go
+++ b/silence/silence.go
@@ -567,7 +567,7 @@ func (s *Silences) Expire(id string) error {
 // existing limits. When this happens, a silence might have an ID even though
 // the operation failed. It is safe to re-use the silence for subsequent calls
 // to Set where previous calls have failed.
-func (s *Silences) Set(sil *pb.Silence) (err error) {
+func (s *Silences) Set(sil *pb.Silence) error {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 

--- a/test/with_api_v2/acceptance/utf8_test.go
+++ b/test/with_api_v2/acceptance/utf8_test.go
@@ -267,7 +267,7 @@ receivers:
 
 	_, err := am.Client().Silence.PostSilences(silenceParams)
 	require.Error(t, err)
-	require.True(t, strings.Contains(err.Error(), "silence invalid: invalid label matcher"))
+	require.True(t, strings.Contains(err.Error(), "invalid silence: invalid label matcher"))
 }
 
 func TestSendAlertsToUTF8Route(t *testing.T) {


### PR DESCRIPTION
This commit fixes a number of bugs that can occur when creating and updating silences:

1. When creating a silence fails because the silence is invalid or would exceed limits, subsequent calls for the same silence fail even when the validation or limits are fixed. This happens because the silence is assigned an ID that does not exist. This commit fixes that issue as it assigns a new ID to silences that do not exist.

2. When updating an existing silence, and the update changes how alerts are matched or the time window in which the silence is active (excluding time extensions), then the existing silence must be expired and a new silence created. However, if the new silence is invalid or would exceed limits, the existing silence is expired, but the new silence is not created. This commit fixes that issue such that existing silences are not expired unless the replacing silence is both valid and within limits.

Fixes #3877