### PR TITLE
opsgenie: Add visible_to

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -592,9 +592,15 @@ type OpsGenieConfig struct {
 	UpdateAlerts bool                      `yaml:"update_alerts,omitempty" json:"update_alerts,omitempty"`
 }
 
-const opsgenieValidTypesRe = `^(team|teams|user|escalation|schedule)$`
+const (
+	opsgenieValidResponderTypesRe = `^(team|teams|user|escalation|schedule)$`
+	opsgenieValidVisibleToTypesRe = `^(team|teams|user)$`
+)
 
-var opsgenieTypeMatcher = regexp.MustCompile(opsgenieValidTypesRe)
+var (
+	opsgenieResponderTypeMatcher = regexp.MustCompile(opsgenieValidResponderTypesRe)
+	opsgenieVisibleToTypeMatcher = regexp.MustCompile(opsgenieValidVisibleToTypesRe)
+)
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
 func (c *OpsGenieConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
@@ -620,8 +626,8 @@ func (c *OpsGenieConfig) UnmarshalYAML(unmarshal func(interface{}) error) error 
 			}
 		} else {
 			r.Type = strings.ToLower(r.Type)
-			if !opsgenieTypeMatcher.MatchString(r.Type) {
-				return fmt.Errorf("opsGenieConfig responder %v type does not match valid options %s", r, opsgenieValidTypesRe)
+			if !opsgenieResponderTypeMatcher.MatchString(r.Type) {
+				return fmt.Errorf("opsGenieConfig responder %v type does not match valid options %s", r, opsgenieValidResponderTypesRe)
 			}
 		}
 	}
@@ -638,8 +644,8 @@ func (c *OpsGenieConfig) UnmarshalYAML(unmarshal func(interface{}) error) error 
 			}
 		} else {
 			v.Type = strings.ToLower(v.Type)
-			if !opsgenieTypeMatcher.MatchString(v.Type) {
-				return fmt.Errorf("opsGenieConfig visible_to %v type does not match valid options %s", v, opsgenieValidTypesRe)
+			if !opsgenieVisibleToTypeMatcher.MatchString(v.Type) {
+				return fmt.Errorf("opsGenieConfig visible_to %v type does not match valid options %s", v, opsgenieValidVisibleToTypesRe)
 			}
 		}
 	}
@@ -653,7 +659,7 @@ type OpsGenieConfigResponder struct {
 	Name     string `yaml:"name,omitempty" json:"name,omitempty"`
 	Username string `yaml:"username,omitempty" json:"username,omitempty"`
 
-	// team, user, escalation, schedule etc.
+	// team, user, escalation, schedule, teams etc.
 	Type string `yaml:"type,omitempty" json:"type,omitempty"`
 }
 
@@ -663,7 +669,7 @@ type OpsGenieConfigVisibleTo struct {
 	Name     string `yaml:"name,omitempty" json:"name,omitempty"`
 	Username string `yaml:"username,omitempty" json:"username,omitempty"`
 
-	// team, user
+	// team, user, teams
 	Type string `yaml:"type,omitempty" json:"type,omitempty"`
 }
 

--- a/config/notifiers_test.go
+++ b/config/notifiers_test.go
@@ -782,16 +782,31 @@ actions:
 	}
 }
 
