### PR TITLE
feat: add timeout option for slack notifier 

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -504,6 +504,9 @@ type SlackConfig struct {
 	LinkNames   bool           `yaml:"link_names" json:"link_names,omitempty"`
 	MrkdwnIn    []string       `yaml:"mrkdwn_in,omitempty" json:"mrkdwn_in,omitempty"`
 	Actions     []*SlackAction `yaml:"actions,omitempty" json:"actions,omitempty"`
+	// Timeout is the maximum time allowed to invoke the slack. Setting this to 0
+	// does not impose a timeout.
+	Timeout time.Duration `yaml:"timeout" json:"timeout"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1439,6 +1439,11 @@ fields:
 
 # The HTTP client's configuration.
 [ http_config: <http_config> | default = global.http_config ]
+# The maximum time to wait for a slack request to complete, before failing the
+# request and allowing it to be retried. The default value of 0s indicates that
+# no timeout should be applied.
+# NOTE: This will have no effect if set higher than the group_interval.
+[ timeout: <duration> | default = 0s ]
 ```
 
 #### `<action_config>`


### PR DESCRIPTION
# Context

This is to manage timeout for the context that is passed to slack calls. Group level context is set to wider intervals on the dispatcher such as 5mins default, whereas we would like to set lower level thresholds for slack integrations to have limit on retries and intermediate blockers in the network.

Relates to https://github.com/prometheus/alertmanager/pull/4354

# Case

In our setup with HA usage of AM, we use proxy for egress comm from alertmanagers to slack(mattermost) that sits in between. Our proxy may lead to block such calls taking way longer than expected leading to no retries and hanging connections at alertmanager side as the [parent context is set at dispatcher that is group interval](https://github.com/prometheus/alertmanager/blob/main/dispatch/dispatch.go#L445). 

We should be able to set smaller duration timeout for outgoing calls to slack, consequently having more controls for robust communication.