### PR TITLE
chore: Group @mantine dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,7 @@ updates:
     open-pull-requests-limit: 20
     schedule:
       interval: "monthly"
+    groups:
+      mantine:
+        patterns:
+          - "@mantine/*"


### PR DESCRIPTION
Add a dependabot grouping to update all `@mantine/*` dependencies in the same update PRs.