### PR TITLE
Fix 's/client/alerts_api/g' broken link in 0.29

### DIFF
--- a/docs/alertmanager.md
+++ b/docs/alertmanager.md
@@ -62,7 +62,7 @@ Silences are configured in the web interface of the Alertmanager.
 
 ## Client behavior
 
-The Alertmanager has [special requirements](clients.md) for behavior of its
+The Alertmanager has [special requirements](alerts_api.md) for behavior of its
 client. Those are only relevant for advanced use cases where Prometheus
 is not used to send alerts.
 


### PR DESCRIPTION
8343ee6 renamed this file but missed adjusting links in the docs.