### PR TITLE
Jira: Add option to disable issue updates

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -905,11 +905,11 @@ type JiraConfig struct {
 	Priority    string   `yaml:"priority,omitempty" json:"priority,omitempty"`
 	IssueType   string   `yaml:"issue_type,omitempty" json:"issue_type,omitempty"`
 
-	DisableUpdates    bool           `yaml:"disable_updates,omitempty" json:"disable_updates,omitempty"`
-	ReopenTransition  string         `yaml:"reopen_transition,omitempty" json:"reopen_transition,omitempty"`
-	ResolveTransition string         `yaml:"resolve_transition,omitempty" json:"resolve_transition,omitempty"`
-	WontFixResolution string         `yaml:"wont_fix_resolution,omitempty" json:"wont_fix_resolution,omitempty"`
-	ReopenDuration    model.Duration `yaml:"reopen_duration,omitempty" json:"reopen_duration,omitempty"`
+	DisableFieldUpdates bool           `yaml:"disable_field_updates,omitempty" json:"disable_field_updates,omitempty"`
+	ReopenTransition    string         `yaml:"reopen_transition,omitempty" json:"reopen_transition,omitempty"`
+	ResolveTransition   string         `yaml:"resolve_transition,omitempty" json:"resolve_transition,omitempty"`
+	WontFixResolution   string         `yaml:"wont_fix_resolution,omitempty" json:"wont_fix_resolution,omitempty"`
+	ReopenDuration      model.Duration `yaml:"reopen_duration,omitempty" json:"reopen_duration,omitempty"`
 
 	Fields map[string]any `yaml:"fields,omitempty" json:"custom_fields,omitempty"`
 }

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -905,6 +905,7 @@ type JiraConfig struct {
 	Priority    string   `yaml:"priority,omitempty" json:"priority,omitempty"`
 	IssueType   string   `yaml:"issue_type,omitempty" json:"issue_type,omitempty"`
 
+	DisableUpdates    bool           `yaml:"disable_updates,omitempty" json:"disable_updates,omitempty"`
 	ReopenTransition  string         `yaml:"reopen_transition,omitempty" json:"reopen_transition,omitempty"`
 	ResolveTransition string         `yaml:"resolve_transition,omitempty" json:"resolve_transition,omitempty"`
 	WontFixResolution string         `yaml:"wont_fix_resolution,omitempty" json:"wont_fix_resolution,omitempty"`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1035,6 +1035,10 @@ labels:
 # Type of the issue (e.g. Bug).
 [ issue_type: <string> ]
 
+# Disable updates to fields once an issue is created. If false, the alertmanager will overwrite changes after every notification.
+# NOTE: Disabling field updates does not disable transitions.
+[ disable_field_updates: <boolean> | default = false ]
+
 # Name of the workflow transition to resolve an issue. The target status must have the category "done".
 # NOTE: The name of the transition can be localized and depends on the language setting of the service account.
 [ resolve_transition: <string> ]

--- a/notify/jira/jira.go
+++ b/notify/jira/jira.go
@@ -100,6 +100,9 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 
 		logger.Debug("create new issue")
 	} else {
+		if n.conf.DisableUpdates {
+			return false, nil
+		}
 		path = "issue/" + existingIssue.Key
 		method = http.MethodPut
 

--- a/notify/jira/jira.go
+++ b/notify/jira/jira.go
@@ -100,8 +100,8 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 
 		logger.Debug("create new issue")
 	} else {
-		if n.conf.DisableUpdates {
-			return false, nil
+		if n.conf.DisableFieldUpdates {
+			return n.transitionIssue(ctx, logger, existingIssue, alerts.HasFiring())
 		}
 		path = "issue/" + existingIssue.Key
 		method = http.MethodPut

--- a/notify/jira/jira_test.go
+++ b/notify/jira/jira_test.go
@@ -597,7 +597,7 @@ func TestJiraNotify(t *testing.T) {
 			errMsg:             "can't find transition REOPEN for issue OPS-3",
 		},
 		{
-			title: "skip update issue",
+			title: "skip update request when DisableUpdates is true",
 			cfg: &config.JiraConfig{
 				Summary:        `{{ template "jira.default.summary" . }}`,
 				Description:    `{{ template "jira.default.description" . }}`,
@@ -636,13 +636,11 @@ func TestJiraNotify(t *testing.T) {
 					},
 				},
 			},
-			// If the test checks these fields, then it means that the flag to skip updates didn't work and a request
-			// was sent to the issue endpoint.
 			issue: issue{
 				Key: "",
 				Fields: &issueFields{
-					Summary:     "This fields in the issue don't matter at this point",
-					Description: "If the test check this values, it means that the flag to skip updates didn't work",
+					Summary:     "These issue fields don't matter at this point",
+					Description: "If the test checks these values, it means that the flag to skip updates didn't work",
 				},
 			},
 			customFieldAssetFn: func(t *testing.T, issue map[string]any) {},

--- a/notify/jira/jira_test.go
+++ b/notify/jira/jira_test.go
@@ -597,20 +597,20 @@ func TestJiraNotify(t *testing.T) {
 			errMsg:             "can't find transition REOPEN for issue OPS-3",
 		},
 		{
-			title: "skip update request when DisableUpdates is true",
+			title: "skip update request when DisableFieldUpdates is true",
 			cfg: &config.JiraConfig{
-				Summary:        `{{ template "jira.default.summary" . }}`,
-				Description:    `{{ template "jira.default.description" . }}`,
-				IssueType:      "{{  .CommonLabels.issue_type }}",
-				Project:        "{{  .CommonLabels.project }}",
-				Priority:       `{{ template "jira.default.priority" . }}`,
-				Labels:         []string{"alertmanager", "{{ .GroupLabels.alertname }}"},
-				DisableUpdates: true,
+				Summary:             `{{ template "jira.default.summary" . }}`,
+				Description:         `{{ template "jira.default.description" . }}`,
+				IssueType:           "{{  .CommonLabels.issue_type }}",
+				Project:             "{{  .CommonLabels.project }}",
+				Priority:            `{{ template "jira.default.priority" . }}`,
+				Labels:              []string{"alertmanager", "{{ .GroupLabels.alertname }}"},
+				DisableFieldUpdates: true,
 			},
 			alert: &types.Alert{
 				Alert: model.Alert{
 					Labels: model.LabelSet{
-						"alertname":  "SkipUpdatesConfig",
+						"alertname":  "DisableFieldUpdates",
 						"project":    "OPS",
 						"issue_type": "Bug",
 					},
@@ -639,8 +639,8 @@ func TestJiraNotify(t *testing.T) {
 			issue: issue{
 				Key: "",
 				Fields: &issueFields{
-					Summary:     "These issue fields don't matter at this point",
-					Description: "If the test checks these values, it means that the flag to skip updates didn't work",
+					Summary:     "These issue fields don't match the issue in the search response above",
+					Description: "If the test checks these values, then it tried to update the fields and it should fail",
 				},
 			},
 			customFieldAssetFn: func(t *testing.T, issue map[string]any) {},


### PR DESCRIPTION
Currently, every Jira notification [sends a request](https://github.com/prometheus/alertmanager/blob/main/notify/jira/jira.go#L109-L114) that overwrites user changes to issue fields (title, description, priority, etc). 

Losing changes may be unexpected for many Jira users, and this PR adds a receiver config to be able to skip the update request for existing issues without affecting resolve and reopen transitions.