### PR TITLE
ui: fix escaping for matcher values with quotes

### DIFF
--- a/ui/app/tests/Filter.elm
+++ b/ui/app/tests/Filter.elm
@@ -16,6 +16,16 @@ parseMatcher =
         , test "should parse empty matcher value" <|
             \() ->
                 Expect.equal (Just (Matcher "alertname" Eq "")) (Utils.Filter.parseMatcher "alertname=\"\"")
+        , test "should unescape quoted matcher value" <|
+            \() ->
+                Expect.equal
+                    (Just (Matcher "alertname" Eq "foo\"bar"))
+                    (Utils.Filter.parseMatcher "alertname=\"foo\\\"bar\"")
+        , test "should unescape backslash matcher value" <|
+            \() ->
+                Expect.equal
+                    (Just (Matcher "alertname" Eq "foo\\bar"))
+                    (Utils.Filter.parseMatcher "alertname=\"foo\\\\bar\"")
         , fuzz (tuple ( string, string )) "should parse random matcher string" <|
             \( key, value ) ->
                 if List.map isNotEmptyTrimmedAlphabetWord [ key, value ] /= [ True, True ] then
@@ -82,5 +92,11 @@ stringifyFilter =
                         [ { key = "foo", op = Eq, value = "bar" }
                         , { key = "baz", op = RegexMatch, value = "quux.*" }
                         ]
+                    )
+        , test "escapes matcher values" <|
+            \() ->
+                Expect.equal "{foo=\"bar\\\"baz\\\\qux\"}"
+                    (Utils.Filter.stringifyFilter
+                        [ { key = "foo", op = Eq, value = "bar\"baz\\qux" } ]
                     )
         ]


### PR DESCRIPTION
## Summary
- unescape matcher values in the filter parser to match backend escape rules
- escape matcher values when stringifying filters so quotes/backslashes round-trip

## Testing
- `make format`
- `make test`
- `make build-all`

Fixes #1913
