### PR TITLE
amtool: fix panic if --verbose is in used.

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -52,6 +52,7 @@ var (
 func initMatchersCompat(_ *kingpin.ParseContext) error {
 	promslogConfig := &promslog.Config{Writer: os.Stdout}
 	if verbose {
+		promslogConfig.Level = &promslog.AllowedLevel{}
 		_ = promslogConfig.Level.Set("debug")
 	}
 	logger := promslog.New(promslogConfig)


### PR DESCRIPTION
fixes #4216 

I pattern to test a command which invokes os.exit comes from https://willsena.dev/golang-how-to-test-code-that-exits-or-crashes/