### PR TITLE
chore: fix typo in route config validation error message

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -924,7 +924,7 @@ func (r *Route) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 
 	if len(r.GroupBy) > 0 && r.GroupByAll {
-		return errors.New("cannot have wildcard group_by (`...`) and other other labels at the same time")
+		return errors.New("cannot have wildcard group_by (`...`) and other labels at the same time")
 	}
 
 	groupBy := map[model.LabelName]struct{}{}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -300,7 +300,7 @@ receivers:
 `
 	_, err := Load(in)
 
-	expected := "cannot have wildcard group_by (`...`) and other other labels at the same time"
+	expected := "cannot have wildcard group_by (`...`) and other labels at the same time"
 
 	if err == nil {
 		t.Fatalf("no error returned, expected:\n%q", expected)


### PR DESCRIPTION
This PR fixes a typo in the route config validation error message.