### PR TITLE
feat(Jira Integration): use grouplabels to calculate hash

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -980,6 +980,7 @@ type JiraConfig struct {
 	ResolveTransition string         `yaml:"resolve_transition,omitempty" json:"resolve_transition,omitempty"`
 	WontFixResolution string         `yaml:"wont_fix_resolution,omitempty" json:"wont_fix_resolution,omitempty"`
 	ReopenDuration    model.Duration `yaml:"reopen_duration,omitempty" json:"reopen_duration,omitempty"`
+	HashIdentifier    string         `yaml:"hash_identifier,omitempty" json:"hash_identifier,omitempty"`
 
 	Fields map[string]any `yaml:"fields,omitempty" json:"custom_fields,omitempty"`
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1076,6 +1076,10 @@ project: <string>
 # Issue description template.
 [ description: <tmpl_string> | default = '{{ template "jira.default.description" . }}' ]
 
+# overrides the default ALERT{<group-hash>} jira label used to correlate issues.
+# Example: {{ .GroupLabels }}
+[ hash_identifier: <tmpl_string> ]
+
 # Labels to be added to the issue.
 labels:
   [ - <tmpl_string> ... ]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1329,6 +1329,10 @@ project: <string>
     [ enable_update: <boolean> | default = true ]
 ]
 
+# overrides the default ALERT{<group-hash>} jira label used to correlate issues.
+# Example: {{ .GroupLabels }}
+[ hash_identifier: <tmpl_string> ]
+
 # Labels to be added to the issue.
 labels:
   [ - <tmpl_string> ... ]

--- a/notify/jira/config.go
+++ b/notify/jira/config.go
@@ -61,6 +61,7 @@ type JiraConfig struct {
 	ResolveTransition string         `yaml:"resolve_transition,omitempty" json:"resolve_transition,omitempty"`
 	WontFixResolution string         `yaml:"wont_fix_resolution,omitempty" json:"wont_fix_resolution,omitempty"`
 	ReopenDuration    model.Duration `yaml:"reopen_duration,omitempty" json:"reopen_duration,omitempty"`
+	HashIdentifier    string         `yaml:"hash_identifier,omitempty" json:"hash_identifier,omitempty"`
 
 	Fields map[string]any `yaml:"fields,omitempty" json:"custom_fields,omitempty"`
 }

--- a/notify/jira/jira.go
+++ b/notify/jira/jira.go
@@ -87,7 +87,21 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		method = http.MethodPost
 	)
 
-	existingIssue, shouldRetry, err := n.searchExistingIssue(ctx, logger, key.Hash(), alerts.HasFiring(), tmplTextFunc)
+	jiraHash := key.Hash()
+	// If a custom identifier is configured, use its hash instead.
+	if n.conf.HashIdentifier != "" {
+		identifier, err := tmplTextFunc(n.conf.HashIdentifier)
+		if err != nil {
+			return false, fmt.Errorf("hash_identifier: %w", err)
+		}
+
+		identifier = strings.TrimSpace(identifier)
+		if identifier != "" {
+			jiraHash = notify.Key(identifier).Hash()
+		}
+	}
+
+	existingIssue, shouldRetry, err := n.searchExistingIssue(ctx, logger, jiraHash, alerts.HasFiring(), tmplTextFunc)
 	if err != nil {
 		return shouldRetry, fmt.Errorf("failed to look up existing issues: %w", err)
 	}
@@ -106,7 +120,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		logger.Debug("updating existing issue", "issue_key", existingIssue.Key)
 	}
 
-	requestBody, err := n.prepareIssueRequestBody(ctx, logger, key.Hash(), tmplTextFunc)
+	requestBody, err := n.prepareIssueRequestBody(ctx, logger, jiraHash, tmplTextFunc)
 	if err != nil {
 		return false, err
 	}

--- a/notify/jira/jira.go
+++ b/notify/jira/jira.go
@@ -86,7 +86,21 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		method = http.MethodPost
 	)
 
-	existingIssue, shouldRetry, err := n.searchExistingIssue(ctx, logger, key.Hash(), alerts.HasFiring(), tmplTextFunc)
+	jiraHash := key.Hash()
+	// If a custom identifier is configured, use its hash instead.
+	if n.conf.HashIdentifier != "" {
+		identifier, err := tmplTextFunc(n.conf.HashIdentifier)
+		if err != nil {
+			return false, fmt.Errorf("hash_identifier: %w", err)
+		}
+
+		identifier = strings.TrimSpace(identifier)
+		if identifier != "" {
+			jiraHash = notify.Key(identifier).Hash()
+		}
+	}
+
+	existingIssue, shouldRetry, err := n.searchExistingIssue(ctx, logger, jiraHash, alerts.HasFiring(), tmplTextFunc)
 	if err != nil {
 		return shouldRetry, fmt.Errorf("failed to look up existing issues: %w", err)
 	}
