### PR TITLE
[4465] Fix CVE-2025-22871: Update Go version to 1.24.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           command: sudo rm -rf /usr/local/go
       # Whenever the Go version is updated here, .promu.yml should also be updated.
       - go/install:
-          version: "1.24.1"
+          version: "1.24.4"
       - run:
           name: Remove generated code
           command: make clean

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/prometheus/alertmanager
 
-go 1.23.0
+go 1.23.10
 
-toolchain go1.24.1
+toolchain go1.24.4
 
 require (
 	github.com/KimMachineGun/automemlimit v0.7.1


### PR DESCRIPTION
- Update go.mod: go directive to 1.23.10, toolchain to go1.24.4
- Update CircleCI go/install version to 1.24.4
- Docker images already use golang-builder:1.24-base (Go 1.24.4)

This addresses CVE-2025-22871 affecting Go 1.23.7 and below, and Go 1.24.1 and below, by ensuring all builds use Go 1.24.4 which contains the security fix for improper handling of bare LF in chunked data chunk-size lines in net/http package.

Fixes: CVE-2025-22871