### PR TITLE
Refactor to use receive only channel

### DIFF
--- a/cluster/channel.go
+++ b/cluster/channel.go
@@ -50,7 +50,7 @@ func NewChannel(
 	peers func() []*memberlist.Node,
 	sendOversize func(*memberlist.Node, []byte) error,
 	logger *slog.Logger,
-	stopc chan struct{},
+	stopc <-chan struct{},
 	reg prometheus.Registerer,
 ) *Channel {
 	oversizeGossipMessageFailureTotal := prometheus.NewCounter(prometheus.CounterOpts{
@@ -100,7 +100,7 @@ func NewChannel(
 
 // handleOverSizedMessages prevents memberlist from opening too many parallel
 // TCP connections to its peers.
-func (c *Channel) handleOverSizedMessages(stopc chan struct{}) {
+func (c *Channel) handleOverSizedMessages(stopc <-chan struct{}) {
 	var wg sync.WaitGroup
 	for {
 		select {


### PR DESCRIPTION
It's clearer to use a receive-only channel for `stopC`, since the channel struct never sends to `stopC` but only receives from it.