### PR TITLE
Discord notifier: Add username and avatar_url

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -251,9 +251,11 @@ type DiscordConfig struct {
 	WebhookURL     *SecretURL                  `yaml:"webhook_url,omitempty" json:"webhook_url,omitempty"`
 	WebhookURLFile string                      `yaml:"webhook_url_file,omitempty" json:"webhook_url_file,omitempty"`
 
-	Content string `yaml:"content,omitempty" json:"content,omitempty"`
-	Title   string `yaml:"title,omitempty" json:"title,omitempty"`
-	Message string `yaml:"message,omitempty" json:"message,omitempty"`
+	Content   string `yaml:"content,omitempty" json:"content,omitempty"`
+	Title     string `yaml:"title,omitempty" json:"title,omitempty"`
+	Message   string `yaml:"message,omitempty" json:"message,omitempty"`
+	Username  string `yaml:"username,omitempty" json:"username,omitempty"`
+	AvatarURL string `yaml:"avatar_url,omitempty" json:"avatar_url,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -886,6 +886,12 @@ webhook_url_file: <filepath>
 # Message content template. Limited to 2000 characters.
 [ content: <tmpl_string> | default = '{{ template "discord.default.content" . }}' ]
 
+# Message username.
+[ username: <tmpl_string> | default = '' ]
+
+# Message avatar URL.
+[ avatar_url: <tmpl_string> | default = '' ]
+
 # The HTTP client's configuration.
 [ http_config: <http_config> | default = global.http_config ]
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -887,10 +887,10 @@ webhook_url_file: <filepath>
 [ content: <tmpl_string> | default = '{{ template "discord.default.content" . }}' ]
 
 # Message username.
-[ username: <tmpl_string> | default = '' ]
+[ username: <string> | default = '' ]
 
 # Message avatar URL.
-[ avatar_url: <tmpl_string> | default = '' ]
+[ avatar_url: <string> | default = '' ]
 
 # The HTTP client's configuration.
 [ http_config: <http_config> | default = global.http_config ]

--- a/notify/discord/discord.go
+++ b/notify/discord/discord.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	netUrl "net/url"
 	"os"
 	"strings"
 
@@ -76,8 +77,10 @@ func New(c *config.DiscordConfig, t *template.Template, l log.Logger, httpOpts .
 }
 
 type webhook struct {
-	Content string         `json:"content"`
-	Embeds  []webhookEmbed `json:"embeds"`
+	Content   string         `json:"content"`
+	Embeds    []webhookEmbed `json:"embeds"`
+	Username  string         `json:"username,omitempty"`
+	AvatarURL string         `json:"avatar_url,omitempty"`
 }
 
 type webhookEmbed struct {
@@ -145,12 +148,21 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	}
 
 	w := webhook{
-		Content: content,
+		Content:  content,
+		Username: n.conf.Username,
 		Embeds: []webhookEmbed{{
 			Title:       title,
 			Description: description,
 			Color:       color,
 		}},
+	}
+
+	if len(n.conf.AvatarURL) != 0 {
+		if _, err := netUrl.Parse(n.conf.AvatarURL); err == nil {
+			w.AvatarURL = n.conf.AvatarURL
+		} else {
+			level.Warn(n.logger).Log("msg", "Bad avatar url", "key", key)
+		}
 	}
 
 	var payload bytes.Buffer

--- a/notify/discord/discord_test.go
+++ b/notify/discord/discord_test.go
@@ -201,6 +201,8 @@ func TestDiscord_Notify(t *testing.T) {
 		Title:          "Test Title",
 		Message:        "Test Message",
 		Content:        "Test Content",
+		Username:       "Test Username",
+		AvatarURL:      "http://example.com/avatar.png",
 	}
 
 	// Create a new Discord notifier
@@ -227,5 +229,5 @@ func TestDiscord_Notify(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, ok)
 
-	require.Equal(t, "{\"content\":\"Test Content\",\"embeds\":[{\"title\":\"Test Title\",\"description\":\"Test Message\",\"color\":10038562}]}\n", resp)
+	require.Equal(t, "{\"content\":\"Test Content\",\"embeds\":[{\"title\":\"Test Title\",\"description\":\"Test Message\",\"color\":10038562}],\"username\":\"Test Username\",\"avatar_url\":\"http://example.com/avatar.png\"}\n", resp)
 }


### PR DESCRIPTION
Allow for custom username and avatar URLs to be set in discord notifications.

Add `username` and `avatar_url` to discord configuration, default empty string.

Re-introduce the rest of what was proposed in #3821 now that #4007 is merged