### PR TITLE
fix(notify): safe telegram html truncation

### DIFF
--- a/notify/telegram/telegram.go
+++ b/notify/telegram/telegram.go
@@ -82,7 +82,7 @@ func (n *Notifier) Notify(ctx context.Context, alert ...*types.Alert) (bool, err
 		tmpl = notify.TmplHTML(n.tmpl, data, &err)
 	}
 
-	messageText, truncated := notify.TruncateInRunes(tmpl(n.conf.Message), maxMessageLenRunes)
+	messageText, truncated := truncateMessage(tmpl(n.conf.Message), maxMessageLenRunes, n.conf.ParseMode)
 	if err != nil {
 		return false, err
 	}
@@ -132,4 +132,11 @@ func (n *Notifier) getBotToken() (string, error) {
 		return strings.TrimSpace(string(content)), nil
 	}
 	return string(n.conf.BotToken), nil
+}
+
+func truncateMessage(message string, maxMessageLenRunes int, parseMode string) (string, bool) {
+	if parseMode == "HTML" {
+		return notify.TruncateInRunesHTML(message, maxMessageLenRunes)
+	}
+	return notify.TruncateInRunes(message, maxMessageLenRunes)
 }


### PR DESCRIPTION
### Fix telegram truncation breaking markup

I've come back 4 years later to fix the bug I introduced with telegram notifier in 2022. 

**Context:**
When truncating telegram alert with HTML formatting, truncate function would cut off mid html tag, leaving malformed HTML. Added `TruncateInRunesHTML` function that fixes this bug. It tracks open tags while scanning and ensures that all the tags are properly closed. It finds the last safe cut point where we can fit the truncation marker plus all necesarry closing tags within the limit.

Tested with unit tests which I also added, and also manually with a long alert message, looks something like this:
```
🔥 TruncationTest 🔥

Status: firing
Severity: critical

Labels:
  • alertname: TruncationTest
  • instance: server-001.example.com:9090
  • job: prometheus
  • label_01: value_for_label_01_with_some_padding
  • label_02: value_for_label_02_with_some_padding
  • label_03: value_for_label_03_with_some_padding
  • label_04: value_for_label_04_with_some_padding
  • label_05: value_for_label_05_with_some_padding
  • label_06: value_for_label_06_with_some_padding
  • label_07: value_for_label_07_with_some_padding
  • label_08: value_for_label_08_with_some_padding
  • label_09: value_for_label_09_with_some_padding
  • label_10: value_for_label_10_with_some_padding
  • label_11: value_for_label_01_with_some_padding
  • label_12: value_for_label_02_with_some_padding
  • label_13: value_for_label_03_with_some_padding
  • label_14: value_for_label_04_with_some_padding
  • label_15: value_for_label_05_with_some_padding
  • label_16: value_for_label_06_with_some_padding
  • label_17: value_for_label_07_with_some_padding
  • label_18: value_for_label_08_with_some_padding
  • label_19: value_for_label_09_with_some_padding
  • label_20: value_for_label_10_with_some_padding
  • label_21: value_for_label_01_with_some_padding
  • label_22: value_for_label_02_with_some_padding
  • label_23: value_for_label_03_with_some_padding
  • label_24: value_for_label_04_with_some_padding
  • label_25: value_for_label_05_with_some_padding
  • label_26: value_for_label_06_with_some_padding
  • label_27: value_for_label_07_with_some_padding
  • label_28: value_for_label_08_with_some_padding
  • label_29: value_for_label_09_with_some_padding
  • label_30: value_for_label_10_with_some_padding
  • label_31: value_for_label_01_with_some_padding
  • label_32: value_for_label_02_with_some_padding
  • label_33: value_for_label_03_with_some_padding
  • label_34: value_for_label_04_with_some_padding
  • label_35: value_for_label_05_with_some_padding
  • label_36: value_for_label_06_with_some_padding
  • label_37: value_for_label_07_with_some_padding
  • label_38: value_for_label_08_with_some_padding
  • label_39: value_for_label_09_with_some_padding
  • label_40: value_for_label_10_with_some_padding
  • namespace: monitoring
  • pod: prometheus-server-0
  • service: prometheus-operated
  • severity: critical

Annotations:
  • description: This is a very long description that will be repeated many times to ensure we exceed the Telegram message limit of 4096 characters. This is a very long description that will be repeated many times to ensure we exceed the Telegram message limit of 4096 characters. This is a very long description that will be repeated many times to ensure we exceed the Telegram message limit of 4096 characters. This is a very long description that will be repeated many times to ensure we exceed the Telegram message limit of 4096 characters. This is a very long description that will be repeated many times to ensure we exceed the Telegram message limit of 4096 characters. This is a very long description that will be repeated many times to ensure we exceed the Telegram message limit of 4096 characters. This is a very long description that will be repeated many times to ensure we exceed the Telegram message limit of 4096 characters. This is a very long description that will be repeated many times to ensure we exceed the Telegram message limit of 4096 chara…
```

Closes related issue #2923 