### PR TITLE
Update description for filter param in OpenAPI

### DIFF
--- a/api/v2/client/alert/get_alerts_parameters.go
+++ b/api/v2/client/alert/get_alerts_parameters.go
@@ -86,7 +86,7 @@ type GetAlertsParams struct {
 
 	/* Filter.
 
-	   A list of matchers to filter alerts by
+	   A matcher expression to filter alerts. For example `alertname="MyAlert"`. It can be repeated to apply multiple matchers.
 	*/
 	Filter []string
 

--- a/api/v2/client/alertgroup/get_alert_groups_parameters.go
+++ b/api/v2/client/alertgroup/get_alert_groups_parameters.go
@@ -86,7 +86,7 @@ type GetAlertGroupsParams struct {
 
 	/* Filter.
 
-	   A list of matchers to filter alerts by
+	   A matcher expression to filter alert groups. For example `alertname="MyAlert"`. It can be repeated to apply multiple matchers.
 	*/
 	Filter []string
 

--- a/api/v2/client/silence/get_silences_parameters.go
+++ b/api/v2/client/silence/get_silences_parameters.go
@@ -78,7 +78,7 @@ type GetSilencesParams struct {
 
 	/* Filter.
 
-	   A list of matchers to filter silences by
+	   A matcher expression to filter silences. For example `alertname="MyAlert"`. It can be repeated to apply multiple matchers.
 	*/
 	Filter []string
 

--- a/api/v2/openapi.yaml
+++ b/api/v2/openapi.yaml
@@ -60,7 +60,7 @@ paths:
       parameters:
         - name: filter
           in: query
-          description: A list of matchers to filter silences by
+          description: A matcher expression to filter silences. For example `alertname="MyAlert"`. It can be repeated to apply multiple matchers.
           required: false
           type: array
           collectionFormat: multi
@@ -162,7 +162,7 @@ paths:
           default: true
         - name: filter
           in: query
-          description: A list of matchers to filter alerts by
+          description: A matcher expression to filter alerts. For example `alertname="MyAlert"`. It can be repeated to apply multiple matchers.
           required: false
           type: array
           collectionFormat: multi
@@ -230,7 +230,7 @@ paths:
           default: true
         - name: filter
           in: query
-          description: A list of matchers to filter alerts by
+          description: A matcher expression to filter alert groups. For example `alertname="MyAlert"`. It can be repeated to apply multiple matchers.
           required: false
           type: array
           collectionFormat: multi

--- a/api/v2/restapi/embedded_spec.go
+++ b/api/v2/restapi/embedded_spec.go
@@ -92,7 +92,7 @@ func init() {
               "type": "string"
             },
             "collectionFormat": "multi",
-            "description": "A list of matchers to filter alerts by",
+            "description": "A matcher expression to filter alerts. For example ` + "`" + `alertname=\"MyAlert\"` + "`" + `. It can be repeated to apply multiple matchers.",
             "name": "filter",
             "in": "query"
           },
@@ -190,7 +190,7 @@ func init() {
               "type": "string"
             },
             "collectionFormat": "multi",
-            "description": "A list of matchers to filter alerts by",
+            "description": "A matcher expression to filter alert groups. For example ` + "`" + `alertname=\"MyAlert\"` + "`" + `. It can be repeated to apply multiple matchers.",
             "name": "filter",
             "in": "query"
           },
@@ -312,7 +312,7 @@ func init() {
               "type": "string"
             },
             "collectionFormat": "multi",
-            "description": "A list of matchers to filter silences by",
+            "description": "A matcher expression to filter silences. For example ` + "`" + `alertname=\"MyAlert\"` + "`" + `. It can be repeated to apply multiple matchers.",
             "name": "filter",
             "in": "query"
           }
@@ -896,7 +896,7 @@ func init() {
               "type": "string"
             },
             "collectionFormat": "multi",
-            "description": "A list of matchers to filter alerts by",
+            "description": "A matcher expression to filter alerts. For example ` + "`" + `alertname=\"MyAlert\"` + "`" + `. It can be repeated to apply multiple matchers.",
             "name": "filter",
             "in": "query"
           },
@@ -1006,7 +1006,7 @@ func init() {
               "type": "string"
             },
             "collectionFormat": "multi",
-            "description": "A list of matchers to filter alerts by",
+            "description": "A matcher expression to filter alert groups. For example ` + "`" + `alertname=\"MyAlert\"` + "`" + `. It can be repeated to apply multiple matchers.",
             "name": "filter",
             "in": "query"
           },
@@ -1140,7 +1140,7 @@ func init() {
               "type": "string"
             },
             "collectionFormat": "multi",
-            "description": "A list of matchers to filter silences by",
+            "description": "A matcher expression to filter silences. For example ` + "`" + `alertname=\"MyAlert\"` + "`" + `. It can be repeated to apply multiple matchers.",
             "name": "filter",
             "in": "query"
           }

--- a/api/v2/restapi/operations/alert/get_alerts_parameters.go
+++ b/api/v2/restapi/operations/alert/get_alerts_parameters.go
@@ -69,7 +69,7 @@ type GetAlertsParams struct {
 	  Default: true
 	*/
 	Active *bool
-	/*A list of matchers to filter alerts by
+	/*A matcher expression to filter alerts. For example `alertname="MyAlert"`. It can be repeated to apply multiple matchers.
 	  In: query
 	  Collection Format: multi
 	*/

--- a/api/v2/restapi/operations/alertgroup/get_alert_groups_parameters.go
+++ b/api/v2/restapi/operations/alertgroup/get_alert_groups_parameters.go
@@ -69,7 +69,7 @@ type GetAlertGroupsParams struct {
 	  Default: true
 	*/
 	Active *bool
-	/*A list of matchers to filter alerts by
+	/*A matcher expression to filter alert groups. For example `alertname="MyAlert"`. It can be repeated to apply multiple matchers.
 	  In: query
 	  Collection Format: multi
 	*/

--- a/api/v2/restapi/operations/silence/get_silences_parameters.go
+++ b/api/v2/restapi/operations/silence/get_silences_parameters.go
@@ -45,7 +45,7 @@ type GetSilencesParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*A list of matchers to filter silences by
+	/*A matcher expression to filter silences. For example `alertname="MyAlert"`. It can be repeated to apply multiple matchers.
 	  In: query
 	  Collection Format: multi
 	*/


### PR DESCRIPTION
Re: https://github.com/prometheus/alertmanager/issues/2812

`filter` is an array, but multiple items have to be added by repeating the param. This can be confusing since "a list of matchers" could be understood as a list separated by comma in a single value, or a group of matchers in promql format.

I'm changing the description to explicitly say that the value has to be a single matcher expression, but multiple values can be applied by repeating the param. Also fixed a typo in alert groups that said "alerts" instead of "alert groups".

The main change is in `api/v2/openapi.yaml`. All the others were autogenerated with `make apiv2`
