### PR TITLE
feat(config): enhance email notifier configuration validation

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net/textproto"
 	"regexp"
+	"slices"
 	"strings"
 	"text/template"
 	"time"
@@ -351,6 +352,9 @@ func (c *EmailConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		}
 		if _, ok := normalizedHeaders["In-Reply-To"]; ok {
 			return errors.New("conflicting configuration: threading.enabled conflicts with custom In-Reply-To header")
+		}
+		if !slices.Contains([]string{"none", "daily"}, c.Threading.ThreadByDate) {
+			return errors.New("threading.thread_by_date must be either 'none' or 'daily'")
 		}
 	}
 

--- a/config/notifiers_test.go
+++ b/config/notifiers_test.go
@@ -1269,3 +1269,61 @@ attachments:
 		})
 	}
 }
+
+func TestEmailConfig_UnmarshalYAML(t *testing.T) {
+	testConfig := []struct {
+		name     string
+		in       string
+		expected error
+	}{
+		{
+			name: "with basic config - it succeeds",
+			in: `
+to: foobar@example.com
+headers: {X-Custom-Header: CustomValue}
+`,
+		},
+		{
+			name: "with empty to address - it fails",
+			in: `
+to: ''`,
+			expected: errors.New("missing to address in email config"),
+		},
+		{
+			name: "with correct threading - it succeeds",
+			in: `
+to: foobar@example.com
+threading:
+  enabled: true
+  thread_by_date: daily
+`,
+		},
+		{
+			name: "with invalid threading - it fails",
+			in: `
+to: foobar@example.com
+threading:
+  enabled: true
+  thread_by_date: weekly
+`,
+			expected: errors.New("threading.thread_by_date must be either 'none' or 'daily'"),
+		},
+		{
+			name: "with duplicate headers - it failes",
+			in: `
+to: foobar@example.com
+headers: {X-Custom-Header: CustomValue, X-CUSTOM-HEADER: AnotherValue}
+`,
+			expected: errors.New("duplicate header \"X-Custom-Header\" in email config"),
+		},
+	}
+
+	for _, tt := range testConfig {
+		t.Run(tt.name, func(t *testing.T) {
+			var cfg EmailConfig
+			err := yaml.UnmarshalStrict([]byte(tt.in), &cfg)
+
+			require.Equal(t, tt.expected, err)
+		})
+	}
+}


### PR DESCRIPTION
validate that threading.thread_by_date is either 'none' or 'daily' in email notifier config

Ref: https://github.com/prometheus/alertmanager/pull/4623#discussion_r2643465154