### PR TITLE
Finish replacing benbjohnson/clock with coder/quartz

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137
 	github.com/aws/aws-sdk-go v1.55.5
-	github.com/benbjohnson/clock v1.3.5
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/coder/quartz v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,6 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:W
 github.com/aws/aws-sdk-go v1.38.35/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.55.5 h1:KKUZBfBoyqy5d3swXyiC7Q76ic40rYcbqH7qjh59kzU=
 github.com/aws/aws-sdk-go v1.55.5/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
-github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=
-github.com/benbjohnson/clock v1.3.5/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/nflog/nflog.go
+++ b/nflog/nflog.go
@@ -27,7 +27,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/benbjohnson/clock"
+	"github.com/coder/quartz"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/matttproud/golang_protobuf_extensions/pbutil"
@@ -76,7 +76,7 @@ func QGroupKey(gk string) QueryParam {
 
 // Log holds the notification log state for alerts that have been notified.
 type Log struct {
-	clock clock.Clock
+	clock quartz.Clock
 
 	logger    log.Logger
 	metrics   *metrics
@@ -259,7 +259,7 @@ func New(o Options) (*Log, error) {
 	}
 
 	l := &Log{
-		clock:     clock.New(),
+		clock:     quartz.NewReal(),
 		retention: o.Retention,
 		logger:    log.NewNopLogger(),
 		st:        state{},
@@ -305,7 +305,7 @@ func (l *Log) Maintenance(interval time.Duration, snapf string, stopc <-chan str
 		level.Error(l.logger).Log("msg", "interval or stop signal are missing - not running maintenance")
 		return
 	}
-	t := l.clock.Ticker(interval)
+	t := l.clock.NewTicker(interval)
 	defer t.Stop()
 
 	var doMaintenance MaintenanceFunc

--- a/nflog/nflog_test.go
+++ b/nflog/nflog_test.go
@@ -24,7 +24,7 @@ import (
 
 	pb "github.com/prometheus/alertmanager/nflog/nflogpb"
 
-	"github.com/benbjohnson/clock"
+	"github.com/coder/quartz"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
@@ -32,7 +32,7 @@ import (
 )
 
 func TestLogGC(t *testing.T) {
-	mockClock := clock.NewMock()
+	mockClock := quartz.NewMock(t)
 	now := mockClock.Now()
 	// We only care about key names and expiration timestamps.
 	newEntry := func(ts time.Time) *pb.MeshEntry {
@@ -62,7 +62,7 @@ func TestLogGC(t *testing.T) {
 
 func TestLogSnapshot(t *testing.T) {
 	// Check whether storing and loading the snapshot is symmetric.
-	mockClock := clock.NewMock()
+	mockClock := quartz.NewMock(t)
 	now := mockClock.Now().UTC()
 
 	cases := []struct {
@@ -142,7 +142,7 @@ func TestWithMaintenance_SupportsCustomCallback(t *testing.T) {
 	}
 
 	l, err := New(opts)
-	clock := clock.NewMock()
+	clock := quartz.NewMock(t)
 	l.clock = clock
 	require.NoError(t, err)
 
@@ -160,12 +160,12 @@ func TestWithMaintenance_SupportsCustomCallback(t *testing.T) {
 	gosched()
 
 	// Before the first tick, no maintenance executed.
-	clock.Add(99 * time.Millisecond)
+	clock.Advance(99 * time.Millisecond)
 	require.EqualValues(t, 0, calls.Load())
 
 	// Tick once.
-	clock.Add(1 * time.Millisecond)
-	require.EqualValues(t, 1, calls.Load())
+	clock.Advance(1 * time.Millisecond)
+	require.Eventually(t, func() bool { return calls.Load() == 1 }, 5*time.Second, time.Second)
 
 	// Stop the maintenance loop. We should get exactly one more execution of the maintenance func.
 	close(stopc)
@@ -212,7 +212,7 @@ func TestReplaceFile(t *testing.T) {
 }
 
 func TestStateMerge(t *testing.T) {
-	mockClock := clock.NewMock()
+	mockClock := quartz.NewMock(t)
 	now := mockClock.Now()
 
 	// We only care about key names and timestamps for the
@@ -274,7 +274,7 @@ func TestStateMerge(t *testing.T) {
 
 func TestStateDataCoding(t *testing.T) {
 	// Check whether encoding and decoding the data is symmetric.
-	mockClock := clock.NewMock()
+	mockClock := quartz.NewMock(t)
 	now := mockClock.Now().UTC()
 
 	cases := []struct {


### PR DESCRIPTION
This commit finishes replacing benbjohnson/clock with coder/quartz and removes it from `go.mod`.  It is stacked on top of #4001.