### PR TITLE
Signficantly improve inhibitor performance via new cache datastructure

### DIFF
--- a/inhibit/inhibit.go
+++ b/inhibit/inhibit.go
@@ -25,7 +25,6 @@ import (
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/prometheus/alertmanager/provider"
-	"github.com/prometheus/alertmanager/store"
 	"github.com/prometheus/alertmanager/types"
 )
 
@@ -72,9 +71,7 @@ func (ih *Inhibitor) run(ctx context.Context) {
 			// Update the inhibition rules' cache.
 			for _, r := range ih.rules {
 				if r.SourceMatchers.Matches(a.Labels) {
-					if err := r.scache.Set(a); err != nil {
-						ih.logger.Error("error on set alert", "err", err)
-					}
+					r.set(a)
 				}
 			}
 		}
@@ -93,8 +90,27 @@ func (ih *Inhibitor) Run() {
 	ih.mtx.Unlock()
 	runCtx, runCancel := context.WithCancel(ctx)
 
-	for _, rule := range ih.rules {
-		go rule.scache.Run(runCtx, 15*time.Minute)
+	for _, r := range ih.rules {
+		go func(r *InhibitRule) {
+			ticker := time.NewTicker(15 * time.Minute)
+			select {
+			case <-runCtx.Done():
+				return
+			case <-ticker.C:
+				r.mtx.Lock()
+				for icacheKey, cacheEntry := range r.icache {
+					for fp, cachedAlert := range cacheEntry {
+						if cachedAlert.alert.Resolved() {
+							delete(cacheEntry, fp)
+						}
+					}
+					if len(cacheEntry) == 0 {
+						delete(r.icache, icacheKey)
+					}
+				}
+				r.mtx.Unlock()
+			}
+		}(r)
 	}
 
 	g.Add(func() error {
@@ -126,23 +142,39 @@ func (ih *Inhibitor) Stop() {
 // interface.
 func (ih *Inhibitor) Mutes(lset model.LabelSet) bool {
 	fp := lset.Fingerprint()
+	now := time.Now()
 
 	for _, r := range ih.rules {
 		if !r.TargetMatchers.Matches(lset) {
 			// If target side of rule doesn't match, we don't need to look any further.
 			continue
 		}
-		// If we are here, the target side matches. If the source side matches, too, we
-		// need to exclude inhibiting alerts for which the same is true.
-		if inhibitedByFP, eq := r.hasEqual(lset, r.SourceMatchers.Matches(lset)); eq {
-			ih.marker.SetInhibited(fp, inhibitedByFP.String())
+		// we know that the target side matches, but we don't know if this alert
+		// is actually inhibited yet - let the InhibitRule figure that out.
+		if inhibiting, matches := r.findInhibitor(lset, now); matches {
+			ih.marker.SetInhibited(fp, inhibiting.String())
 			return true
 		}
 	}
+
 	ih.marker.SetInhibited(fp)
 
 	return false
 }
+
+type cachedAlert struct {
+	alert                  *types.Alert
+	matchesSourceAndTarget bool
+}
+
+func newCachedAlert(a *types.Alert, targetMatchers labels.Matchers) cachedAlert {
+	return cachedAlert{
+		alert:                  a,
+		matchesSourceAndTarget: targetMatchers.Matches(a.Labels),
+	}
+}
+
+type iCacheEntry map[model.Fingerprint]cachedAlert
 
 // An InhibitRule specifies that a class of (source) alerts should inhibit
 // notifications for another class of (target) alerts if all specified matching
@@ -161,7 +193,9 @@ type InhibitRule struct {
 	Equal map[model.LabelName]struct{}
 
 	// Cache of alerts matching source labels.
-	scache *store.Alerts
+	icache map[model.Fingerprint]iCacheEntry
+
+	mtx *sync.RWMutex
 }
 
 // NewInhibitRule returns a new InhibitRule based on a configuration definition.
@@ -221,30 +255,65 @@ func NewInhibitRule(cr config.InhibitRule) *InhibitRule {
 		SourceMatchers: sourcem,
 		TargetMatchers: targetm,
 		Equal:          equal,
-		scache:         store.NewAlerts(),
+		icache:         make(map[model.Fingerprint]iCacheEntry),
+		mtx:            &sync.RWMutex{},
 	}
 }
 
-// hasEqual checks whether the source cache contains alerts matching the equal
-// labels for the given label set. If so, the fingerprint of one of those alerts
-// is returned. If excludeTwoSidedMatch is true, alerts that match both the
-// source and the target side of the rule are disregarded.
-func (r *InhibitRule) hasEqual(lset model.LabelSet, excludeTwoSidedMatch bool) (model.Fingerprint, bool) {
-Outer:
-	for _, a := range r.scache.List() {
-		// The cache might be stale and contain resolved alerts.
-		if a.Resolved() {
-			continue
-		}
-		for n := range r.Equal {
-			if a.Labels[n] != lset[n] {
-				continue Outer
-			}
-		}
-		if excludeTwoSidedMatch && r.TargetMatchers.Matches(a.Labels) {
-			continue Outer
-		}
-		return a.Fingerprint(), true
+func (r *InhibitRule) set(a *types.Alert) {
+	// these two operations are by far the most expensive part of the method
+	// since they don't require hilding the mutex, call them here as a tiny
+	// optimization
+	icacheKey := r.icacheKey(a.Labels)
+	fp := a.Fingerprint()
+
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+
+	cacheEntry, ok := r.icache[icacheKey]
+	if !ok {
+		cacheEntry = make(iCacheEntry)
+		r.icache[icacheKey] = cacheEntry
 	}
+
+	cacheEntry[fp] = newCachedAlert(a, r.TargetMatchers)
+}
+
+func (r *InhibitRule) icacheKey(lset model.LabelSet) model.Fingerprint {
+	equalLabels := model.LabelSet{}
+	for label := range r.Equal {
+		equalLabels[label] = lset[label]
+	}
+	return equalLabels.Fingerprint()
+}
+
+// findInhibitor determines if any alert inhibits an lset that matches the target
+// matchers. The fingerprint of the first matching result is returned.
+func (r *InhibitRule) findInhibitor(lset model.LabelSet, now time.Time) (model.Fingerprint, bool) {
+	r.mtx.RLock()
+	defer r.mtx.RUnlock()
+
+	var sourceMatchersEvaluated, lsetMatchesSource bool
+	if cacheEntry, ok := r.icache[r.icacheKey(lset)]; ok {
+		for fp, cachedAlert := range cacheEntry {
+			if cachedAlert.alert.ResolvedAt(now) {
+				continue
+			}
+
+			if cachedAlert.matchesSourceAndTarget {
+				if !sourceMatchersEvaluated {
+					lsetMatchesSource = r.SourceMatchers.Matches(lset)
+					sourceMatchersEvaluated = true
+				}
+				if lsetMatchesSource {
+					continue
+				}
+			}
+
+			return fp, true
+		}
+
+	}
+
 	return model.Fingerprint(0), false
 }


### PR DESCRIPTION
This PR improves or matches performance of the existing inhibitor in almost all benchmark cases. When each inhibition rule has many inhibiting alerts, performance is improved by several orders of magnitude. No change to the inhibitor interface is necessary.
```
                                                     │    main.txt    │    icache-for-upstream-final.txt    │
                                                     │     sec/op     │    sec/op     vs base               │
Mutes/1_inhibition_rule,_1_inhibiting_alert-4            1.865µ ±  4%   1.597µ ±  7%  -14.35% (p=0.002 n=6)
Mutes/10_inhibition_rules,_1_inhibiting_alert-4          2.007µ ±  7%   1.464µ ±  5%  -27.04% (p=0.002 n=6)
Mutes/100_inhibition_rules,_1_inhibiting_alert-4         1.941µ ±  7%   1.447µ ± 16%  -25.46% (p=0.002 n=6)
Mutes/1000_inhibition_rules,_1_inhibiting_alert-4        1.884µ ±  3%   1.422µ ± 10%  -24.55% (p=0.002 n=6)
Mutes/10000_inhibition_rules,_1_inhibiting_alert-4       1.879µ ± 13%   1.419µ ±  4%  -24.49% (p=0.002 n=6)
Mutes/1_inhibition_rule,_10_inhibiting_alerts-4          1.973µ ±  8%   1.404µ ±  4%  -28.86% (p=0.002 n=6)
Mutes/1_inhibition_rule,_100_inhibiting_alerts-4         3.726µ ± 10%   1.348µ ± 13%  -63.84% (p=0.002 n=6)
Mutes/1_inhibition_rule,_1000_inhibiting_alerts-4       21.485µ ±  5%   1.411µ ±  3%  -93.43% (p=0.002 n=6)
Mutes/1_inhibition_rule,_10000_inhibiting_alerts-4     184.245µ ±  9%   1.489µ ±  6%  -99.19% (p=0.002 n=6)
Mutes/100_inhibition_rules,_1000_inhibiting_alerts-4    20.453µ ± 14%   1.409µ ±  5%  -93.11% (p=0.002 n=6)
Mutes/10_inhibition_rules,_last_rule_matches-4           2.226µ ±  8%   1.912µ ±  8%  -14.13% (p=0.002 n=6)
Mutes/100_inhibition_rules,_last_rule_matches-4          6.959µ ±  2%   6.293µ ±  5%   -9.57% (p=0.002 n=6)
Mutes/1000_inhibition_rules,_last_rule_matches-4         55.08µ ±  4%   48.42µ ±  3%  -12.10% (p=0.002 n=6)
Mutes/10000_inhibition_rules,_last_rule_matches-4        534.1µ ±  7%   488.9µ ±  4%   -8.45% (p=0.002 n=6)
geomean                                                  8.267µ         3.181µ        -61.52%                                            8.267µ         3.364µ        -59.31%
```

The new implementation replaces the `InhibitRule`'s `scache` with an `icache` (meaning "intersection cache") which pre-calculates the equal label values a target alert would need to be inhibited by each inhibitor alert. Practically, this is implemented by calculating a fingerprint for just the `equalLabels` of each inhibiting alert and storing that alert in a map keyed by the `equalLabels` fingerprint. This allows O(1) access to the set of inhibiting alerts for an `InhibitRule` in the `Inhibitor.Mutes` method.  The new data structure is essentially just:
```
map[model.Fingerpint]map[model.Fingerprint]*types.Alert
// equaLabelsFp -> fp -> alert
```
To insert a new inhibitor alert "A":
1. does "A" match the source labels? If not, exit
2. make a `LabelSet` of just the subset of A's labels which are in the InhibitRule's `equal_labels`. Compute the fingerpint for this LabelSet and call it "E"
3. find the entry in the icache for E and insert A into it using A's fingerprint

To check if an alert "T" is inhibited:
1. does T match the target labels? If not, exit. T is not inhibited
2. make a `LabelSet` of just the subset of T's labels which are in the InhibitRule's `equal_labels`. Compute the fingerpint for this LabelSet and call it "E"
3. does an entry exist in the InhibitRule's icache for E? If not, exit. T is not inhibited
4. Find the first non-resolved alert in the icache entry and return it. T is inhibited by this alert.

The new implementation has a few other minor improvements which help performance: it reduces the number of time an inhibitor alert's fingerprint is calculated by caching it in the icache, it pre-calculates whether an inhibitor matches the source and target matchers for an inhibit rules, it calls `time.Now()` less frequently, and it avoids checking if a target alert matches the source matchers unless necessary.

In the real world, this change helps most when an inhibit rule covers many inhibitors and target alerts. For example, a rule where all critical alerts inhibit all warning alerts with the same `instance` and `alertname` can result in many possible inhibitors attached to a rule where each inhibitor alert only inhibits one target alert. The old implementation of the inhibitor is extremely inefficient in this case: assuming N inhibiting alerts and a fixed number of `equalLabels`, it performs O(N) string comparisons per target. The new implementation is effectively O(1) in this case (except in a pathological case where all alerts in the inhibitor are resolved, since the new implementation still has to iterate past resolved alerts). 

The new implementation does require slightly more memory per inhibiting alert than the old one: we store the alert's fingerprint and a boolean to check if the inhibitor matches both the source and the target. This works out to be about 16 extra bytes per cached inhibitor alert after accounting for padding. For 10,000 alerts, that's about 160KB. I think this is a totally acceptable increase in memory requirements.  

We've been running a very similar patch in our production environment which adds _all_ inhibiting alerts to the `marker` for more than a month. In our environment this still results in a more then 4x reduction in time spent in the `Inhibitor.Mutes` method. This change was motivated by observations which show a large amount of CPU spent doing string comparisons in the inhibitor.
