### PR TITLE
chore: document slack app configs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,6 +102,10 @@ global:
   # The API URL to use for Slack notifications.
   [ slack_api_url: <secret> ]
   [ slack_api_url_file: <filepath> ]
+  [ slack_app_token: <secret> ]
+  [ slack_app_token_file: <filepath> ]
+  [ slack_app_url: <string> ]
+
   [ victorops_api_key: <secret> ]
   [ victorops_api_key_file: <filepath> ]
   [ victorops_api_url: <string> | default = "https://alert.victorops.com/integrations/generic/20131114/alert/" ]
@@ -1554,10 +1558,18 @@ The notification contains an [attachment](https://docs.slack.dev/legacy/legacy-m
 # Whether to notify about resolved alerts.
 [ send_resolved: <boolean> | default = false ]
 
-# The Slack webhook URL. Either api_url or api_url_file should be set.
+# The Slack webhook URL. Either api_url/api_url_file OR app_token/app_token_file should be set, but not both.
 # Defaults to global settings if none are set here.
 [ api_url: <secret> | default = global.slack_api_url ]
 [ api_url_file: <filepath> | default = global.slack_api_url_file ]
+
+# Slack App token for OAuth authentication. Mutually exclusive with api_url/api_url_file.
+# Defaults to global settings if no local authorization or webhook URL is configured.
+[ app_token: <secret> | default = global.slack_app_token ]
+[ app_token_file: <filepath> | default = global.slack_app_token_file ]
+
+# The Slack App URL. Required when using app_token authentication.
+[ app_url: <string> | default = global.slack_app_url ]
 
 # The channel or user to send notifications to.
 channel: <tmpl_string>
@@ -1576,7 +1588,7 @@ actions:
 fields:
   [ <field_config> ... ]
 [ footer: <tmpl_string> | default = '{{ template "slack.default.footer" . }}' ]
-[ mrkdwn_in: '[' <string>, ... ']' | default = ["fallback", "pretext", "text"] ]
+[ mrkdwn_in: [ <string>, ... ] | default = ["fallback", "pretext", "text"] ]
 [ pretext: <tmpl_string> | default = '{{ template "slack.default.pretext" . }}' ]
 [ short_fields: <boolean> | default = false ]
 [ text: <tmpl_string> | default = '{{ template "slack.default.text" . }}' ]


### PR DESCRIPTION
New AM version  [v0.30.0](https://github.com/prometheus/alertmanager/releases/tag/v0.30.0) has support for slack app, but fields were not documented, added fix for that.