### PR TITLE
Fix more flaky tests in TestClusterJoinAndReconnect

### DIFF
--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -348,9 +348,9 @@ func testTLSConnection(t *testing.T) {
 	p2.WaitReady(context.Background())
 	require.Equal(t, "ready", p2.Status())
 
-	require.Equal(t, 2, p1.ClusterSize())
+	require.Eventually(t, func() bool { return p1.ClusterSize() == 2 }, 5*time.Second, time.Second)
 	p2.Leave(0 * time.Second)
-	require.Equal(t, 1, p1.ClusterSize())
+	require.Eventually(t, func() bool { return p1.ClusterSize() == 1 }, 5*time.Second, time.Second)
 	require.Len(t, p1.failedPeers, 1)
 	require.Equal(t, p2.Self().Address(), p1.peers[p2.Self().Address()].Address())
 	require.Equal(t, p2.Name(), p1.failedPeers[0].Name)
@@ -423,8 +423,8 @@ func testPeerNames(t *testing.T, name1, name2 string) {
 	require.NoError(t, p2.WaitReady(context.Background()))
 
 	if name1 != name2 {
-		require.Equal(t, 2, p1.ClusterSize())
-		require.Equal(t, 2, p2.ClusterSize())
+		require.Eventually(t, func() bool { return p1.ClusterSize() == 2 }, 5*time.Second, time.Second)
+		require.Eventually(t, func() bool { return p2.ClusterSize() == 2 }, 5*time.Second, time.Second)
 		require.NotEqual(t, p1.Name(), p2.Name(), "peers should have different names")
 	}
 }


### PR DESCRIPTION
As explained in more detail in commit
`88b4e13d09975b61290493f8893bb4fb7796a93f`, the tests in `cluster_test.go` will occasionally fail. The underlying reason for the failure is that the test only waits for `p2` to be ready, but this does not reflect whether `p1` has updated its memberlist.

However, that commit only fixed the test `TestJoinLeave`. I have now ran the other tests in `cluster_test.go` 2400 times, and identified the following problematic tests: `TestSetPeerNames` and `TestTLSConnection`.

Since the underlying faulty code is mostly identical, so is the corresponding fix.

_Note_

For those, whom reviewed my previous pull request: Back then I simply fixed the first failure I found. This time I tried to find all the failures in `cluster_test.go`.