### PR TITLE
Fix descriptions for --enable-feature

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -155,7 +155,7 @@ func Execute() {
 	app.Flag("timeout", "Timeout for the executed command").Default("30s").DurationVar(&timeout)
 	app.Flag("http.config.file", "HTTP client configuration file for amtool to connect to Alertmanager.").PlaceHolder("<filename>").ExistingFileVar(&httpConfigFile)
 	app.Flag("version-check", "Check alertmanager version. Use --no-version-check to disable.").Default("true").BoolVar(&versionCheck)
-	app.Flag("enable-feature", fmt.Sprintf("Experimental features to enable. The flag can be repeated to enable multiple features. Valid options: %s", strings.Join(featurecontrol.AllowedFlags, ", "))).Default("").StringVar(&featureFlags)
+	app.Flag("enable-feature", fmt.Sprintf("Comma-separated experimental features to enable. Valid options: %s", strings.Join(featurecontrol.AllowedFlags, ", "))).Default("").StringVar(&featureFlags)
 
 	app.Version(version.Print("amtool"))
 	app.GetFlag("help").Short('h')

--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -176,7 +176,7 @@ func run() int {
 		tlsConfigFile          = kingpin.Flag("cluster.tls-config", "[EXPERIMENTAL] Path to config yaml file that can enable mutual TLS within the gossip protocol.").Default("").String()
 		allowInsecureAdvertise = kingpin.Flag("cluster.allow-insecure-public-advertise-address-discovery", "[EXPERIMENTAL] Allow alertmanager to discover and listen on a public IP address.").Bool()
 		label                  = kingpin.Flag("cluster.label", "The cluster label is an optional string to include on each packet and stream. It uniquely identifies the cluster and prevents cross-communication issues when sending gossip messages.").Default("").String()
-		featureFlags           = kingpin.Flag("enable-feature", fmt.Sprintf("Experimental features to enable. The flag can be repeated to enable multiple features. Valid options: %s", strings.Join(featurecontrol.AllowedFlags, ", "))).Default("").String()
+		featureFlags           = kingpin.Flag("enable-feature", fmt.Sprintf("Comma-separated experimental features to enable. Valid options: %s", strings.Join(featurecontrol.AllowedFlags, ", "))).Default("").String()
 	)
 
 	promslogflag.AddFlags(kingpin.CommandLine, &promslogConfig)


### PR DESCRIPTION
Currently, passing multiple `--enable-feature` doesn't work:

```console
$ docker run --rm -it --entrypoint sh prom/alertmanager:v0.28.0
/alertmanager $ alertmanager --config.file=/etc/alertmanager/alertmanager.yml --enable-feature=auto-gomemlimit --enable-feature=auto-gomaxprocs
alertmanager: error: flag 'enable-feature' cannot be repeated, try --help
```

The intended syntax seems to be a single `--enable-feature` flag, with a comma-separated list of features as value. This is what is tested here:

https://github.com/prometheus/alertmanager/blob/3b06b97af4d146e141af92885a185891eb79a5b0/featurecontrol/featurecontrol_test.go#L40-L44