### PR TITLE
Add a test for `Notify` of the Discord integration

### DIFF
--- a/notify/discord/discord.go
+++ b/notify/discord/discord.go
@@ -137,11 +137,11 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	if n.conf.WebhookURL != nil {
 		url = n.conf.WebhookURL.String()
 	} else {
-		content, err := os.ReadFile(n.conf.WebhookURLFile)
+		b, err := os.ReadFile(n.conf.WebhookURLFile)
 		if err != nil {
 			return false, fmt.Errorf("read webhook_url_file: %w", err)
 		}
-		url = strings.TrimSpace(string(content))
+		url = strings.TrimSpace(string(b))
 	}
 
 	w := webhook{


### PR DESCRIPTION
Just to ensure this works correclty as expected, I originally thought there was a bug with the shadowing of the `content` varible but there isn't - to avoid further confusion I have followed up on this document left by George: https://github.com/prometheus/alertmanager/pull/3555#discussion_r1398448423