### PR TITLE
Increase dependabot open PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "gomod"
     directory: "/"
+    open-pull-requests-limit: 20
     schedule:
       interval: "monthly"
   - package-ecosystem: "docker"
@@ -10,5 +11,6 @@ updates:
       interval: "monthly"
   - package-ecosystem: "npm"
     directory: "/ui/react-app"
+    open-pull-requests-limit: 20
     schedule:
       interval: "monthly"


### PR DESCRIPTION
Increase the dependabot open PR limit to allow for more dependency updates at a time.