### PR TITLE
Replace benbjohnson/clock with coder/quartz

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/prometheus/alertmanager
 
-go 1.21
+go 1.21.8
+
+toolchain go1.22.4
 
 require (
 	github.com/KimMachineGun/automemlimit v0.6.1
@@ -10,6 +12,7 @@ require (
 	github.com/benbjohnson/clock v1.3.5
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cespare/xxhash/v2 v2.3.0
+	github.com/coder/quartz v0.1.0
 	github.com/go-kit/log v0.2.1
 	github.com/go-openapi/analysis v0.23.0
 	github.com/go-openapi/errors v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -112,6 +112,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/coder/quartz v0.1.0 h1:cLL+0g5l7xTf6ordRnUMMiZtRE8Sq5LxpghS63vEXrQ=
+github.com/coder/quartz v0.1.0/go.mod h1:vsiCc+AHViMKH2CQpGIpFgdHIEQsxwm8yCscqKmzbRA=
 github.com/containerd/cgroups/v3 v3.0.1 h1:4hfGvu8rfGIwVIDd+nLzn/B9ZXx4BcCjzt5ToenJRaE=
 github.com/containerd/cgroups/v3 v3.0.1/go.mod h1:/vtwk1VXrtoa5AaZLkypuOJgA/6DyPMZHJPGQNtlHnw=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=

--- a/silence/silence.go
+++ b/silence/silence.go
@@ -28,7 +28,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/benbjohnson/clock"
+	"github.com/coder/quartz"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	uuid "github.com/gofrs/uuid"
@@ -188,7 +188,7 @@ func (s *Silencer) Mutes(lset model.LabelSet) bool {
 
 // Silences holds a silence state that can be modified, queried, and snapshot.
 type Silences struct {
-	clock clock.Clock
+	clock quartz.Clock
 
 	logger    log.Logger
 	metrics   *metrics
@@ -350,7 +350,7 @@ func New(o Options) (*Silences, error) {
 	}
 
 	s := &Silences{
-		clock:     clock.New(),
+		clock:     quartz.NewReal(),
 		mc:        matcherCache{},
 		logger:    log.NewNopLogger(),
 		retention: o.Retention,
@@ -397,7 +397,7 @@ func (s *Silences) Maintenance(interval time.Duration, snapf string, stopc <-cha
 		level.Error(s.logger).Log("msg", "interval or stop signal are missing - not running maintenance")
 		return
 	}
-	t := s.clock.Ticker(interval)
+	t := s.clock.NewTicker(interval)
 	defer t.Stop()
 
 	var doMaintenance MaintenanceFunc

--- a/silence/silence_bench_test.go
+++ b/silence/silence_bench_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/benbjohnson/clock"
+	"github.com/coder/quartz"
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
@@ -52,7 +52,7 @@ func benchmarkMutes(b *testing.B, n int) {
 	silences, err := New(Options{})
 	require.NoError(b, err)
 
-	clock := clock.NewMock()
+	clock := quartz.NewMock(b)
 	silences.clock = clock
 	now := clock.Now()
 
@@ -108,7 +108,7 @@ func benchmarkQuery(b *testing.B, numSilences int) {
 	s, err := New(Options{})
 	require.NoError(b, err)
 
-	clock := clock.NewMock()
+	clock := quartz.NewMock(b)
 	s.clock = clock
 	now := clock.Now()
 


### PR DESCRIPTION
This commit replaces the archived and no longer maintained benbjohnson/clock package with coder/quartz. It is one of two pull requests. This pull request updates the `silence` package.