@@ -104,7 +118,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		logger.Debug("updating existing issue", "issue_key", existingIssue.Key, "summary_update_enabled", n.conf.Summary.EnableUpdateValue(), "description_update_enabled", n.conf.Description.EnableUpdateValue())
 	}
 
-	requestBody, err := n.prepareIssueRequestBody(ctx, logger, key.Hash(), tmplTextFunc)
+	requestBody, err := n.prepareIssueRequestBody(ctx, logger, jiraHash, tmplTextFunc)
 	if err != nil {
 		return false, err
 	}

--- a/notify/jira/jira_test.go
+++ b/notify/jira/jira_test.go
@@ -490,6 +490,53 @@ func TestJiraNotify(t *testing.T) {
 		errMsg             string
 	}{
 		{
+			title: "create new issue with group labels as hash identifier",
+			cfg: &JiraConfig{
+				Summary:           JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
+				Description:       JiraFieldConfig{Template: `{{ template "jira.default.description" . }}`},
+				IssueType:         "Incident",
+				Project:           "OPS",
+				Priority:          `{{ template "jira.default.priority" . }}`,
+				Labels:            []string{"alertmanager", "{{ .GroupLabels.alertname }}"},
+				ReopenDuration:    model.Duration(1 * time.Hour),
+				ReopenTransition:  "REOPEN",
+				ResolveTransition: "CLOSE",
+				WontFixResolution: "WONTFIX",
+				HashIdentifier:    `{{ .GroupLabels }}`,
+			},
+			alert: &types.Alert{
+				Alert: model.Alert{
+					Labels: model.LabelSet{
+						"alertname": "test",
+						"instance":  "vm1",
+						"severity":  "critical",
+					},
+					StartsAt: time.Now(),
+					EndsAt:   time.Now().Add(time.Hour),
+				},
+			},
+			searchResponse: issueSearchResult{
+				Issues: []issue{},
+			},
+			issue: issue{
+				Key: "",
+				Fields: &issueFields{
+					Summary:     stringPtr("[FIRING:1] test (vm1 critical)"),
+					Description: jiraStringDescription("\n\n# Alerts Firing:\n\nLabels:\n  - alertname = test\n  - instance = vm1\n  - severity = critical\n\nAnnotations:\n\nSource: \n\n\n\n\n"),
+					Issuetype:   &idNameValue{Name: "Incident"},
+					Labels: []string{
+						"ALERT{602a8de61908ae3ce97961992ec1ed4ea9500c331b79baaf6f565ccdc1750c0c}",
+						"alertmanager",
+						"test",
+					},
+					Project:  &issueProject{Key: "OPS"},
+					Priority: &idNameValue{Name: "High"},
+				},
+			},
+			customFieldAssetFn: func(t *testing.T, issue map[string]any) {},
+			errMsg:             "",
+		},
+		{
 			title: "create new issue",
 			cfg: &JiraConfig{
 				Summary:           JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},


### PR DESCRIPTION
**Problem**

The hash used to identify existing Jira issues is not unique across multiple Jira projects.

**Root Cause**

Currently, the hash is generated using the ExtractGroupKey function, which relies on both the route matchers and group labels, see [here](https://github.com/prometheus/alertmanager/blob/main/dispatch/dispatch.go#L430).

```
func (ag *aggrGroup) GroupKey() string {
    return fmt.Sprintf("%s:%s", ag.routeKey, ag.labels)
}
```


Example result:

`"{}/{env=\"prod\"}:{alertname=\"HighErrorRate\", cluster=\"bb\", service=\"api\"}"`


This makes the hash unique only within a single Jira project.
In larger environments, where the same alert may be mirrored or transferred across multiple Jira projects you cant identitify the same issue by its hash.

**Change Summary**

This update modifies the hash calculation to use only the group labels via the notify.GroupLabels function.
This ensures that the resulting hash uniquely identifies an issue based solely on alert labels, independent of the Jira project.

**Impact**

Jira issue lookup remains scoped to a single project, as defined by the JQL query:
```
jql.WriteString(fmt.Sprintf(`project=%q and labels=%q order by status ASC,resolutiondate DESC`, project, alertLabel))
```

This change does not cause cross-project updates or searches.

It lays the groundwork for a future enhancement to allow configurable multi-project issue lookups.

**Future Considerations**

A potential next step could be introducing a parameter that defines which Jira projects should be included in the update/search scope.