### PR TITLE
inhibit: compare value of different source and target labels

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -966,9 +966,11 @@ type InhibitRule struct {
 	TargetMatchRE MatchRegexps `yaml:"target_match_re,omitempty" json:"target_match_re,omitempty"`
 	// TargetMatchers defines a set of label matchers that have to be fulfilled for target alerts.
 	TargetMatchers Matchers `yaml:"target_matchers,omitempty" json:"target_matchers,omitempty"`
-	// A set of labels that must be equal between the source and target alert
+	// A set of labels that must be equal between the source and target alert.
 	// for them to be a match.
 	Equal []string `yaml:"equal,omitempty" json:"equal,omitempty"`
+	// EqualPairs defines a set of pairs that have to be equal in the source and target alert.
+	EqualPairs []LabelPair `yaml:"equal_pairs,omitempty" json:"equal_pairs,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for InhibitRule.
@@ -998,6 +1000,12 @@ func (r *InhibitRule) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 
 	return nil
+}
+
+// LabelPair defines a source / target label pair.
+type LabelPair struct {
+	SourceLabel model.LabelName `yaml:"source_label,omitempty" json:"source_label,omitempty"`
+	TargetLabel model.LabelName `yaml:"target_label,omitempty" json:"target_label,omitempty"`
 }
 
 // Receiver configuration provides configuration on how to contact a receiver.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -473,6 +473,18 @@ source_matchers:
 # Labels that must have an equal value in the source and target
 # alert for the inhibition to take effect.
 [ equal: '[' <labelname>, ... ']' ]
+
+# Label pairs that must have an equal value in the source and target
+# alert for the inhibition to take effect.
+equal_pairs:
+  [ - <label_pair> ... ]
+
+```
+
+#### `<label_pair>`
+```yaml
+source_label: <labelname>
+target_label: <labelname>
 ```
 
 ## Label matchers

--- a/inhibit/inhibit.go
+++ b/inhibit/inhibit.go
@@ -156,12 +156,21 @@ type InhibitRule struct {
 	// The set of Filters which define the group of target alerts (which are
 	// inhibited by the source alerts).
 	TargetMatchers labels.Matchers
-	// A set of label names whose label values need to be identical in source and
+	// A set of label name pairs whose label values need to be identical in source and
 	// target alerts in order for the inhibition to take effect.
-	Equal map[model.LabelName]struct{}
+	EqualPairs LabelPairs
 
 	// Cache of alerts matching source labels.
 	scache *store.Alerts
+}
+
+// LabelPairs defines a set of source / target label pairs.
+type LabelPairs []LabelPair
+
+// LabelPair defines a source / target label pair.
+type LabelPair struct {
+	SourceLabel model.LabelName
+	TargetLabel model.LabelName
 }
 
 // NewInhibitRule returns a new InhibitRule based on a configuration definition.
@@ -169,6 +178,7 @@ func NewInhibitRule(cr config.InhibitRule) *InhibitRule {
 	var (
 		sourcem labels.Matchers
 		targetm labels.Matchers
+		pairs   LabelPairs
 	)
 	// cr.SourceMatch will be deprecated. This for loop appends regex matchers.
 	for ln, lv := range cr.SourceMatch {
@@ -212,15 +222,26 @@ func NewInhibitRule(cr config.InhibitRule) *InhibitRule {
 	// We append the new-style matchers. This can be simplified once the deprecated matcher syntax is removed.
 	targetm = append(targetm, cr.TargetMatchers...)
 
-	equal := map[model.LabelName]struct{}{}
 	for _, ln := range cr.Equal {
-		equal[model.LabelName(ln)] = struct{}{}
+		pair := LabelPair{
+			SourceLabel: model.LabelName(ln),
+			TargetLabel: model.LabelName(ln),
+		}
+		pairs = append(pairs, pair)
+	}
+
+	for _, p := range cr.EqualPairs {
+		pair := LabelPair{
+			SourceLabel: p.SourceLabel,
+			TargetLabel: p.TargetLabel,
+		}
+		pairs = append(pairs, pair)
 	}
 
 	return &InhibitRule{
 		SourceMatchers: sourcem,
 		TargetMatchers: targetm,
-		Equal:          equal,
+		EqualPairs:     pairs,
 		scache:         store.NewAlerts(),
 	}
 }
@@ -237,8 +258,8 @@ Outer:
 		if a.ResolvedAt(now) {
 			continue
 		}
-		for n := range r.Equal {
-			if a.Labels[n] != lset[n] {
+		for _, p := range r.EqualPairs {
+			if a.Labels[p.SourceLabel] != lset[p.TargetLabel] {
 				continue Outer
 			}
 		}


### PR DESCRIPTION
Adds equal_pairs config option to inhibit rules, which allows to compare the value of different source and target labels.

Closes https://github.com/prometheus/alertmanager/issues/2254

Credit [@swoga](https://github.com/swoga) https://github.com/prometheus/alertmanager/pull/3525