### PR TITLE
docs: Correct heading level for Slack

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1397,7 +1397,7 @@ The fields are documented in the [Rocketchat API api models](https://github.com/
 [ msg: <tmpl_string> ]
 ```
 
-#### `<slack_config>`
+### `<slack_config>`
 
 Slack notifications can be sent via [Incoming webhooks](https://api.slack.com/messaging/webhooks) or [Bot tokens](https://api.slack.com/authentication/token-types).
 


### PR DESCRIPTION
Makes it show up in the ToC