### PR TITLE
Add Inhibitor.MutesAll()

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -186,8 +186,8 @@ func (api *API) Register(r *route.Router, routePrefix string) *http.ServeMux {
 
 // Update config and resolve timeout of each API. APIv2 also needs
 // setAlertStatus to be updated.
-func (api *API) Update(cfg *config.Config, setAlertStatus func(model.LabelSet)) {
-	api.v2.Update(cfg, setAlertStatus)
+func (api *API) Update(cfg *config.Config, setAlertStatus func(model.LabelSet), setAlertStatuses func(...model.LabelSet)) {
+	api.v2.Update(cfg, setAlertStatus, setAlertStatuses)
 }
 
 func (api *API) limitHandler(h http.Handler) http.Handler {

--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -490,6 +490,11 @@ func run() int {
 		api.Update(conf, func(labels model.LabelSet) {
 			inhibitor.Mutes(labels)
 			silencer.Mutes(labels)
+		}, func(ls ...model.LabelSet) {
+			inhibitor.MutesAll(ls...)
+			for _, lset := range ls {
+				silencer.Mutes(lset)
+			}
 		})
 
 		disp = dispatch.NewDispatcher(alerts, routes, pipeline, marker, timeoutFunc, nil, logger, dispMetrics)

--- a/inhibit/inhibit.go
+++ b/inhibit/inhibit.go
@@ -126,23 +126,7 @@ func (ih *Inhibitor) Stop() {
 // Mutes returns true iff the given label set is muted. It implements the Muter
 // interface.
 func (ih *Inhibitor) Mutes(lset model.LabelSet) bool {
-	fp := lset.Fingerprint()
-
-	for _, r := range ih.rules {
-		if !r.TargetMatchers.Matches(lset) {
-			// If target side of rule doesn't match, we don't need to look any further.
-			continue
-		}
-		// If we are here, the target side matches. If the source side matches, too, we
-		// need to exclude inhibiting alerts for which the same is true.
-		if inhibitedByFP, eq := r.hasEqual(lset, r.SourceMatchers.Matches(lset)); eq {
-			ih.marker.SetInhibited(fp, inhibitedByFP.String())
-			return true
-		}
-	}
-	ih.marker.SetInhibited(fp)
-
-	return false
+	return ih.MutesAll(lset)[0]
 }
 
 func (ih *Inhibitor) MutesAll(lsets ...model.LabelSet) []bool {

--- a/inhibit/inhibit_bench_test.go
+++ b/inhibit/inhibit_bench_test.go
@@ -46,7 +46,13 @@ func BenchmarkMutes(b *testing.B) {
 	b.Run("1000 inhibition rules, 1 inhibiting alert, 1 target alert", func(b *testing.B) {
 		benchmarkMutes(b, allRulesMatchBenchmark(b, 1000, 1, 1))
 	})
+	b.Run("1000 inhibition rules, 100 inhibiting alert, 100 target alert", func(b *testing.B) {
+		benchmarkMutes(b, allRulesMatchBenchmark(b, 1000, 100, 100))
+	})
 	b.Run("10000 inhibition rules, 1 inhibiting alert, 1 target alert", func(b *testing.B) {
+		benchmarkMutes(b, allRulesMatchBenchmark(b, 10000, 1, 1))
+	})
+	b.Run("10000 inhibition rules, 1000 inhibiting alert, 1000 target alert", func(b *testing.B) {
 		benchmarkMutes(b, allRulesMatchBenchmark(b, 10000, 1, 1))
 	})
 	b.Run("1 inhibition rule, 10 inhibiting alerts, 1 target alert", func(b *testing.B) {

--- a/inhibit/inhibit_bench_test.go
+++ b/inhibit/inhibit_bench_test.go
@@ -52,8 +52,8 @@ func BenchmarkMutes(b *testing.B) {
 	b.Run("10000 inhibition rules, 1 inhibiting alert, 1 target alert", func(b *testing.B) {
 		benchmarkMutes(b, allRulesMatchBenchmark(b, 10000, 1, 1))
 	})
-	b.Run("10000 inhibition rules, 1000 inhibiting alert, 1000 target alert", func(b *testing.B) {
-		benchmarkMutes(b, allRulesMatchBenchmark(b, 10000, 1, 1))
+	b.Run("10000 inhibition rules, 100 inhibiting alert, 100 target alert", func(b *testing.B) {
+		benchmarkMutes(b, allRulesMatchBenchmark(b, 10000, 100, 100))
 	})
 	b.Run("1 inhibition rule, 10 inhibiting alerts, 1 target alert", func(b *testing.B) {
 		benchmarkMutes(b, allRulesMatchBenchmark(b, 1, 10, 1))

--- a/inhibit/inhibit_bench_test.go
+++ b/inhibit/inhibit_bench_test.go
@@ -34,47 +34,59 @@ import (
 // BenchmarkMutes benchmarks the Mutes method for the Muter interface
 // for different numbers of inhibition rules.
 func BenchmarkMutes(b *testing.B) {
-	b.Run("1 inhibition rule, 1 inhibiting alert", func(b *testing.B) {
-		benchmarkMutes(b, allRulesMatchBenchmark(b, 1, 1))
+	b.Run("1 inhibition rule, 1 inhibiting alert, 1 target alert", func(b *testing.B) {
+		benchmarkMutes(b, allRulesMatchBenchmark(b, 1, 1, 1))
 	})
-	b.Run("10 inhibition rules, 1 inhibiting alert", func(b *testing.B) {
-		benchmarkMutes(b, allRulesMatchBenchmark(b, 10, 1))
+	b.Run("10 inhibition rules, 1 inhibiting alert, 1 target alert", func(b *testing.B) {
+		benchmarkMutes(b, allRulesMatchBenchmark(b, 10, 1, 1))
 	})
-	b.Run("100 inhibition rules, 1 inhibiting alert", func(b *testing.B) {
-		benchmarkMutes(b, allRulesMatchBenchmark(b, 100, 1))
+	b.Run("100 inhibition rules, 1 inhibiting alert, 1 target alert", func(b *testing.B) {
+		benchmarkMutes(b, allRulesMatchBenchmark(b, 100, 1, 1))
 	})
-	b.Run("1000 inhibition rules, 1 inhibiting alert", func(b *testing.B) {
-		benchmarkMutes(b, allRulesMatchBenchmark(b, 1000, 1))
+	b.Run("1000 inhibition rules, 1 inhibiting alert, 1 target alert", func(b *testing.B) {
+		benchmarkMutes(b, allRulesMatchBenchmark(b, 1000, 1, 1))
 	})
-	b.Run("10000 inhibition rules, 1 inhibiting alert", func(b *testing.B) {
-		benchmarkMutes(b, allRulesMatchBenchmark(b, 10000, 1))
+	b.Run("10000 inhibition rules, 1 inhibiting alert, 1 target alert", func(b *testing.B) {
+		benchmarkMutes(b, allRulesMatchBenchmark(b, 10000, 1, 1))
 	})
-	b.Run("1 inhibition rule, 10 inhibiting alerts", func(b *testing.B) {
-		benchmarkMutes(b, allRulesMatchBenchmark(b, 1, 10))
+	b.Run("1 inhibition rule, 10 inhibiting alerts, 1 target alert", func(b *testing.B) {
+		benchmarkMutes(b, allRulesMatchBenchmark(b, 1, 10, 1))
 	})
-	b.Run("1 inhibition rule, 100 inhibiting alerts", func(b *testing.B) {
-		benchmarkMutes(b, allRulesMatchBenchmark(b, 1, 100))
+	b.Run("1 inhibition rule, 100 inhibiting alerts, 1 target alert", func(b *testing.B) {
+		benchmarkMutes(b, allRulesMatchBenchmark(b, 1, 100, 1))
 	})
-	b.Run("1 inhibition rule, 1000 inhibiting alerts", func(b *testing.B) {
-		benchmarkMutes(b, allRulesMatchBenchmark(b, 1, 1000))
+	b.Run("1 inhibition rule, 100 inhibiting alerts, 100 target alert", func(b *testing.B) {
+		benchmarkMutes(b, allRulesMatchBenchmark(b, 1, 100, 100))
 	})
-	b.Run("1 inhibition rule, 10000 inhibiting alerts", func(b *testing.B) {
-		benchmarkMutes(b, allRulesMatchBenchmark(b, 1, 10000))
+	b.Run("1 inhibition rule, 1000 inhibiting alerts, 1 target alert", func(b *testing.B) {
+		benchmarkMutes(b, allRulesMatchBenchmark(b, 1, 1000, 1))
 	})
-	b.Run("100 inhibition rules, 1000 inhibiting alerts", func(b *testing.B) {
-		benchmarkMutes(b, allRulesMatchBenchmark(b, 100, 1000))
+	b.Run("1 inhibition rule, 1000 inhibiting alerts, 1000 target alert", func(b *testing.B) {
+		benchmarkMutes(b, allRulesMatchBenchmark(b, 1, 1000, 1000))
 	})
-	b.Run("10 inhibition rules, last rule matches", func(b *testing.B) {
-		benchmarkMutes(b, lastRuleMatchesBenchmark(b, 10))
+	b.Run("1 inhibition rule, 10000 inhibiting alerts, 1 target alert", func(b *testing.B) {
+		benchmarkMutes(b, allRulesMatchBenchmark(b, 1, 10000, 1))
 	})
-	b.Run("100 inhibition rules, last rule matches", func(b *testing.B) {
-		benchmarkMutes(b, lastRuleMatchesBenchmark(b, 100))
+	b.Run("100 inhibition rules, 1000 inhibiting alerts, 1 target alert", func(b *testing.B) {
+		benchmarkMutes(b, allRulesMatchBenchmark(b, 100, 1000, 1))
 	})
-	b.Run("1000 inhibition rules, last rule matches", func(b *testing.B) {
-		benchmarkMutes(b, lastRuleMatchesBenchmark(b, 1000))
+	b.Run("10 inhibition rules, last rule matches, 1 target alert", func(b *testing.B) {
+		benchmarkMutes(b, lastRuleMatchesBenchmark(b, 10, 1))
 	})
-	b.Run("10000 inhibition rules, last rule matches", func(b *testing.B) {
-		benchmarkMutes(b, lastRuleMatchesBenchmark(b, 10000))
+	b.Run("100 inhibition rules, last rule matches, 1 target alert", func(b *testing.B) {
+		benchmarkMutes(b, lastRuleMatchesBenchmark(b, 100, 1))
+	})
+	b.Run("100 inhibition rules, last rule matches, 100 target alerts", func(b *testing.B) {
+		benchmarkMutes(b, lastRuleMatchesBenchmark(b, 100, 100))
+	})
+	b.Run("1000 inhibition rules, last rule matches, 1 target alert", func(b *testing.B) {
+		benchmarkMutes(b, lastRuleMatchesBenchmark(b, 1000, 1))
+	})
+	b.Run("1000 inhibition rules, last rule matches, 1000 target alert", func(b *testing.B) {
+		benchmarkMutes(b, lastRuleMatchesBenchmark(b, 1000, 1000))
+	})
+	b.Run("10000 inhibition rules, last rule matches, 1 target alert", func(b *testing.B) {
+		benchmarkMutes(b, lastRuleMatchesBenchmark(b, 10000, 1))
 	})
 }
 
@@ -104,7 +116,7 @@ type benchmarkOptions struct {
 // matchers, and is determined with numInhibitingAlerts.
 //
 // It expects dst=0 to be muted and will fail if not.
-func allRulesMatchBenchmark(b *testing.B, numInhibitionRules, numInhibitingAlerts int) benchmarkOptions {
+func allRulesMatchBenchmark(b *testing.B, numInhibitionRules, numInhibitingAlerts, numTargetAlerts int) benchmarkOptions {
 	return benchmarkOptions{
 		n: numInhibitionRules,
 		newRuleFunc: func(idx int) config.InhibitRule {
@@ -131,8 +143,10 @@ func allRulesMatchBenchmark(b *testing.B, numInhibitionRules, numInhibitingAlert
 			}
 			return alerts
 		}, benchFunc: func(mutesFunc func(set model.LabelSet) bool) error {
-			if ok := mutesFunc(model.LabelSet{"dst": "0"}); !ok {
-				return errors.New("expected dst=0 to be muted")
+			for i := 0; i < numTargetAlerts; i++ {
+				if ok := mutesFunc(model.LabelSet{"dst": "0"}); !ok {
+					return errors.New("expected dst=0 to be muted")
+				}
 			}
 			return nil
 		},
@@ -147,7 +161,7 @@ func allRulesMatchBenchmark(b *testing.B, numInhibitionRules, numInhibitingAlert
 // across all inhibition rules (dst=0).
 //
 // It expects dst=0 to be muted and will fail if not.
-func lastRuleMatchesBenchmark(b *testing.B, n int) benchmarkOptions {
+func lastRuleMatchesBenchmark(b *testing.B, n, numTargetAlerts int) benchmarkOptions {
 	return benchmarkOptions{
 		n: n,
 		newRuleFunc: func(idx int) config.InhibitRule {
@@ -173,8 +187,10 @@ func lastRuleMatchesBenchmark(b *testing.B, n int) benchmarkOptions {
 				},
 			}}
 		}, benchFunc: func(mutesFunc func(set model.LabelSet) bool) error {
-			if ok := mutesFunc(model.LabelSet{"dst": "0"}); !ok {
-				return errors.New("expected dst=0 to be muted")
+			for i := 0; i < numTargetAlerts; i++ {
+				if ok := mutesFunc(model.LabelSet{"dst": "0"}); !ok {
+					return errors.New("expected dst=0 to be muted")
+				}
 			}
 			return nil
 		},

--- a/inhibit/inhibit_test.go
+++ b/inhibit/inhibit_test.go
@@ -227,9 +227,15 @@ func TestInhibitRuleMatches(t *testing.T) {
 		},
 	}
 
-	for _, c := range cases {
-		if actual := ih.Mutes(c.target); actual != c.expected {
-			t.Errorf("Expected (*Inhibitor).Mutes(%v) to return %t but got %t", c.target, c.expected, actual)
+	targets := make([]model.LabelSet, len(cases))
+	for i, c := range cases {
+		targets[i] = c.target
+	}
+	mutes := ih.MutesAll(targets...)
+	for i := range cases {
+		c := cases[i]
+		if mutes[i] != c.expected {
+			t.Errorf("Expected (*Inhibitor).Mutes(%v) to return %t but got %t", c.target, c.expected, mutes[i])
 		}
 	}
 }
@@ -323,9 +329,15 @@ func TestInhibitRuleMatchers(t *testing.T) {
 		},
 	}
 
-	for _, c := range cases {
-		if actual := ih.Mutes(c.target); actual != c.expected {
-			t.Errorf("Expected (*Inhibitor).Mutes(%v) to return %t but got %t", c.target, c.expected, actual)
+	targets := make([]model.LabelSet, len(cases))
+	for i, c := range cases {
+		targets[i] = c.target
+	}
+	mutes := ih.MutesAll(targets...)
+	for i := range cases {
+		c := cases[i]
+		if mutes[i] != c.expected {
+			t.Errorf("Expected (*Inhibitor).Mutes(%v) to return %t but got %t", c.target, c.expected, mutes[i])
 		}
 	}
 }
@@ -407,7 +419,7 @@ func TestInhibit(t *testing.T) {
 		lbls  model.LabelSet
 		muted bool
 	}
-	for i, tc := range []struct {
+	for _, tc := range []struct {
 		alerts   []*types.Alert
 		expected []exp
 	}{
@@ -466,8 +478,14 @@ func TestInhibit(t *testing.T) {
 		}()
 		inhibitor.Run()
 
-		for _, expected := range tc.expected {
-			if inhibitor.Mutes(expected.lbls) != expected.muted {
+		labelSet := make([]model.LabelSet, len(tc.expected))
+		for i, e := range tc.expected {
+			labelSet[i] = e.lbls
+		}
+		mutes := inhibitor.MutesAll(labelSet...)
+		for i := range tc.expected {
+			expected := tc.expected[i]
+			if mutes[i] != expected.muted {
 				mute := "unmuted"
 				if expected.muted {
 					mute = "muted"


### PR DESCRIPTION
For the context please refer to #3932.

I added benchmarks, which consider more than one target alert.
The following benchstat output compares:
- invoking `Inhibitor.Mutes()` for each target alert (old.txt)
- with the `Inhibitor.MutesAll()` implementation (new.txt).
`Inhibitor.MutesAll()` increase the speed in certain cases at the cost of some memory.
```
goos: darwin
goarch: arm64
pkg: github.com/prometheus/alertmanager/inhibit
                                                                        │    old.txt    │               new.txt                 │
                                                                        │    sec/op     │    sec/op     vs base                 │
Mutes/1_inhibition_rule,_1_inhibiting_alert,_1_target_alert-10              768.5n ± 3%    842.5n ± 5%    +9.62% (p=0.001 n=10)
Mutes/10_inhibition_rules,_1_inhibiting_alert,_1_target_alert-10            769.5n ± 2%    834.4n ± 0%    +8.44% (p=0.000 n=10)
Mutes/100_inhibition_rules,_1_inhibiting_alert,_1_target_alert-10           779.3n ± 1%    841.4n ± 1%    +7.96% (p=0.000 n=10)
Mutes/1000_inhibition_rules,_1_inhibiting_alert,_1_target_alert-10          839.5n ± 1%    914.7n ± 4%    +8.96% (p=0.000 n=10)
Mutes/1000_inhibition_rules,_100_inhibiting_alert,_100_target_alert-10     157.39µ ± 1%    54.41µ ± 1%   -65.43% (p=0.000 n=10)
Mutes/10000_inhibition_rules,_1_inhibiting_alert,_1_target_alert-10         897.5n ± 3%    962.6n ± 2%    +7.25% (p=0.000 n=10)
Mutes/10000_inhibition_rules,_100_inhibiting_alert,_100_target_alert-10     63.07µ ± 6%    57.59µ ± 3%    -8.68% (p=0.000 n=10)
Mutes/1_inhibition_rule,_10_inhibiting_alerts,_1_target_alert-10            886.9n ± 1%   1087.0n ± 1%   +22.57% (p=0.000 n=10)
Mutes/1_inhibition_rule,_100_inhibiting_alerts,_1_target_alert-10           1.929µ ± 2%    3.083µ ± 1%   +59.84% (p=0.000 n=10)
Mutes/1_inhibition_rule,_100_inhibiting_alerts,_100_target_alert-10        174.18µ ± 1%    60.44µ ± 1%   -65.30% (p=0.000 n=10)
Mutes/1_inhibition_rule,_1000_inhibiting_alerts,_1_target_alert-10          12.67µ ± 1%    25.82µ ± 1%  +103.87% (p=0.000 n=10)
Mutes/1_inhibition_rule,_1000_inhibiting_alerts,_1000_target_alert-10     12425.7µ ± 1%    582.3µ ± 1%   -95.31% (p=0.000 n=10)
Mutes/1_inhibition_rule,_10000_inhibiting_alerts,_1_target_alert-10         104.4µ ± 1%    278.8µ ± 1%  +167.13% (p=0.000 n=10)
Mutes/100_inhibition_rules,_1000_inhibiting_alerts,_1_target_alert-10       11.89µ ± 2%    24.69µ ± 0%  +107.65% (p=0.000 n=10)
Mutes/10_inhibition_rules,_last_rule_matches,_1_target_alert-10             1.012µ ± 3%    1.125µ ± 1%   +11.22% (p=0.000 n=10)
Mutes/100_inhibition_rules,_last_rule_matches,_1_target_alert-10            3.178µ ± 1%    3.872µ ± 1%   +21.86% (p=0.000 n=10)
Mutes/100_inhibition_rules,_last_rule_matches,_100_target_alerts-10         299.9µ ± 1%    227.9µ ± 1%   -24.00% (p=0.000 n=10)
Mutes/1000_inhibition_rules,_last_rule_matches,_1_target_alert-10           24.62µ ± 3%    31.57µ ± 1%   +28.24% (p=0.000 n=10)
Mutes/1000_inhibition_rules,_last_rule_matches,_1000_target_alert-10        24.29m ± 0%    18.27m ± 0%   -24.77% (p=0.000 n=10)
Mutes/10000_inhibition_rules,_last_rule_matches,_1_target_alert-10          239.6µ ± 6%    306.5µ ± 0%   +27.94% (p=0.000 n=10)
geomean                                                                     18.71µ         17.34µ         -7.36%
```

In cases where a low count of alerts is involved `Inhibitor.MutesAll()` is 2-3 times slower, due to the additional memory allocations.
This should still be sufficiently fast given the small scale.
When the count of target alerts is increased `Inhibitor.MutesAll()` becomes faster.
Invoking it as part of `GET /alerts` still needs to be done.
