### PR TITLE
feat(template): add toJson function

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -83,20 +83,21 @@ templating.
 
 ## Strings
 
-| Name          | Arguments     | Returns  | Notes    |
-| ------------- | ------------- | -------- | -------- |
-| title | string |[strings.Title](http://golang.org/pkg/strings/#Title), capitalises first character of each word. |
-| toUpper | string | [strings.ToUpper](http://golang.org/pkg/strings/#ToUpper), converts all characters to upper case. |
-| toLower | string | [strings.ToLower](http://golang.org/pkg/strings/#ToLower), converts all characters to lower case. |
-| trimSpace | string | [strings.TrimSpace](https://pkg.go.dev/strings#TrimSpace), removes leading and trailing white spaces. |
-| match | pattern, string | [Regexp.MatchString](https://golang.org/pkg/regexp/#MatchString). Match a string using Regexp. |
-| reReplaceAll | pattern, replacement, text | [Regexp.ReplaceAllString](http://golang.org/pkg/regexp/#Regexp.ReplaceAllString) Regexp substitution, unanchored. |
-| join | sep string, s []string | [strings.Join](http://golang.org/pkg/strings/#Join), concatenates the elements of s to create a single string. The separator string sep is placed between elements in the resulting string. (note: argument order inverted for easier pipelining in templates.) |
-| safeHtml | text string | [html/template.HTML](https://golang.org/pkg/html/template/#HTML), Marks string as HTML not requiring auto-escaping. |
-| safeUrl | text string | [html/template.URL](https://golang.org/pkg/html/template/#URL), Marks string as URL not requiring auto-escaping. |
-| urlUnescape | text string | [url.QueryUnescape](https://pkg.go.dev/net/url#QueryUnescape), unescapes a URL with % encoding |
-| stringSlice | ...string | Returns the passed strings as a slice of strings. |
-| date | string, time.Time | Returns the text representation of the time in the specified format. For documentation on formats refer to [pkg.go.dev/time](https://pkg.go.dev/time#pkg-constants). |
-| tz | string, time.Time | Returns the time in the timezone. For example, Europe/Paris. |
-| since | time.Time | [time.Duration](https://pkg.go.dev/time#Since), returns the duration of how much time passed from the provided time till the current system time. |
-| humanizeDuration | number or string | Returns a human-readable string representing the duration, and the error if it happened. |
+| Name             | Arguments                  | Description |
+| ---------------- | -------------------------- | ----------- |
+| date             | string, time.Time          | Returns the text representation of the time in the specified format. For documentation on formats refer to [pkg.go.dev/time](https://pkg.go.dev/time#pkg-constants). |
+| humanizeDuration | number or string           | Returns a human-readable string representing the duration, and the error if it happened. |
+| join             | sep string, s []string     | [strings.Join](http://golang.org/pkg/strings/#Join), concatenates the elements of s to create a single string. The separator string sep is placed between elements in the resulting string. (note: argument order inverted for easier pipelining in templates.) |
+| match            | pattern, string            | [Regexp.MatchString](https://golang.org/pkg/regexp/#MatchString). Match a string using Regexp. |
+| reReplaceAll     | pattern, replacement, text | [Regexp.ReplaceAllString](http://golang.org/pkg/regexp/#Regexp.ReplaceAllString) Regexp substitution, unanchored. |
+| safeHtml         | text string                | [html/template.HTML](https://golang.org/pkg/html/template/#HTML), Marks string as HTML not requiring auto-escaping. |
+| safeUrl          | text string                | [html/template.URL](https://golang.org/pkg/html/template/#URL), Marks string as URL not requiring auto-escaping. |
+| since            | time.Time                  | [time.Since](https://pkg.go.dev/time#Since), returns the duration of how much time passed from the provided time till the current system time. |
+| stringSlice      | ...string                  | Returns the passed strings as a slice of strings. |
+| title            | string                     | [strings.Title](http://golang.org/pkg/strings/#Title), capitalises first character of each word. |
+| toJson           | any                        | [json.Marshal](https://pkg.go.dev/encoding/json#Marshal), returns the JSON encoding of the value. |
+| toLower          | string                     | [strings.ToLower](http://golang.org/pkg/strings/#ToLower), converts all characters to lower case. |
+| toUpper          | string                     | [strings.ToUpper](http://golang.org/pkg/strings/#ToUpper), converts all characters to upper case. |
+| trimSpace        | string                     | [strings.TrimSpace](https://pkg.go.dev/strings#TrimSpace), removes leading and trailing white spaces. |
+| tz               | string, time.Time          | Returns the time in the timezone. For example, Europe/Paris. |
+| urlUnescape      | text string                | [url.QueryUnescape](https://pkg.go.dev/net/url#QueryUnescape), unescapes a URL with % encoding |

--- a/template/template.go
+++ b/template/template.go
@@ -15,6 +15,7 @@ package template
 
 import (
 	"bytes"
+	"encoding/json"
 	tmplhtml "html/template"
 	"io"
 	"net/url"
@@ -213,6 +214,13 @@ var DefaultFuncs = FuncMap{
 	},
 	"since":            time.Since,
 	"humanizeDuration": commonTemplates.HumanizeDuration,
+	"toJson": func(v any) (string, error) {
+		bytes, err := json.Marshal(v)
+		if err != nil {
+			return "", err
+		}
+		return string(bytes), nil
+	},
 }
 
 // Pair is a key/value string pair.


### PR DESCRIPTION
This change introduces a new template function called `toJson` which can convert internal Alertmanager data structures into their JSON representation.

This is useful in notify integrations where JSON objects can be passed to external services.