### PR TITLE
Refactor metric registration

### DIFF
--- a/api/metrics/metrics.go
+++ b/api/metrics/metrics.go
@@ -13,7 +13,10 @@
 
 package metrics
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
 
 // Alerts stores metrics for alerts.
 type Alerts struct {
@@ -25,19 +28,19 @@ type Alerts struct {
 // NewAlerts returns an *Alerts struct for the given API version.
 // Since v1 was deprecated in 0.27, v2 is now hardcoded.
 func NewAlerts(r prometheus.Registerer) *Alerts {
-	numReceivedAlerts := prometheus.NewCounterVec(prometheus.CounterOpts{
+	if r == nil {
+		return nil
+	}
+	numReceivedAlerts := promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 		Name:        "alertmanager_alerts_received_total",
 		Help:        "The total number of received alerts.",
 		ConstLabels: prometheus.Labels{"version": "v2"},
 	}, []string{"status"})
-	numInvalidAlerts := prometheus.NewCounter(prometheus.CounterOpts{
+	numInvalidAlerts := promauto.With(r).NewCounter(prometheus.CounterOpts{
 		Name:        "alertmanager_alerts_invalid_total",
 		Help:        "The total number of received alerts that were invalid.",
 		ConstLabels: prometheus.Labels{"version": "v2"},
 	})
-	if r != nil {
-		r.MustRegister(numReceivedAlerts, numInvalidAlerts)
-	}
 	return &Alerts{
 		firing:   numReceivedAlerts.WithLabelValues("firing"),
 		resolved: numReceivedAlerts.WithLabelValues("resolved"),

--- a/cluster/channel.go
+++ b/cluster/channel.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/memberlist"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/prometheus/alertmanager/cluster/clusterpb"
 )
@@ -53,22 +54,25 @@ func NewChannel(
 	stopc <-chan struct{},
 	reg prometheus.Registerer,
 ) *Channel {
-	oversizeGossipMessageFailureTotal := prometheus.NewCounter(prometheus.CounterOpts{
+	if reg == nil {
+		return nil
+	}
+	oversizeGossipMessageFailureTotal := promauto.With(reg).NewCounter(prometheus.CounterOpts{
 		Name:        "alertmanager_oversized_gossip_message_failure_total",
 		Help:        "Number of oversized gossip message sends that failed.",
 		ConstLabels: prometheus.Labels{"key": key},
 	})
-	oversizeGossipMessageSentTotal := prometheus.NewCounter(prometheus.CounterOpts{
+	oversizeGossipMessageSentTotal := promauto.With(reg).NewCounter(prometheus.CounterOpts{
 		Name:        "alertmanager_oversized_gossip_message_sent_total",
 		Help:        "Number of oversized gossip message sent.",
 		ConstLabels: prometheus.Labels{"key": key},
 	})
-	oversizeGossipMessageDroppedTotal := prometheus.NewCounter(prometheus.CounterOpts{
+	oversizeGossipMessageDroppedTotal := promauto.With(reg).NewCounter(prometheus.CounterOpts{
 		Name:        "alertmanager_oversized_gossip_message_dropped_total",
 		Help:        "Number of oversized gossip messages that were dropped due to a full message queue.",
 		ConstLabels: prometheus.Labels{"key": key},
 	})
-	oversizeGossipDuration := prometheus.NewHistogram(prometheus.HistogramOpts{
+	oversizeGossipDuration := promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 		Name:                            "alertmanager_oversize_gossip_message_duration_seconds",
 		Help:                            "Duration of oversized gossip message requests.",
 		ConstLabels:                     prometheus.Labels{"key": key},
@@ -77,8 +81,6 @@ func NewChannel(
 		NativeHistogramMaxBucketNumber:  100,
 		NativeHistogramMinResetDuration: 1 * time.Hour,
 	})
-
-	reg.MustRegister(oversizeGossipDuration, oversizeGossipMessageFailureTotal, oversizeGossipMessageDroppedTotal, oversizeGossipMessageSentTotal)
 
 	c := &Channel{
 		key:                               key,

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -29,6 +29,7 @@ import (
 	"github.com/hashicorp/memberlist"
 	"github.com/oklog/ulid"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 // ClusterPeer represents a single Peer in a gossip cluster.
@@ -338,7 +339,7 @@ func (p *Peer) setInitialFailed(peers []string, myAddr string) {
 }
 
 func (p *Peer) register(reg prometheus.Registerer, name string) {
-	peerInfo := prometheus.NewGauge(
+	peerInfo := promauto.With(reg).NewGauge(
 		prometheus.GaugeOpts{
 			Name:        "alertmanager_cluster_peer_info",
 			Help:        "A metric with a constant '1' value labeled by peer name.",
@@ -346,7 +347,7 @@ func (p *Peer) register(reg prometheus.Registerer, name string) {
 		},
 	)
 	peerInfo.Set(1)
-	clusterFailedPeers := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+	promauto.With(reg).NewGaugeFunc(prometheus.GaugeOpts{
 		Name: "alertmanager_cluster_failed_peers",
 		Help: "Number indicating the current number of failed peers in the cluster.",
 	}, func() float64 {
@@ -355,40 +356,37 @@ func (p *Peer) register(reg prometheus.Registerer, name string) {
 
 		return float64(len(p.failedPeers))
 	})
-	p.failedReconnectionsCounter = prometheus.NewCounter(prometheus.CounterOpts{
+	p.failedReconnectionsCounter = promauto.With(reg).NewCounter(prometheus.CounterOpts{
 		Name: "alertmanager_cluster_reconnections_failed_total",
 		Help: "A counter of the number of failed cluster peer reconnection attempts.",
 	})
 
-	p.reconnectionsCounter = prometheus.NewCounter(prometheus.CounterOpts{
+	p.reconnectionsCounter = promauto.With(reg).NewCounter(prometheus.CounterOpts{
 		Name: "alertmanager_cluster_reconnections_total",
 		Help: "A counter of the number of cluster peer reconnections.",
 	})
 
-	p.failedRefreshCounter = prometheus.NewCounter(prometheus.CounterOpts{
+	p.failedRefreshCounter = promauto.With(reg).NewCounter(prometheus.CounterOpts{
 		Name: "alertmanager_cluster_refresh_join_failed_total",
 		Help: "A counter of the number of failed cluster peer joined attempts via refresh.",
 	})
-	p.refreshCounter = prometheus.NewCounter(prometheus.CounterOpts{
+	p.refreshCounter = promauto.With(reg).NewCounter(prometheus.CounterOpts{
 		Name: "alertmanager_cluster_refresh_join_total",
 		Help: "A counter of the number of cluster peer joined via refresh.",
 	})
 
-	p.peerLeaveCounter = prometheus.NewCounter(prometheus.CounterOpts{
+	p.peerLeaveCounter = promauto.With(reg).NewCounter(prometheus.CounterOpts{
 		Name: "alertmanager_cluster_peers_left_total",
 		Help: "A counter of the number of peers that have left.",
 	})
-	p.peerUpdateCounter = prometheus.NewCounter(prometheus.CounterOpts{
+	p.peerUpdateCounter = promauto.With(reg).NewCounter(prometheus.CounterOpts{
 		Name: "alertmanager_cluster_peers_update_total",
 		Help: "A counter of the number of peers that have updated metadata.",
 	})
-	p.peerJoinCounter = prometheus.NewCounter(prometheus.CounterOpts{
+	p.peerJoinCounter = promauto.With(reg).NewCounter(prometheus.CounterOpts{
 		Name: "alertmanager_cluster_peers_joined_total",
 		Help: "A counter of the number of peers that have joined.",
 	})
-
-	reg.MustRegister(peerInfo, clusterFailedPeers, p.failedReconnectionsCounter, p.reconnectionsCounter,
-		p.peerLeaveCounter, p.peerUpdateCounter, p.peerJoinCounter, p.refreshCounter, p.failedRefreshCounter)
 }
 
 func (p *Peer) runPeriodicTask(d time.Duration, f func()) {

--- a/cluster/delegate.go
+++ b/cluster/delegate.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/hashicorp/memberlist"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/prometheus/alertmanager/cluster/clusterpb"
 )
@@ -54,56 +55,56 @@ func newDelegate(l *slog.Logger, reg prometheus.Registerer, p *Peer, retransmit 
 		NumNodes:       p.ClusterSize,
 		RetransmitMult: retransmit,
 	}
-	messagesReceived := prometheus.NewCounterVec(prometheus.CounterOpts{
+	messagesReceived := promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 		Name: "alertmanager_cluster_messages_received_total",
 		Help: "Total number of cluster messages received.",
 	}, []string{"msg_type"})
-	messagesReceivedSize := prometheus.NewCounterVec(prometheus.CounterOpts{
+	messagesReceivedSize := promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 		Name: "alertmanager_cluster_messages_received_size_total",
 		Help: "Total size of cluster messages received.",
 	}, []string{"msg_type"})
-	messagesSent := prometheus.NewCounterVec(prometheus.CounterOpts{
+	messagesSent := promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 		Name: "alertmanager_cluster_messages_sent_total",
 		Help: "Total number of cluster messages sent.",
 	}, []string{"msg_type"})
-	messagesSentSize := prometheus.NewCounterVec(prometheus.CounterOpts{
+	messagesSentSize := promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 		Name: "alertmanager_cluster_messages_sent_size_total",
 		Help: "Total size of cluster messages sent.",
 	}, []string{"msg_type"})
-	messagesPruned := prometheus.NewCounter(prometheus.CounterOpts{
+	messagesPruned := promauto.With(reg).NewCounter(prometheus.CounterOpts{
 		Name: "alertmanager_cluster_messages_pruned_total",
 		Help: "Total number of cluster messages pruned.",
 	})
-	gossipClusterMembers := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+	promauto.With(reg).NewGaugeFunc(prometheus.GaugeOpts{
 		Name: "alertmanager_cluster_members",
 		Help: "Number indicating current number of members in cluster.",
 	}, func() float64 {
 		return float64(p.ClusterSize())
 	})
-	peerPosition := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+	promauto.With(reg).NewGaugeFunc(prometheus.GaugeOpts{
 		Name: "alertmanager_peer_position",
 		Help: "Position the Alertmanager instance believes it's in. The position determines a peer's behavior in the cluster.",
 	}, func() float64 {
 		return float64(p.Position())
 	})
-	healthScore := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+	promauto.With(reg).NewGaugeFunc(prometheus.GaugeOpts{
 		Name: "alertmanager_cluster_health_score",
 		Help: "Health score of the cluster. Lower values are better and zero means 'totally healthy'.",
 	}, func() float64 {
 		return float64(p.mlist.GetHealthScore())
 	})
-	messagesQueued := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+	promauto.With(reg).NewGaugeFunc(prometheus.GaugeOpts{
 		Name: "alertmanager_cluster_messages_queued",
 		Help: "Number of cluster messages which are queued.",
 	}, func() float64 {
 		return float64(bcast.NumQueued())
 	})
-	nodeAlive := prometheus.NewCounterVec(prometheus.CounterOpts{
+	nodeAlive := promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 		Name: "alertmanager_cluster_alive_messages_total",
 		Help: "Total number of received alive messages.",
 	}, []string{"peer"},
 	)
-	nodePingDuration := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	nodePingDuration := promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 		Name:                            "alertmanager_cluster_pings_seconds",
 		Help:                            "Histogram of latencies for ping messages.",
 		Buckets:                         []float64{.005, .01, .025, .05, .1, .25, .5},
@@ -112,7 +113,7 @@ func newDelegate(l *slog.Logger, reg prometheus.Registerer, p *Peer, retransmit 
 		NativeHistogramMinResetDuration: 1 * time.Hour,
 	}, []string{"peer"},
 	)
-	conflictsCount := prometheus.NewCounter(prometheus.CounterOpts{
+	conflictsCount := promauto.With(reg).NewCounter(prometheus.CounterOpts{
 		Name: "alertmanager_cluster_peer_name_conflicts_total",
 		Help: "Total number of times memberlist has noticed conflicting peer names",
 	})
@@ -125,11 +126,6 @@ func newDelegate(l *slog.Logger, reg prometheus.Registerer, p *Peer, retransmit 
 	messagesSentSize.WithLabelValues(fullState)
 	messagesSent.WithLabelValues(update)
 	messagesSentSize.WithLabelValues(update)
-
-	reg.MustRegister(messagesReceived, messagesReceivedSize, messagesSent, messagesSentSize,
-		gossipClusterMembers, peerPosition, healthScore, messagesQueued, messagesPruned,
-		nodeAlive, nodePingDuration, conflictsCount,
-	)
 
 	d := &delegate{
 		logger:               l,

--- a/cluster/tls_transport_test.go
+++ b/cluster/tls_transport_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 )
@@ -43,7 +44,7 @@ func newTLSTransport(file, address string, port int) (*TLSTransport, error) {
 		return nil, err
 	}
 
-	return NewTLSTransport(context2.Background(), promslog.NewNopLogger(), nil, address, port, cfg)
+	return NewTLSTransport(context2.Background(), promslog.NewNopLogger(), prometheus.NewRegistry(), address, port, cfg)
 }
 
 func TestNewTLSTransport(t *testing.T) {
@@ -128,7 +129,7 @@ func TestFinalAdvertiseAddr(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		tlsConf := loadTLSTransportConfig(t, "testdata/tls_config_node1.yml")
-		transport, err := NewTLSTransport(context2.Background(), logger, nil, tc.bindAddr, tc.bindPort, tlsConf)
+		transport, err := NewTLSTransport(context2.Background(), logger, prometheus.NewRegistry(), tc.bindAddr, tc.bindPort, tlsConf)
 		require.NoError(t, err)
 		ip, port, err := transport.FinalAdvertiseAddr(tc.inputIP, tc.inputPort)
 		if len(tc.expectedError) > 0 {
@@ -152,11 +153,11 @@ func TestFinalAdvertiseAddr(t *testing.T) {
 
 func TestWriteTo(t *testing.T) {
 	tlsConf1 := loadTLSTransportConfig(t, "testdata/tls_config_node1.yml")
-	t1, _ := NewTLSTransport(context2.Background(), logger, nil, "127.0.0.1", 0, tlsConf1)
+	t1, _ := NewTLSTransport(context2.Background(), logger, prometheus.NewRegistry(), "127.0.0.1", 0, tlsConf1)
 	defer t1.Shutdown()
 
 	tlsConf2 := loadTLSTransportConfig(t, "testdata/tls_config_node2.yml")
-	t2, _ := NewTLSTransport(context2.Background(), logger, nil, "127.0.0.1", 0, tlsConf2)
+	t2, _ := NewTLSTransport(context2.Background(), logger, prometheus.NewRegistry(), "127.0.0.1", 0, tlsConf2)
 	defer t2.Shutdown()
 
 	from := fmt.Sprintf("%s:%d", t1.bindAddr, t1.GetAutoBindPort())
@@ -171,11 +172,11 @@ func TestWriteTo(t *testing.T) {
 
 func BenchmarkWriteTo(b *testing.B) {
 	tlsConf1 := loadTLSTransportConfig(b, "testdata/tls_config_node1.yml")
-	t1, _ := NewTLSTransport(context2.Background(), logger, nil, "127.0.0.1", 0, tlsConf1)
+	t1, _ := NewTLSTransport(context2.Background(), logger, prometheus.NewRegistry(), "127.0.0.1", 0, tlsConf1)
 	defer t1.Shutdown()
 
 	tlsConf2 := loadTLSTransportConfig(b, "testdata/tls_config_node2.yml")
-	t2, _ := NewTLSTransport(context2.Background(), logger, nil, "127.0.0.1", 0, tlsConf2)
+	t2, _ := NewTLSTransport(context2.Background(), logger, prometheus.NewRegistry(), "127.0.0.1", 0, tlsConf2)
 	defer t2.Shutdown()
 
 	b.ResetTimer()
@@ -193,12 +194,12 @@ func BenchmarkWriteTo(b *testing.B) {
 
 func TestDialTimeout(t *testing.T) {
 	tlsConf1 := loadTLSTransportConfig(t, "testdata/tls_config_node1.yml")
-	t1, err := NewTLSTransport(context2.Background(), logger, nil, "127.0.0.1", 0, tlsConf1)
+	t1, err := NewTLSTransport(context2.Background(), logger, prometheus.NewRegistry(), "127.0.0.1", 0, tlsConf1)
 	require.NoError(t, err)
 	defer t1.Shutdown()
 
 	tlsConf2 := loadTLSTransportConfig(t, "testdata/tls_config_node2.yml")
-	t2, err := NewTLSTransport(context2.Background(), logger, nil, "127.0.0.1", 0, tlsConf2)
+	t2, err := NewTLSTransport(context2.Background(), logger, prometheus.NewRegistry(), "127.0.0.1", 0, tlsConf2)
 	require.NoError(t, err)
 	defer t2.Shutdown()
 
@@ -238,7 +239,7 @@ func TestShutdown(t *testing.T) {
 	_ = promslogConfig.Level.Set("debug")
 
 	tlsConf1 := loadTLSTransportConfig(t, "testdata/tls_config_node1.yml")
-	t1, _ := NewTLSTransport(context2.Background(), logger, nil, "127.0.0.1", 0, tlsConf1)
+	t1, _ := NewTLSTransport(context2.Background(), logger, prometheus.NewRegistry(), "127.0.0.1", 0, tlsConf1)
 	// Sleeping to make sure listeners have started and can subsequently be shut down gracefully.
 	time.Sleep(500 * time.Millisecond)
 	err := t1.Shutdown()

--- a/config/coordinator.go
+++ b/config/coordinator.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 // Coordinator coordinates Alertmanager configurations beyond the lifetime of a
@@ -53,20 +54,18 @@ func NewCoordinator(configFilePath string, r prometheus.Registerer, l *slog.Logg
 }
 
 func (c *Coordinator) registerMetrics(r prometheus.Registerer) {
-	configHash := prometheus.NewGauge(prometheus.GaugeOpts{
+	configHash := promauto.With(r).NewGauge(prometheus.GaugeOpts{
 		Name: "alertmanager_config_hash",
 		Help: "Hash of the currently loaded alertmanager configuration. Note that this is not a cryptographically strong hash.",
 	})
-	configSuccess := prometheus.NewGauge(prometheus.GaugeOpts{
+	configSuccess := promauto.With(r).NewGauge(prometheus.GaugeOpts{
 		Name: "alertmanager_config_last_reload_successful",
 		Help: "Whether the last configuration reload attempt was successful.",
 	})
-	configSuccessTime := prometheus.NewGauge(prometheus.GaugeOpts{
+	configSuccessTime := promauto.With(r).NewGauge(prometheus.GaugeOpts{
 		Name: "alertmanager_config_last_reload_success_timestamp_seconds",
 		Help: "Timestamp of the last successful configuration reload.",
 	})
-
-	r.MustRegister(configHash, configSuccess, configSuccessTime)
 
 	c.configHashMetric = configHash
 	c.configSuccessMetric = configSuccess

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"
 
 	"github.com/prometheus/alertmanager/notify"
@@ -40,32 +41,28 @@ type DispatcherMetrics struct {
 
 // NewDispatcherMetrics returns a new registered DispatchMetrics.
 func NewDispatcherMetrics(registerLimitMetrics bool, r prometheus.Registerer) *DispatcherMetrics {
+	if r == nil {
+		return nil
+	}
 	m := DispatcherMetrics{
-		aggrGroups: prometheus.NewGauge(
+		aggrGroups: promauto.With(r).NewGauge(
 			prometheus.GaugeOpts{
 				Name: "alertmanager_dispatcher_aggregation_groups",
 				Help: "Number of active aggregation groups",
 			},
 		),
-		processingDuration: prometheus.NewSummary(
+		processingDuration: promauto.With(r).NewSummary(
 			prometheus.SummaryOpts{
 				Name: "alertmanager_dispatcher_alert_processing_duration_seconds",
 				Help: "Summary of latencies for the processing of alerts.",
 			},
 		),
-		aggrGroupLimitReached: prometheus.NewCounter(
+		aggrGroupLimitReached: promauto.With(r).NewCounter(
 			prometheus.CounterOpts{
 				Name: "alertmanager_dispatcher_aggregation_group_limit_reached_total",
 				Help: "Number of times when dispatcher failed to create new aggregation group due to limit.",
 			},
 		),
-	}
-
-	if r != nil {
-		r.MustRegister(m.aggrGroups, m.processingDuration)
-		if registerLimitMetrics {
-			r.MustRegister(m.aggrGroupLimitReached)
-		}
 	}
 
 	return &m

--- a/nflog/nflog_test.go
+++ b/nflog/nflog_test.go
@@ -48,7 +48,7 @@ func TestLogGC(t *testing.T) {
 			"a3": newEntry(now.Add(-time.Second)),
 		},
 		clock:   mockClock,
-		metrics: newMetrics(nil),
+		metrics: newMetrics(prometheus.NewRegistry()),
 	}
 	n, err := l.GC()
 	require.NoError(t, err, "unexpected error in garbage collection")
@@ -331,7 +331,7 @@ func TestStateDataCoding(t *testing.T) {
 }
 
 func TestQuery(t *testing.T) {
-	opts := Options{Retention: time.Second}
+	opts := Options{Metrics: prometheus.NewRegistry(), Retention: time.Second}
 	nl, err := New(opts)
 	if err != nil {
 		require.NoError(t, err, "constructing nflog failed")

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"github.com/cespare/xxhash/v2"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"
 
 	"github.com/prometheus/alertmanager/featurecontrol"
@@ -276,32 +277,32 @@ func NewMetrics(r prometheus.Registerer, ff featurecontrol.Flagger) *Metrics {
 	}
 
 	m := &Metrics{
-		numNotifications: prometheus.NewCounterVec(prometheus.CounterOpts{
+		numNotifications: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "alertmanager",
 			Name:      "notifications_total",
 			Help:      "The total number of attempted notifications.",
 		}, labels),
-		numTotalFailedNotifications: prometheus.NewCounterVec(prometheus.CounterOpts{
+		numTotalFailedNotifications: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "alertmanager",
 			Name:      "notifications_failed_total",
 			Help:      "The total number of failed notifications.",
 		}, append(labels, "reason")),
-		numNotificationRequestsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+		numNotificationRequestsTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "alertmanager",
 			Name:      "notification_requests_total",
 			Help:      "The total number of attempted notification requests.",
 		}, labels),
-		numNotificationRequestsFailedTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+		numNotificationRequestsFailedTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "alertmanager",
 			Name:      "notification_requests_failed_total",
 			Help:      "The total number of failed notification requests.",
 		}, labels),
-		numNotificationSuppressedTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+		numNotificationSuppressedTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "alertmanager",
 			Name:      "notifications_suppressed_total",
 			Help:      "The total number of notifications suppressed for being silenced, inhibited, outside of active time intervals or within muted time intervals.",
 		}, []string{"reason"}),
-		notificationLatencySeconds: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		notificationLatencySeconds: promauto.With(r).NewHistogramVec(prometheus.HistogramOpts{
 			Namespace:                       "alertmanager",
 			Name:                            "notification_latency_seconds",
 			Help:                            "The latency of notifications in seconds.",
@@ -312,12 +313,6 @@ func NewMetrics(r prometheus.Registerer, ff featurecontrol.Flagger) *Metrics {
 		}, labels),
 		ff: ff,
 	}
-
-	r.MustRegister(
-		m.numNotifications, m.numTotalFailedNotifications,
-		m.numNotificationRequestsTotal, m.numNotificationRequestsFailedTotal,
-		m.numNotificationSuppressedTotal, m.notificationLatencySeconds,
-	)
 
 	return m
 }


### PR DESCRIPTION
Migrate metrics to use promauto to avoid forgotten metric registration.