### PR TITLE
Fix alertmanager test port allocation race conditions

### DIFF
--- a/test/cli/acceptance.go
+++ b/test/cli/acceptance.go
@@ -357,7 +357,7 @@ func (am *Alertmanager) testRouteCommand(labels ...string) ([]byte, error) {
 }
 
 func (am *Alertmanager) getURL(path string) string {
-	return fmt.Sprintf("http://%s%s%s", am.APIAddr, am.Opts.RoutePrefix, path)
+	return fmt.Sprintf("http://%s%s%s", am.APIAddr(), am.Opts.RoutePrefix, path)
 }
 
 // Version runs the 'amtool' command with the --version option and checks


### PR DESCRIPTION
At the moment we try to allocate ports in the tests, the close them, and then start alertmanager on those ports. This is very brittle and often fails.

Fix the race conditions by directly starting alertmanager on system-allocated free ports (using :0 in the address) and then detecting the ports used, and using those in the test.

closes: #4742