### PR TITLE
chore: don't depend on godebug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,6 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/hashicorp/memberlist v0.5.3
 	github.com/jessevdk/go-flags v1.6.1
-	github.com/kylelemons/godebug v1.1.0
 	github.com/matttproud/golang_protobuf_extensions v1.0.4
 	github.com/oklog/run v1.2.0
 	github.com/oklog/ulid/v2 v2.1.1
@@ -97,6 +96,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/julienschmidt/httprouter v1.3.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mdlayher/socket v0.4.1 // indirect
 	github.com/mdlayher/vsock v1.2.1 // indirect
 	github.com/miekg/dns v1.1.41 // indirect


### PR DESCRIPTION
We don't need to depend on this, so we shouldn't. The new error looks this:
```
Error Trace:	/home/solomonjacobs/get/f-alertmanager/provider/mem/mem_test.go:224
Error:      	Received unexpected error:
                field `Labels` mismatch.
                 Expected: {bar="foo"}
                 Got: {bar="boo"}
                field `Annotations` mismatch.
                 Expected: {foo="bar"}
                 Got: {boo="bar"}
                field `UpdatedAt` mismatch.
                 Expected: 2025-11-22 20:48:30.75618754 +0100 CET m=+0.000942595
                 Got: 2025-11-22 20:48:30.85618754 +0100 CET m=+0.100942595
                field `Timeout` mismatch.
                 Expected: false
                 Got: true
```