### PR TITLE
Change heading format for <slack_config> section

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1407,7 +1407,7 @@ The fields are documented in the [Rocketchat API api models](https://github.com/
 [ msg: <tmpl_string> ]
 ```
 
-### `<slack_config>`
+#### `<slack_config>`
 
 Slack notifications can be sent via [Incoming webhooks](https://api.slack.com/messaging/webhooks) or [Bot tokens](https://api.slack.com/authentication/token-types).
 


### PR DESCRIPTION
Updated the heading for <slack_config> section in configuration documentation to match other sections.

<img width="1396" height="818" alt="Screenshot 2025-09-12 at 12 01 15 PM" src="https://github.com/user-attachments/assets/702c18d8-23bc-4a15-93ab-d4d3224e44b0" />
