### PR TITLE
smtp: Customize the SSL/TLS port support (#4757)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -555,6 +555,9 @@ func (c *Config) UnmarshalYAML(unmarshal func(any) error) error {
 				ec.RequireTLS = new(bool)
 				*ec.RequireTLS = c.Global.SMTPRequireTLS
 			}
+			if ec.ForceImplicitTLS == nil {
+				ec.ForceImplicitTLS = c.Global.SMTPForceImplicitTLS
+			}
 		}
 		for _, sc := range rcv.SlackConfigs {
 			if sc.AppURL == nil {
@@ -992,6 +995,7 @@ type GlobalConfig struct {
 	SMTPAuthIdentity      string               `yaml:"smtp_auth_identity,omitempty" json:"smtp_auth_identity,omitempty"`
 	SMTPRequireTLS        bool                 `yaml:"smtp_require_tls" json:"smtp_require_tls,omitempty"`
 	SMTPTLSConfig         *commoncfg.TLSConfig `yaml:"smtp_tls_config,omitempty" json:"smtp_tls_config,omitempty"`
+	SMTPForceImplicitTLS  *bool                `yaml:"smtp_force_implicit_tls,omitempty" json:"smtp_force_implicit_tls,omitempty"`
 	SlackAPIURL           *SecretURL           `yaml:"slack_api_url,omitempty" json:"slack_api_url,omitempty"`
 	SlackAPIURLFile       string               `yaml:"slack_api_url_file,omitempty" json:"slack_api_url_file,omitempty"`
 	SlackAppToken         Secret               `yaml:"slack_app_token,omitempty" json:"slack_app_token,omitempty"`

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -315,7 +315,12 @@ type EmailConfig struct {
 	Text             string               `yaml:"text,omitempty" json:"text,omitempty"`
 	RequireTLS       *bool                `yaml:"require_tls,omitempty" json:"require_tls,omitempty"`
 	TLSConfig        *commoncfg.TLSConfig `yaml:"tls_config,omitempty" json:"tls_config,omitempty"`
-	Threading        ThreadingConfig      `yaml:"threading,omitempty" json:"threading,omitempty"`
+	// ForceImplicitTLS controls whether to use implicit TLS (direct TLS connection).
+	// true: force use of implicit TLS (direct TLS connection)
+	// false: force disable implicit TLS (use explicit TLS/STARTTLS if required)
+	// nil (default): auto-detect based on port (465=implicit, other=explicit) for backward compatibility
+	ForceImplicitTLS *bool           `yaml:"force_implicit_tls,omitempty" json:"force_implicit_tls,omitempty"`
+	Threading        ThreadingConfig `yaml:"threading,omitempty" json:"threading,omitempty"`
 }
 
 // ThreadingConfig configures mail threading.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -988,6 +988,11 @@ to: <tmpl_string>
 # Note that Go does not support unencrypted connections to remote SMTP endpoints.
 [ require_tls: <bool> | default = global.smtp_require_tls ]
 
+# Force use of implicit TLS (direct TLS connection) for better security.
+# true: force use of implicit TLS (direct TLS connection on any port)
+# nil (default): auto-detect based on port (465=implicit, other=explicit) for backward compatibility
+[ implicit_tls: <bool> | default = nil ]
+
 # TLS configuration.
 tls_config:
   [ <tls_config> | default = global.smtp_tls_config ]
@@ -1000,6 +1005,27 @@ tls_config:
 # Further headers email header key/value pairs. Overrides any headers
 # previously set by the notification implementation.
 [ headers: { <string>: <tmpl_string>, ... } ]
+
+#### Email TLS Configuration Examples
+
+```yaml
+# Example 1: Force implicit TLS on any port (recommended for security)
+receivers:
+  - name: email-implicit-tls
+    email_configs:
+      - to: alerts@example.com
+        smarthost: smtp.example.com:8465
+        implicit_tls: true  # Use direct TLS connection on port 8465
+
+# Example 2: Backward compatible (no implicit_tls specified)
+receivers:
+  - name: email-default
+    email_configs:
+      - to: alerts@example.com
+        smarthost: smtp.example.com:465  # Auto-detects implicit TLS
+      - to: alerts@example.com
+        smarthost: smtp.example.com:587  # Auto-detects explicit TLS
+```
 
 # Email threading configuration.
 threading:


### PR DESCRIPTION
## Summary
The current email notification implementation has hardcoded logic that only enables direct TLS connections for port 465. This creates a limitation when using TLS on other ports, causing `create SMTP client: EOF` errors when the server expects TLS connections on non-465 ports.

## Description
In [notify/email/email.go:133](https://github.com/prometheus/alertmanager/blob/main/notify/email/email.go#L133), there's hardcoded logic that only uses `tls.Dial()` for port 465, while all other ports use plain TCP connections. This causes issues when SMTP servers require TLS connections on ports other than 465.

However, some SMTP servers may be configured to require TLS connections on non-standard ports but don't support STARTTLS, leading to EOF errors.