### PR TITLE
fix(matchers/compat): use legacy name validation scheme in classic mode

### DIFF
--- a/matcher/compat/parse.go
+++ b/matcher/compat/parse.go
@@ -190,7 +190,7 @@ func FallbackMatchersParser(l *slog.Logger) ParseMatchers {
 // isValidClassicLabelName returns true if the string is a valid classic label name.
 func isValidClassicLabelName(_ *slog.Logger) func(model.LabelName) bool {
 	return func(name model.LabelName) bool {
-		return name.IsValid()
+		return name.IsValidLegacy()
 	}
 }
 


### PR DESCRIPTION
When importing alertmanager in a project with `prometheus/common` >= [v0.62.0](https://github.com/prometheus/common/releases/tag/v0.62.0) in [classic mode](https://prometheus.io/docs/alerting/latest/configuration/#classic-mode), calls to `compat.IsValidLabelName` use `UTF8Validation` scheme due to a new default for [NameValidationScheme](https://github.com/prometheus/common/blob/v0.62.0/model/metric.go#L37). This PR addresses this change by correctly using the legacy validation logic. 
As a workaround, set `model.NameValidationScheme` to `model.LegacyValidation`.