### PR TITLE
feat: allow env variables inside config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -202,7 +202,8 @@ func LoadFile(filename string) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	cfg, err := Load(string(content))
+	expanded := os.ExpandEnv(string(content))
+	cfg, err := Load(expanded)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This will allow users to do things like setting `ALERTMANAGER_HEARTBEAT_URL="http://heyo"` and making the config like so:

```receivers:
  - name: heartbeat
    webhook_configs:
      - send_resolved: true
        url: ${ALERTMANAGER_HEARTBEAT_URL}
```

Which would get rendered to:

```receivers:
  - name: heartbeat
    webhook_configs:
      - send_resolved: true
        url: http://heyo
```