### PR TITLE
chore: modernize with range over int

### DIFF
--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -165,7 +165,7 @@ func TestAggrGroup(t *testing.T) {
 		}
 	}
 
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		// New alert should come in after group interval.
 		ag.insert(a3)
 
@@ -207,7 +207,7 @@ func TestAggrGroup(t *testing.T) {
 		t.Fatalf("expected alerts %v but got %v", exp, batch)
 	}
 
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		// New alert should come in after group interval.
 		ag.insert(a3)
 

--- a/inhibit/inhibit_bench_test.go
+++ b/inhibit/inhibit_bench_test.go
@@ -119,7 +119,7 @@ func allRulesMatchBenchmark(b *testing.B, numInhibitionRules, numInhibitingAlert
 		},
 		newAlertsFunc: func(idx int, _ config.InhibitRule) []types.Alert {
 			var alerts []types.Alert
-			for i := 0; i < numInhibitingAlerts; i++ {
+			for i := range numInhibitingAlerts {
 				alerts = append(alerts, types.Alert{
 					Alert: model.Alert{
 						Labels: model.LabelSet{

--- a/matcher/parse/lexer_test.go
+++ b/matcher/parse/lexer_test.go
@@ -700,7 +700,7 @@ func TestLexer_Scan(t *testing.T) {
 // error has occurred.
 func TestLexer_ScanError(t *testing.T) {
 	l := lexer{input: "\"hello"}
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		tok, err := l.scan()
 		require.Equal(t, token{}, tok)
 		require.EqualError(t, err, "0:6: \"hello: missing end \"")
@@ -738,7 +738,7 @@ func TestLexer_Peek(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expected1, tok)
 	// Check that peek() returns the second token until the next scan().
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		tok, err = l.peek()
 		require.NoError(t, err)
 		require.Equal(t, expected2, tok)
@@ -748,7 +748,7 @@ func TestLexer_Peek(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expected2, tok)
 	// Should not be able to peek() further tokens.
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		tok, err = l.peek()
 		require.NoError(t, err)
 		require.Equal(t, token{}, tok)

--- a/notify/incidentio/incidentio_test.go
+++ b/notify/incidentio/incidentio_test.go
@@ -325,7 +325,7 @@ func TestIncidentIOPayloadTruncation(t *testing.T) {
 
 	// Create alerts with large annotations
 	var alerts []*types.Alert
-	for i := 0; i < 10; i++ { // 10 alerts * 100KB = 1MB total in annotations alone
+	for i := range 10 { // 10 alerts * 100KB = 1MB total in annotations alone
 		alert := &types.Alert{
 			Alert: model.Alert{
 				Labels: model.LabelSet{
@@ -394,7 +394,7 @@ func TestIncidentIOPayloadTruncationWithLabelTruncation(t *testing.T) {
 
 	// Create many alerts with many labels to push size over limit even without annotations
 	var alerts []*types.Alert
-	for i := 0; i < 100; i++ { // Many alerts
+	for i := range 100 { // Many alerts
 		labels := model.LabelSet{
 			"alertname": model.LabelValue("TestAlert" + string(rune('0'+i%10))),
 			"severity":  "critical",
@@ -403,7 +403,7 @@ func TestIncidentIOPayloadTruncationWithLabelTruncation(t *testing.T) {
 		}
 
 		// Add many extra labels with long values
-		for j := 0; j < 50; j++ {
+		for j := range 50 {
 			labelName := model.LabelName("label_" + string(rune('a'+j%26)) + "_" + string(rune('0'+j/26)))
 			labelValue := make([]byte, 1024) // 1KB per label value
 			for k := range labelValue {

--- a/provider/mem/mem_test.go
+++ b/provider/mem/mem_test.go
@@ -96,7 +96,7 @@ func TestAlertsSubscribePutStarvation(t *testing.T) {
 
 	alertsToInsert := []*types.Alert{}
 	// Exhaust alert channel
-	for i := 0; i < alertChannelLength+1; i++ {
+	for i := range alertChannelLength + 1 {
 		alertsToInsert = append(alertsToInsert, &types.Alert{
 			Alert: model.Alert{
 				// Make sure the fingerprints differ
@@ -147,7 +147,7 @@ func TestDeadLock(t *testing.T) {
 		t.Fatal(err)
 	}
 	alertsToInsert := []*types.Alert{}
-	for i := 0; i < 200+1; i++ {
+	for i := range 200 + 1 {
 		alertsToInsert = append(alertsToInsert, &types.Alert{
 			Alert: model.Alert{
 				// Make sure the fingerprints differ

--- a/silence/silence_bench_test.go
+++ b/silence/silence_bench_test.go
@@ -276,7 +276,7 @@ func benchmarkQuery(b *testing.B, numSilences int) {
 	lset := model.LabelSet{"aaaa": "AAAA", "bbbb": "BBBB", "cccc": "CCCC"}
 
 	// Create silences using Set() to properly populate indices
-	for i := 0; i < numSilences; i++ {
+	for i := range numSilences {
 		id := strconv.Itoa(i)
 		// Include an offset to avoid optimizations.
 		patA := "A{4}|" + id
@@ -343,7 +343,7 @@ func benchmarkQueryParallel(b *testing.B, numSilences int) {
 	lset := model.LabelSet{"aaaa": "AAAA", "bbbb": "BBBB", "cccc": "CCCC"}
 
 	// Create silences with pre-compiled matchers
-	for i := 0; i < numSilences; i++ {
+	for i := range numSilences {
 		id := strconv.Itoa(i)
 		patA := "A{4}|" + id
 		patB := id

--- a/test/cli/acceptance.go
+++ b/test/cli/acceptance.go
@@ -136,7 +136,7 @@ func (t *AcceptanceTest) Do(at float64, f func()) {
 func (t *AcceptanceTest) AlertmanagerCluster(conf string, size int) *AlertmanagerCluster {
 	amc := AlertmanagerCluster{}
 
-	for i := 0; i < size; i++ {
+	for range size {
 		am := &Alertmanager{
 			t:    t,
 			opts: t.opts,
@@ -353,7 +353,7 @@ func (am *Alertmanager) Start(additionalArg []string) error {
 	}()
 
 	time.Sleep(50 * time.Millisecond)
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		resp, err := http.Get(am.getURL("/"))
 		if err != nil {
 			time.Sleep(500 * time.Millisecond)
@@ -380,7 +380,7 @@ func (am *Alertmanager) WaitForCluster(size int) error {
 	var status general.GetStatusOK
 
 	// Poll for 2s
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		status, err := am.clientV2.General.GetStatus(params)
 		if err != nil {
 			return err

--- a/test/with_api_v2/acceptance.go
+++ b/test/with_api_v2/acceptance.go
@@ -115,7 +115,7 @@ func (t *AcceptanceTest) Do(at float64, f func()) {
 func (t *AcceptanceTest) AlertmanagerCluster(conf string, size int) *AlertmanagerCluster {
 	amc := AlertmanagerCluster{}
 
-	for i := 0; i < size; i++ {
+	for range size {
 		am := &Alertmanager{
 			t:    t,
 			opts: t.opts,
@@ -334,7 +334,7 @@ func (am *Alertmanager) Start(additionalArg []string) error {
 
 	time.Sleep(50 * time.Millisecond)
 	var lastErr error
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		_, lastErr = am.clientV2.General.GetStatus(nil)
 		if lastErr == nil {
 			return nil
@@ -352,7 +352,7 @@ func (am *Alertmanager) WaitForCluster(size int) error {
 	var status *general.GetStatusOK
 
 	// Poll for 2s
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		var err error
 		status, err = am.clientV2.General.GetStatus(params)
 		if err != nil {

--- a/test/with_api_v2/acceptance/send_test.go
+++ b/test/with_api_v2/acceptance/send_test.go
@@ -286,7 +286,7 @@ receivers:
 func TestResolved(t *testing.T) {
 	t.Parallel()
 
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		conf := `
 global:
   resolve_timeout: 10s


### PR DESCRIPTION
A purely mechanical change with no effect on behaviour. Stops `gopls` from complaining.

Corresponding spec, see here:
https://github.com/golang/go/issues/61405

Introduced in `Go 1.22`, see here:
https://go.dev/ref/spec#For_range