### PR TITLE
tests: Use t.TempDir()

### DIFF
--- a/nflog/nflog_test.go
+++ b/nflog/nflog_test.go
@@ -103,7 +103,7 @@ func TestLogSnapshot(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		f, err := os.CreateTemp("", "snapshot")
+		f, err := os.CreateTemp(t.TempDir(), "snapshot")
 		require.NoError(t, err, "creating temp file failed")
 
 		l1 := &Log{
@@ -132,7 +132,7 @@ func TestLogSnapshot(t *testing.T) {
 }
 
 func TestWithMaintenance_SupportsCustomCallback(t *testing.T) {
-	f, err := os.CreateTemp("", "snapshot")
+	f, err := os.CreateTemp(t.TempDir(), "snapshot")
 	require.NoError(t, err, "creating temp file failed")
 	stopc := make(chan struct{})
 	reg := prometheus.NewPedanticRegistry()

--- a/notify/discord/discord_test.go
+++ b/notify/discord/discord_test.go
@@ -151,7 +151,7 @@ func TestDiscordReadingURLFromFile(t *testing.T) {
 	ctx, u, fn := test.GetContextWithCancelingURL()
 	defer fn()
 
-	f, err := os.CreateTemp("", "webhook_url")
+	f, err := os.CreateTemp(t.TempDir(), "webhook_url")
 	require.NoError(t, err, "creating temp file failed")
 	_, err = f.WriteString(u.String() + "\n")
 	require.NoError(t, err, "writing to temp file failed")
@@ -183,11 +183,8 @@ func TestDiscord_Notify(t *testing.T) {
 	}))
 
 	// Create a temporary file to simulate the WebhookURLFile
-	tempFile, err := os.CreateTemp("", "webhook_url")
+	tempFile, err := os.CreateTemp(t.TempDir(), "webhook_url")
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, os.Remove(tempFile.Name()))
-	})
 
 	// Write the fake webhook URL to the temp file
 	_, err = tempFile.WriteString(srv.URL)

--- a/notify/email/email_test.go
+++ b/notify/email/email_test.go
@@ -455,12 +455,13 @@ func TestEmailNotifyWithAuthentication(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fileWithCorrectPassword, err := os.CreateTemp("", "smtp-password-correct")
+	td := t.TempDir()
+	fileWithCorrectPassword, err := os.CreateTemp(td, "smtp-password-correct")
 	require.NoError(t, err, "creating temp file failed")
 	_, err = fileWithCorrectPassword.WriteString(c.Password)
 	require.NoError(t, err, "writing to temp file failed")
 
-	fileWithIncorrectPassword, err := os.CreateTemp("", "smtp-password-incorrect")
+	fileWithIncorrectPassword, err := os.CreateTemp(td, "smtp-password-incorrect")
 	require.NoError(t, err, "creating temp file failed")
 	_, err = fileWithIncorrectPassword.WriteString(c.Password + "wrong")
 	require.NoError(t, err, "writing to temp file failed")

--- a/notify/incidentio/incidentio_test.go
+++ b/notify/incidentio/incidentio_test.go
@@ -77,7 +77,7 @@ func TestIncidentIOURLFromFile(t *testing.T) {
 	ctx, u, fn := test.GetContextWithCancelingURL()
 	defer fn()
 
-	f, err := os.CreateTemp("", "incidentio_test")
+	f, err := os.CreateTemp(t.TempDir(), "incidentio_test")
 	require.NoError(t, err, "creating temp file failed")
 	_, err = f.WriteString(u.String() + "\n")
 	require.NoError(t, err, "writing to temp file failed")

--- a/notify/mattermost/mattermost_test.go
+++ b/notify/mattermost/mattermost_test.go
@@ -140,7 +140,7 @@ func TestMattermostReadingURLFromFile(t *testing.T) {
 	ctx, u, fn := test.GetContextWithCancelingURL()
 	defer fn()
 
-	f, err := os.CreateTemp("", "webhook_url")
+	f, err := os.CreateTemp(t.TempDir(), "webhook_url")
 	require.NoError(t, err, "creating temp file failed")
 	_, err = f.WriteString(u.String() + "\n")
 	require.NoError(t, err, "writing to temp file failed")
@@ -172,11 +172,8 @@ func TestMattermost_Notify(t *testing.T) {
 	}))
 
 	// Create a temporary file to simulate the WebhookURLFile
-	tempFile, err := os.CreateTemp("", "webhook_url")
+	tempFile, err := os.CreateTemp(t.TempDir(), "webhook_url")
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, os.Remove(tempFile.Name()))
-	})
 
 	// Write the fake webhook URL to the temp file
 	_, err = tempFile.WriteString(srv.URL)

