### PR TITLE
Add safeURL and urldecode template functions

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -94,7 +94,9 @@ templating.
 | join | sep string, s []string | [strings.Join](http://golang.org/pkg/strings/#Join), concatenates the elements of s to create a single string. The separator string sep is placed between elements in the resulting string. (note: argument order inverted for easier pipelining in templates.) |
 | safeHtml | text string | [html/template.HTML](https://golang.org/pkg/html/template/#HTML), Marks string as HTML not requiring auto-escaping. |
 | safeUrl | text string | [html/template.URL](https://golang.org/pkg/html/template/#URL), Marks string as URL not requiring auto-escaping. |
+| safeURL | text string | [html/template.URL](https://golang.org/pkg/html/template/#URL), Marks string as URL not requiring auto-escaping. |
 | urlUnescape | text string | [url.QueryUnescape](https://pkg.go.dev/net/url#QueryUnescape), unescapes a URL with % encoding |
+| urldecode | text string | URL decodes a string, returning the decoded string (or original string if decoding fails). |
 | stringSlice | ...string | Returns the passed strings as a slice of strings. |
 | date | string, time.Time | Returns the text representation of the time in the specified format. For documentation on formats refer to [pkg.go.dev/time](https://pkg.go.dev/time#pkg-constants). |
 | tz | string, time.Time | Returns the time in the timezone. For example, Europe/Paris. |

--- a/template/template.go
+++ b/template/template.go
@@ -191,7 +191,17 @@ var DefaultFuncs = FuncMap{
 	"safeUrl": func(text string) tmplhtml.URL {
 		return tmplhtml.URL(text)
 	},
+	"safeURL": func(text string) tmplhtml.URL {
+		return tmplhtml.URL(text)
+	},
 	"urlUnescape": url.QueryUnescape,
+	"urldecode": func(s string) string {
+		decoded, err := url.QueryUnescape(s)
+		if err != nil {
+			return s // Return original string if decoding fails
+		}
+		return decoded
+	},
 	"reReplaceAll": func(pattern, repl, text string) string {
 		re := regexp.MustCompile(pattern)
 		return re.ReplaceAllString(text, repl)

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -390,6 +390,27 @@ func TestTemplateExpansion(t *testing.T) {
 			exp:   "search?q=test foo",
 		},
 		{
+			title: "Template using urldecode",
+			in:    `{{ "search?q=test%20foo" | urldecode }}`,
+			exp:   "search?q=test foo",
+		},
+		{
+			title: "Template using urldecode with complex encoding",
+			in:    `{{ "expr=up%3D%3D0" | urldecode }}`,
+			exp:   "expr=up==0",
+		},
+		{
+			title: "Template using urldecode with invalid encoding",
+			in:    `{{ "invalid%zz%encoding" | urldecode }}`,
+			exp:   "invalid%zz%encoding", // Should return original on error
+		},
+		{
+			title: "HTML template using safeURL",
+			in:    `<a href="{{ "q=test%20foo" | safeURL }}">link</a>`,
+			html:  true,
+			exp:   `<a href="q=test%20foo">link</a>`,
+		},
+		{
 			title: "Template using stringSlice",
 			in:    `{{ with .GroupLabels }}{{ with .Remove (stringSlice "key1" "key3") }}{{ .SortedPairs.Values }}{{ end }}{{ end }}`,
 			data: Data{


### PR DESCRIPTION
This PR addresses issue #4710 by adding two new template functions to improve URL handling in Alertmanager notifications:

1. **`safeURL` function**: An alias for the existing `safeUrl` function to provide consistency with common naming conventions. Both functions now work identically.

2. **`urldecode` function**: A new function that URL-decodes strings. This is particularly useful for decoding query parameters or other URL-encoded data in notification templates. The function returns the original string if decoding fails, ensuring template rendering doesn't break on invalid encoding.

The changes include:
- Implementation of both functions in `template/template.go`
- Documentation updates in `docs/notifications.md`
- Comprehensive tests covering normal usage, complex encoding, and error cases

These additions enhance the flexibility of notification templates when working with URL-encoded data.