### PR TITLE
feat(cluster): persistant peer names

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -165,6 +165,7 @@ func run() int {
 		clusterBindAddr = kingpin.Flag("cluster.listen-address", "Listen address for cluster. Set to empty string to disable HA mode.").
 				Default(defaultClusterAddr).String()
 		clusterAdvertiseAddr   = kingpin.Flag("cluster.advertise-address", "Explicit address to advertise in cluster.").String()
+		clusterPeerName        = kingpin.Flag("cluster.peer-name", "Explicit name of the peer, rather than generating a random one").Default("").String()
 		peers                  = kingpin.Flag("cluster.peer", "Initial peers (may be repeated).").Strings()
 		peerTimeout            = kingpin.Flag("cluster.peer-timeout", "Time to wait between peers to send notifications.").Default("15s").Duration()
 		gossipInterval         = kingpin.Flag("cluster.gossip-interval", "Interval between sending gossip messages. By lowering this value (more frequent) gossip messages are propagated across the cluster more quickly at the expense of increased bandwidth.").Default(cluster.DefaultGossipInterval.String()).Duration()
@@ -256,6 +257,7 @@ func run() int {
 			tlsTransportConfig,
 			*allowInsecureAdvertise,
 			*label,
+			*clusterPeerName,
 		)
 		if err != nil {
 			logger.Error("unable to initialize gossip mesh", "err", err)


### PR DESCRIPTION
Currently the default behaviour is to generate a new, random peer name on every startup.
It might be desired to have a persistent peer name in consistent setups like running the cluster on bare-metal nodes.

This change adds an optional cli arg that allows specifying a custom peer name.
If no peer name is specified a random name is generated.

Duplicated peer names are detected, logged and increment the new metric `alertmanager_cluster_peer_name_conflicts_total`.
