### PR TITLE
Add timeout option for webhook notifier.

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -536,8 +536,9 @@ type WebhookConfig struct {
 	// allows an unlimited number of alerts.
 	MaxAlerts uint64 `yaml:"max_alerts" json:"max_alerts"`
 
-	// Timeout is the maximum time allowed to invoke the webhook.
-	Timeout *time.Duration `yaml:"timeout" json:"timeout"`
+	// Timeout is the maximum time allowed to invoke the webhook. Setting this to 0
+	// does not impose a timeout.
+	Timeout time.Duration `yaml:"timeout" json:"timeout"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -535,6 +535,9 @@ type WebhookConfig struct {
 	// Alerts exceeding this threshold will be truncated. Setting this to 0
 	// allows an unlimited number of alerts.
 	MaxAlerts uint64 `yaml:"max_alerts" json:"max_alerts"`
+
+	// Timeout is the maximum time allowed to invoke the webhook.
+	Timeout *time.Duration `yaml:"timeout" json:"timeout"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1596,9 +1596,10 @@ url_file: <filepath>
 [ max_alerts: <int> | default = 0 ]
 
 # The maximum time to wait for a webhook request to complete, before failing the
-# request and allowing it to be retried.
+# request and allowing it to be retried. The default value of 0s indicates that
+# no timeout should be applied.
 # NOTE: This will have no effect if set higher than the group_interval.
-[ timeout: <duration> | default = <none> ]
+[ timeout: <duration> | default = 0s ]
 
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1594,6 +1594,12 @@ url_file: <filepath>
 # above this threshold are truncated. When leaving this at its default value of
 # 0, all alerts are included.
 [ max_alerts: <int> | default = 0 ]
+
+# The maximum time to wait for a webhook request to complete, before failing the
+# request and allowing it to be retried.
+# NOTE: This will have no effect if set higher than the group_interval.
+[ timeout: <duration> | default = <none> ]
+
 ```
 
 The Alertmanager

--- a/notify/webhook/webhook.go
+++ b/notify/webhook/webhook.go
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -113,16 +112,16 @@ func (n *Notifier) Notify(ctx context.Context, alerts ...*types.Alert) (bool, er
 		url = strings.TrimSpace(string(content))
 	}
 
-	if n.conf.Timeout != nil {
-		postCtx, cancel := context.WithTimeoutCause(ctx, *n.conf.Timeout, fmt.Errorf("configured webhook timeout (%s) reached", *n.conf.Timeout))
+	if n.conf.Timeout > 0 {
+		postCtx, cancel := context.WithTimeoutCause(ctx, n.conf.Timeout, fmt.Errorf("configured webhook timeout reached (%s)", n.conf.Timeout))
 		defer cancel()
 		ctx = postCtx
 	}
 
 	resp, err := notify.PostJSON(ctx, n.client, url, &buf)
 	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) && ctx.Err() != nil {
-			err = context.Cause(ctx)
+		if ctx.Err() != nil {
+			err = fmt.Errorf("%w: %w", err, context.Cause(ctx))
 		}
 		return true, notify.RedactURL(err)
 	}


### PR DESCRIPTION
We have witnessed cases where POST requests hang, because the receiver has become temporarily unresponsive, leading to failed notification attempts. If the request times out before the dispatcher timeout, because of some aspect of how the HTTP client is configured, then the request is retried, but this does not happen reliably.

To cover all eventualities, it makes sense to have a shorter per-request timeout. I think this timeout needs to be opt-in from the user perspective, as it requires prior knowledge of how fast the webhook should respond, and that it could lead to duplicate notifications.