### PR TITLE
Fix logged notification count

### DIFF
--- a/notify/notify.go
+++ b/notify/notify.go
@@ -828,7 +828,7 @@ func (r RetryStage) exec(ctx context.Context, l *slog.Logger, alerts ...*types.A
 	}
 
 	for {
-		i++
+
 		// Always check the context first to not notify again.
 		select {
 		case <-ctx.Done():
@@ -852,6 +852,7 @@ func (r RetryStage) exec(ctx context.Context, l *slog.Logger, alerts ...*types.A
 		case <-tick.C:
 			now := time.Now()
 			retry, err := r.integration.Notify(ctx, sent...)
+			i++
 			dur := time.Since(now)
 			r.metrics.notificationLatencySeconds.WithLabelValues(r.labelValues...).Observe(dur.Seconds())
 			r.metrics.numNotificationRequestsTotal.WithLabelValues(r.labelValues...).Inc()

--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -499,6 +499,7 @@ func TestRetryStageWithContextCanceled(t *testing.T) {
 	counter := r.metrics.numTotalFailedNotifications
 
 	require.Equal(t, 1, int(prom_testutil.ToFloat64(counter.WithLabelValues(r.integration.Name(), ContextCanceledReason.String()))))
+	require.Contains(t, err.Error(), "notify retry canceled after 1 attempts: context canceled")
 
 	require.Error(t, err)
 	require.NotNil(t, resctx)


### PR DESCRIPTION
A simple fix to correct the log message. In cases where context cancelation occurs, the logs show notification was attempted twice when in fact it was only attempted once