### PR TITLE
fix: replace `interface{}` with any

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -610,11 +610,11 @@ func (p *Peer) Status() string {
 
 // Info returns a JSON-serializable dump of cluster state.
 // Useful for debug.
-func (p *Peer) Info() map[string]interface{} {
+func (p *Peer) Info() map[string]any {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
 
-	return map[string]interface{}{
+	return map[string]any{
 		"self":    p.mlist.LocalNode(),
 		"members": p.mlist.Members(),
 	}

--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -218,7 +218,7 @@ func run() int {
 	}
 
 	if ff.EnableAutoGOMAXPROCS() {
-		l := func(format string, a ...interface{}) {
+		l := func(format string, a ...any) {
 			logger.Info("automaxprocs", "msg", fmt.Sprintf(strings.TrimPrefix(format, "maxprocs: "), a...))
 		}
 		if _, err := maxprocs.Set(maxprocs.Logger(l)); err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -56,7 +56,7 @@ func init() {
 type Secret string
 
 // MarshalYAML implements the yaml.Marshaler interface for Secret.
-func (s Secret) MarshalYAML() (interface{}, error) {
+func (s Secret) MarshalYAML() (any, error) {
 	if MarshalSecretValue {
 		return string(s), nil
 	}
@@ -67,7 +67,7 @@ func (s Secret) MarshalYAML() (interface{}, error) {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for Secret.
-func (s *Secret) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (s *Secret) UnmarshalYAML(unmarshal func(any) error) error {
 	type plain Secret
 	return unmarshal((*plain)(s))
 }
@@ -95,7 +95,7 @@ func (u *URL) Copy() *URL {
 }
 
 // MarshalYAML implements the yaml.Marshaler interface for URL.
-func (u URL) MarshalYAML() (interface{}, error) {
+func (u URL) MarshalYAML() (any, error) {
 	if u.URL != nil {
 		return u.String(), nil
 	}
@@ -103,7 +103,7 @@ func (u URL) MarshalYAML() (interface{}, error) {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for URL.
-func (u *URL) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (u *URL) UnmarshalYAML(unmarshal func(any) error) error {
 	var s string
 	if err := unmarshal(&s); err != nil {
 		return err
@@ -142,7 +142,7 @@ func (u *URL) UnmarshalJSON(data []byte) error {
 type SecretURL URL
 
 // MarshalYAML implements the yaml.Marshaler interface for SecretURL.
-func (s SecretURL) MarshalYAML() (interface{}, error) {
+func (s SecretURL) MarshalYAML() (any, error) {
 	if s.URL != nil {
 		if MarshalSecretValue {
 			return s.String(), nil
@@ -153,7 +153,7 @@ func (s SecretURL) MarshalYAML() (interface{}, error) {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for SecretURL.
-func (s *SecretURL) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (s *SecretURL) UnmarshalYAML(unmarshal func(any) error) error {
 	var str string
 	if err := unmarshal(&str); err != nil {
 		return err
@@ -308,7 +308,7 @@ type MuteTimeInterval struct {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for MuteTimeInterval.
-func (mt *MuteTimeInterval) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (mt *MuteTimeInterval) UnmarshalYAML(unmarshal func(any) error) error {
 	type plain MuteTimeInterval
 	if err := unmarshal((*plain)(mt)); err != nil {
 		return err
@@ -326,7 +326,7 @@ type TimeInterval struct {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for MuteTimeInterval.
-func (ti *TimeInterval) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (ti *TimeInterval) UnmarshalYAML(unmarshal func(any) error) error {
 	type plain TimeInterval
 	if err := unmarshal((*plain)(ti)); err != nil {
 		return err
@@ -361,7 +361,7 @@ func (c Config) String() string {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for Config.
-func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *Config) UnmarshalYAML(unmarshal func(any) error) error {
 	// We want to set c to the defaults and then overwrite it with the input.
 	// To make unmarshal fill the plain data struct rather than calling UnmarshalYAML
 	// again, we have to hide it using a type indirection.
@@ -768,7 +768,7 @@ type HostPort struct {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for HostPort.
-func (hp *HostPort) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (hp *HostPort) UnmarshalYAML(unmarshal func(any) error) error {
 	var (
 		s   string
 		err error
@@ -812,7 +812,7 @@ func (hp *HostPort) UnmarshalJSON(data []byte) error {
 }
 
 // MarshalYAML implements the yaml.Marshaler interface for HostPort.
-func (hp HostPort) MarshalYAML() (interface{}, error) {
+func (hp HostPort) MarshalYAML() (any, error) {
 	return hp.String(), nil
 }
 
@@ -870,7 +870,7 @@ type GlobalConfig struct {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for GlobalConfig.
-func (c *GlobalConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *GlobalConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	*c = DefaultGlobalConfig()
 	type plain GlobalConfig
 	return unmarshal((*plain)(c))
@@ -899,7 +899,7 @@ type Route struct {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for Route.
-func (r *Route) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (r *Route) UnmarshalYAML(unmarshal func(any) error) error {
 	type plain Route
 	if err := unmarshal((*plain)(r)); err != nil {
 		return err
@@ -972,7 +972,7 @@ type InhibitRule struct {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for InhibitRule.
-func (r *InhibitRule) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (r *InhibitRule) UnmarshalYAML(unmarshal func(any) error) error {
 	type plain InhibitRule
 	if err := unmarshal((*plain)(r)); err != nil {
 		return err
@@ -1024,7 +1024,7 @@ type Receiver struct {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for Receiver.
-func (c *Receiver) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *Receiver) UnmarshalYAML(unmarshal func(any) error) error {
 	type plain Receiver
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
@@ -1039,7 +1039,7 @@ func (c *Receiver) UnmarshalYAML(unmarshal func(interface{}) error) error {
 type MatchRegexps map[string]Regexp
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for MatchRegexps.
-func (m *MatchRegexps) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (m *MatchRegexps) UnmarshalYAML(unmarshal func(any) error) error {
 	type plain MatchRegexps
 	if err := unmarshal((*plain)(m)); err != nil {
 		return err
@@ -1062,7 +1062,7 @@ type Regexp struct {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for Regexp.
-func (re *Regexp) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (re *Regexp) UnmarshalYAML(unmarshal func(any) error) error {
 	var s string
 	if err := unmarshal(&s); err != nil {
 		return err
@@ -1077,7 +1077,7 @@ func (re *Regexp) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // MarshalYAML implements the yaml.Marshaler interface for Regexp.
-func (re Regexp) MarshalYAML() (interface{}, error) {
+func (re Regexp) MarshalYAML() (any, error) {
 	if re.original != "" {
 		return re.original, nil
 	}
@@ -1112,7 +1112,7 @@ func (re Regexp) MarshalJSON() ([]byte, error) {
 type Matchers labels.Matchers
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for Matchers.
-func (m *Matchers) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (m *Matchers) UnmarshalYAML(unmarshal func(any) error) error {
 	var lines []string
 	if err := unmarshal(&lines); err != nil {
 		return err
@@ -1129,7 +1129,7 @@ func (m *Matchers) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // MarshalYAML implements the yaml.Marshaler interface for Matchers.
-func (m Matchers) MarshalYAML() (interface{}, error) {
+func (m Matchers) MarshalYAML() (any, error) {
 	result := make([]string, len(m))
 	for i, matcher := range m {
 		result[i] = matcher.String()

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -225,7 +225,7 @@ type WebexConfig struct {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (c *WebexConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *WebexConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	*c = DefaultWebexConfig
 	type plain WebexConfig
 	if err := unmarshal((*plain)(c)); err != nil {
@@ -259,7 +259,7 @@ type DiscordConfig struct {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (c *DiscordConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *DiscordConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	*c = DefaultDiscordConfig
 	type plain DiscordConfig
 	if err := unmarshal((*plain)(c)); err != nil {
@@ -299,7 +299,7 @@ type EmailConfig struct {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (c *EmailConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *EmailConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	*c = DefaultEmailConfig
 	type plain EmailConfig
 	if err := unmarshal((*plain)(c)); err != nil {
@@ -360,7 +360,7 @@ type PagerdutyImage struct {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (c *PagerdutyConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *PagerdutyConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	*c = DefaultPagerdutyConfig
 	type plain PagerdutyConfig
 	if err := unmarshal((*plain)(c)); err != nil {
@@ -403,7 +403,7 @@ type SlackAction struct {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for SlackAction.
-func (c *SlackAction) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *SlackAction) UnmarshalYAML(unmarshal func(any) error) error {
 	type plain SlackAction
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
@@ -438,7 +438,7 @@ type SlackConfirmationField struct {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for SlackConfirmationField.
-func (c *SlackConfirmationField) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *SlackConfirmationField) UnmarshalYAML(unmarshal func(any) error) error {
 	type plain SlackConfirmationField
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
@@ -460,7 +460,7 @@ type SlackField struct {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for SlackField.
-func (c *SlackField) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *SlackField) UnmarshalYAML(unmarshal func(any) error) error {
 	type plain SlackField
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
@@ -507,7 +507,7 @@ type SlackConfig struct {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (c *SlackConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *SlackConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	*c = DefaultSlackConfig
 	type plain SlackConfig
 	if err := unmarshal((*plain)(c)); err != nil {
@@ -542,7 +542,7 @@ type WebhookConfig struct {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (c *WebhookConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *WebhookConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	*c = DefaultWebhookConfig
 	type plain WebhookConfig
 	if err := unmarshal((*plain)(c)); err != nil {
@@ -579,7 +579,7 @@ const wechatValidTypesRe = `^(text|markdown)$`
 var wechatTypeMatcher = regexp.MustCompile(wechatValidTypesRe)
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (c *WechatConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *WechatConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	*c = DefaultWechatConfig
 	type plain WechatConfig
 	if err := unmarshal((*plain)(c)); err != nil {
@@ -624,7 +624,7 @@ const opsgenieValidTypesRe = `^(team|teams|user|escalation|schedule)$`
 var opsgenieTypeMatcher = regexp.MustCompile(opsgenieValidTypesRe)
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (c *OpsGenieConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *OpsGenieConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	*c = DefaultOpsGenieConfig
 	type plain OpsGenieConfig
 	if err := unmarshal((*plain)(c)); err != nil {
@@ -684,7 +684,7 @@ type VictorOpsConfig struct {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (c *VictorOpsConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *VictorOpsConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	*c = DefaultVictorOpsConfig
 	type plain VictorOpsConfig
 	if err := unmarshal((*plain)(c)); err != nil {
@@ -746,7 +746,7 @@ type PushoverConfig struct {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (c *PushoverConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *PushoverConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	*c = DefaultPushoverConfig
 	type plain PushoverConfig
 	if err := unmarshal((*plain)(c)); err != nil {
@@ -786,7 +786,7 @@ type SNSConfig struct {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (c *SNSConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *SNSConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	*c = DefaultSNSConfig
 	type plain SNSConfig
 	if err := unmarshal((*plain)(c)); err != nil {
@@ -815,7 +815,7 @@ type TelegramConfig struct {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (c *TelegramConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *TelegramConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	*c = DefaultTelegramConfig
 	type plain TelegramConfig
 	if err := unmarshal((*plain)(c)); err != nil {
@@ -850,7 +850,7 @@ type MSTeamsConfig struct {
 	Text    string `yaml:"text,omitempty" json:"text,omitempty"`
 }
 
-func (c *MSTeamsConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *MSTeamsConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	*c = DefaultMSTeamsConfig
 	type plain MSTeamsConfig
 	if err := unmarshal((*plain)(c)); err != nil {
@@ -878,7 +878,7 @@ type MSTeamsV2Config struct {
 	Text  string `yaml:"text,omitempty" json:"text,omitempty"`
 }
 
-func (c *MSTeamsV2Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *MSTeamsV2Config) UnmarshalYAML(unmarshal func(any) error) error {
 	*c = DefaultMSTeamsV2Config
 	type plain MSTeamsV2Config
 	if err := unmarshal((*plain)(c)); err != nil {
@@ -917,7 +917,7 @@ type JiraConfig struct {
 	Fields map[string]any `yaml:"fields,omitempty" json:"custom_fields,omitempty"`
 }
 
-func (c *JiraConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *JiraConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	*c = DefaultJiraConfig
 	type plain JiraConfig
 	if err := unmarshal((*plain)(c)); err != nil {
@@ -986,7 +986,7 @@ type RocketchatConfig struct {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (c *RocketchatConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *RocketchatConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	*c = DefaultRocketchatConfig
 	type plain RocketchatConfig
 	if err := unmarshal((*plain)(c)); err != nil {

--- a/notify/discord/discord_test.go
+++ b/notify/discord/discord_test.go
@@ -58,7 +58,7 @@ func TestDiscordRetry(t *testing.T) {
 func TestDiscordTemplating(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		dec := json.NewDecoder(r.Body)
-		out := make(map[string]interface{})
+		out := make(map[string]any)
 		err := dec.Decode(&out)
 		if err != nil {
 			panic(err)

--- a/notify/email/email_test.go
+++ b/notify/email/email_test.go
@@ -80,7 +80,7 @@ type mailDev struct {
 	*url.URL
 }
 
-func (m *mailDev) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (m *mailDev) UnmarshalYAML(unmarshal func(any) error) error {
 	var s string
 	if err := unmarshal(&s); err != nil {
 		return err

--- a/notify/jira/types.go
+++ b/notify/jira/types.go
@@ -73,7 +73,7 @@ type issueTransitions struct {
 
 // MarshalJSON merges the struct issueFields and issueFields.CustomField together.
 func (i issueFields) MarshalJSON() ([]byte, error) {
-	jsonFields := map[string]interface{}{
+	jsonFields := map[string]any{
 		"description": i.Description,
 		"summary":     i.Summary,
 	}

--- a/notify/msteams/msteams_test.go
+++ b/notify/msteams/msteams_test.go
@@ -58,7 +58,7 @@ func TestMSTeamsRetry(t *testing.T) {
 func TestMSTeamsTemplating(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		dec := json.NewDecoder(r.Body)
-		out := make(map[string]interface{})
+		out := make(map[string]any)
 		err := dec.Decode(&out)
 		if err != nil {
 			panic(err)

--- a/notify/msteamsv2/msteamsv2_test.go
+++ b/notify/msteamsv2/msteamsv2_test.go
@@ -112,7 +112,7 @@ func TestNotifier_Notify_WithReason(t *testing.T) {
 func TestMSTeamsV2Templating(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		dec := json.NewDecoder(r.Body)
-		out := make(map[string]interface{})
+		out := make(map[string]any)
 		err := dec.Decode(&out)
 		if err != nil {
 			panic(err)

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -637,7 +637,7 @@ type hashBuffer struct {
 }
 
 var hashBuffers = sync.Pool{
-	New: func() interface{} { return &hashBuffer{buf: make([]byte, 0, 1024)} },
+	New: func() any { return &hashBuffer{buf: make([]byte, 0, 1024)} },
 }
 
 func hashAlert(a *types.Alert) uint64 {

--- a/notify/pagerduty/pagerduty_test.go
+++ b/notify/pagerduty/pagerduty_test.go
@@ -162,7 +162,7 @@ func TestPagerDutyV2RoutingKeyFromFile(t *testing.T) {
 func TestPagerDutyTemplating(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		dec := json.NewDecoder(r.Body)
-		out := make(map[string]interface{})
+		out := make(map[string]any)
 		err := dec.Decode(&out)
 		if err != nil {
 			panic(err)

--- a/notify/victorops/victorops_test.go
+++ b/notify/victorops/victorops_test.go
@@ -146,7 +146,7 @@ func TestVictorOpsReadingApiKeyFromFile(t *testing.T) {
 func TestVictorOpsTemplating(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		dec := json.NewDecoder(r.Body)
-		out := make(map[string]interface{})
+		out := make(map[string]any)
 		err := dec.Decode(&out)
 		if err != nil {
 			panic(err)

--- a/template/template.go
+++ b/template/template.go
@@ -131,7 +131,7 @@ func (t *Template) FromGlob(path string) error {
 }
 
 // ExecuteTextString needs a meaningful doc comment (TODO(fabxc)).
-func (t *Template) ExecuteTextString(text string, data interface{}) (string, error) {
+func (t *Template) ExecuteTextString(text string, data any) (string, error) {
 	if text == "" {
 		return "", nil
 	}
@@ -149,7 +149,7 @@ func (t *Template) ExecuteTextString(text string, data interface{}) (string, err
 }
 
 // ExecuteHTMLString needs a meaningful doc comment (TODO(fabxc)).
-func (t *Template) ExecuteHTMLString(html string, data interface{}) (string, error) {
+func (t *Template) ExecuteHTMLString(html string, data any) (string, error) {
 	if html == "" {
 		return "", nil
 	}
@@ -166,7 +166,7 @@ func (t *Template) ExecuteHTMLString(html string, data interface{}) (string, err
 	return buf.String(), err
 }
 
-type FuncMap map[string]interface{}
+type FuncMap map[string]any
 
 var DefaultFuncs = FuncMap{
 	"toUpper": strings.ToUpper,

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -293,7 +293,7 @@ func TestTemplateExpansion(t *testing.T) {
 	for _, tc := range []struct {
 		title string
 		in    string
-		data  interface{}
+		data  any
 		html  bool
 
 		exp  string
@@ -414,7 +414,7 @@ func TestTemplateExpansionWithOptions(t *testing.T) {
 		options []Option
 		title   string
 		in      string
-		data    interface{}
+		data    any
 		html    bool
 
 		exp  string
@@ -475,7 +475,7 @@ func TestTemplateFuncs(t *testing.T) {
 	for _, tc := range []struct {
 		title  string
 		in     string
-		data   interface{}
+		data   any
 		exp    string
 		expErr string
 	}{{

--- a/test/cli/mock.go
+++ b/test/cli/mock.go
@@ -121,7 +121,7 @@ type TestAlert struct {
 
 // Alert creates a new alert declaration with the given key/value pairs
 // as identifying labels.
-func Alert(keyval ...interface{}) *TestAlert {
+func Alert(keyval ...any) *TestAlert {
 	if len(keyval)%2 == 1 {
 		panic("bad key/values")
 	}
@@ -165,7 +165,7 @@ func (a *TestAlert) nativeAlert(opts *AcceptanceOpts) *models.GettableAlert {
 }
 
 // Annotate the alert with the given key/value pairs.
-func (a *TestAlert) Annotate(keyval ...interface{}) *TestAlert {
+func (a *TestAlert) Annotate(keyval ...any) *TestAlert {
 	if len(keyval)%2 == 1 {
 		panic("bad key/values")
 	}

--- a/test/with_api_v2/mock.go
+++ b/test/with_api_v2/mock.go
@@ -148,7 +148,7 @@ type TestAlert struct {
 
 // Alert creates a new alert declaration with the given key/value pairs
 // as identifying labels.
-func Alert(keyval ...interface{}) *TestAlert {
+func Alert(keyval ...any) *TestAlert {
 	if len(keyval)%2 == 1 {
 		panic("bad key/values")
 	}
@@ -192,7 +192,7 @@ func (a *TestAlert) nativeAlert(opts *AcceptanceOpts) *models.GettableAlert {
 }
 
 // Annotate the alert with the given key/value pairs.
-func (a *TestAlert) Annotate(keyval ...interface{}) *TestAlert {
+func (a *TestAlert) Annotate(keyval ...any) *TestAlert {
 	if len(keyval)%2 == 1 {
 		panic("bad key/values")
 	}

--- a/timeinterval/timeinterval.go
+++ b/timeinterval/timeinterval.go
@@ -206,7 +206,7 @@ var monthsInv = map[int]string{
 }
 
 // UnmarshalYAML implements the Unmarshaller interface for Location.
-func (tz *Location) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (tz *Location) UnmarshalYAML(unmarshal func(any) error) error {
 	var str string
 	if err := unmarshal(&str); err != nil {
 		return err
@@ -234,7 +234,7 @@ func (tz *Location) UnmarshalJSON(in []byte) error {
 }
 
 // UnmarshalYAML implements the Unmarshaller interface for WeekdayRange.
-func (r *WeekdayRange) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (r *WeekdayRange) UnmarshalYAML(unmarshal func(any) error) error {
 	var str string
 	if err := unmarshal(&str); err != nil {
 		return err
@@ -261,7 +261,7 @@ func (r *WeekdayRange) UnmarshalJSON(in []byte) error {
 }
 
 // UnmarshalYAML implements the Unmarshaller interface for DayOfMonthRange.
-func (r *DayOfMonthRange) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (r *DayOfMonthRange) UnmarshalYAML(unmarshal func(any) error) error {
 	var str string
 	if err := unmarshal(&str); err != nil {
 		return err
@@ -304,7 +304,7 @@ func (r *DayOfMonthRange) UnmarshalJSON(in []byte) error {
 }
 
 // UnmarshalYAML implements the Unmarshaller interface for MonthRange.
-func (r *MonthRange) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (r *MonthRange) UnmarshalYAML(unmarshal func(any) error) error {
 	var str string
 	if err := unmarshal(&str); err != nil {
 		return err
@@ -327,7 +327,7 @@ func (r *MonthRange) UnmarshalJSON(in []byte) error {
 }
 
 // UnmarshalYAML implements the Unmarshaller interface for YearRange.
-func (r *YearRange) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (r *YearRange) UnmarshalYAML(unmarshal func(any) error) error {
 	var str string
 	if err := unmarshal(&str); err != nil {
 		return err
@@ -348,7 +348,7 @@ func (r *YearRange) UnmarshalJSON(in []byte) error {
 }
 
 // UnmarshalYAML implements the Unmarshaller interface for TimeRanges.
-func (tr *TimeRange) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (tr *TimeRange) UnmarshalYAML(unmarshal func(any) error) error {
 	var y yamlTimeRange
 	if err := unmarshal(&y); err != nil {
 		return err
@@ -378,7 +378,7 @@ func (tr *TimeRange) UnmarshalJSON(in []byte) error {
 }
 
 // MarshalYAML implements the yaml.Marshaler interface for WeekdayRange.
-func (r WeekdayRange) MarshalYAML() (interface{}, error) {
+func (r WeekdayRange) MarshalYAML() (any, error) {
 	bytes, err := r.MarshalText()
 	return string(bytes), err
 }
@@ -403,7 +403,7 @@ func (r WeekdayRange) MarshalText() ([]byte, error) {
 }
 
 // MarshalYAML implements the yaml.Marshaler interface for TimeRange.
-func (tr TimeRange) MarshalYAML() (out interface{}, err error) {
+func (tr TimeRange) MarshalYAML() (out any, err error) {
 	startHr := tr.StartMinute / 60
 	endHr := tr.EndMinute / 60
 	startMin := tr.StartMinute % 60
@@ -413,7 +413,7 @@ func (tr TimeRange) MarshalYAML() (out interface{}, err error) {
 	endStr := fmt.Sprintf("%02d:%02d", endHr, endMin)
 
 	yTr := yamlTimeRange{startStr, endStr}
-	return interface{}(yTr), err
+	return any(yTr), err
 }
 
 // MarshalJSON implements the json.Marshaler interface for TimeRange.
@@ -440,7 +440,7 @@ func (tz Location) MarshalText() ([]byte, error) {
 }
 
 // MarshalYAML implements the yaml.Marshaler interface for Location.
-func (tz Location) MarshalYAML() (interface{}, error) {
+func (tz Location) MarshalYAML() (any, error) {
 	bytes, err := tz.MarshalText()
 	return string(bytes), err
 }
@@ -462,7 +462,7 @@ func (ir InclusiveRange) MarshalText() ([]byte, error) {
 }
 
 // MarshalYAML implements the yaml.Marshaler interface for InclusiveRange.
-func (ir InclusiveRange) MarshalYAML() (interface{}, error) {
+func (ir InclusiveRange) MarshalYAML() (any, error) {
 	bytes, err := ir.MarshalText()
 	return string(bytes), err
 }


### PR DESCRIPTION
Small fix` type any = interface{}` as this type is available since go 1.18