### PR TITLE
Add George Robinson as an Alertmanager mantainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,3 +1,4 @@
 * Simon Pasquier <pasquier.simon@gmail.com> @simonpasquier
 * Andrey Kuzmin <unsoundscapes@gmail.com> @w0rm
 * Josue Abreu <josue.abreu@gmail.com> @gotjosh
+* George Robinson <george.robinson@grafana.com> @grobinson-grafana


### PR DESCRIPTION
George has been a cornerstone of the Alertmanager community. From meticulously triaging issues to delivering critical UTF-8 support, his contributions have touched every aspect of the project.

We are proud to officially welcome him as a maintainer.

Thank you for your invaluable dedication and hard work, George.

Signed-off-by: gotjosh <josue.abreu@gmail.com>
