### PR TITLE
reduce the time Dispatch.Group holds the mutex

### DIFF
--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"sort"
 	"sync"
 	"time"
@@ -240,11 +241,7 @@ func (d *Dispatcher) Groups(routeFilter func(*Route) bool, alertFilter func(*typ
 		// have a mutex protecting their internal state.
 		// The aggrGroup methods use the internal lock. It is important to avoid
 		// accessing internal fields on the aggrGroup objects.
-		copiedMap := map[model.Fingerprint]*aggrGroup{}
-		for fp, ag := range ags {
-			copiedMap[fp] = ag
-		}
-		aggrGroupsPerRoute[route] = copiedMap
+		aggrGroupsPerRoute[route] = maps.Clone(ags)
 	}
 	d.mtx.RUnlock()
 


### PR DESCRIPTION
`Groups` calls can take a long time when there are many aggrGroups or when on of the filter functions is slow. Right now, `Groups` holds the `Dispatcher` lock for the entire duration of `Groups`. This is aggravated by the fact that the API passes filter functions which themselves call `Silences.Mutes` and `Inhibits.Mutes` which themselves hold locks. 

Since the `Dispatcher` needs to hold a write lock on `Dispatcher.mtx` in order to ingest alerts, `Groups` calls essentially block alert ingestion.  Since `Groups` depends on `Silences.Mutes`, this also means that calls to `Silences.Mutes` can block ingestion. Since that blocks all the various `Silences` API endpoints _and_ some of the gossip channels, this becomes. big knot of locks which causes the alertmanager to hang up if something is hammering `GET /alerts/groups`. Unfortunately, many dashboard services do just that.

This patch just copies the `aggrGroupsPerRoute` map out of the dispatcher and then releases the lock for the rest of the `Groups` call. This ensures that we never need to hold the dispatcher lock and the silencer or inhibitor locks at the same time. 

We've been running this patch in production for quite a while now. We've found that performance is substantially improved, especially around startup time (when the silencer/inhibitor are both extra slow). We've also measured much less mutex contention after adding this.

I don't have any synthetic benchmarks for this one unfortunately.

Here's some profiling comparisons of an alertmanager restart before and after the patch:
<img width="664" height="828" alt="Screenshot 2024-12-23 at 4 09 06 PM" src="https://github.com/user-attachments/assets/9f3488bf-c2c0-4c4c-babd-0bec8287d437" />
<img width="1570" height="439" alt="Screenshot 2024-12-23 at 4 02 40 PM" src="https://github.com/user-attachments/assets/571bb477-b6d4-4f57-bb29-1e8b82afb099" />