### PR TITLE
fix(ci): update promci to v0.4.6 to handle artifact actions deprecation (2)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
     needs: ci
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - uses: prometheus/promci@3cb0c3871f223bd5ce1226995bd52ffb314798b6 # v0.1.0
+      - uses: prometheus/promci@c3c93a50d581b928af720f0134b2b2dad32a6c41 # v0.4.6
       - uses: ./.github/promci/actions/build
         with:
           parallelism: 12


### PR DESCRIPTION
Same as #4258, I missed an update in previous PR

The update addresses failing GitHub Actions caused by the deprecation of v3 actions/upload-artifact and actions/download-artifact APIs.

This change:
- Updates promci from previous version to v0.4.6
- I hope resolves CI failures in artifact upload/download steps

https://github.com/prometheus/promci/releases/tag/v0.4.6 https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/