### PR TITLE
Fix goroutine leak at silence bulk import

### DIFF
--- a/cli/silence_import.go
+++ b/cli/silence_import.go
@@ -137,7 +137,7 @@ func (c *silenceImportCmd) bulkImport(ctx context.Context, _ *kingpin.ParseConte
 		silencec <- &s
 		count++
 	}
-	
+
 	wg.Wait()
 
 	if errCount > 0 {


### PR DESCRIPTION
In silence bulk import, I noticed that if a decoding error occurs, the number of goroutines remains equal to the number of workers which is worker count. This happened because the channel wasn’t closed when an error occurred and the function exited. I fixed this issue by ensuring the channel is closed even in error cases.

I tested like this.
```go
func TestName(t *testing.T) {
	var err error
	alertmanagerURL, err = url.Parse("http://example.com")
	if err != nil {
		log.Fatal(err)
	}

	goroutineCount := runtime.NumGoroutine()
	println("before bulk import ", goroutineCount) // print 2
	cmd := silenceImportCmd{
		force:   false,
		workers: 10,
		file:    "./test.json",
	}
	cmd.bulkImport(context.TODO(), nil)

	for i := 0; i < 100; i++ {
		goroutineCount := runtime.NumGoroutine()
		println(goroutineCount) // as-is: 13 (worker count), to-be: 2
		time.Sleep(1 * time.Second)
	}
}
```
``` test.json
[
  {
    "ID": "123",
    "Comment": "First silence",
    "CreatedBy": "user1",
    "EndsAt": 1 // this makes decode error
  },
  {
    "ID": "456",
    "Comment": "Second silence",
    "CreatedBy": "user2"
  }
]
```
