### PR TITLE
Use stdlib sync/atomic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,8 +13,6 @@ linters:
       rules:
         main:
           deny:
-            - pkg: sync/atomic
-              desc: "Use go.uber.org/atomic instead of sync/atomic"
             - pkg: github.com/stretchr/testify/assert
               desc: "Use github.com/stretchr/testify/require instead of github.com/stretchr/testify/assert"
             - pkg: github.com/go-kit/kit/log

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,6 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/trivago/tgo v1.0.7
 	github.com/xlab/treeprint v1.2.0
-	go.uber.org/atomic v1.11.0
 	go.uber.org/automaxprocs v1.6.0
 	golang.org/x/mod v0.29.0
 	golang.org/x/net v0.46.0

--- a/go.sum
+++ b/go.sum
@@ -578,8 +578,6 @@ go.opentelemetry.io/otel/trace v1.38.0 h1:Fxk5bKrDZJUH+AMyyIXGcFAPah0oRcT+LuNtJr
 go.opentelemetry.io/otel/trace v1.38.0/go.mod h1:j1P9ivuFsTceSWe1oY+EeW3sc+Pp42sO++GHkg4wwhs=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
-go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
-go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/automaxprocs v1.6.0 h1:O3y2/QNTOdbF+e/dpXNNW7Rx2hZ4sTIPyybbxyNqTUs=
 go.uber.org/automaxprocs v1.6.0/go.mod h1:ifeIMSnPZuznNm6jmdzmU3/bfk01Fe2fotchwEFJ8r8=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=

--- a/nflog/nflog_test.go
+++ b/nflog/nflog_test.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -28,7 +29,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 )
 
 func TestLogGC(t *testing.T) {

--- a/provider/mem/mem_test.go
+++ b/provider/mem/mem_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -28,7 +29,6 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 
 	"github.com/prometheus/alertmanager/store"
 	"github.com/prometheus/alertmanager/types"
@@ -555,12 +555,12 @@ func (l *limitCountCallback) PreStore(_ *types.Alert, existing bool) error {
 
 func (l *limitCountCallback) PostStore(_ *types.Alert, existing bool) {
 	if !existing {
-		l.alerts.Inc()
+		l.alerts.Add(1)
 	}
 }
 
 func (l *limitCountCallback) PostDelete(_ *types.Alert) {
-	l.alerts.Dec()
+	l.alerts.Add(-1)
 }
 
 func TestAlertsConcurrently(t *testing.T) {

--- a/silence/silence_test.go
+++ b/silence/silence_test.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -32,7 +33,6 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 
 	"github.com/prometheus/alertmanager/featurecontrol"
 	"github.com/prometheus/alertmanager/matcher/compat"


### PR DESCRIPTION
Since Go 1.19 now has enough functionality that we can use the standard library `sync/atomic`.

Related to: https://github.com/prometheus/prometheus/issues/14866