### PR TITLE
Update release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,3 +36,4 @@ jobs:
           docker_hub_password: ${{ secrets.docker_hub_password }}
           quay_io_login: ${{ secrets.quay_io_login }}
           quay_io_password: ${{ secrets.quay_io_password }}
+          github_token: ${{ secrets.PROMBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Add github token variable for promci to publish release artifacts. Based on github actions, this workflow has never worked due to the GITHUB_TOKEN variable being missing. https://github.com/prometheus/alertmanager/actions/workflows/release.yml