### PR TITLE
Group otel dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
         patterns:
           - "github.com/aws/*"
           - "github.com/go-openapi/*"
+      go.opentelemetry.io:
+        patterns:
+          - "go.opentelemetry.io/*"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
Group the `go.opentelemetry.io` dependencies in dependabot to reduce the number of PRs.