### PR TITLE
Add tests for create and then update silences

### DIFF
--- a/api/v2/testing.go
+++ b/api/v2/testing.go
@@ -14,19 +14,17 @@
 package v2
 
 import (
-	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/go-openapi/strfmt"
-	"github.com/stretchr/testify/require"
 
 	open_api_models "github.com/prometheus/alertmanager/api/v2/models"
 	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/prometheus/alertmanager/silence/silencepb"
 )
 
-func createSilence(t *testing.T, ID, creator string, start, ends time.Time) (open_api_models.PostableSilence, []byte) {
+func createSilence(t *testing.T, ID, creator string, start, ends time.Time) open_api_models.PostableSilence {
 	t.Helper()
 
 	comment := "test"
@@ -46,10 +44,7 @@ func createSilence(t *testing.T, ID, creator string, start, ends time.Time) (ope
 			Comment:   &comment,
 		},
 	}
-	b, err := json.Marshal(&sil)
-	require.NoError(t, err)
-
-	return sil, b
+	return sil
 }
 
 func createSilenceMatcher(t *testing.T, name, pattern string, matcherType silencepb.Matcher_Type) *silencepb.Matcher {


### PR DESCRIPTION
This commit adds a unit test for the `postSilencesHandler` to create and then update a silence. It shows that changing the ID of an existing silence returns 404 Not Found, and removing the ID of an existing silence re-creates that silence with a different ID.