### PR TITLE
Add urldecode and safeURL template functions

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -191,7 +191,11 @@ var DefaultFuncs = FuncMap{
 	"safeUrl": func(text string) tmplhtml.URL {
 		return tmplhtml.URL(text)
 	},
+	"safeURL": func(text string) tmplhtml.URL {
+		return tmplhtml.URL(text)
+	},
 	"urlUnescape": url.QueryUnescape,
+	"urldecode": url.QueryUnescape,
 	"reReplaceAll": func(pattern, repl, text string) string {
 		re := regexp.MustCompile(pattern)
 		return re.ReplaceAllString(text, repl)

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -390,6 +390,17 @@ func TestTemplateExpansion(t *testing.T) {
 			exp:   "search?q=test foo",
 		},
 		{
+			title: "Template using urldecode",
+			in:    `{{ "search?q=test%20foo" | urldecode }}`,
+			exp:   "search?q=test foo",
+		},
+		{
+			title: "URL template using safeURL",
+			in:    `<a href="/search?{{ "q=test%20foo" | safeURL }}"></a>`,
+			html:  true,
+			exp:   `<a href="/search?q=test%20foo"></a>`,
+		},
+		{
 			title: "Template using stringSlice",
 			in:    `{{ with .GroupLabels }}{{ with .Remove (stringSlice "key1" "key3") }}{{ .SortedPairs.Values }}{{ end }}{{ end }}`,
 			data: Data{


### PR DESCRIPTION
This PR adds two new template functions to address double-encoding issues when working with URLs in Alertmanager templates, as described in issue #4710.

## Changes

- **urldecode**: Decodes URL-encoded strings using `url.QueryUnescape`. Useful for extracting and manipulating query parameters from URLs (e.g., extracting expr from Prometheus GeneratorURL for Grafana Explore links).

- **safeURL**: Marks a URL string as safe to prevent double-encoding by html/template. This provides an alias for `safeUrl` with capital URL naming for consistency.

## Use Cases

These functions solve the problem where `.GeneratorURL` from Prometheus is already URL-encoded, but html/template escapes it again, resulting in double-encoded output (e.g., %2520 instead of %20).

### Example Usage

```
{{ $expr := ( reReplaceAll ".*expr=([^&]+).*" "$1" (urldecode .GeneratorURL) ) }}
<a href="https://grafana.com/explore?expr={{ $expr }}">See in Grafana</a>
```

Or for trusted URLs:
```
<a href="{{ .GeneratorURL | safeURL }}">See in Prometheus</a>
```

## Testing

- Added unit tests for both `urldecode` and `safeURL` functions
- Tests verify correct URL decoding and prevention of double-encoding

Fixes #4710