### PR TITLE
Dockerfile: Use absolute paths for Alertmanager files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY .build/${OS}-${ARCH}/alertmanager /bin/alertmanager
 COPY examples/ha/alertmanager.yml      /etc/alertmanager/alertmanager.yml
 
 RUN mkdir -p /alertmanager && \
-    chown -R nobody:nobody etc/alertmanager /alertmanager
+    chown -R nobody:nobody /etc/alertmanager /alertmanager
 
 USER       nobody
 EXPOSE     9093


### PR DESCRIPTION
Dockerfile was mixing absolute and relative Alertmanager configuration and storage paths.