### PR TITLE
Add documentation for custom headers

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -820,6 +820,18 @@ oauth2:
 # Configures the TLS settings.
 tls_config:
   [ <tls_config> ]
+
+# Custom HTTP headers to be sent along with each request.
+# Headers that are set by Prometheus itself can't be overwritten.
+http_headers:
+  # Header name.
+  [ <string>:
+    # Header values.
+    [ values: [<string>, ...] ]
+    # Headers values. Hidden in configuration page.
+    [ secrets: [<secret>, ...] ]
+    # Files to read header values from.
+    [ files: [<string>, ...] ] ]
 ```
 
 #### `<oauth2>`


### PR DESCRIPTION
The option to configure custom http headers via the `http_headers` configuration option in `http_config` was added on [prometheus/common #416](https://github.com/prometheus/common/pull/416].

This was documented in prometheus [prometheus/prometheus #14660](https://github.com/prometheus/prometheus/pull/14660] but not in alertmanager.

I have migrated over the documentation after verifying that the `http_headers` configuration option indeed works starting with alertmanager 0.28.