### PR TITLE
SMTP: Support SASL XOAUTH2

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -412,6 +412,9 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 				ec.AuthPassword = c.Global.SMTPAuthPassword
 				ec.AuthPasswordFile = c.Global.SMTPAuthPasswordFile
 			}
+			if ec.AuthXOAuth2 == nil {
+				ec.AuthXOAuth2 = c.Global.SMTPAuthXOAuth2
+			}
 			if ec.AuthSecret == "" {
 				ec.AuthSecret = c.Global.SMTPAuthSecret
 			}
@@ -820,6 +823,7 @@ type GlobalConfig struct {
 	SMTPAuthPasswordFile  string               `yaml:"smtp_auth_password_file,omitempty" json:"smtp_auth_password_file,omitempty"`
 	SMTPAuthSecret        Secret               `yaml:"smtp_auth_secret,omitempty" json:"smtp_auth_secret,omitempty"`
 	SMTPAuthIdentity      string               `yaml:"smtp_auth_identity,omitempty" json:"smtp_auth_identity,omitempty"`
+	SMTPAuthXOAuth2       *commoncfg.OAuth2    `yaml:"smtp_auth_xoauth2,omitempty" json:"smtp_auth_xoauth2,omitempty"`
 	SMTPRequireTLS        bool                 `yaml:"smtp_require_tls" json:"smtp_require_tls,omitempty"`
 	SMTPTLSConfig         *commoncfg.TLSConfig `yaml:"smtp_tls_config,omitempty" json:"smtp_tls_config,omitempty"`
 	SlackAPIURL           *SecretURL           `yaml:"slack_api_url,omitempty" json:"slack_api_url,omitempty"`

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -291,6 +291,7 @@ type EmailConfig struct {
 	AuthPasswordFile string               `yaml:"auth_password_file,omitempty" json:"auth_password_file,omitempty"`
 	AuthSecret       Secret               `yaml:"auth_secret,omitempty" json:"auth_secret,omitempty"`
 	AuthIdentity     string               `yaml:"auth_identity,omitempty" json:"auth_identity,omitempty"`
+	AuthXOAuth2      *commoncfg.OAuth2    `yaml:"auth_xoauth2,omitempty" json:"auth_xoauth2,omitempty"`
 	Headers          map[string]string    `yaml:"headers,omitempty" json:"headers,omitempty"`
 	HTML             string               `yaml:"html,omitempty" json:"html,omitempty"`
 	Text             string               `yaml:"text,omitempty" json:"text,omitempty"`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,6 +91,8 @@ global:
   [ smtp_auth_identity: <string> ]
   # SMTP Auth using CRAM-MD5.
   [ smtp_auth_secret: <secret> ]
+  # SMTP Auth using SASL-XOAUTH2.
+  [ smtp_auth_xoauth2: { <oauth2> } ]
   # The default SMTP TLS requirement.
   # Note that Go does not support unencrypted connections to remote SMTP endpoints.
   [ smtp_require_tls: <bool> | default = true ]
@@ -920,6 +922,7 @@ to: <tmpl_string>
 [ auth_username: <string> | default = global.smtp_auth_username ]
 [ auth_password: <secret> | default = global.smtp_auth_password ]
 [ auth_password_file: <string> | default = global.smtp_auth_password_file ]
+[ auth_xoauth2: { <oauth2> | default = global.smtp_auth_xoauth2 } ]
 [ auth_secret: <secret> | default = global.smtp_auth_secret ]
 [ auth_identity: <string> | default = global.smtp_auth_identity ]
 

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	go.uber.org/automaxprocs v1.6.0
 	golang.org/x/mod v0.20.0
 	golang.org/x/net v0.30.0
+	golang.org/x/oauth2 v0.23.0
 	golang.org/x/text v0.19.0
 	golang.org/x/tools v0.24.0
 	gopkg.in/telebot.v3 v3.3.8
@@ -99,7 +100,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect
 	go.opentelemetry.io/otel/trace v1.24.0 // indirect
 	golang.org/x/crypto v0.28.0 // indirect
-	golang.org/x/oauth2 v0.23.0 // indirect
 	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/sys v0.26.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/coder/quartz v0.1.2
+	github.com/emersion/go-sasl v0.0.0-20200509203442-7bfe0ed36a21
 	github.com/emersion/go-smtp v0.21.3
 	github.com/go-openapi/analysis v0.23.0
 	github.com/go-openapi/errors v0.22.0
@@ -60,7 +61,6 @@ require (
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
-	github.com/emersion/go-sasl v0.0.0-20200509203442-7bfe0ed36a21 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect

--- a/notify/email/email_oauth2_test.go
+++ b/notify/email/email_oauth2_test.go
@@ -1,0 +1,202 @@
+// Copyright 2019 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Some tests require a running mail catcher. We use MailDev for this purpose,
+// it can work without or with authentication (LOGIN only). It exposes a REST
+// API which we use to retrieve and check the sent emails.
+//
+// Those tests are only executed when specific environment variables are set,
+// otherwise they are skipped. The tests must be run by the CI.
+//
+// To run the tests locally, you should start 2 MailDev containers:
+//
+// $ docker run --rm -p 1080:1080 -p 1025:1025 --entrypoint bin/maildev djfarrelly/maildev@sha256:624e0ec781e11c3531da83d9448f5861f258ee008c1b2da63b3248bfd680acfa -v
+// $ docker run --rm -p 1081:1080 -p 1026:1025 --entrypoint bin/maildev djfarrelly/maildev@sha256:624e0ec781e11c3531da83d9448f5861f258ee008c1b2da63b3248bfd680acfa --incoming-user user --incoming-pass pass -v
+//
+// $ EMAIL_NO_AUTH_CONFIG=testdata/noauth.yml EMAIL_AUTH_CONFIG=testdata/auth.yml make
+//
+// See also https://github.com/djfarrelly/MailDev for more details.
+package email
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/emersion/go-sasl"
+	"github.com/emersion/go-smtp"
+	commoncfg "github.com/prometheus/common/config"
+	"github.com/prometheus/common/promslog"
+
+	// nolint:depguard // require cannot be called outside the main goroutine: https://pkg.go.dev/testing#T.FailNow
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/alertmanager/config"
+)
+
+const (
+	TestBearerUsername = "fxcp"
+	TestBearerToken    = "VkIvciKi9ijpiKNWrQmYCJrzgd9QYCMB"
+)
+
+func TestEmail_OAuth2(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	t.Cleanup(cancel)
+
+	// Setup mock SMTP server which will reject at the DATA stage.
+	srv, l, err := mockSMTPServer(t, &xOAuth2Backend{})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		// We expect that the server has already been closed in the test.
+		require.ErrorIs(t, srv.Shutdown(ctx), smtp.ErrServerClosed)
+	})
+
+	done := make(chan any, 1)
+	go func() {
+		// nolint:testifylint // require cannot be called outside the main goroutine: https://pkg.go.dev/testing#T.FailNow
+		assert.NoError(t, srv.Serve(l))
+		close(done)
+	}()
+
+	oidcServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"access_token":"%s","token_type":"Bearer","expires_in":3600}`, TestBearerToken)
+	}))
+
+	// Wait for mock SMTP server to become ready.
+	require.Eventuallyf(t, func() bool {
+		c, err := smtp.Dial(srv.Addr)
+		if err != nil {
+			t.Logf("dial failed to %q: %s", srv.Addr, err)
+			return false
+		}
+
+		// Ping.
+		if err = c.Noop(); err != nil {
+			t.Logf("ping failed to %q: %s", srv.Addr, err)
+			return false
+		}
+
+		// Ensure we close the connection to not prevent server from shutting down cleanly.
+		if err = c.Close(); err != nil {
+			t.Logf("close failed to %q: %s", srv.Addr, err)
+			return false
+		}
+
+		return true
+	}, time.Second*10, time.Millisecond*100, "mock SMTP server failed to start")
+
+	// Use mock SMTP server and prepare alert to be sent.
+	require.IsType(t, &net.TCPAddr{}, l.Addr())
+	addr := l.Addr().(*net.TCPAddr)
+	cfg := &config.EmailConfig{
+		Smarthost:    config.HostPort{Host: addr.IP.String(), Port: strconv.Itoa(addr.Port)},
+		Hello:        "localhost",
+		Headers:      make(map[string]string),
+		From:         "alertmanager@system",
+		To:           "sre@company",
+		AuthUsername: TestBearerUsername,
+		AuthXOAuth2: &commoncfg.OAuth2{
+			ClientID:     "client_id",
+			ClientSecret: "client_secret",
+			TokenURL:     oidcServer.URL,
+			Scopes:       []string{"email"},
+		},
+	}
+
+	tmpl, firingAlert, err := prepare(cfg)
+	require.NoError(t, err)
+
+	e := New(cfg, tmpl, promslog.NewNopLogger())
+
+	// Send the alert to mock SMTP server.
+	retry, err := e.Notify(context.Background(), firingAlert)
+	require.ErrorContains(t, err, "501 5.5.4 Rejected!")
+	require.True(t, retry)
+	require.NoError(t, srv.Shutdown(ctx))
+
+	require.Eventuallyf(t, func() bool {
+		<-done
+		return true
+	}, time.Second*10, time.Millisecond*100, "mock SMTP server goroutine failed to close in time")
+}
+
+// xOAuth2Backend will reject submission at the DATA stage.
+type xOAuth2Backend struct{}
+
+func (b *xOAuth2Backend) NewSession(c *smtp.Conn) (smtp.Session, error) {
+	return &mockSMTPxOAuth2Session{
+		conn:    c,
+		backend: b,
+	}, nil
+}
+
+type mockSMTPxOAuth2Session struct {
+	conn    *smtp.Conn
+	backend smtp.Backend
+}
+
+func (s *mockSMTPxOAuth2Session) AuthMechanisms() []string {
+	return []string{sasl.Plain, sasl.Login, "XOAUTH2"}
+}
+
+func (s *mockSMTPxOAuth2Session) Auth(string) (sasl.Server, error) {
+	return &xOAuth2BackendAuth{}, nil
+}
+
+func (s *mockSMTPxOAuth2Session) Mail(string, *smtp.MailOptions) error {
+	return nil
+}
+
+func (s *mockSMTPxOAuth2Session) Rcpt(string, *smtp.RcptOptions) error {
+	return nil
+}
+
+func (s *mockSMTPxOAuth2Session) Data(io.Reader) error {
+	return &smtp.SMTPError{Code: 501, EnhancedCode: smtp.EnhancedCode{5, 5, 4}, Message: "Rejected!"}
+}
+
+func (*mockSMTPxOAuth2Session) Reset() {}
+
+func (*mockSMTPxOAuth2Session) Logout() error { return nil }
+
+type xOAuth2BackendAuth struct{}
+
+func (*xOAuth2BackendAuth) Next(response []byte) ([]byte, bool, error) {
+	// Generate empty challenge.
+	if response == nil {
+		return []byte{}, false, nil
+	}
+
+	token := make([]byte, base64.RawStdEncoding.DecodedLen(len(response)))
+
+	_, err := base64.RawStdEncoding.Decode(token, response)
+	if err != nil {
+		return nil, true, err
+	}
+
+	expectedToken := fmt.Sprintf("user=%s\x01auth=Bearer %s\x01\x01", TestBearerUsername, TestBearerToken)
+	if expectedToken == string(token) {
+		return nil, true, nil
+	}
+
+	return nil, true, fmt.Errorf("unexpected token: %s, expected: %s", token, expectedToken)
+}

--- a/notify/email/email_test.go
+++ b/notify/email/email_test.go
@@ -143,10 +143,11 @@ func (m *mailDev) doEmailRequest(method, path string) (int, []byte, error) {
 
 // emailTestConfig is the configuration for the tests.
 type emailTestConfig struct {
-	Smarthost config.HostPort `yaml:"smarthost"`
-	Username  string          `yaml:"username"`
-	Password  string          `yaml:"password"`
-	Server    *mailDev        `yaml:"server"`
+	Smarthost config.HostPort   `yaml:"smarthost"`
+	Username  string            `yaml:"username"`
+	Password  string            `yaml:"password"`
+	Server    *mailDev          `yaml:"server"`
+	XOAuth2   *commoncfg.OAuth2 `yaml:"xoauth2,omitempty"`
 }
 
 func loadEmailTestConfiguration(f string) (emailTestConfig, error) {

--- a/notify/email/testdata/auth_xoauth2.yml
+++ b/notify/email/testdata/auth_xoauth2.yml
@@ -1,0 +1,7 @@
+smarthost: smtp.gmail.com:587
+username: ""
+xoauth2:
+  client_id:
+  client_secret:
+  token_url: "https://oauth2.googleapis.com/token"
+  scopes: [ "https://mail.google.com/" ]


### PR DESCRIPTION
Fixes #3244 
Fixes #1950

Some Cloud providers like Google and Microsoft disable basic auth for sending mail. 

Currently, both offer SASL-XOAUTH2 as replacement, which needs to be implemented in AlertManager.

An alternative solution would be vendor specific notifier.

Reference:
* https://developers.google.com/google-apps/gmail/xoauth2_protocol#the_sasl_xoauth2_mechanism.
* https://learn.microsoft.com/en-us/exchange/client-developer/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth#sasl-xoauth2