### PR TITLE
feat: implement phantom_threading to group email alerts into threads

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -315,6 +315,13 @@ type EmailConfig struct {
 	Text             string               `yaml:"text,omitempty" json:"text,omitempty"`
 	RequireTLS       *bool                `yaml:"require_tls,omitempty" json:"require_tls,omitempty"`
 	TLSConfig        *commoncfg.TLSConfig `yaml:"tls_config,omitempty" json:"tls_config,omitempty"`
+	Threading        ThreadingConfig      `yaml:"threading,omitempty" json:"threading,omitempty"`
+}
+
+// ThreadingConfig configures mail threading.
+type ThreadingConfig struct {
+	Enabled      bool   `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	ThreadByDate string `yaml:"thread_by_date,omitempty" json:"thread_by_date,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
@@ -337,6 +344,15 @@ func (c *EmailConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		normalizedHeaders[normalized] = v
 	}
 	c.Headers = normalizedHeaders
+
+	if c.Threading.Enabled {
+		if _, ok := normalizedHeaders["References"]; ok {
+			return errors.New("conflicting configuration: threading.enabled conflicts with custom References header")
+		}
+		if _, ok := normalizedHeaders["In-Reply-To"]; ok {
+			return errors.New("conflicting configuration: threading.enabled conflicts with custom In-Reply-To header")
+		}
+	}
 
 	return nil
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -992,6 +992,15 @@ tls_config:
 # Further headers email header key/value pairs. Overrides any headers
 # previously set by the notification implementation.
 [ headers: { <string>: <tmpl_string>, ... } ]
+
+# Email threading configuration.
+threading:
+  # Whether to enable threading, which makes alert notifications in the same
+  # alert group show up in the same email thread.
+  [ enabled: <boolean> | default = false ]
+  # What granularity of current date to thread by. Accepted values: daily, none.
+  # (none means group by alert group key, no date).
+  [ thread_by_date: <string> | default = daily ]
 ```
 
 ### `<mattermost_config>`

--- a/notify/email/email.go
+++ b/notify/email/email.go
@@ -265,6 +265,31 @@ func (n *Email) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
 		fmt.Fprintf(buffer, "Message-Id: %s\r\n", fmt.Sprintf("<%d.%d@%s>", time.Now().UnixNano(), rand.Uint64(), n.hostname))
 	}
 
+	if n.conf.Threading.Enabled {
+		key, err := notify.ExtractGroupKey(ctx)
+		if err != nil {
+			return false, err
+		}
+		// Add threading headers. All notifications for the same alert group
+		// (identified by key hash) are threaded together.
+		threadBy := ""
+		if n.conf.Threading.ThreadByDate != "none" {
+			// ThreadByDate is 'daily':
+			// Use current date so all mails for this alert today thread together.
+			threadBy = time.Now().Format("2006-01-02")
+		}
+		keyHash := key.Hash()
+		if len(keyHash) > 16 {
+			keyHash = keyHash[:16]
+		}
+		// The thread root ID is a Message-ID that doesn't correspond to
+		// any actual email. Email clients following the (commonly used) JWZ
+		// algorithm will create a dummy container to group these messages.
+		threadRootID := fmt.Sprintf("<alert-%s-%s@alertmanager>", keyHash, threadBy)
+		fmt.Fprintf(buffer, "References: %s\r\n", threadRootID)
+		fmt.Fprintf(buffer, "In-Reply-To: %s\r\n", threadRootID)
+	}
+
 	multipartBuffer := &bytes.Buffer{}
 	multipartWriter := multipart.NewWriter(multipartBuffer)
 


### PR DESCRIPTION
Some email clients such as Gmail apparently use their own heuristics for threading and already implement this behavior based on the subject.

But for users of other email clients that only implement threading based on the relevant headers (e.g. notmuch), those users currently get one email thread for each newly firing alert.

With phantom_threading enabled, all alert emails (of the same alert) on the same day are grouped into the same thread. Much nicer :)

---

I have tested this manually and you can see the effect start to work in this screenshot:

![2025-10-22-alertmanager-threading](https://github.com/user-attachments/assets/fb649e05-7014-4aca-adfa-44e04cc80c23)

(Monday morning, I got one thread per alert email notification; in the evening, the threading change was effective and emails are grouped into the daily thread.)