### PR TITLE
Add `Wrap: true` to `TextBlock` named `text` in msteamsv2 receiver

### DIFF
--- a/notify/msteamsv2/msteamsv2.go
+++ b/notify/msteamsv2/msteamsv2.go
@@ -166,6 +166,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 						{
 							Type: "TextBlock",
 							Text: text,
+							Wrap: true,
 						},
 					},
 				},


### PR DESCRIPTION
`TextBlock` used for `text` in msteamsv2 receiver must have `wrap: true` to display the content correctly #4088