### PR TITLE
chore: log when there is no route matched

### DIFF
--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -171,7 +171,11 @@ func (d *Dispatcher) run(it provider.AlertIterator) {
 			}
 
 			now := time.Now()
-			for _, r := range d.route.Match(alert.Labels) {
+			routes := d.route.Match(alert.Labels)
+			if len(routes) == 0 {
+				d.logger.Info("No routes matched the alert", "alert", alert)
+			}
+			for _, r := range routes {
 				d.processAlert(alert, r)
 			}
 			d.metrics.processingDuration.Observe(time.Since(now).Seconds())


### PR DESCRIPTION
This is to get some insights in case no route is matched for the alert. This is something we almost don't want at all. Any alert should have a matcher under normal circumstances. Would be good to log to ease troubleshooting.