### PR TITLE
bugfix: only increment Silences version if a silence is added

### DIFF
--- a/silence/silence_test.go
+++ b/silence/silence_test.go
@@ -428,8 +428,10 @@ func TestSilenceSet(t *testing.T) {
 		StartsAt: start1.Add(2 * time.Minute),
 		EndsAt:   start1.Add(5 * time.Minute),
 	}
+	versionBeforeOp := s.Version()
 	require.NoError(t, s.Set(sil1))
 	require.NotEqual(t, "", sil1.Id)
+	require.NotEqual(t, versionBeforeOp, s.Version())
 
 	want := state{
 		sil1.Id: &pb.MeshSilence{
@@ -453,8 +455,10 @@ func TestSilenceSet(t *testing.T) {
 		Matchers: []*pb.Matcher{{Name: "a", Pattern: "b"}},
 		EndsAt:   start2.Add(1 * time.Minute),
 	}
+	versionBeforeOp = s.Version()
 	require.NoError(t, s.Set(sil2))
 	require.NotEqual(t, "", sil2.Id)
+	require.NotEqual(t, versionBeforeOp, s.Version())
 
 	want = state{
 		sil1.Id: want[sil1.Id],
@@ -474,15 +478,19 @@ func TestSilenceSet(t *testing.T) {
 	// Should be able to update silence without modifications. It is expected to
 	// keep the same ID.
 	sil3 := cloneSilence(sil2)
+	versionBeforeOp = s.Version()
 	require.NoError(t, s.Set(sil3))
 	require.Equal(t, sil2.Id, sil3.Id)
+	require.Equal(t, versionBeforeOp, s.Version())
 
 	// Should be able to update silence with comment. It is also expected to
 	// keep the same ID.
 	sil4 := cloneSilence(sil3)
 	sil4.Comment = "c"
+	versionBeforeOp = s.Version()
 	require.NoError(t, s.Set(sil4))
 	require.Equal(t, sil3.Id, sil4.Id)
+	require.Equal(t, versionBeforeOp, s.Version())
 
 	// Extend sil4 to expire at a later time. This should not expire the
 	// existing silence, and so should also keep the same ID.
@@ -490,6 +498,7 @@ func TestSilenceSet(t *testing.T) {
 	start5 := s.nowUTC()
 	sil5 := cloneSilence(sil4)
 	sil5.EndsAt = start5.Add(100 * time.Minute)
+	versionBeforeOp = s.Version()
 	require.NoError(t, s.Set(sil5))
 	require.Equal(t, sil4.Id, sil5.Id)
 	want = state{
@@ -507,6 +516,7 @@ func TestSilenceSet(t *testing.T) {
 		},
 	}
 	require.Equal(t, want, s.st, "unexpected state after silence creation")
+	require.Equal(t, versionBeforeOp, s.Version())
 
 	// Replace the silence sil5 with another silence with different matchers.
 	// Unlike previous updates, changing the matchers for an existing silence
@@ -518,6 +528,7 @@ func TestSilenceSet(t *testing.T) {
 
 	sil6 := cloneSilence(sil5)
 	sil6.Matchers = []*pb.Matcher{{Name: "a", Pattern: "c"}}
+	versionBeforeOp = s.Version()
 	require.NoError(t, s.Set(sil6))
 	require.NotEqual(t, sil5.Id, sil6.Id)
 	want = state{
@@ -546,6 +557,7 @@ func TestSilenceSet(t *testing.T) {
 		},
 	}
 	require.Equal(t, want, s.st, "unexpected state after silence creation")
+	require.NotEqual(t, versionBeforeOp, s.Version())
 
 	// Re-create the silence that we just replaced. Changing the start time,
 	// just like changing the matchers, creates a new silence with a different
@@ -555,6 +567,7 @@ func TestSilenceSet(t *testing.T) {
 	sil7 := cloneSilence(sil5)
 	sil7.StartsAt = start1
 	sil7.EndsAt = start1.Add(5 * time.Minute)
+	versionBeforeOp = s.Version()
 	require.NoError(t, s.Set(sil7))
 	require.NotEqual(t, sil2.Id, sil7.Id)
 	want = state{
@@ -574,12 +587,14 @@ func TestSilenceSet(t *testing.T) {
 		},
 	}
 	require.Equal(t, want, s.st, "unexpected state after silence creation")
+	require.NotEqual(t, versionBeforeOp, s.Version())
 
 	// Updating an existing silence with an invalid silence should not expire
 	// the original silence.
 	clock.Add(time.Millisecond)
 	sil8 := cloneSilence(sil7)
 	sil8.EndsAt = time.Time{}
+	versionBeforeOp = s.Version()
 	require.EqualError(t, s.Set(sil8), "invalid silence: invalid zero end timestamp")
 
 	// sil7 should not be expired because the update failed.
@@ -587,6 +602,7 @@ func TestSilenceSet(t *testing.T) {
 	sil7, err = s.QueryOne(QIDs(sil7.Id))
 	require.NoError(t, err)
 	require.Equal(t, types.SilenceStateActive, getState(sil7, s.nowUTC()))
+	require.Equal(t, versionBeforeOp, s.Version())
 }
 
 func TestSilenceLimits(t *testing.T) {


### PR DESCRIPTION
This is a small change which adds a second return value to `state.merge` to differentiate between cases where a silence is updated in place and where a silence is added. This is used by callers to decide if the `Silences.version` ought to be incremented. It fixes a bug where the `Silences.Version()` returns a incremented value for operations which don't need to increment the value. In our environment this change results in a significant performance improvement for production workloads because many fewer `QMatches` queries are issued by `Silencer.Mutes`.

I believe this is a just a bug for three reasons:
1. `Silences` reads "Increments whenever silences are added" (and other operations that mutate the silence state, such as the GC, do not increment the version) (https://github.com/prometheus/alertmanager/blob/main/silence/silence.go#L200)
2. All application code assumes that the underlying data in a `pb.Silence` could've changed even if the `Silences.Version()` hasn't changed. For example, in `Silencer.Mutes`, we issue a `QIDs` query to recheck every silence even if the marker version matches the `Silences` version (https://github.com/prometheus/alertmanager/blob/main/silence/silence.go#L139-L142).
3. Logically, an individual Silence's state can change without _any_ modification to the `Silences` object, so no future querier can ever assume that an unchanged version means that the results of a query will not change. Instead, they can only assume that no new silences have been added. This extends further than just the Silence's state since the `Silences` API does not guarantee that an expired silence will be retained between calls to `Query`.

All existing tests pass without modification after this change. I believe this exercises some querying logic which further indicates that there's no change to guarantees of the `Silences` API. 

Additionally, I've added conditions to `TestSielnceSet` which check the result of `Silences.Version()` before and after each operation. I could not find any existing tests which validate the behavior of `Silences.Version()`, but this test is the place where it makes the most sense to me. I've limited the guarentee from the API to just "the version changes if and only if a silence with a new ID is added." The test does not enforce that the version increases or changes by only one. The modified test fails without this change, but passes with it:
```
go test ./silence/
--- FAIL: TestSilenceSet (0.00s)
    silence_test.go:413:
        	Error Trace:	/home/ehunter/nfs-de/oss/forks/alertmanager/silence/silence_test.go:413
        	Error:      	Not equal:
        	            	expected: 3
        	            	actual  : 2
        	Test:       	TestSilenceSet
FAIL
FAIL	github.com/prometheus/alertmanager/silence	0.030s
FAIL
```
We've also been running this patch in our environment for a while without any issues.