### PR TITLE
Describe Default Receiver in the Alertmanager Configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -175,7 +175,10 @@ current node.
 See [Alertmanager concepts](https://prometheus.io/docs/alerting/alertmanager/#grouping) for more information on grouping.
 
 ```yaml
+# The default receiver is required. It acts as a last resort for alerts
+# that don't match any specific route.
 [ receiver: <string> ]
+
 # The labels by which incoming alerts are grouped together. For example,
 # multiple alerts coming in for cluster=A and alertname=LatencyHigh would
 # be batched into a single group.


### PR DESCRIPTION
This update describes the **required** default receiver on the configuration page.
Developers may not know that not specifying a default receiver may throw an error message saying:
> err="root route must specify a default receiver"

Though the default receiver attribute was specified in the example below, it wasn't clear if it was simply an example or a requirement.

```yml
Example

# The root route with all parameters, which are inherited by the child
# routes if they are not overwritten.
route:
  receiver: 'default-receiver'
  group_wait: 30s
```