### PR TITLE
fix(inhibit): drop invalid inhibit marker

### DIFF
--- a/inhibit/inhibit.go
+++ b/inhibit/inhibit.go
@@ -139,7 +139,6 @@ func (ih *Inhibitor) Mutes(lset model.LabelSet) bool {
 			return true
 		}
 	}
-	ih.marker.SetInhibited(fp)
 
 	return false
 }


### PR DESCRIPTION
We must not mark active alerts as inhibited.
This should fix one of marker state leakage mentioned in #4402