### PR TITLE
update expr for AlertmanagerClusterFailedToSendAlerts alerts

### DIFF
--- a/doc/alertmanager-mixin/alerts.libsonnet
+++ b/doc/alertmanager-mixin/alerts.libsonnet
@@ -64,8 +64,8 @@
                 rate(alertmanager_notifications_failed_total{%(alertmanagerSelector)s, integration=~`%(alertmanagerCriticalIntegrationsRegEx)s`}[15m])
               /
                 ignoring (reason) group_left rate(alertmanager_notifications_total{%(alertmanagerSelector)s, integration=~`%(alertmanagerCriticalIntegrationsRegEx)s`}[15m])
+                > 0.01
               )
-              > 0.01
             ||| % $._config,
             'for': '5m',
             labels: {
@@ -83,8 +83,8 @@
                 rate(alertmanager_notifications_failed_total{%(alertmanagerSelector)s, integration!~`%(alertmanagerCriticalIntegrationsRegEx)s`}[15m])
               /
                 ignoring (reason) group_left rate(alertmanager_notifications_total{%(alertmanagerSelector)s, integration!~`%(alertmanagerCriticalIntegrationsRegEx)s`}[15m])
+                > 0.01
               )
-              > 0.01
             ||| % $._config,
             'for': '5m',
             labels: {


### PR DESCRIPTION
AlertmanagerClusterFailedToSendAlerts critical alert is defined in
https://github.com/prometheus/alertmanager/blob/release-0.29/doc/alertmanager-mixin/alerts.libsonnet#L61-L78
configured wrong smtp port for email_configs
```
receivers:
  - name: 'email.hook'
    email_configs:
    - to: **@**.com
      from: **@**.com
      smarthost: 'smtp.**.com:259' => wrong smtp port
      require_tls: false
```
saw the erorrs in alertmanager logs
```
time=2026-01-06T06:40:36.220Z level=ERROR source=dispatch.go:360 msg="Notify for alerts failed" component=dispatcher num_alerts=1 err="email.hook/email[0]: notify retry canceled after 3 attempts: establish connection to server: dial tcp [**:**:**:**]:259: connect: connection timed out"
```
expected the AlertmanagerClusterFailedToSendAlerts to be fired, but not
<img width="1920" height="2235" alt="Image" src="https://github.com/user-attachments/assets/2a8e8a7a-cf63-43d8-8fe3-e7146d842649" />
checked with the prometheus query, move the `> 0.01` inside the bracket, would see the alert fired
<img width="1920" height="1653" alt="Image" src="https://github.com/user-attachments/assets/d5a4da52-8fe0-4291-bdc7-4c30ccaa0649" />

same for the AlertmanagerClusterFailedToSendAlerts warning alert