### PR TITLE
fix: <mute_time_interval> was renamed

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -145,7 +145,7 @@ inhibit_rules:
 # DEPRECATED: use time_intervals below.
 # A list of mute time intervals for muting routes.
 mute_time_intervals:
-  [ - <mute_time_interval> ... ]
+  [ - <time_interval> ... ]
 
 # A list of time intervals for muting/activating routes.
 time_intervals:


### PR DESCRIPTION
In https://github.com/prometheus/alertmanager/pull/2779 the field was changed, but part was forgotten.