### PR TITLE
fix(telegram): passing ParseMode when sending message

### DIFF
--- a/notify/telegram/telegram.go
+++ b/notify/telegram/telegram.go
@@ -94,6 +94,7 @@ func (n *Notifier) Notify(ctx context.Context, alert ...*types.Alert) (bool, err
 		DisableNotification:   n.conf.DisableNotifications,
 		DisableWebPagePreview: true,
 		ThreadID:              n.conf.MessageThreadID,
+		ParseMode:             n.conf.ParseMode,
 	})
 	if err != nil {
 		return true, err


### PR DESCRIPTION
Before commit [1], the message parse mode value is the same as bot parse mode. Therefore, we don't need to pass ParseMode whenever sending message. But after that commit, if we don't pass SendOpts's ParseMode, the library will use the default mode which is empty string "", and HTML tags aren't parsed.

[1] https://github.com/tucnak/telebot/commit/864bef4e4d3a60b8079db4fdb51cac2e779349cd

Close-Issue: https://github.com/prometheus/alertmanager/issues/4026