### PR TITLE
Add parseJSON template func

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -15,6 +15,7 @@ package template
 
 import (
 	"bytes"
+	"encoding/json"
 	tmplhtml "html/template"
 	"io"
 	"net/url"
@@ -204,6 +205,11 @@ var DefaultFuncs = FuncMap{
 			return time.Time{}, err
 		}
 		return t.In(loc), nil
+	},
+	"parseJSON": func(jsonStr string) (interface{}, error) {
+		var result interface{}
+		err := json.Unmarshal([]byte(jsonStr), &result)
+		return result, err
 	},
 	"since":            time.Since,
 	"humanizeDuration": commonTemplates.HumanizeDuration,

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -561,7 +561,18 @@ func TestTemplateFuncs(t *testing.T) {
 		in:    "{{ . | since | humanizeDuration }}",
 		data:  time.Now().Add(-1 * time.Hour),
 		exp:   "1h 0m 0s",
-	}} {
+	},
+		{
+			title: "Template using parseJSON - valid JSON",
+			in:    `{{ $json := . | parseJSON }}{{ $json.key }}`,
+			data:  `{"key": "value"}`,
+			exp:   "value",
+		}, {
+			title:  "Template using parseJSON - invalid JSON",
+			in:     `{{ . | parseJSON }}`,
+			data:   `{"key": "value"`,
+			expErr: "template: :1:7: executing \"\" at <parseJSON>: error calling parseJSON: unexpected end of JSON input",
+		}} {
 		tc := tc
 		t.Run(tc.title, func(t *testing.T) {
 			wg := sync.WaitGroup{}


### PR DESCRIPTION
This PR introduces a new parseJSON function to the template functions. The parseJSON function allows users to parse JSON strings within templates.

**Changes:**

- Added parseJSON function to the template functions map.
- The parseJSON function takes a JSON string as input and returns the parsed JSON object or an error if the JSON is invalid.
- Updated TestTemplateFuncs in template/template_test.go to include test cases for the parseJSON function:
- Valid JSON string test case.
- Invalid JSON string test case.