### PR TITLE
Fix error handling in template rendering for Telegram

### DIFF
--- a/notify/telegram/telegram.go
+++ b/notify/telegram/telegram.go
@@ -80,6 +80,9 @@ func (n *Notifier) Notify(ctx context.Context, alert ...*types.Alert) (bool, err
 	}
 
 	messageText, truncated := notify.TruncateInRunes(tmpl(n.conf.Message), maxMessageLenRunes)
+	if err != nil {
+		return true, err
+	}
 	if truncated {
 		n.logger.Warn("Truncated message", "alert", key, "max_runes", maxMessageLenRunes)
 	}


### PR DESCRIPTION
`notify.TmplText` and `notify.TmplHTML` use an unusual error handling pattern: the error is not explicitly returned but still must be checked by callers.

In the Telegram notifier the check is missing. Because of this, if template rendering fails, Alertmanager still attempts to send an empty message to Telegram and logs an error with text `Bad Request: message text is empty (400)`.

With this patch applied, Alertmanager will log the actual error that happens during template rendering.