### PR TITLE
chore(notify.go): Clean up duplicate code in RetryStage.exec

### DIFF
--- a/notify/notify.go
+++ b/notify/notify.go
@@ -942,18 +942,6 @@ func (r RetryStage) exec(ctx context.Context, l *slog.Logger, alerts ...*types.A
 				return ctx, alerts, nil
 			}
 		case <-ctx.Done():
-			if iErr == nil {
-				iErr = ctx.Err()
-				if errors.Is(iErr, context.Canceled) {
-					iErr = NewErrorWithReason(ContextCanceledReason, iErr)
-				} else if errors.Is(iErr, context.DeadlineExceeded) {
-					iErr = NewErrorWithReason(ContextDeadlineExceededReason, iErr)
-				}
-			}
-			if iErr != nil {
-				return ctx, nil, fmt.Errorf("%s/%s: notify retry canceled after %d attempts: %w", r.groupName, r.integration.String(), i, iErr)
-			}
-			return ctx, nil, nil
 		}
 	}
 }


### PR DESCRIPTION
The code in the two selects in case ctx is done is exactly the same. Remove the second copy, the first one will be reached via the for loop.