### PR TITLE
Fix format issues of msteams adapter card

### DIFF
--- a/notify/msteamsv2/msteamsv2.go
+++ b/notify/msteamsv2/msteamsv2.go
@@ -61,7 +61,7 @@ type Content struct {
 type Body struct {
 	Type   string `json:"type"`
 	Text   string `json:"text"`
-	Weight string `json:"weigth,omitempty"`
+	Weight string `json:"weight,omitempty"`
 	Size   string `json:"size,omitempty"`
 	Wrap   bool   `json:"wrap,omitempty"`
 	Style  string `json:"style,omitempty"`
@@ -170,6 +170,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 						{
 							Type: "TextBlock",
 							Text: text,
+							Wrap: true,
 						},
 					},
 					Msteams: Msteams{


### PR DESCRIPTION
* Fix typo for 'weight' to correct format of title
* Add wrap to content of adapter card to avoid truncating long text