### PR TITLE
Change URL type from secret to string in configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1747,7 +1747,7 @@ The webhook receiver allows configuring a generic receiver.
 
 # The endpoint to send HTTP POST requests to.
 # url and url_file are mutually exclusive.
-url: <secret>
+url: <string>
 url_file: <filepath>
 
 # The HTTP client's configuration.


### PR DESCRIPTION
Just a small suggestion: perhaps using `url: <string>` would be clearer? I'm not entirely sure.

@metalmatze 