### PR TITLE
docs: replace 'whitelist' with 'allow' for inclusive language

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ $ amtool config routes test --config.file=doc/examples/simple.yml --tree --verif
 Alertmanager's high availability is in production use at many companies and is enabled by default.
 
 > Important: Both UDP and TCP are needed in alertmanager 0.15 and higher for the cluster to work.
->  - If you are using a firewall, make sure to whitelist the clustering port for both protocols.
+>  - If you are using a firewall, make sure to allow the clustering port for both protocols.
 >  - If you are running in a container, make sure to expose the clustering port for both protocols.
 
 To create a highly available cluster of the Alertmanager the instances need to


### PR DESCRIPTION
## Description

This PR updates the README to replace the term 'whitelist' with 'allow' in the High Availability section, using more inclusive language.

## Changes

- Replaced 'whitelist' with 'allow' in the firewall configuration note
- No functional changes, documentation only

## Rationale

Many open source projects are moving away from terms like 'whitelist/blacklist' to more inclusive alternatives like 'allow/block' or 'allowlist/denylist'. This change aligns with modern documentation best practices.

## Type of Change

- [x] Documentation update

## Checklist

- [x] Documentation-only change
- [x] Follows project style guidelines
- [x] No functional changes