### PR TITLE
fix(jira.go): allow to disable resolve transition  if not set in config

### DIFF
--- a/notify/jira/jira.go
+++ b/notify/jira/jira.go
@@ -346,6 +346,10 @@ func (n *Notifier) transitionIssue(ctx context.Context, logger *slog.Logger, i *
 		transition = n.conf.ResolveTransition
 	}
 
+	if transition == "" {
+		return false, nil
+	}
+
 	transitionID, shouldRetry, err := n.getIssueTransitionByName(ctx, i.Key, transition)
 	if err != nil {
 		return shouldRetry, err


### PR DESCRIPTION
this resolves #4820 

Small code change to allow disable of resolve transition. We don´t want to reopen already closed issues and it´s causing a lot of error logs

`{"time":"2025-12-17T20:35:08.365043961+01:00","level":"ERROR","source":"dispatch.go:515","msg":"Notify for alerts failed","component":"dispatcher","aggrGroup":"{}/{type=\"checkly_problem\"}:{alertname=\"E2E Tagging Validation Failed\", environment=\"Produktion\"}","num_alerts":3,"err":"mon_global/jira[0]: notify retry canceled due to unrecoverable error after 1 attempts: can't find transition  for issue MON-7423"}`