### PR TITLE
docs: update description of filter query params in openapi doc

### DIFF
--- a/api/v2/client/alert/get_alerts_parameters.go
+++ b/api/v2/client/alert/get_alerts_parameters.go
@@ -78,7 +78,7 @@ type GetAlertsParams struct {
 
 	/* Active.
 
-	   Show active alerts
+	   Include active alerts in results. If false, excludes active alerts and returns only suppressed (silenced or inhibited) alerts.
 
 	   Default: true
 	*/
@@ -92,7 +92,7 @@ type GetAlertsParams struct {
 
 	/* Inhibited.
 
-	   Show inhibited alerts
+	   Include inhibited alerts in results. If false, excludes inhibited alerts. Note that true (default) shows both inhibited and non-inhibited alerts.
 
 	   Default: true
 	*/
@@ -106,7 +106,7 @@ type GetAlertsParams struct {
 
 	/* Silenced.
 
-	   Show silenced alerts
+	   Include silenced alerts in results. If false, excludes silenced alerts. Note that true (default) shows both silenced and non-silenced alerts.
 
 	   Default: true
 	*/
@@ -114,7 +114,7 @@ type GetAlertsParams struct {
 
 	/* Unprocessed.
 
-	   Show unprocessed alerts
+	   Include unprocessed alerts in results. If false, excludes unprocessed alerts. Note that true (default) shows both processed and unprocessed alerts.
 
 	   Default: true
 	*/

--- a/api/v2/client/alertgroup/get_alert_groups_parameters.go
+++ b/api/v2/client/alertgroup/get_alert_groups_parameters.go
@@ -78,7 +78,7 @@ type GetAlertGroupsParams struct {
 
 	/* Active.
 
-	   Show active alerts
+	   Include active alerts within the returned groups. If false, excludes active alerts from groups and only shows suppressed (silenced or inhibited) alerts.
 
 	   Default: true
 	*/
@@ -92,7 +92,7 @@ type GetAlertGroupsParams struct {
 
 	/* Inhibited.
 
-	   Show inhibited alerts
+	   Include inhibited alerts within the returned groups. If false, excludes inhibited alerts from groups. Note that true (default) shows both inhibited and non-inhibited alerts.
 
 	   Default: true
 	*/
@@ -100,7 +100,7 @@ type GetAlertGroupsParams struct {
 
 	/* Muted.
 
-	   Show muted alerts
+	   Include muted (silenced or inhibited) alert groups in results. If false, excludes entire groups where all alerts are muted.
 
 	   Default: true
 	*/
@@ -114,7 +114,7 @@ type GetAlertGroupsParams struct {
 
 	/* Silenced.
 
-	   Show silenced alerts
+	   Include silenced alerts within the returned groups. If false, excludes silenced alerts from groups. Note that true (default) shows both silenced and non-silenced alerts.
 
 	   Default: true
 	*/

--- a/api/v2/openapi.yaml
+++ b/api/v2/openapi.yaml
@@ -143,22 +143,22 @@ paths:
         - in: query
           name: active
           type: boolean
-          description: Show active alerts
+          description: Include active alerts in results. If false, excludes active alerts and returns only suppressed (silenced or inhibited) alerts.
           default: true
         - in: query
           name: silenced
           type: boolean
-          description: Show silenced alerts
+          description: Include silenced alerts in results. If false, excludes silenced alerts. Note that true (default) shows both silenced and non-silenced alerts.
           default: true
         - in: query
           name: inhibited
           type: boolean
-          description: Show inhibited alerts
+          description: Include inhibited alerts in results. If false, excludes inhibited alerts. Note that true (default) shows both inhibited and non-inhibited alerts.
           default: true
         - in: query
           name: unprocessed
           type: boolean
-          description: Show unprocessed alerts
+          description: Include unprocessed alerts in results. If false, excludes unprocessed alerts. Note that true (default) shows both processed and unprocessed alerts.
           default: true
         - name: filter
           in: query
@@ -211,22 +211,22 @@ paths:
         - in: query
           name: active
           type: boolean
-          description: Show active alerts
+          description: Include active alerts within the returned groups. If false, excludes active alerts from groups and only shows suppressed (silenced or inhibited) alerts.
           default: true
         - in: query
           name: silenced
           type: boolean
-          description: Show silenced alerts
+          description: Include silenced alerts within the returned groups. If false, excludes silenced alerts from groups. Note that true (default) shows both silenced and non-silenced alerts.
           default: true
         - in: query
           name: inhibited
           type: boolean
-          description: Show inhibited alerts
+          description: Include inhibited alerts within the returned groups. If false, excludes inhibited alerts from groups. Note that true (default) shows both inhibited and non-inhibited alerts.
           default: true
         - in: query
           name: muted
           type: boolean
-          description: Show muted alerts
+          description: Include muted (silenced or inhibited) alert groups in results. If false, excludes entire groups where all alerts are muted.
           default: true
         - name: filter
           in: query

--- a/api/v2/restapi/embedded_spec.go
+++ b/api/v2/restapi/embedded_spec.go
@@ -61,28 +61,28 @@ func init() {
           {
             "type": "boolean",
             "default": true,
-            "description": "Show active alerts",
+            "description": "Include active alerts in results. If false, excludes active alerts and returns only suppressed (silenced or inhibited) alerts.",
             "name": "active",
             "in": "query"
           },
           {
             "type": "boolean",
             "default": true,
-            "description": "Show silenced alerts",
+            "description": "Include silenced alerts in results. If false, excludes silenced alerts. Note that true (default) shows both silenced and non-silenced alerts.",
             "name": "silenced",
             "in": "query"
           },
           {
             "type": "boolean",
             "default": true,
-            "description": "Show inhibited alerts",
+            "description": "Include inhibited alerts in results. If false, excludes inhibited alerts. Note that true (default) shows both inhibited and non-inhibited alerts.",
             "name": "inhibited",
             "in": "query"
           },
           {
             "type": "boolean",
             "default": true,
-            "description": "Show unprocessed alerts",
+            "description": "Include unprocessed alerts in results. If false, excludes unprocessed alerts. Note that true (default) shows both processed and unprocessed alerts.",
             "name": "unprocessed",
             "in": "query"
           },
@@ -159,28 +159,28 @@ func init() {
           {
             "type": "boolean",
             "default": true,
-            "description": "Show active alerts",
+            "description": "Include active alerts within the returned groups. If false, excludes active alerts from groups and only shows suppressed (silenced or inhibited) alerts.",
             "name": "active",
             "in": "query"
           },
           {
             "type": "boolean",
             "default": true,
-            "description": "Show silenced alerts",
+            "description": "Include silenced alerts within the returned groups. If false, excludes silenced alerts from groups. Note that true (default) shows both silenced and non-silenced alerts.",
             "name": "silenced",
             "in": "query"
           },
           {
             "type": "boolean",
             "default": true,
-            "description": "Show inhibited alerts",
+            "description": "Include inhibited alerts within the returned groups. If false, excludes inhibited alerts from groups. Note that true (default) shows both inhibited and non-inhibited alerts.",
             "name": "inhibited",
             "in": "query"
           },
           {
             "type": "boolean",
             "default": true,
-            "description": "Show muted alerts",
+            "description": "Include muted (silenced or inhibited) alert groups in results. If false, excludes entire groups where all alerts are muted.",
             "name": "muted",
             "in": "query"
           },
@@ -865,28 +865,28 @@ func init() {
           {
             "type": "boolean",
             "default": true,
-            "description": "Show active alerts",
+            "description": "Include active alerts in results. If false, excludes active alerts and returns only suppressed (silenced or inhibited) alerts.",
             "name": "active",
             "in": "query"
           },
           {
             "type": "boolean",
             "default": true,
-            "description": "Show silenced alerts",
+            "description": "Include silenced alerts in results. If false, excludes silenced alerts. Note that true (default) shows both silenced and non-silenced alerts.",
             "name": "silenced",
             "in": "query"
           },
           {
             "type": "boolean",
             "default": true,
-            "description": "Show inhibited alerts",
+            "description": "Include inhibited alerts in results. If false, excludes inhibited alerts. Note that true (default) shows both inhibited and non-inhibited alerts.",
             "name": "inhibited",
             "in": "query"
           },
           {
             "type": "boolean",
             "default": true,
-            "description": "Show unprocessed alerts",
+            "description": "Include unprocessed alerts in results. If false, excludes unprocessed alerts. Note that true (default) shows both processed and unprocessed alerts.",
             "name": "unprocessed",
             "in": "query"
           },
@@ -975,28 +975,28 @@ func init() {
           {
             "type": "boolean",
             "default": true,
-            "description": "Show active alerts",
+            "description": "Include active alerts within the returned groups. If false, excludes active alerts from groups and only shows suppressed (silenced or inhibited) alerts.",
             "name": "active",
             "in": "query"
           },
           {
             "type": "boolean",
             "default": true,
-            "description": "Show silenced alerts",
+            "description": "Include silenced alerts within the returned groups. If false, excludes silenced alerts from groups. Note that true (default) shows both silenced and non-silenced alerts.",
             "name": "silenced",
             "in": "query"
           },
           {
             "type": "boolean",
             "default": true,
-            "description": "Show inhibited alerts",
+            "description": "Include inhibited alerts within the returned groups. If false, excludes inhibited alerts from groups. Note that true (default) shows both inhibited and non-inhibited alerts.",
             "name": "inhibited",
             "in": "query"
           },
           {
             "type": "boolean",
             "default": true,
-            "description": "Show muted alerts",
+            "description": "Include muted (silenced or inhibited) alert groups in results. If false, excludes entire groups where all alerts are muted.",
             "name": "muted",
             "in": "query"
           },

--- a/api/v2/restapi/operations/alert/get_alerts_parameters.go
+++ b/api/v2/restapi/operations/alert/get_alerts_parameters.go
@@ -64,7 +64,7 @@ type GetAlertsParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*Show active alerts
+	/*Include active alerts in results. If false, excludes active alerts and returns only suppressed (silenced or inhibited) alerts.
 	  In: query
 	  Default: true
 	*/
@@ -74,7 +74,7 @@ type GetAlertsParams struct {
 	  Collection Format: multi
 	*/
 	Filter []string
-	/*Show inhibited alerts
+	/*Include inhibited alerts in results. If false, excludes inhibited alerts. Note that true (default) shows both inhibited and non-inhibited alerts.
 	  In: query
 	  Default: true
 	*/
@@ -83,12 +83,12 @@ type GetAlertsParams struct {
 	  In: query
 	*/
 	Receiver *string
-	/*Show silenced alerts
+	/*Include silenced alerts in results. If false, excludes silenced alerts. Note that true (default) shows both silenced and non-silenced alerts.
 	  In: query
 	  Default: true
 	*/
 	Silenced *bool
-	/*Show unprocessed alerts
+	/*Include unprocessed alerts in results. If false, excludes unprocessed alerts. Note that true (default) shows both processed and unprocessed alerts.
 	  In: query
 	  Default: true
 	*/

--- a/api/v2/restapi/operations/alertgroup/get_alert_groups_parameters.go
+++ b/api/v2/restapi/operations/alertgroup/get_alert_groups_parameters.go
@@ -64,7 +64,7 @@ type GetAlertGroupsParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*Show active alerts
+	/*Include active alerts within the returned groups. If false, excludes active alerts from groups and only shows suppressed (silenced or inhibited) alerts.
 	  In: query
 	  Default: true
 	*/
@@ -74,12 +74,12 @@ type GetAlertGroupsParams struct {
 	  Collection Format: multi
 	*/
 	Filter []string
-	/*Show inhibited alerts
+	/*Include inhibited alerts within the returned groups. If false, excludes inhibited alerts from groups. Note that true (default) shows both inhibited and non-inhibited alerts.
 	  In: query
 	  Default: true
 	*/
 	Inhibited *bool
-	/*Show muted alerts
+	/*Include muted (silenced or inhibited) alert groups in results. If false, excludes entire groups where all alerts are muted.
 	  In: query
 	  Default: true
 	*/
@@ -88,7 +88,7 @@ type GetAlertGroupsParams struct {
 	  In: query
 	*/
 	Receiver *string
-	/*Show silenced alerts
+	/*Include silenced alerts within the returned groups. If false, excludes silenced alerts from groups. Note that true (default) shows both silenced and non-silenced alerts.
 	  In: query
 	  Default: true
 	*/


### PR DESCRIPTION
Re: https://github.com/prometheus/alertmanager/issues/2928

Current documentation for filter query params can be read as exclusive instead of inclusive, ie, `silenced=true` can be understood as excluding non-silenced alerts, when the implementation is actually inclusive and the value means "include silenced alerts as well".

I'm changing the descriptions to mention what results you should expect from the default.