### PR TITLE
go 1.22.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus/alertmanager
 
-go 1.22.0
+go 1.22.9
 
 require (
 	github.com/KimMachineGun/automemlimit v0.6.1


### PR DESCRIPTION
go 1.22.9

- fixes: #3839 

https://artifacthub.io/packages/helm/prometheus-community/alertmanager?modal=security-report

![image](https://github.com/user-attachments/assets/5a83e3d8-a321-4a80-b641-33159966eb33)
