### PR TITLE
docs: clarify route:mute_time_intervals

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -222,7 +222,7 @@ matchers:
 [ repeat_interval: <duration> | default = 4h ]
 
 # Times when the route should be muted. These must match the name of a
-# mute time interval defined in the mute_time_intervals section.
+# time interval defined in the time_intervals section.
 # Additionally, the root node cannot have any mute times.
 # When a route is muted it will not send any notifications, but
 # otherwise acts normally (including ending the route-matching process


### PR DESCRIPTION
It was referring to itself, maybe because of the deprecated homonym global:mute_time_intervals ?