### PR TITLE
chore(tests): fix incorrect types test assertion

### DIFF
--- a/types/types_test.go
+++ b/types/types_test.go
@@ -127,14 +127,19 @@ func TestMemMarker_Count(t *testing.T) {
 	require.Equal(t, 1, countByState(AlertStateActive))
 	require.Equal(t, 1, countTotal())
 
-	// Insert a suppressed alert.
+	// Insert a silenced alert.
 	marker.SetActiveOrSilenced(a2.Fingerprint(), 1, []string{"1"}, nil)
 	require.Equal(t, 1, countByState(AlertStateSuppressed))
 	require.Equal(t, 2, countTotal())
 
-	// Insert a resolved alert - it'll count as active.
+	// Insert a resolved silenced alert - it'll count as suppressed.
 	marker.SetActiveOrSilenced(a3.Fingerprint(), 1, []string{"1"}, nil)
-	require.Equal(t, 1, countByState(AlertStateActive))
+	require.Equal(t, 2, countByState(AlertStateSuppressed))
+	require.Equal(t, 3, countTotal())
+
+	// Remove the silence from a3 - it'll count as active.
+	marker.SetActiveOrSilenced(a3.Fingerprint(), 1, nil, nil)
+	require.Equal(t, 2, countByState(AlertStateActive))
 	require.Equal(t, 3, countTotal())
 }
 


### PR DESCRIPTION
This commit changes an incorrect assertion that a
suppressed silenced alert is marked as active.

Change-Id: 86e470c80eb5aa3fd59b32374e664ee2
Relates-To: https://github.com/prometheus/alertmanager/issues/4315