### PR TITLE
refactor: use b.Loop() to simplify the code and improve performance

### DIFF
--- a/inhibit/inhibit_bench_test.go
+++ b/inhibit/inhibit_bench_test.go
@@ -204,9 +204,8 @@ func benchmarkMutes(b *testing.B, opts benchmarkOptions) {
 
 	// Wait some time for the inhibitor to seed its cache.
 	<-time.After(time.Second)
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		require.NoError(b, opts.benchFunc(ih.Mutes))
 	}
 }

--- a/matcher/parse/bench_test.go
+++ b/matcher/parse/bench_test.go
@@ -23,7 +23,7 @@ const (
 )
 
 func BenchmarkParseSimple(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if _, err := Matchers(simpleExample); err != nil {
 			b.Fatal(err)
 		}
@@ -31,7 +31,7 @@ func BenchmarkParseSimple(b *testing.B) {
 }
 
 func BenchmarkParseComplex(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if _, err := Matchers(complexExample); err != nil {
 			b.Fatal(err)
 		}

--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -1076,7 +1076,7 @@ func BenchmarkHashAlert(b *testing.B) {
 			Labels: model.LabelSet{"foo": "the_first_value", "bar": "the_second_value", "another": "value"},
 		},
 	}
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		hashAlert(alert)
 	}
 }

--- a/silence/silence_bench_test.go
+++ b/silence/silence_bench_test.go
@@ -76,8 +76,7 @@ func benchmarkMutes(b *testing.B, n int) {
 	m := types.NewMarker(prometheus.NewRegistry())
 	s := NewSilencer(silences, m, promslog.NewNopLogger())
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		s.Mutes(model.LabelSet{"foo": "bar"})
 	}
 	b.StopTimer()
@@ -145,8 +144,7 @@ func benchmarkQuery(b *testing.B, numSilences int) {
 	require.NoError(b, err)
 	require.Len(b, sils, numSilences/10)
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		sils, _, err := s.Query(
 			QState(types.SilenceStateActive),
 			QMatches(lset),


### PR DESCRIPTION
These changes use b.Loop() to simplify the code and improve performance
Supported by Go Team, more info: [https://go.dev/blog/testing-b-loop ](https://go.dev/blog/testing-b-loop%C2%A0)

Before:

```shell
➜  alertmanager git:(main)  go test -run=^$ -bench=. ./matcher/parse   
goos: darwin
goarch: arm64
pkg: github.com/prometheus/alertmanager/matcher/parse
cpu: Apple M4
BenchmarkParseSimple-10     	 2337806	       500.5 ns/op
BenchmarkParseComplex-10    	  680635	      1950 ns/op
PASS
ok  	github.com/prometheus/alertmanager/matcher/parse	3.287s
➜  alertmanager git:(main) go test -run=^$ -bench=. ./notify    
goos: darwin
goarch: arm64
pkg: github.com/prometheus/alertmanager/notify
cpu: Apple M4
BenchmarkHashAlert-10    	 8728893	       126.3 ns/op
PASS
ok  	github.com/prometheus/alertmanager/notify	1.768s

```



After:

```shell
➜  alertmanager git:(main)  go test -run=^$ -bench=. ./matcher/parse         
goos: darwin
goarch: arm64
pkg: github.com/prometheus/alertmanager/matcher/parse
cpu: Apple M4
BenchmarkParseSimple-10     	 2392150	       493.4 ns/op
BenchmarkParseComplex-10    	  690627	      1762 ns/op
PASS
ok  	github.com/prometheus/alertmanager/matcher/parse	3.117s
➜  alertmanager git:(main) 
➜  alertmanager git:(main)  go test -run=^$ -bench=. ./notify                  
goos: darwin
goarch: arm64
pkg: github.com/prometheus/alertmanager/notify
cpu: Apple M4
BenchmarkHashAlert-10    	 8409073	       129.0 ns/op
PASS
ok  	github.com/prometheus/alertmanager/notify	1.343s

```