### PR TITLE
Add full width to adaptive card for msteamsv2

### DIFF
--- a/notify/msteamsv2/msteamsv2.go
+++ b/notify/msteamsv2/msteamsv2.go
@@ -51,10 +51,11 @@ type Notifier struct {
 
 // https://learn.microsoft.com/en-us/connectors/teams/?tabs=text1#adaptivecarditemschema
 type Content struct {
-	Schema  string `json:"$schema"`
-	Type    string `json:"type"`
-	Version string `json:"version"`
-	Body    []Body `json:"body"`
+	Schema  string  `json:"$schema"`
+	Type    string  `json:"type"`
+	Version string  `json:"version"`
+	Body    []Body  `json:"body"`
+	Msteams Msteams `json:"msteams,omitempty"`
 }
 
 type Body struct {
@@ -65,6 +66,10 @@ type Body struct {
 	Wrap   bool   `json:"wrap,omitempty"`
 	Style  string `json:"style,omitempty"`
 	Color  string `json:"color,omitempty"`
+}
+
+type Msteams struct {
+	Width string `json:"width"`
 }
 
 type Attachment struct {
@@ -166,6 +171,9 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 							Type: "TextBlock",
 							Text: text,
 						},
+					},
+					Msteams: Msteams{
+						Width: "full",
 					},
 				},
 			},


### PR DESCRIPTION
As reported in comments of https://github.com/prometheus/alertmanager/issues/4088, a separate PR for the full width support of adaptive card is raised. @grobinson-grafana please have a review. Thanks

FYI: I have compiled alertmanager and tested the changes.