### PR TITLE
Fix invalid silence causes incomplete updates

### DIFF
--- a/silence/silence.go
+++ b/silence/silence.go
@@ -518,9 +518,6 @@ func matchesEmpty(m *pb.Matcher) bool {
 }
 
 func validateSilence(s *pb.Silence) error {
-	if s.Id == "" {
-		return errors.New("ID missing")
-	}
 	if len(s.Matchers) == 0 {
 		return errors.New("at least one matcher required")
 	}
@@ -543,9 +540,6 @@ func validateSilence(s *pb.Silence) error {
 	}
 	if s.EndsAt.Before(s.StartsAt) {
 		return errors.New("end time must not be before start time")
-	}
-	if s.UpdatedAt.IsZero() {
-		return errors.New("invalid zero update timestamp")
 	}
 	return nil
 }
@@ -571,14 +565,8 @@ func (s *Silences) toMeshSilence(sil *pb.Silence) *pb.MeshSilence {
 	}
 }
 
-func (s *Silences) setSilence(sil *pb.Silence, now time.Time, skipValidate bool) error {
+func (s *Silences) setSilence(sil *pb.Silence, now time.Time) error {
 	sil.UpdatedAt = now
-
-	if !skipValidate {
-		if err := validateSilence(sil); err != nil {
-			return fmt.Errorf("silence invalid: %w", err)
-		}
-	}
 
 	msil := s.toMeshSilence(sil)
 	b, err := marshalMeshSilence(msil)
@@ -611,13 +599,21 @@ func (s *Silences) Set(sil *pb.Silence) error {
 	defer s.mtx.Unlock()
 
 	now := s.nowUTC()
+	if sil.StartsAt.IsZero() {
+		sil.StartsAt = now
+	}
+
+	if err := validateSilence(sil); err != nil {
+		return fmt.Errorf("invalid silence: %w", err)
+	}
+
 	prev, ok := s.getSilence(sil.Id)
 	if sil.Id != "" && !ok {
 		return ErrNotFound
 	}
 
 	if ok && canUpdate(prev, sil, now) {
-		return s.setSilence(sil, now, false)
+		return s.setSilence(sil, now)
 	}
 
 	// If we got here it's either a new silence or a replacing one (which would
@@ -647,7 +643,7 @@ func (s *Silences) Set(sil *pb.Silence) error {
 		sil.StartsAt = now
 	}
 
-	return s.setSilence(sil, now, false)
+	return s.setSilence(sil, now)
 }
 
 // canUpdate returns true if silence a can be updated to b without
@@ -705,10 +701,7 @@ func (s *Silences) expire(id string) error {
 		sil.StartsAt = now
 		sil.EndsAt = now
 	}
-
-	// Skip validation of the silence when expiring it. Without this, silences created
-	// with valid UTF-8 matchers cannot be expired when Alertmanager is run in classic mode.
-	return s.setSilence(sil, now, true)
+	return s.setSilence(sil, now)
 }
 
 // QueryParam expresses parameters along which silences are queried.

--- a/test/with_api_v2/acceptance/utf8_test.go
+++ b/test/with_api_v2/acceptance/utf8_test.go
@@ -267,7 +267,7 @@ receivers:
 
 	_, err := am.Client().Silence.PostSilences(silenceParams)
 	require.Error(t, err)
-	require.True(t, strings.Contains(err.Error(), "silence invalid: invalid label matcher"))
+	require.True(t, strings.Contains(err.Error(), "invalid silence: invalid label matcher"))
 }
 
 func TestSendAlertsToUTF8Route(t *testing.T) {


### PR DESCRIPTION
This commit fixes a bug where an invalid silence causes incomplete updates of existing silences. What happens here is in some cases where the new silence is invalid, it can expire the old silence without creating the new silence. What should happen instead is the entire operation is aborted, and the original silence is left in place. This has been fixed by moving validation out of the `setSilence` method and putting it at the start of the `Set` method instead.