### PR TITLE
chore: improves logging around webhook dispatch failure

### DIFF
--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -350,7 +350,7 @@ func (d *Dispatcher) processAlert(alert *types.Alert, route *Route) {
 	go ag.run(func(ctx context.Context, alerts ...*types.Alert) bool {
 		_, _, err := d.stage.Exec(ctx, d.logger, alerts...)
 		if err != nil {
-			logger := d.logger.With("num_alerts", len(alerts), "err", err)
+			logger := d.logger.With("aggrGroup", ag.GroupKey(), "num_alerts", len(alerts), "err", err)
 			if errors.Is(ctx.Err(), context.Canceled) {
 				// It is expected for the context to be canceled on
 				// configuration reload or shutdown. In this case, the

--- a/notify/webhook/webhook.go
+++ b/notify/webhook/webhook.go
@@ -87,7 +87,7 @@ func (n *Notifier) Notify(ctx context.Context, alerts ...*types.Alert) (bool, er
 		n.logger.Error("error extracting group key", "err", err)
 	}
 
-	// @tjhop: should we debug log the key here like most other Notify() implementations?
+	n.logger.Debug("extracted group key", "key", groupKey.String())
 
 	msg := &Message{
 		Version:         "4",


### PR DESCRIPTION
## description

Tying the alerts that are being processed to failures reported under the dispatcher can be tricky, especially if there are many possible alerts that go through the same integration with different origins, etc. 

There are a few different ways we could associate these like using the aggrGroup logger instead of the dispatcher logger, including the alerts list in the log directly. It felt cleanest to just attach the aggrGroup key to the log so that it can be associated with any logs that come from the aggrGroup logger. I'm open to alternatives though.

## changes

- adds aggrGroup key to logs reporting dispatcher execution errors
- adds matching debug log to webhook notifier as it was missing