-func TestOpsgenieTypeMatcher(t *testing.T) {
-	good := []string{"team", "user", "escalation", "schedule"}
+func TestOpsgenieResponderTypeMatcher(t *testing.T) {
+	good := []string{"team", "user", "teams", "escalation", "schedule"}
 	for _, g := range good {
-		if !opsgenieTypeMatcher.MatchString(g) {
+		if !opsgenieResponderTypeMatcher.MatchString(g) {
 			t.Fatalf("failed to match with %s", g)
 		}
 	}
 	bad := []string{"0user", "team1", "2escalation3", "sche4dule", "User", "TEAM"}
 	for _, b := range bad {
-		if opsgenieTypeMatcher.MatchString(b) {
+		if opsgenieResponderTypeMatcher.MatchString(b) {
+			t.Errorf("mistakenly match with %s", b)
+		}
+	}
+}
+
+func TestOpsgenieVisibleToTypeMatcher(t *testing.T) {
+	good := []string{"team", "user", "teams"}
+	for _, g := range good {
+		if !opsgenieVisibleToTypeMatcher.MatchString(g) {
+			t.Fatalf("failed to match with %s", g)
+		}
+	}
+	bad := []string{"0user", "team1", "2escalation3", "sche4dule", "User", "TEAM", "escalation", "schedule"}
+	for _, b := range bad {
+		if opsgenieVisibleToTypeMatcher.MatchString(b) {
 			t.Errorf("mistakenly match with %s", b)
 		}
 	}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1121,14 +1121,15 @@ type: <tmpl_string>
 #### `<visible_to>`
 
 ```yaml
-# Exactly one of these fields should be defined.
+# Exactly one of these fields must have a value after templating.
+# If none of the fields, including type, are set, the array item will be ignored.
 [ id: <tmpl_string> ]
 [ name: <tmpl_string> ]
 [ username: <tmpl_string> ]
 
 # One of `team`, `teams` or `user`.
 #
-# The `teams` responder is configured using the `name` field above.
+# The `teams` type is configured using the `name` field above.
 # This field can contain a comma-separated list of team names.
 # If the list is empty, no additional visibility will be configured.
 type: <tmpl_string>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1075,6 +1075,10 @@ OpsGenie notifications are sent via the [OpsGenie API](https://docs.opsgenie.com
 responders:
   [ - <responder> ... ]
 
+# List of teams and users the alert will become visible to without sending any notification.
+visible_to:
+  [ - <visible_to> ... ]
+
 # Comma separated list of tags attached to the notifications.
 [ tags: <tmpl_string> ]
 
@@ -1111,6 +1115,22 @@ responders:
 # The `teams` responder is configured using the `name` field above.
 # This field can contain a comma-separated list of team names.
 # If the list is empty, no responders are configured.
+type: <tmpl_string>
+```
+
+#### `<visible_to>`
+
+```yaml
+# Exactly one of these fields should be defined.
+[ id: <tmpl_string> ]
+[ name: <tmpl_string> ]
+[ username: <tmpl_string> ]
+
+# One of `team`, `teams` or `user`.
+#
+# The `teams` responder is configured using the `name` field above.
+# This field can contain a comma-separated list of team names.
+# If the list is empty, no additional visibility will be configured.
 type: <tmpl_string>
 ```
 

--- a/notify/opsgenie/opsgenie.go
+++ b/notify/opsgenie/opsgenie.go
@@ -238,8 +238,8 @@ func (n *Notifier) createRequests(ctx context.Context, as ...*types.Alert) ([]*h
 				teams := safeSplit(visibleTo.Name, ",")
 				for _, team := range teams {
 					newVisibleTo := opsGenieCreateMessageVisibleTo{
-						Name: tmpl(team),
-						Type: tmpl("team"),
+						Name: team,
+						Type: "team",
 					}
 					visibleTos = append(visibleTos, newVisibleTo)
 				}

--- a/notify/opsgenie/opsgenie_test.go
+++ b/notify/opsgenie/opsgenie_test.go
@@ -140,7 +140,7 @@ func TestOpsGenie(t *testing.T) {
 			},
 			expectedEmptyAlertBody: `{"alias":"6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b","message":"","details":{},"source":""}
 `,
-			expectedBody: `{"alias":"6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b","message":"message","description":"description","details":{"Actions":"doThis,doThat","Description":"description","Entity":"test-domain","Message":"message","Note":"this is a note","Priority":"P1","ResponderName1":"TeamA","ResponderName2":"EscalationA","ResponderName3":"TeamA,TeamB","ResponderType1":"team","ResponderType2":"escalation","ResponderType3":"teams","Source":"http://prometheus","Tags":"tag1,tag2"},"source":"http://prometheus","responders":[{"name":"TeamA","type":"team"},{"name":"EscalationA","type":"escalation"}],"tags":["tag1","tag2"],"note":"this is a note","priority":"P1","entity":"test-domain","actions":["doThis","doThat"]}
+			expectedBody: `{"alias":"6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b","message":"message","description":"description","details":{"Actions":"doThis,doThat","Description":"description","Entity":"test-domain","Message":"message","Note":"this is a note","Priority":"P1","ResponderName1":"TeamA","ResponderName2":"EscalationA","ResponderName3":"TeamA,TeamB","ResponderType1":"team","ResponderType2":"escalation","ResponderType3":"teams","Source":"http://prometheus","Tags":"tag1,tag2","VisibleToName1":"TeamA","VisibleToName2":"user1","VisibleToType1":"team","VisibleToType2":"user"},"source":"http://prometheus","responders":[{"name":"TeamA","type":"team"},{"name":"EscalationA","type":"escalation"}],"tags":["tag1","tag2"],"note":"this is a note","priority":"P1","entity":"test-domain","actions":["doThis","doThat"]}
 `,
 		},
 		{
@@ -176,7 +176,7 @@ func TestOpsGenie(t *testing.T) {
 			},
 			expectedEmptyAlertBody: `{"alias":"6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b","message":"","details":{"Description":"adjusted "},"source":""}
 `,
-			expectedBody: `{"alias":"6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b","message":"message","description":"description","details":{"Actions":"doThis,doThat","Description":"adjusted description","Entity":"test-domain","Message":"message","Note":"this is a note","Priority":"P1","ResponderName1":"TeamA","ResponderName2":"EscalationA","ResponderName3":"TeamA,TeamB","ResponderType1":"team","ResponderType2":"escalation","ResponderType3":"teams","Source":"http://prometheus","Tags":"tag1,tag2"},"source":"http://prometheus","responders":[{"name":"TeamA","type":"team"},{"name":"EscalationA","type":"escalation"}],"tags":["tag1","tag2"],"note":"this is a note","priority":"P1","entity":"test-domain","actions":["doThis","doThat"]}
+			expectedBody: `{"alias":"6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b","message":"message","description":"description","details":{"Actions":"doThis,doThat","Description":"adjusted description","Entity":"test-domain","Message":"message","Note":"this is a note","Priority":"P1","ResponderName1":"TeamA","ResponderName2":"EscalationA","ResponderName3":"TeamA,TeamB","ResponderType1":"team","ResponderType2":"escalation","ResponderType3":"teams","Source":"http://prometheus","Tags":"tag1,tag2","VisibleToName1":"TeamA","VisibleToName2":"user1","VisibleToType1":"team","VisibleToType2":"user"},"source":"http://prometheus","responders":[{"name":"TeamA","type":"team"},{"name":"EscalationA","type":"escalation"}],"tags":["tag1","tag2"],"note":"this is a note","priority":"P1","entity":"test-domain","actions":["doThis","doThat"]}
 `,
 		},
 		{
@@ -206,7 +206,50 @@ func TestOpsGenie(t *testing.T) {
 			},
 			expectedEmptyAlertBody: `{"alias":"6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b","message":"","details":{"Description":"adjusted "},"source":""}
 `,
-			expectedBody: `{"alias":"6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b","message":"message","description":"description","details":{"Actions":"doThis,doThat","Description":"adjusted description","Entity":"test-domain","Message":"message","Note":"this is a note","Priority":"P1","ResponderName1":"TeamA","ResponderName2":"EscalationA","ResponderName3":"TeamA,TeamB","ResponderType1":"team","ResponderType2":"escalation","ResponderType3":"teams","Source":"http://prometheus","Tags":"tag1,tag2"},"source":"http://prometheus","responders":[{"name":"TeamA","type":"team"},{"name":"TeamB","type":"team"}],"tags":["tag1","tag2"],"note":"this is a note","priority":"P1"}
+			expectedBody: `{"alias":"6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b","message":"message","description":"description","details":{"Actions":"doThis,doThat","Description":"adjusted description","Entity":"test-domain","Message":"message","Note":"this is a note","Priority":"P1","ResponderName1":"TeamA","ResponderName2":"EscalationA","ResponderName3":"TeamA,TeamB","ResponderType1":"team","ResponderType2":"escalation","ResponderType3":"teams","Source":"http://prometheus","Tags":"tag1,tag2","VisibleToName1":"TeamA","VisibleToName2":"user1","VisibleToType1":"team","VisibleToType2":"user"},"source":"http://prometheus","responders":[{"name":"TeamA","type":"team"},{"name":"TeamB","type":"team"}],"tags":["tag1","tag2"],"note":"this is a note","priority":"P1"}
+`,
+		},
+		{
+			title: "config with visible_to",
+			cfg: &config.OpsGenieConfig{
+				NotifierConfig: config.NotifierConfig{
+					VSendResolved: true,
+				},
+				Message:     `{{ .CommonLabels.Message }}`,
+				Description: `{{ .CommonLabels.Description }}`,
+				Source:      `{{ .CommonLabels.Source }}`,
+				Responders: []config.OpsGenieConfigResponder{
+					{
+						Name: `{{ .CommonLabels.ResponderName1 }}`,
+						Type: `{{ .CommonLabels.ResponderType1 }}`,
+					},
+					{
+						Name: `{{ .CommonLabels.ResponderName2 }}`,
+						Type: `{{ .CommonLabels.ResponderType2 }}`,
+					},
+				},
+				VisibleTo: []config.OpsGenieConfigVisibleTo{
+					{
+						Name: `{{ .CommonLabels.VisibleToName1 }}`,
+						Type: `{{ .CommonLabels.VisibleToType1 }}`,
+					},
+					{
+						Name: `{{ .CommonLabels.VisibleToName2 }}`,
+						Type: `{{ .CommonLabels.VisibleToType2 }}`,
+					},
+				},
+				Tags:       `{{ .CommonLabels.Tags }}`,
+				Note:       `{{ .CommonLabels.Note }}`,
+				Priority:   `{{ .CommonLabels.Priority }}`,
+				Entity:     `{{ .CommonLabels.Entity }}`,
+				Actions:    `{{ .CommonLabels.Actions }}`,
+				APIKey:     `{{ .ExternalURL }}`,
+				APIURL:     &config.URL{URL: u},
+				HTTPConfig: &commoncfg.HTTPClientConfig{},
+			},
+			expectedEmptyAlertBody: `{"alias":"6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b","message":"","details":{},"source":""}
+`,
+			expectedBody: `{"alias":"6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b","message":"message","description":"description","details":{"Actions":"doThis,doThat","Description":"description","Entity":"test-domain","Message":"message","Note":"this is a note","Priority":"P1","ResponderName1":"TeamA","ResponderName2":"EscalationA","ResponderName3":"TeamA,TeamB","ResponderType1":"team","ResponderType2":"escalation","ResponderType3":"teams","Source":"http://prometheus","Tags":"tag1,tag2","VisibleToName1":"TeamA","VisibleToName2":"user1","VisibleToType1":"team","VisibleToType2":"user"},"source":"http://prometheus","responders":[{"name":"TeamA","type":"team"},{"name":"EscalationA","type":"escalation"}],"visibleTo":[{"name":"TeamA","type":"team"},{"name":"user1","type":"user"}],"tags":["tag1","tag2"],"note":"this is a note","priority":"P1","entity":"test-domain","actions":["doThis","doThat"]}
 `,
 		},
 	} {
@@ -248,6 +291,10 @@ func TestOpsGenie(t *testing.T) {
 						"ResponderType2": "escalation",
 						"ResponderName3": "TeamA,TeamB",
 						"ResponderType3": "teams",
+						"VisibleToName1": "TeamA",
+						"VisibleToType1": "team",
+						"VisibleToName2": "user1",
+						"VisibleToType2": "user",
 						"Tags":           "tag1,tag2",
 						"Note":           "this is a note",
 						"Priority":       "P1",


### PR DESCRIPTION
Add visible_to with the same support for templating and fields as the
existing responders field.

Opsgenie documentation:

>   Teams and users that the alert will become visible to without sending
>   any notification. type field is mandatory for each item, where possible
>   values are team and user. In addition to the type field, either id or
>   name should be given for teams and either id or username should be given
>   for users. Please note: that alert will be visible to the teams that are
>   specified within responders field by default, so there is no need to
>   re-specify them within visibleTo field. You can refer below for example
>   values.

The functionality has been tested with unit tests, and with the following
configuration:

```yaml
  route:
    receiver: og
    group_wait: 30s
    group_interval: 5m
    repeat_interval: 12h
  receivers:
  - name: og
    opsgenie_configs:
    - send_resolved: true
      api_key: ...top secret...
      api_url: https://api.eu.opsgenie.com/
      message: 'Lab message'
      description: 'Static description'
      source: lab
      details:
        foo: bar
      priority: P4
      visible_to:
      - type: user
        username: foo@example.com
```

Fixes #3953
