### PR TITLE
mixin: longer rate interval for Alertmanager[Cluster]FailedToSendAlerts

### DIFF
--- a/doc/alertmanager-mixin/alerts.libsonnet
+++ b/doc/alertmanager-mixin/alerts.libsonnet
@@ -42,9 +42,9 @@
             alert: 'AlertmanagerFailedToSendAlerts',
             expr: |||
               (
-                rate(alertmanager_notifications_failed_total{%(alertmanagerSelector)s}[5m])
+                rate(alertmanager_notifications_failed_total{%(alertmanagerSelector)s}[15m])
               /
-                ignoring (reason) group_left rate(alertmanager_notifications_total{%(alertmanagerSelector)s}[5m])
+                ignoring (reason) group_left rate(alertmanager_notifications_total{%(alertmanagerSelector)s}[15m])
               )
               > 0.01
             ||| % $._config,
@@ -61,9 +61,9 @@
             alert: 'AlertmanagerClusterFailedToSendAlerts',
             expr: |||
               min by (%(alertmanagerClusterLabels)s, integration) (
-                rate(alertmanager_notifications_failed_total{%(alertmanagerSelector)s, integration=~`%(alertmanagerCriticalIntegrationsRegEx)s`}[5m])
+                rate(alertmanager_notifications_failed_total{%(alertmanagerSelector)s, integration=~`%(alertmanagerCriticalIntegrationsRegEx)s`}[15m])
               /
-                ignoring (reason) group_left rate(alertmanager_notifications_total{%(alertmanagerSelector)s, integration=~`%(alertmanagerCriticalIntegrationsRegEx)s`}[5m])
+                ignoring (reason) group_left rate(alertmanager_notifications_total{%(alertmanagerSelector)s, integration=~`%(alertmanagerCriticalIntegrationsRegEx)s`}[15m])
               )
               > 0.01
             ||| % $._config,
@@ -80,9 +80,9 @@
             alert: 'AlertmanagerClusterFailedToSendAlerts',
             expr: |||
               min by (%(alertmanagerClusterLabels)s, integration) (
-                rate(alertmanager_notifications_failed_total{%(alertmanagerSelector)s, integration!~`%(alertmanagerCriticalIntegrationsRegEx)s`}[5m])
+                rate(alertmanager_notifications_failed_total{%(alertmanagerSelector)s, integration!~`%(alertmanagerCriticalIntegrationsRegEx)s`}[15m])
               /
-                ignoring (reason) group_left rate(alertmanager_notifications_total{%(alertmanagerSelector)s, integration!~`%(alertmanagerCriticalIntegrationsRegEx)s`}[5m])
+                ignoring (reason) group_left rate(alertmanager_notifications_total{%(alertmanagerSelector)s, integration!~`%(alertmanagerCriticalIntegrationsRegEx)s`}[15m])
               )
               > 0.01
             ||| % $._config,


### PR DESCRIPTION
5m is an unfortunate value since its the same as the default group_interval. If only a single alert fires and a single notifier fails consistently the alert will never fire, since the rate[5m] will be 0 after less then the group_interval.