--- a/notify/msteams/msteams_test.go
+++ b/notify/msteams/msteams_test.go
@@ -215,7 +215,7 @@ func TestMSTeamsReadingURLFromFile(t *testing.T) {
 	ctx, u, fn := test.GetContextWithCancelingURL()
 	defer fn()
 
-	f, err := os.CreateTemp("", "webhook_url")
+	f, err := os.CreateTemp(t.TempDir(), "webhook_url")
 	require.NoError(t, err, "creating temp file failed")
 	_, err = f.WriteString(u.String() + "\n")
 	require.NoError(t, err, "writing to temp file failed")

--- a/notify/msteamsv2/msteamsv2_test.go
+++ b/notify/msteamsv2/msteamsv2_test.go
@@ -205,7 +205,7 @@ func TestMSTeamsV2ReadingURLFromFile(t *testing.T) {
 	ctx, u, fn := test.GetContextWithCancelingURL()
 	defer fn()
 
-	f, err := os.CreateTemp("", "webhook_url")
+	f, err := os.CreateTemp(t.TempDir(), "webhook_url")
 	require.NoError(t, err, "creating temp file failed")
 	_, err = f.WriteString(u.String() + "\n")
 	require.NoError(t, err, "writing to temp file failed")

--- a/notify/opsgenie/opsgenie_test.go
+++ b/notify/opsgenie/opsgenie_test.go
@@ -76,7 +76,7 @@ func TestGettingOpsGegineApikeyFromFile(t *testing.T) {
 
 	key := "key"
 
-	f, err := os.CreateTemp("", "opsgenie_test")
+	f, err := os.CreateTemp(t.TempDir(), "opsgenie_test")
 	require.NoError(t, err, "creating temp file failed")
 	_, err = f.WriteString(key)
 	require.NoError(t, err, "writing to temp file failed")

--- a/notify/pagerduty/pagerduty_test.go
+++ b/notify/pagerduty/pagerduty_test.go
@@ -113,7 +113,7 @@ func TestPagerDutyRedactedURLV2(t *testing.T) {
 
 func TestPagerDutyV1ServiceKeyFromFile(t *testing.T) {
 	key := "01234567890123456789012345678901"
-	f, err := os.CreateTemp("", "pagerduty_test")
+	f, err := os.CreateTemp(t.TempDir(), "pagerduty_test")
 	require.NoError(t, err, "creating temp file failed")
 	_, err = f.WriteString(key)
 	require.NoError(t, err, "writing to temp file failed")
@@ -137,7 +137,7 @@ func TestPagerDutyV1ServiceKeyFromFile(t *testing.T) {
 
 func TestPagerDutyV2RoutingKeyFromFile(t *testing.T) {
 	key := "01234567890123456789012345678901"
-	f, err := os.CreateTemp("", "pagerduty_test")
+	f, err := os.CreateTemp(t.TempDir(), "pagerduty_test")
 	require.NoError(t, err, "creating temp file failed")
 	_, err = f.WriteString(key)
 	require.NoError(t, err, "writing to temp file failed")

--- a/notify/pushover/pushover_test.go
+++ b/notify/pushover/pushover_test.go
@@ -68,7 +68,7 @@ func TestPushoverReadingUserKeyFromFile(t *testing.T) {
 	defer fn()
 
 	const userKey = "user key"
-	f, err := os.CreateTemp("", "pushover_user_key")
+	f, err := os.CreateTemp(t.TempDir(), "pushover_user_key")
 	require.NoError(t, err, "creating temp file failed")
 	_, err = f.WriteString(userKey)
 	require.NoError(t, err, "writing to temp file failed")
@@ -93,7 +93,7 @@ func TestPushoverReadingTokenFromFile(t *testing.T) {
 	defer fn()
 
 	const token = "token"
-	f, err := os.CreateTemp("", "pushover_token")
+	f, err := os.CreateTemp(t.TempDir(), "pushover_token")
 	require.NoError(t, err, "creating temp file failed")
 	_, err = f.WriteString(token)
 	require.NoError(t, err, "writing to temp file failed")

--- a/notify/rocketchat/rocketchat_test.go
+++ b/notify/rocketchat/rocketchat_test.go
@@ -46,7 +46,7 @@ func TestRocketchatRetry(t *testing.T) {
 }
 
 func TestGettingRocketchatTokenFromFile(t *testing.T) {
-	f, err := os.CreateTemp("", "rocketchat_test")
+	f, err := os.CreateTemp(t.TempDir(), "rocketchat_test")
 	require.NoError(t, err, "creating temp file failed")
 	_, err = f.WriteString("secret")
 	require.NoError(t, err, "writing to temp file failed")

--- a/notify/slack/slack_test.go
+++ b/notify/slack/slack_test.go
@@ -72,7 +72,7 @@ func TestGettingSlackURLFromFile(t *testing.T) {
 	ctx, u, fn := test.GetContextWithCancelingURL()
 	defer fn()
 
-	f, err := os.CreateTemp("", "slack_test")
+	f, err := os.CreateTemp(t.TempDir(), "slack_test")
 	require.NoError(t, err, "creating temp file failed")
 	_, err = f.WriteString(u.String())
 	require.NoError(t, err, "writing to temp file failed")
@@ -94,7 +94,7 @@ func TestTrimmingSlackURLFromFile(t *testing.T) {
 	ctx, u, fn := test.GetContextWithCancelingURL()
 	defer fn()
 
-	f, err := os.CreateTemp("", "slack_test_newline")
+	f, err := os.CreateTemp(t.TempDir(), "slack_test_newline")
 	require.NoError(t, err, "creating temp file failed")
 	_, err = f.WriteString(u.String() + "\n\n")
 	require.NoError(t, err, "writing to temp file failed")

--- a/notify/telegram/telegram_test.go
+++ b/notify/telegram/telegram_test.go
@@ -88,7 +88,7 @@ func TestTelegramRetry(t *testing.T) {
 func TestTelegramNotify(t *testing.T) {
 	token := "secret"
 
-	fileWithToken, err := os.CreateTemp("", "telegram-bot-token")
+	fileWithToken, err := os.CreateTemp(t.TempDir(), "telegram-bot-token")
 	require.NoError(t, err, "creating temp file failed")
 	_, err = fileWithToken.WriteString(token)
 	require.NoError(t, err, "writing to temp file failed")

--- a/notify/victorops/victorops_test.go
+++ b/notify/victorops/victorops_test.go
@@ -121,7 +121,7 @@ func TestVictorOpsRedactedURL(t *testing.T) {
 
 func TestVictorOpsReadingApiKeyFromFile(t *testing.T) {
 	key := "key"
-	f, err := os.CreateTemp("", "victorops_test")
+	f, err := os.CreateTemp(t.TempDir(), "victorops_test")
 	require.NoError(t, err, "creating temp file failed")
 	_, err = f.WriteString(key)
 	require.NoError(t, err, "writing to temp file failed")

--- a/notify/webhook/webhook_test.go
+++ b/notify/webhook/webhook_test.go
@@ -122,7 +122,7 @@ func TestWebhookReadingURLFromFile(t *testing.T) {
 	ctx, u, fn := test.GetContextWithCancelingURL()
 	defer fn()
 
-	f, err := os.CreateTemp("", "webhook_url")
+	f, err := os.CreateTemp(t.TempDir(), "webhook_url")
 	require.NoError(t, err, "creating temp file failed")
 	_, err = f.WriteString(u.String() + "\n")
 	require.NoError(t, err, "writing to temp file failed")

--- a/silence/silence_test.go
+++ b/silence/silence_test.go
@@ -386,7 +386,7 @@ func TestSilencesSnapshot(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		f, err := os.CreateTemp("", "snapshot")
+		f, err := os.CreateTemp(t.TempDir(), "snapshot")
 		require.NoError(t, err, "creating temp file failed")
 
 		s1 := &Silences{st: state{}, metrics: newMetrics(nil, nil)}
@@ -414,7 +414,7 @@ func TestSilencesSnapshot(t *testing.T) {
 
 // This tests a regression introduced by https://github.com/prometheus/alertmanager/pull/2689.
 func TestSilences_Maintenance_DefaultMaintenanceFuncDoesntCrash(t *testing.T) {
-	f, err := os.CreateTemp("", "snapshot")
+	f, err := os.CreateTemp(t.TempDir(), "snapshot")
 	require.NoError(t, err, "creating temp file failed")
 	clock := quartz.NewMock(t)
 	s := &Silences{st: state{}, logger: promslog.NewNopLogger(), clock: clock, metrics: newMetrics(nil, nil)}
@@ -434,7 +434,7 @@ func TestSilences_Maintenance_DefaultMaintenanceFuncDoesntCrash(t *testing.T) {
 }
 
 func TestSilences_Maintenance_SupportsCustomCallback(t *testing.T) {
-	f, err := os.CreateTemp("", "snapshot")
+	f, err := os.CreateTemp(t.TempDir(), "snapshot")
 	require.NoError(t, err, "creating temp file failed")
 	clock := quartz.NewMock(t)
 	reg := prometheus.NewRegistry()


### PR DESCRIPTION
A lot of tests create temporary files. Only one cleans up.
Use t.TempDir() in the CreateTemp calls, to get automatic cleanup.

Signed-off-by: Guido Trotter <guido@hudson-trading.com>
