### PR TITLE
Update Go

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,14 @@
 version: 2.1
 orbs:
   prometheus: prometheus/prometheus@0.17.1
-  go: circleci/go@3.0.0
+  go: circleci/go@3.0.3
 jobs:
   test_frontend:
     # We need to use a machine executor because the front-end validation runs
     # containers with mounted volumes which isn't supported with the docker
     # executor (even with setup_remote_docker).
     machine:
-      image: ubuntu-2204:current
+      image: ubuntu-2404:current
     steps:
       - checkout
       - run: sudo service docker restart
@@ -18,7 +18,7 @@ jobs:
           command: sudo rm -rf /usr/local/go
       # Whenever the Go version is updated here, .promu.yml should also be updated.
       - go/install:
-          version: "1.24.1"
+          version: "1.25.2"
       - run:
           name: Remove generated code
           command: make clean
@@ -47,7 +47,7 @@ jobs:
   test:
     docker:
       # Whenever the Go version is updated here, .promu.yml should also be updated.
-      - image: quay.io/prometheus/golang-builder:1.24-base
+      - image: quay.io/prometheus/golang-builder:1.25-base
       # maildev containers are for running the email tests against a "real" SMTP server.
       # See notify/email_test.go for details.
       - image: maildev/maildev:2.1.0
@@ -104,7 +104,7 @@ jobs:
   mixin:
     docker:
       # Whenever the Go version is updated here, .promu.yml should also be updated.
-      - image: quay.io/prometheus/golang-builder:1.24-base
+      - image: quay.io/prometheus/golang-builder:1.25-base
     steps:
       - checkout
       # pin the mixtool version until https://github.com/monitoring-mixins/mixtool/issues/135 is merged.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,12 @@ updates:
       aws:
         patterns:
           - "github.com/aws/*"
+          - "github.com/go-openapi/*"
   - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     # Whenever the Go version is updated here, .promu.yml
     # should also be updated.
     container:
-      image: quay.io/prometheus/golang-builder:1.24-base
+      image: quay.io/prometheus/golang-builder:1.25-base
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: prometheus/promci@c3c93a50d581b928af720f0134b2b2dad32a6c41 # v0.4.6

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -25,15 +25,20 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Install Go
-        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: 1.24.x
+          persist-credentials: false
+      - name: Install Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: 1.25.x
       - name: Install snmp_exporter/generator dependencies
         run: sudo apt-get update && sudo apt-get -y install libsnmp-dev
         if: github.repository == 'prometheus/snmp_exporter'
+      - name: Get golangci-lint version
+        id: golangci-lint-version
+        run: echo "version=$(make print-golangci-lint-version)" >> $GITHUB_OUTPUT
       - name: Lint
-        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
           args: --verbose
-          version: v2.3.0
+          version: ${{ steps.golangci-lint-version.outputs.version }}

--- a/.github/workflows/mixin.yml
+++ b/.github/workflows/mixin.yml
@@ -14,7 +14,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
       # pin the mixtool version until https://github.com/monitoring-mixins/mixtool/issues/135 is merged.
       - run: go install github.com/monitoring-mixins/mixtool/cmd/mixtool@2282201396b69055bb0f92f187049027a16d2130
       - run: go install github.com/google/go-jsonnet/cmd/jsonnetfmt@latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,6 +60,7 @@ linters:
         - name: unexported-return
         - name: var-declaration
         - name: var-naming
+          disabled: true
     testifylint:
       disable:
         - float-compare

--- a/.promu.yml
+++ b/.promu.yml
@@ -1,7 +1,7 @@
 go:
     # Whenever the Go version is updated here,
     # .circle/config.yml should also be updated.
-    version: 1.24
+    version: 1.25
 repository:
     path: github.com/prometheus/alertmanager
 build:

--- a/Makefile.common
+++ b/Makefile.common
@@ -61,7 +61,8 @@ PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_
 SKIP_GOLANGCI_LINT :=
 GOLANGCI_LINT :=
 GOLANGCI_LINT_OPTS ?=
-GOLANGCI_LINT_VERSION ?= v2.3.0
+GOLANGCI_LINT_VERSION ?= v2.4.0
+GOLANGCI_FMT_OPTS ?=
 # golangci-lint only supports linux, darwin and windows platforms on i386/amd64/arm64.
 # windows isn't included here because of the path separator being different.
 ifeq ($(GOHOSTOS),$(filter $(GOHOSTOS),linux darwin))
@@ -138,7 +139,7 @@ common-deps:
 update-go-deps:
 	@echo ">> updating Go dependencies"
 	@for m in $$($(GO) list -mod=readonly -m -f '{{ if and (not .Indirect) (not .Main)}}{{.Path}}{{end}}' all); do \
-		$(GO) get -d $$m; \
+		$(GO) get $$m; \
 	done
 	$(GO) mod tidy
 
@@ -156,9 +157,13 @@ $(GOTEST_DIR):
 	@mkdir -p $@
 
 .PHONY: common-format
-common-format:
+common-format: $(GOLANGCI_LINT)
 	@echo ">> formatting code"
 	$(GO) fmt $(pkgs)
+ifdef GOLANGCI_LINT
+	@echo ">> formatting code with golangci-lint"
+	$(GOLANGCI_LINT) fmt $(GOLANGCI_FMT_OPTS)
+endif
 
 .PHONY: common-vet
 common-vet:
@@ -248,8 +253,8 @@ $(PROMU):
 	cp $(PROMU_TMP)/promu-$(PROMU_VERSION).$(GO_BUILD_PLATFORM)/promu $(FIRST_GOPATH)/bin/promu
 	rm -r $(PROMU_TMP)
 
-.PHONY: proto
-proto:
+.PHONY: common-proto
+common-proto:
 	@echo ">> generating code from proto files"
 	@./scripts/genproto.sh
 
@@ -260,6 +265,10 @@ $(GOLANGCI_LINT):
 		| sed -e '/install -d/d' \
 		| sh -s -- -b $(FIRST_GOPATH)/bin $(GOLANGCI_LINT_VERSION)
 endif
+
+.PHONY: common-print-golangci-lint-version
+common-print-golangci-lint-version:
+	@echo $(GOLANGCI_LINT_VERSION)
 
 .PHONY: precheck
 precheck::

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/prometheus/alertmanager
 
-go 1.23.0
-
-toolchain go1.24.1
+go 1.24.0
 
 require (
 	github.com/KimMachineGun/automemlimit v0.7.4

--- a/notify/util.go
+++ b/notify/util.go
@@ -133,7 +133,7 @@ func TruncateInBytes(s string, n int) (string, bool) {
 func TmplText(tmpl *template.Template, data *template.Data, err *error) func(string) string {
 	return func(name string) (s string) {
 		if *err != nil {
-			return
+			return s
 		}
 		s, *err = tmpl.ExecuteTextString(name, data)
 		return s
@@ -145,7 +145,7 @@ func TmplText(tmpl *template.Template, data *template.Data, err *error) func(str
 func TmplHTML(tmpl *template.Template, data *template.Data, err *error) func(string) string {
 	return func(name string) (s string) {
 		if *err != nil {
-			return
+			return s
 		}
 		s, *err = tmpl.ExecuteHTMLString(name, data)
 		return s


### PR DESCRIPTION
* Update Go to 1.25.
* Update minimum Go version to 1.24.0.
* Group github.com/go-openapi dependencies.
* Enable dependabot for github actions.