### PR TITLE
feat(dispatch): expose readonly interfaces

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -83,7 +83,7 @@ type Options struct {
 	// GroupFunc returns a list of alert groups. The alerts are grouped
 	// according to the current active configuration. Alerts returned are
 	// filtered by the arguments provided to the function.
-	GroupFunc func(func(*dispatch.Route) bool, func(*types.Alert, time.Time) bool) (dispatch.AlertGroups, map[model.Fingerprint][]string)
+	GroupFunc func(func(dispatch.Route) bool, func(*types.Alert, time.Time) bool) map[dispatch.Route]map[model.Fingerprint]dispatch.AggregationGroup
 }
 
 func (o Options) validate() error {

--- a/api/v2/type.go
+++ b/api/v2/type.go
@@ -1,0 +1,40 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+import (
+	"github.com/prometheus/common/model"
+
+	"github.com/prometheus/alertmanager/types"
+)
+
+// AlertGroup represents how alerts exist within an aggrGroup.
+type AlertGroup struct {
+	Alerts   types.AlertSlice
+	Labels   model.LabelSet
+	Receiver string
+	GroupKey string
+	RouteID  string
+}
+
+type AlertGroups []*AlertGroup
+
+func (ag AlertGroups) Swap(i, j int) { ag[i], ag[j] = ag[j], ag[i] }
+func (ag AlertGroups) Less(i, j int) bool {
+	if ag[i].Labels.Equal(ag[j].Labels) {
+		return ag[i].Receiver < ag[j].Receiver
+	}
+	return ag[i].Labels.Before(ag[j].Labels)
+}
+func (ag AlertGroups) Len() int { return len(ag) }

--- a/cli/routing.go
+++ b/cli/routing.go
@@ -75,40 +75,40 @@ func (c *routingShow) routingShowAction(ctx context.Context, _ *kingpin.ParseCon
 	return nil
 }
 
-func getRouteTreeSlug(route *dispatch.Route, showContinue, showReceiver bool) string {
+func getRouteTreeSlug(route dispatch.Route, showContinue, showReceiver bool) string {
 	var branchSlug bytes.Buffer
-	if route.Matchers.Len() == 0 {
+	if route.Matchers().Len() == 0 {
 		branchSlug.WriteString("default-route")
 	} else {
-		branchSlug.WriteString(route.Matchers.String())
+		branchSlug.WriteString(route.Matchers().String())
 	}
-	if route.Continue && showContinue {
+	if route.Continues() && showContinue {
 		branchSlug.WriteString(branchSlugSeparator)
 		branchSlug.WriteString("continue: true")
 	}
 	if showReceiver {
 		branchSlug.WriteString(branchSlugSeparator)
 		branchSlug.WriteString("receiver: ")
-		branchSlug.WriteString(route.RouteOpts.Receiver)
+		branchSlug.WriteString(route.Options().Receiver)
 	}
 	return branchSlug.String()
 }
 
-func convertRouteToTree(route *dispatch.Route, tree treeprint.Tree) {
+func convertRouteToTree(route dispatch.Route, tree treeprint.Tree) {
 	branch := tree.AddBranch(getRouteTreeSlug(route, true, true))
-	for _, r := range route.Routes {
+	for _, r := range route.Routes() {
 		convertRouteToTree(r, branch)
 	}
 }
 
-func getMatchingTree(route *dispatch.Route, tree treeprint.Tree, lset models.LabelSet) {
+func getMatchingTree(route dispatch.Route, tree treeprint.Tree, lset models.LabelSet) {
 	final := true
 	branch := tree.AddBranch(getRouteTreeSlug(route, false, false))
-	for _, r := range route.Routes {
-		if r.Matchers.Matches(convertClientToCommonLabelSet(lset)) {
+	for _, r := range route.Routes() {
+		if r.Matchers().Matches(convertClientToCommonLabelSet(lset)) {
 			getMatchingTree(r, branch, lset)
 			final = false
-			if !r.Continue {
+			if !r.Continues() {
 				break
 			}
 		}

--- a/cli/test_routing.go
+++ b/cli/test_routing.go
@@ -52,19 +52,19 @@ func configureRoutingTestCmd(cc *kingpin.CmdClause, c *routingShow) {
 }
 
 // resolveAlertReceivers returns list of receiver names which given LabelSet resolves to.
-func resolveAlertReceivers(mainRoute *dispatch.Route, labels *models.LabelSet) ([]string, error) {
+func resolveAlertReceivers(mainRoute dispatch.Route, labels *models.LabelSet) ([]string, error) {
 	var (
-		finalRoutes []*dispatch.Route
+		finalRoutes []dispatch.Route
 		receivers   []string
 	)
 	finalRoutes = mainRoute.Match(convertClientToCommonLabelSet(*labels))
 	for _, r := range finalRoutes {
-		receivers = append(receivers, r.RouteOpts.Receiver)
+		receivers = append(receivers, r.Options().Receiver)
 	}
 	return receivers, nil
 }
 
-func printMatchingTree(mainRoute *dispatch.Route, ls models.LabelSet) {
+func printMatchingTree(mainRoute dispatch.Route, ls models.LabelSet) {
 	tree := treeprint.New()
 	getMatchingTree(mainRoute, tree, ls)
 	fmt.Println("Matching routes:")

--- a/cli/test_routing_test.go
+++ b/cli/test_routing_test.go
@@ -30,7 +30,7 @@ type routingTestDefinition struct {
 	configFile        string
 }
 
-func checkResolvedReceivers(mainRoute *dispatch.Route, ls models.LabelSet, expectedReceivers []string) error {
+func checkResolvedReceivers(mainRoute dispatch.Route, ls models.LabelSet, expectedReceivers []string) error {
 	resolvedReceivers, err := resolveAlertReceivers(mainRoute, &ls)
 	if err != nil {
 		return err

--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -358,7 +358,7 @@ func run() int {
 		disp.Stop()
 	}()
 
-	groupFn := func(routeFilter func(*dispatch.Route) bool, alertFilter func(*types.Alert, time.Time) bool) (dispatch.AlertGroups, map[model.Fingerprint][]string) {
+	groupFn := func(routeFilter func(dispatch.Route) bool, alertFilter func(*types.Alert, time.Time) bool) map[dispatch.Route]map[model.Fingerprint]dispatch.AggregationGroup {
 		return disp.Groups(routeFilter, alertFilter)
 	}
 
@@ -430,8 +430,8 @@ func run() int {
 		// Build the routing tree and record which receivers are used.
 		routes := dispatch.NewRoute(conf.Route, nil)
 		activeReceivers := make(map[string]struct{})
-		routes.Walk(func(r *dispatch.Route) {
-			activeReceivers[r.RouteOpts.Receiver] = struct{}{}
+		routes.Walk(func(r dispatch.Route) {
+			activeReceivers[r.Options().Receiver] = struct{}{}
 		})
 
 		// Build the map of receiver to integrations.
@@ -499,12 +499,12 @@ func run() int {
 		})
 
 		disp = dispatch.NewDispatcher(alerts, routes, pipeline, marker, timeoutFunc, *dispatchMaintenanceInterval, nil, logger, dispMetrics)
-		routes.Walk(func(r *dispatch.Route) {
-			if r.RouteOpts.RepeatInterval > *retention {
+		routes.Walk(func(r dispatch.Route) {
+			if r.Options().RepeatInterval > *retention {
 				configLogger.Warn(
 					"repeat_interval is greater than the data retention period. It can lead to notifications being repeated more often than expected.",
 					"repeat_interval",
-					r.RouteOpts.RepeatInterval,
+					r.Options().RepeatInterval,
 					"retention",
 					*retention,
 					"route",
@@ -512,13 +512,13 @@ func run() int {
 				)
 			}
 
-			if r.RouteOpts.RepeatInterval < r.RouteOpts.GroupInterval {
+			if r.Options().RepeatInterval < r.Options().GroupInterval {
 				configLogger.Warn(
 					"repeat_interval is less than group_interval. Notifications will not repeat until the next group_interval.",
 					"repeat_interval",
-					r.RouteOpts.RepeatInterval,
+					r.Options().RepeatInterval,
 					"group_interval",
-					r.RouteOpts.GroupInterval,
+					r.Options().GroupInterval,
 					"route",
 					r.Key(),
 				)

--- a/dispatch/group.go
+++ b/dispatch/group.go
@@ -1,0 +1,28 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dispatch
+
+import (
+	"github.com/prometheus/common/model"
+
+	"github.com/prometheus/alertmanager/types"
+)
+
+// AggregationGroup interface is used to expose Aggregation Groups within the dispatcher.
+type AggregationGroup interface {
+	Alerts() []*types.Alert
+	Labels() model.LabelSet
+	GroupKey() string
+	RouteID() string
+}

--- a/dispatch/route_test.go
+++ b/dispatch/route_test.go
@@ -1,4 +1,4 @@
-// Copyright 2015 Prometheus Team
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -254,7 +254,8 @@ routes:
 		var keys []string
 
 		for _, r := range tree.Match(test.input) {
-			matches = append(matches, &r.RouteOpts)
+			options := r.Options()
+			matches = append(matches, &options)
 			keys = append(keys, r.Key())
 		}
 
@@ -344,8 +345,8 @@ routes:
 	}
 
 	var got []string
-	tree.Walk(func(r *Route) {
-		got = append(got, r.RouteOpts.Receiver)
+	tree.Walk(func(r Route) {
+		got = append(got, r.Options().Receiver)
 	})
 
 	if !reflect.DeepEqual(got, expected) {
@@ -375,12 +376,12 @@ routes:
 	}
 
 	tree := NewRoute(&ctree, nil)
-	parent := tree.Routes[0]
-	child1 := parent.Routes[0]
-	child2 := parent.Routes[1]
-	require.True(t, parent.RouteOpts.GroupByAll)
-	require.True(t, child1.RouteOpts.GroupByAll)
-	require.False(t, child2.RouteOpts.GroupByAll)
+	parent := tree.Routes()[0]
+	child1 := parent.Routes()[0]
+	child2 := parent.Routes()[1]
+	require.True(t, parent.Options().GroupByAll)
+	require.True(t, child1.Options().GroupByAll)
+	require.False(t, child2.Options().GroupByAll)
 }
 
 func TestRouteMatchers(t *testing.T) {
@@ -604,7 +605,8 @@ routes:
 		var keys []string
 
 		for _, r := range tree.Match(test.input) {
-			matches = append(matches, &r.RouteOpts)
+			options := r.Options()
+			matches = append(matches, &options)
 			keys = append(keys, r.Key())
 		}
 
@@ -840,7 +842,8 @@ routes:
 		var keys []string
 
 		for _, r := range tree.Match(test.input) {
-			matches = append(matches, &r.RouteOpts)
+			options := r.Options()
+			matches = append(matches, &options)
 			keys = append(keys, r.Key())
 		}
 
@@ -915,7 +918,7 @@ routes:
 	}
 
 	var actual []string
-	r.Walk(func(r *Route) {
+	r.Walk(func(r Route) {
 		actual = append(actual, r.ID())
 	})
 	require.ElementsMatch(t, actual, expected)


### PR DESCRIPTION
Groups() method in dispatcher does extensive data manipulation to
staisfy the API. Instead it can return a snapshot of its internal state
and let the API handle the data processing.

- expose readonly interfaces for AggregationGroup and Route
- move Groups logic out of dispatcher and into the api handler