### PR TITLE
fix(inhibit): fix inhibitor cache & index metrics

### DIFF
--- a/inhibit/inhibit.go
+++ b/inhibit/inhibit.go
@@ -94,17 +94,17 @@ func (ih *Inhibitor) run(ctx context.Context) {
 					}
 					r.updateIndex(a)
 
-					cached := r.scache.Len()
-					indexed := r.sindex.Len()
-
-					if r.Name != "" {
-						r.metrics.sourceAlertsCacheItems.With(prometheus.Labels{"rule": r.Name}).Set(float64(cached))
-						r.metrics.sourceAlertsIndexItems.With(prometheus.Labels{"rule": r.Name}).Set(float64(indexed))
-					}
-
-					cachedSum += cached
-					indexedSum += indexed
 				}
+				cached := r.scache.Len()
+				indexed := r.sindex.Len()
+
+				if r.Name != "" {
+					r.metrics.sourceAlertsCacheItems.With(prometheus.Labels{"rule": r.Name}).Set(float64(cached))
+					r.metrics.sourceAlertsIndexItems.With(prometheus.Labels{"rule": r.Name}).Set(float64(indexed))
+				}
+
+				cachedSum += cached
+				indexedSum += indexed
 			}
 			ih.metrics.sourceAlertsCacheItems.Set(float64(cachedSum))
 			ih.metrics.sourceAlertsIndexItems.Set(float64(indexedSum))


### PR DESCRIPTION
Inhibitor metrics were reset to zero if an alert matched no rules.
This change fixes the logic by moving measurement logic out of the matching loop.

Fixes metrics introduced in #4629
