### PR TITLE
Add chat_id_file configuration parameter for Telegram

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -881,6 +881,7 @@ type TelegramConfig struct {
 	BotToken             Secret `yaml:"bot_token,omitempty" json:"token,omitempty"`
 	BotTokenFile         string `yaml:"bot_token_file,omitempty" json:"token_file,omitempty"`
 	ChatID               int64  `yaml:"chat_id,omitempty" json:"chat,omitempty"`
+	ChatIDFile           string `yaml:"chat_id_file,omitempty" json:"chat_id_file,omitempty"`
 	MessageThreadID      int    `yaml:"message_thread_id,omitempty" json:"message_thread_id,omitempty"`
 	Message              string `yaml:"message,omitempty" json:"message,omitempty"`
 	DisableNotifications bool   `yaml:"disable_notifications,omitempty" json:"disable_notifications,omitempty"`
@@ -900,8 +901,11 @@ func (c *TelegramConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	if c.BotToken != "" && c.BotTokenFile != "" {
 		return errors.New("at most one of bot_token & bot_token_file must be configured")
 	}
-	if c.ChatID == 0 {
-		return errors.New("missing chat_id on telegram_config")
+	if c.ChatID == 0 && c.ChatIDFile == "" {
+		return errors.New("missing chat_id or chat_id_file on telegram_config")
+	}
+	if c.ChatID != 0 && c.ChatIDFile != "" {
+		return errors.New("at most one of chat_id & chat_id_file must be configured")
 	}
 	if c.ParseMode != "" &&
 		c.ParseMode != "Markdown" &&

--- a/notify/telegram/telegram.go
+++ b/notify/telegram/telegram.go
@@ -19,6 +19,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 
 	commoncfg "github.com/prometheus/common/config"
@@ -92,7 +93,12 @@ func (n *Notifier) Notify(ctx context.Context, alert ...*types.Alert) (bool, err
 		return true, err
 	}
 
-	message, err := n.client.Send(telebot.ChatID(n.conf.ChatID), messageText, &telebot.SendOptions{
+	chatID, err := n.getChatID()
+	if err != nil {
+		return true, err
+	}
+
+	message, err := n.client.Send(telebot.ChatID(chatID), messageText, &telebot.SendOptions{
 		DisableNotification:   n.conf.DisableNotifications,
 		DisableWebPagePreview: true,
 		ThreadID:              n.conf.MessageThreadID,
@@ -129,4 +135,20 @@ func (n *Notifier) getBotToken() (string, error) {
 		return strings.TrimSpace(string(content)), nil
 	}
 	return string(n.conf.BotToken), nil
+}
+
+func (n *Notifier) getChatID() (int64, error) {
+	if len(n.conf.ChatIDFile) > 0 {
+		content, err := os.ReadFile(n.conf.ChatIDFile)
+		if err != nil {
+			return 0, fmt.Errorf("could not read %s: %w", n.conf.ChatIDFile, err)
+		}
+		chatIDStr := strings.TrimSpace(string(content))
+		chatID, err := strconv.ParseInt(chatIDStr, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("could not parse chat_id from %s: %w", n.conf.ChatIDFile, err)
+		}
+		return chatID, nil
+	}
+	return n.conf.ChatID, nil
 }


### PR DESCRIPTION
This PR adds support for reading `chat_id` from a file, similar to `bot_token_file`. This allows users to securely pass `chat_id` using secrets or volumes in docker-compose without exposing it in cleartext in the config file.

## Changes
- Added `ChatIDFile` field to `TelegramConfig` struct
- Updated validation to require either `chat_id` or `chat_id_file` (but not both)
- Added `getChatID()` method to read chat_id from file
- Updated `Notify()` method to use the new `getChatID()` method

## Testing
- Follows the same pattern as `bot_token_file`
- Validates that either `chat_id` or `chat_id_file` is provided
- Validates that both are not provided simultaneously
- Reads and parses chat_id from file as int64

Fixes #4672