### PR TITLE
replace Resolved with ResolvedAt to reduce amount call to time.Now()

### DIFF
--- a/inhibit/inhibit.go
+++ b/inhibit/inhibit.go
@@ -230,10 +230,11 @@ func NewInhibitRule(cr config.InhibitRule) *InhibitRule {
 // is returned. If excludeTwoSidedMatch is true, alerts that match both the
 // source and the target side of the rule are disregarded.
 func (r *InhibitRule) hasEqual(lset model.LabelSet, excludeTwoSidedMatch bool) (model.Fingerprint, bool) {
+	now := time.Now()
 Outer:
 	for _, a := range r.scache.List() {
 		// The cache might be stale and contain resolved alerts.
-		if a.Resolved() {
+		if a.ResolvedAt(now) {
 			continue
 		}
 		for n := range r.Equal {


### PR DESCRIPTION
with big number of inhibitions I see pretty bad picture when we spend plenty of time in time.Now()
This can be fixed by calling it once per `hasEqual`
<img width="838" alt="image" src="https://github.com/user-attachments/assets/c5e1155f-1cbb-4558-9c96-35fcf16d1c5b">
