### PR TITLE
Document that the hash exposed in alertmanager_config_hash is not cryptographically strong

### DIFF
--- a/config/coordinator.go
+++ b/config/coordinator.go
@@ -55,7 +55,7 @@ func NewCoordinator(configFilePath string, r prometheus.Registerer, l *slog.Logg
 func (c *Coordinator) registerMetrics(r prometheus.Registerer) {
 	configHash := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "alertmanager_config_hash",
-		Help: "Hash of the currently loaded alertmanager configuration.",
+		Help: "Hash of the currently loaded alertmanager configuration. Note that this is not a cryptographically strong hash.",
 	})
 	configSuccess := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "alertmanager_config_last_reload_successful",


### PR DESCRIPTION
This hash is presented to operators to track the contents of the Alertmanager config file.

The method used to calculate the hash takes only the lower 48 bits of an MD5 hash, in order to stuff the hash into the metric value.

Although this is probably obvious to many operators, I think it's worth documenting that this method isn't cryptographically strong and that collisions are common, to add an extra layer of discouragement for anybody from trying to use this metric for secure purposes.