### PR TITLE
Update dependabot to group AWS deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     open-pull-requests-limit: 20
     schedule:
       interval: "monthly"
+    groups:
+      aws:
+        patterns:
+          - "github.com/aws/*"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
This should help update all the aws-sdk-go-v2 deps together, reducing pull requests and reducing the risk that these deps become out of sync.