### PR TITLE
refactor(config): use cmp.Or to merge global config defaults

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@
 package config
 
 import (
+	"cmp"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -514,54 +515,36 @@ func (c *Config) UnmarshalYAML(unmarshal func(any) error) error {
 			return fmt.Errorf("notification config name %q is not unique", rcv.Name)
 		}
 		for _, wh := range rcv.WebhookConfigs {
-			if wh.HTTPConfig == nil {
-				wh.HTTPConfig = c.Global.HTTPConfig
-			}
+			wh.HTTPConfig = cmp.Or(wh.HTTPConfig, c.Global.HTTPConfig)
 		}
 		for _, ec := range rcv.EmailConfigs {
-			if ec.TLSConfig == nil {
-				ec.TLSConfig = c.Global.SMTPTLSConfig
-			}
+			ec.TLSConfig = cmp.Or(ec.TLSConfig, c.Global.SMTPTLSConfig)
+			ec.Smarthost = cmp.Or(ec.Smarthost, c.Global.SMTPSmarthost)
 			if ec.Smarthost.String() == "" {
-				if c.Global.SMTPSmarthost.String() == "" {
-					return errors.New("no global SMTP smarthost set")
-				}
-				ec.Smarthost = c.Global.SMTPSmarthost
+				return errors.New("no global SMTP smarthost set")
 			}
+			ec.From = cmp.Or(ec.From, c.Global.SMTPFrom)
 			if ec.From == "" {
-				if c.Global.SMTPFrom == "" {
-					return errors.New("no global SMTP from set")
-				}
-				ec.From = c.Global.SMTPFrom
+				return errors.New("no global SMTP from set")
 			}
-			if ec.Hello == "" {
-				ec.Hello = c.Global.SMTPHello
-			}
-			if ec.AuthUsername == "" {
-				ec.AuthUsername = c.Global.SMTPAuthUsername
-			}
+			ec.Hello = cmp.Or(ec.Hello, c.Global.SMTPHello)
+			ec.AuthUsername = cmp.Or(ec.AuthUsername, c.Global.SMTPAuthUsername)
 			if ec.AuthPassword == "" && ec.AuthPasswordFile == "" {
 				ec.AuthPassword = c.Global.SMTPAuthPassword
 				ec.AuthPasswordFile = c.Global.SMTPAuthPasswordFile
 			}
-			if ec.AuthSecret == "" && ec.AuthSecretFile == "" {
-				ec.AuthSecret = c.Global.SMTPAuthSecret
-				ec.AuthSecretFile = c.Global.SMTPAuthSecretFile
-			}
-			if ec.AuthIdentity == "" {
-				ec.AuthIdentity = c.Global.SMTPAuthIdentity
-			}
+			ec.AuthSecret = cmp.Or(ec.AuthSecret, c.Global.SMTPAuthSecret)
+			ec.AuthSecretFile = cmp.Or(ec.AuthSecretFile, c.Global.SMTPAuthSecretFile)
+			ec.AuthIdentity = cmp.Or(ec.AuthIdentity, c.Global.SMTPAuthIdentity)
 			if ec.RequireTLS == nil {
 				ec.RequireTLS = new(bool)
 				*ec.RequireTLS = c.Global.SMTPRequireTLS
 			}
 		}
 		for _, sc := range rcv.SlackConfigs {
+			sc.AppURL = cmp.Or(sc.AppURL, c.Global.SlackAppURL)
 			if sc.AppURL == nil {
-				if c.Global.SlackAppURL == nil {
-					return errors.New("no global Slack App URL set")
-				}
-				sc.AppURL = c.Global.SlackAppURL
+				return errors.New("no global Slack App URL set")
 			}
 			// we only want to set the app token from global if there's no local authorization or webhook url
 			if sc.AppToken == "" && len(sc.AppTokenFile) == 0 && (sc.HTTPConfig == nil || sc.HTTPConfig.Authorization == nil) && sc.APIURL == nil {
@@ -593,57 +576,38 @@ func (c *Config) UnmarshalYAML(unmarshal func(any) error) error {
 			}
 		}
 		for _, poc := range rcv.PushoverConfigs {
-			if poc.HTTPConfig == nil {
-				poc.HTTPConfig = c.Global.HTTPConfig
-			}
+			poc.HTTPConfig = cmp.Or(poc.HTTPConfig, c.Global.HTTPConfig)
 		}
 		for _, pdc := range rcv.PagerdutyConfigs {
-			if pdc.HTTPConfig == nil {
-				pdc.HTTPConfig = c.Global.HTTPConfig
-			}
+			pdc.HTTPConfig = cmp.Or(pdc.HTTPConfig, c.Global.HTTPConfig)
+			pdc.URL = cmp.Or(pdc.URL, c.Global.PagerdutyURL)
 			if pdc.URL == nil {
-				if c.Global.PagerdutyURL == nil {
-					return errors.New("no global PagerDuty URL set")
-				}
-				pdc.URL = c.Global.PagerdutyURL
+				return errors.New("no global PagerDuty URL set")
 			}
 		}
 		for _, iio := range rcv.IncidentioConfigs {
-			if iio.HTTPConfig == nil {
-				iio.HTTPConfig = c.Global.HTTPConfig
-			}
+			iio.HTTPConfig = cmp.Or(iio.HTTPConfig, c.Global.HTTPConfig)
 		}
 		for _, ogc := range rcv.OpsGenieConfigs {
-			if ogc.HTTPConfig == nil {
-				ogc.HTTPConfig = c.Global.HTTPConfig
-			}
+			ogc.HTTPConfig = cmp.Or(ogc.HTTPConfig, c.Global.HTTPConfig)
+			ogc.APIURL = cmp.Or(ogc.APIURL, c.Global.OpsGenieAPIURL)
 			if ogc.APIURL == nil {
-				if c.Global.OpsGenieAPIURL == nil {
-					return errors.New("no global OpsGenie URL set")
-				}
-				ogc.APIURL = c.Global.OpsGenieAPIURL
+				return errors.New("no global OpsGenie URL set")
 			}
 			if !strings.HasSuffix(ogc.APIURL.Path, "/") {
 				ogc.APIURL.Path += "/"
 			}
+			ogc.APIKey = cmp.Or(ogc.APIKey, c.Global.OpsGenieAPIKey)
+			ogc.APIKeyFile = cmp.Or(ogc.APIKeyFile, c.Global.OpsGenieAPIKeyFile)
 			if ogc.APIKey == "" && len(ogc.APIKeyFile) == 0 {
-				if c.Global.OpsGenieAPIKey == "" && len(c.Global.OpsGenieAPIKeyFile) == 0 {
-					return errors.New("no global OpsGenie API Key set either inline or in a file")
-				}
-				ogc.APIKey = c.Global.OpsGenieAPIKey
-				ogc.APIKeyFile = c.Global.OpsGenieAPIKeyFile
+				return errors.New("no global OpsGenie API Key set either inline or in a file")
 			}
 		}
 		for _, wcc := range rcv.WechatConfigs {
-			if wcc.HTTPConfig == nil {
-				wcc.HTTPConfig = c.Global.HTTPConfig
-			}
-
+			wcc.HTTPConfig = cmp.Or(wcc.HTTPConfig, c.Global.HTTPConfig)
+			wcc.APIURL = cmp.Or(wcc.APIURL, c.Global.WeChatAPIURL)
 			if wcc.APIURL == nil {
-				if c.Global.WeChatAPIURL == nil {
-					return errors.New("no global Wechat URL set")
-				}
-				wcc.APIURL = c.Global.WeChatAPIURL
+				return errors.New("no global Wechat URL set")
 			}
 
 			if wcc.APISecret == "" && len(wcc.APISecretFile) == 0 {
@@ -654,11 +618,9 @@ func (c *Config) UnmarshalYAML(unmarshal func(any) error) error {
 				wcc.APISecretFile = c.Global.WeChatAPISecretFile
 			}
 
+			wcc.CorpID = cmp.Or(wcc.CorpID, c.Global.WeChatAPICorpID)
 			if wcc.CorpID == "" {
-				if c.Global.WeChatAPICorpID == "" {
-					return errors.New("no global Wechat CorpID set")
-				}
-				wcc.CorpID = c.Global.WeChatAPICorpID
+				return errors.New("no global Wechat CorpID set")
 			}
 
 			if !strings.HasSuffix(wcc.APIURL.Path, "/") {
@@ -666,113 +628,78 @@ func (c *Config) UnmarshalYAML(unmarshal func(any) error) error {
 			}
 		}
 		for _, voc := range rcv.VictorOpsConfigs {
-			if voc.HTTPConfig == nil {
-				voc.HTTPConfig = c.Global.HTTPConfig
-			}
+			voc.HTTPConfig = cmp.Or(voc.HTTPConfig, c.Global.HTTPConfig)
+			voc.APIURL = cmp.Or(voc.APIURL, c.Global.VictorOpsAPIURL)
 			if voc.APIURL == nil {
-				if c.Global.VictorOpsAPIURL == nil {
-					return errors.New("no global VictorOps URL set")
-				}
-				voc.APIURL = c.Global.VictorOpsAPIURL
+				return errors.New("no global VictorOps URL set")
 			}
 			if !strings.HasSuffix(voc.APIURL.Path, "/") {
 				voc.APIURL.Path += "/"
 			}
+			voc.APIKey = cmp.Or(voc.APIKey, c.Global.VictorOpsAPIKey)
+			voc.APIKeyFile = cmp.Or(voc.APIKeyFile, c.Global.VictorOpsAPIKeyFile)
 			if voc.APIKey == "" && len(voc.APIKeyFile) == 0 {
-				if c.Global.VictorOpsAPIKey == "" && len(c.Global.VictorOpsAPIKeyFile) == 0 {
-					return errors.New("no global VictorOps API Key set")
-				}
-				voc.APIKey = c.Global.VictorOpsAPIKey
-				voc.APIKeyFile = c.Global.VictorOpsAPIKeyFile
+				return errors.New("no global VictorOps API Key set")
 			}
 		}
 		for _, sns := range rcv.SNSConfigs {
-			if sns.HTTPConfig == nil {
-				sns.HTTPConfig = c.Global.HTTPConfig
-			}
+			sns.HTTPConfig = cmp.Or(sns.HTTPConfig, c.Global.HTTPConfig)
 		}
 
 		for _, telegram := range rcv.TelegramConfigs {
-			if telegram.HTTPConfig == nil {
-				telegram.HTTPConfig = c.Global.HTTPConfig
-			}
-			if telegram.APIUrl == nil {
-				telegram.APIUrl = c.Global.TelegramAPIUrl
-			}
+			telegram.HTTPConfig = cmp.Or(telegram.HTTPConfig, c.Global.HTTPConfig)
+			telegram.APIUrl = cmp.Or(telegram.APIUrl, c.Global.TelegramAPIUrl)
 		}
 		for _, discord := range rcv.DiscordConfigs {
-			if discord.HTTPConfig == nil {
-				discord.HTTPConfig = c.Global.HTTPConfig
-			}
+			discord.HTTPConfig = cmp.Or(discord.HTTPConfig, c.Global.HTTPConfig)
 			if discord.WebhookURL == nil && len(discord.WebhookURLFile) == 0 {
 				return errors.New("no discord webhook URL or URLFile provided")
 			}
 		}
 		for _, webex := range rcv.WebexConfigs {
-			if webex.HTTPConfig == nil {
-				webex.HTTPConfig = c.Global.HTTPConfig
-			}
+			webex.HTTPConfig = cmp.Or(webex.HTTPConfig, c.Global.HTTPConfig)
+			webex.APIURL = cmp.Or(webex.APIURL, c.Global.WebexAPIURL)
 			if webex.APIURL == nil {
-				if c.Global.WebexAPIURL == nil {
-					return errors.New("no global Webex URL set")
-				}
-
-				webex.APIURL = c.Global.WebexAPIURL
+				return errors.New("no global Webex URL set")
 			}
 		}
 		for _, msteams := range rcv.MSTeamsConfigs {
-			if msteams.HTTPConfig == nil {
-				msteams.HTTPConfig = c.Global.HTTPConfig
-			}
+			msteams.HTTPConfig = cmp.Or(msteams.HTTPConfig, c.Global.HTTPConfig)
 			if msteams.WebhookURL == nil && len(msteams.WebhookURLFile) == 0 {
 				return errors.New("no msteams webhook URL or URLFile provided")
 			}
 		}
 		for _, msteamsv2 := range rcv.MSTeamsV2Configs {
-			if msteamsv2.HTTPConfig == nil {
-				msteamsv2.HTTPConfig = c.Global.HTTPConfig
-			}
+			msteamsv2.HTTPConfig = cmp.Or(msteamsv2.HTTPConfig, c.Global.HTTPConfig)
 			if msteamsv2.WebhookURL == nil && len(msteamsv2.WebhookURLFile) == 0 {
 				return errors.New("no msteamsv2 webhook URL or URLFile provided")
 			}
 		}
 		for _, jira := range rcv.JiraConfigs {
-			if jira.HTTPConfig == nil {
-				jira.HTTPConfig = c.Global.HTTPConfig
-			}
+			jira.HTTPConfig = cmp.Or(jira.HTTPConfig, c.Global.HTTPConfig)
+			jira.APIURL = cmp.Or(jira.APIURL, c.Global.JiraAPIURL)
 			if jira.APIURL == nil {
-				if c.Global.JiraAPIURL == nil {
-					return errors.New("no global Jira Cloud URL set")
-				}
-				jira.APIURL = c.Global.JiraAPIURL
+				return errors.New("no global Jira Cloud URL set")
 			}
 		}
 		for _, rocketchat := range rcv.RocketchatConfigs {
-			if rocketchat.HTTPConfig == nil {
-				rocketchat.HTTPConfig = c.Global.HTTPConfig
-			}
-			if rocketchat.APIURL == nil {
-				rocketchat.APIURL = c.Global.RocketchatAPIURL
-			}
+			rocketchat.HTTPConfig = cmp.Or(rocketchat.HTTPConfig, c.Global.HTTPConfig)
+			rocketchat.APIURL = cmp.Or(rocketchat.APIURL, c.Global.RocketchatAPIURL)
+
+			rocketchat.TokenID = cmp.Or(rocketchat.TokenID, c.Global.RocketchatTokenID)
+			rocketchat.TokenIDFile = cmp.Or(rocketchat.TokenIDFile, c.Global.RocketchatTokenIDFile)
 			if rocketchat.TokenID == nil && len(rocketchat.TokenIDFile) == 0 {
-				if c.Global.RocketchatTokenID == nil && len(c.Global.RocketchatTokenIDFile) == 0 {
-					return errors.New("no global Rocketchat TokenID set either inline or in a file")
-				}
-				rocketchat.TokenID = c.Global.RocketchatTokenID
-				rocketchat.TokenIDFile = c.Global.RocketchatTokenIDFile
+				return errors.New("no global Rocketchat TokenID set either inline or in a file")
 			}
+
+			rocketchat.Token = cmp.Or(rocketchat.Token, c.Global.RocketchatToken)
+			rocketchat.TokenFile = cmp.Or(rocketchat.TokenFile, c.Global.RocketchatTokenFile)
 			if rocketchat.Token == nil && len(rocketchat.TokenFile) == 0 {
-				if c.Global.RocketchatToken == nil && len(c.Global.RocketchatTokenFile) == 0 {
-					return errors.New("no global Rocketchat Token set either inline or in a file")
-				}
-				rocketchat.Token = c.Global.RocketchatToken
-				rocketchat.TokenFile = c.Global.RocketchatTokenFile
+				return errors.New("no global Rocketchat Token set either inline or in a file")
 			}
 		}
 		for _, mattermost := range rcv.MattermostConfigs {
-			if mattermost.HTTPConfig == nil {
-				mattermost.HTTPConfig = c.Global.HTTPConfig
-			}
+			mattermost.HTTPConfig = cmp.Or(mattermost.HTTPConfig, c.Global.HTTPConfig)
 		}
 
 		names[rcv.Name] = struct{}{}


### PR DESCRIPTION
cmp.Or is part of the standard-library since go 1.22. This PR uses it to apply global-defaults in the configuration.