### PR TITLE
Pushover: Add monospace message formatting, add documentation for existing HTML styling

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -741,7 +741,8 @@ type PushoverConfig struct {
 	Retry       duration `yaml:"retry,omitempty" json:"retry,omitempty"`
 	Expire      duration `yaml:"expire,omitempty" json:"expire,omitempty"`
 	TTL         duration `yaml:"ttl,omitempty" json:"ttl,omitempty"`
-	HTML        bool     `yaml:"html" json:"html,omitempty"`
+	HTML        bool     `yaml:"html,omitempty" json:"html,omitempty"`
+	Monospace   bool     `yaml:"monospace,omitempty" json:"monospace,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
@@ -762,6 +763,9 @@ func (c *PushoverConfig) UnmarshalYAML(unmarshal func(interface{}) error) error 
 	}
 	if c.Token != "" && c.TokenFile != "" {
 		return errors.New("at most one of token & token_file must be configured")
+	}
+	if c.HTML && c.Monospace {
+		return errors.New("at most one of monospace & html must be configured")
 	}
 	return nil
 }

--- a/config/notifiers_test.go
+++ b/config/notifiers_test.go
@@ -516,6 +516,26 @@ user_key: 'user key'
 	}
 }
 
+func TestPushoverHTMLOrMonospace(t *testing.T) {
+	in := `
+token: 'pushover token'
+user_key: 'user key'
+html: true
+monospace: true
+`
+	var cfg PushoverConfig
+	err := yaml.UnmarshalStrict([]byte(in), &cfg)
+
+	expected := "at most one of monospace & html must be configured"
+
+	if err == nil {
+		t.Fatalf("no error returned, expected:\n%v", expected)
+	}
+	if err.Error() != expected {
+		t.Errorf("\nexpected:\n%v\ngot:\n%v", expected, err.Error())
+	}
+}
+
 func TestLoadSlackConfiguration(t *testing.T) {
 	tests := []struct {
 		in       string

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1330,6 +1330,11 @@ token_file: <filepath>
 # Optional time to live (TTL) to use for notification, see https://pushover.net/api#ttl
 [ ttl: <duration> ]
 
+# Optional HTML/monospace formatting for the message, see https://pushover.net/api#html
+# html and monospace formatting are mutually exclusive.
+[ html: <boolean> | default = false ]
+[ monospace: <boolean> | default = false ]
+
 # The HTTP client's configuration.
 [ http_config: <http_config> | default = global.http_config ]
 ```

--- a/notify/pushover/pushover.go
+++ b/notify/pushover/pushover.go
@@ -124,6 +124,10 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		message = tmpl(n.conf.Message)
 	}
 
+	if n.conf.Monospace {
+		parameters.Add("monospace", "1")
+	}
+
 	message, truncated = notify.TruncateInRunes(message, maxMessageLenRunes)
 	if truncated {
 		n.logger.Warn("Truncated message", "incident", key, "max_runes", maxMessageLenRunes)

--- a/notify/pushover/pushover_test.go
+++ b/notify/pushover/pushover_test.go
@@ -14,6 +14,7 @@
 package pushover
 
 import (
+	"net/http"
 	"os"
 	"testing"
 
@@ -22,7 +23,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/alertmanager/config"
+	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/notify/test"
+	"github.com/prometheus/alertmanager/types"
 )
 
 func TestPushoverRetry(t *testing.T) {
@@ -108,4 +111,28 @@ func TestPushoverReadingTokenFromFile(t *testing.T) {
 	require.NoError(t, err)
 
 	test.AssertNotifyLeaksNoSecret(ctx, t, notifier, token)
+}
+
+func TestPushoverMonospaceParameter(t *testing.T) {
+	ctx, apiURL, fn := test.GetContextWithCancelingURL(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		require.Equal(t, "1", r.FormValue("monospace"), `expected monospace parameter to be set to "1"`)
+	})
+	defer fn()
+
+	notifier, err := New(
+		&config.PushoverConfig{
+			UserKey:    config.Secret("user_key"),
+			Token:      config.Secret("token"),
+			Monospace:  true,
+			HTTPConfig: &commoncfg.HTTPClientConfig{},
+		},
+		test.CreateTmpl(t),
+		promslog.NewNopLogger(),
+	)
+	notifier.apiURL = apiURL.String()
+	require.NoError(t, err)
+
+	_, err = notifier.Notify(notify.WithGroupKey(ctx, "1"), &types.Alert{})
+	require.NoError(t, err)
 }


### PR DESCRIPTION
Hey all,

this is my first contibution to alertmanager. Please let me know if I missed something.

There are two changes in this PR, but hey seemed very related:

- Document the (already existing) feature of enabling HTML message formatting when using Pushover
- Add the possibility to use monospace formatting for messages in Pushover (+documentation, +test)

API documentation can be found [here](https://pushover.net/api#html).