### PR TITLE
refactor: replace config.Secret with commoncfg.Secret

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -41,48 +41,12 @@ const secretToken = "<secret>"
 
 var secretTokenJSON string
 
-// MarshalSecretValue if set to true will expose Secret type
-// through the marshal interfaces. Useful for outside projects
-// that load and marshal the Alertmanager config.
-var MarshalSecretValue bool = commoncfg.MarshalSecretValue
-
 func init() {
 	b, err := json.Marshal(secretToken)
 	if err != nil {
 		panic(err)
 	}
 	secretTokenJSON = string(b)
-}
-
-// Secret is a string that must not be revealed on marshaling.
-type Secret string
-
-// MarshalYAML implements the yaml.Marshaler interface for Secret.
-func (s Secret) MarshalYAML() (any, error) {
-	if MarshalSecretValue {
-		return string(s), nil
-	}
-	if s != "" {
-		return secretToken, nil
-	}
-	return nil, nil
-}
-
-// UnmarshalYAML implements the yaml.Unmarshaler interface for Secret.
-func (s *Secret) UnmarshalYAML(unmarshal func(any) error) error {
-	type plain Secret
-	return unmarshal((*plain)(s))
-}
-
-// MarshalJSON implements the json.Marshaler interface for Secret.
-func (s Secret) MarshalJSON() ([]byte, error) {
-	if MarshalSecretValue {
-		return json.Marshal(string(s))
-	}
-	if len(s) == 0 {
-		return json.Marshal("")
-	}
-	return json.Marshal(secretToken)
 }
 
 // URL is a custom type that represents an HTTP or HTTPS URL and allows validation at configuration load time.
@@ -146,7 +110,7 @@ type SecretURL URL
 // MarshalYAML implements the yaml.Marshaler interface for SecretURL.
 func (s SecretURL) MarshalYAML() (any, error) {
 	if s.URL != nil {
-		if MarshalSecretValue {
+		if commoncfg.MarshalSecretValue {
 			return s.String(), nil
 		}
 		return secretToken, nil
@@ -175,7 +139,7 @@ func (s SecretURL) MarshalJSON() ([]byte, error) {
 	if s.URL == nil {
 		return json.Marshal("")
 	}
-	if MarshalSecretValue {
+	if commoncfg.MarshalSecretValue {
 		return json.Marshal(s.String())
 	}
 	return json.Marshal(secretToken)
@@ -192,7 +156,7 @@ func (s *SecretURL) UnmarshalJSON(data []byte) error {
 	}
 	// Redact the secret URL in case of errors
 	if err := json.Unmarshal(data, (*URL)(s)); err != nil {
-		if MarshalSecretValue {
+		if commoncfg.MarshalSecretValue {
 			return err
 		}
 		return errors.New(strings.ReplaceAll(err.Error(), string(data), "[REDACTED]"))
@@ -217,12 +181,12 @@ func containsTemplating(s string) (bool, error) {
 // SecretTemplateURL is a Secret string that represents a URL which may contain
 // Go template syntax. Unlike SecretURL, it allows templated values and only
 // validates non-templated URLs at unmarshal time.
-type SecretTemplateURL Secret
+type SecretTemplateURL commoncfg.Secret
 
 // MarshalYAML implements the yaml.Marshaler interface for SecretTemplateURL.
 func (s SecretTemplateURL) MarshalYAML() (any, error) {
 	if s != "" {
-		if MarshalSecretValue {
+		if commoncfg.MarshalSecretValue {
 			return string(s), nil
 		}
 		return secretToken, nil
@@ -232,7 +196,7 @@ func (s SecretTemplateURL) MarshalYAML() (any, error) {
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for SecretTemplateURL.
 func (s *SecretTemplateURL) UnmarshalYAML(unmarshal func(any) error) error {
-	type plain Secret
+	type plain commoncfg.Secret
 	if err := unmarshal((*plain)(s)); err != nil {
 		return err
 	}
@@ -262,7 +226,7 @@ func (s *SecretTemplateURL) UnmarshalYAML(unmarshal func(any) error) error {
 
 // MarshalJSON implements the json.Marshaler interface for SecretTemplateURL.
 func (s SecretTemplateURL) MarshalJSON() ([]byte, error) {
-	return Secret(s).MarshalJSON()
+	return commoncfg.Secret(s).MarshalJSON()
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface for SecretTemplateURL.
@@ -926,9 +890,9 @@ type GlobalConfig struct {
 	SMTPHello             string               `yaml:"smtp_hello,omitempty" json:"smtp_hello,omitempty"`
 	SMTPSmarthost         HostPort             `yaml:"smtp_smarthost,omitempty" json:"smtp_smarthost,omitempty"`
 	SMTPAuthUsername      string               `yaml:"smtp_auth_username,omitempty" json:"smtp_auth_username,omitempty"`
-	SMTPAuthPassword      Secret               `yaml:"smtp_auth_password,omitempty" json:"smtp_auth_password,omitempty"`
+	SMTPAuthPassword      commoncfg.Secret     `yaml:"smtp_auth_password,omitempty" json:"smtp_auth_password,omitempty"`
 	SMTPAuthPasswordFile  string               `yaml:"smtp_auth_password_file,omitempty" json:"smtp_auth_password_file,omitempty"`
-	SMTPAuthSecret        Secret               `yaml:"smtp_auth_secret,omitempty" json:"smtp_auth_secret,omitempty"`
+	SMTPAuthSecret        commoncfg.Secret     `yaml:"smtp_auth_secret,omitempty" json:"smtp_auth_secret,omitempty"`
 	SMTPAuthSecretFile    string               `yaml:"smtp_auth_secret_file,omitempty" json:"smtp_auth_secret_file,omitempty"`
 	SMTPAuthIdentity      string               `yaml:"smtp_auth_identity,omitempty" json:"smtp_auth_identity,omitempty"`
 	SMTPRequireTLS        bool                 `yaml:"smtp_require_tls" json:"smtp_require_tls,omitempty"`
@@ -936,28 +900,28 @@ type GlobalConfig struct {
 	SMTPForceImplicitTLS  *bool                `yaml:"smtp_force_implicit_tls,omitempty" json:"smtp_force_implicit_tls,omitempty"`
 	SlackAPIURL           *SecretURL           `yaml:"slack_api_url,omitempty" json:"slack_api_url,omitempty"`
 	SlackAPIURLFile       string               `yaml:"slack_api_url_file,omitempty" json:"slack_api_url_file,omitempty"`
-	SlackAppToken         Secret               `yaml:"slack_app_token,omitempty" json:"slack_app_token,omitempty"`
+	SlackAppToken         commoncfg.Secret     `yaml:"slack_app_token,omitempty" json:"slack_app_token,omitempty"`
 	SlackAppTokenFile     string               `yaml:"slack_app_token_file,omitempty" json:"slack_app_token_file,omitempty"`
 	SlackAppURL           *URL                 `yaml:"slack_app_url,omitempty" json:"slack_app_url,omitempty"`
 	PagerdutyURL          *URL                 `yaml:"pagerduty_url,omitempty" json:"pagerduty_url,omitempty"`
 	OpsGenieAPIURL        *URL                 `yaml:"opsgenie_api_url,omitempty" json:"opsgenie_api_url,omitempty"`
-	OpsGenieAPIKey        Secret               `yaml:"opsgenie_api_key,omitempty" json:"opsgenie_api_key,omitempty"`
+	OpsGenieAPIKey        commoncfg.Secret     `yaml:"opsgenie_api_key,omitempty" json:"opsgenie_api_key,omitempty"`
 	OpsGenieAPIKeyFile    string               `yaml:"opsgenie_api_key_file,omitempty" json:"opsgenie_api_key_file,omitempty"`
 	WeChatAPIURL          *URL                 `yaml:"wechat_api_url,omitempty" json:"wechat_api_url,omitempty"`
-	WeChatAPISecret       Secret               `yaml:"wechat_api_secret,omitempty" json:"wechat_api_secret,omitempty"`
+	WeChatAPISecret       commoncfg.Secret     `yaml:"wechat_api_secret,omitempty" json:"wechat_api_secret,omitempty"`
 	WeChatAPISecretFile   string               `yaml:"wechat_api_secret_file,omitempty" json:"wechat_api_secret_file,omitempty"`
 	WeChatAPICorpID       string               `yaml:"wechat_api_corp_id,omitempty" json:"wechat_api_corp_id,omitempty"`
 	VictorOpsAPIURL       *URL                 `yaml:"victorops_api_url,omitempty" json:"victorops_api_url,omitempty"`
-	VictorOpsAPIKey       Secret               `yaml:"victorops_api_key,omitempty" json:"victorops_api_key,omitempty"`
+	VictorOpsAPIKey       commoncfg.Secret     `yaml:"victorops_api_key,omitempty" json:"victorops_api_key,omitempty"`
 	VictorOpsAPIKeyFile   string               `yaml:"victorops_api_key_file,omitempty" json:"victorops_api_key_file,omitempty"`
 	TelegramAPIUrl        *URL                 `yaml:"telegram_api_url,omitempty" json:"telegram_api_url,omitempty"`
-	TelegramBotToken      Secret               `yaml:"telegram_bot_token,omitempty" json:"telegram_bot_token,omitempty"`
+	TelegramBotToken      commoncfg.Secret     `yaml:"telegram_bot_token,omitempty" json:"telegram_bot_token,omitempty"`
 	TelegramBotTokenFile  string               `yaml:"telegram_bot_token_file,omitempty" json:"telegram_bot_token_file,omitempty"`
 	WebexAPIURL           *URL                 `yaml:"webex_api_url,omitempty" json:"webex_api_url,omitempty"`
 	RocketchatAPIURL      *URL                 `yaml:"rocketchat_api_url,omitempty" json:"rocketchat_api_url,omitempty"`
-	RocketchatToken       *Secret              `yaml:"rocketchat_token,omitempty" json:"rocketchat_token,omitempty"`
+	RocketchatToken       *commoncfg.Secret    `yaml:"rocketchat_token,omitempty" json:"rocketchat_token,omitempty"`
 	RocketchatTokenFile   string               `yaml:"rocketchat_token_file,omitempty" json:"rocketchat_token_file,omitempty"`
-	RocketchatTokenID     *Secret              `yaml:"rocketchat_token_id,omitempty" json:"rocketchat_token_id,omitempty"`
+	RocketchatTokenID     *commoncfg.Secret    `yaml:"rocketchat_token_id,omitempty" json:"rocketchat_token_id,omitempty"`
 	RocketchatTokenIDFile string               `yaml:"rocketchat_token_id_file,omitempty" json:"rocketchat_token_id_file,omitempty"`
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -525,22 +525,6 @@ func TestHideConfigSecrets(t *testing.T) {
 	}
 }
 
-func TestShowMarshalSecretValues(t *testing.T) {
-	MarshalSecretValue = true
-	defer func() { MarshalSecretValue = false }()
-
-	c, err := LoadFile("testdata/conf.good.yml")
-	if err != nil {
-		t.Fatalf("Error parsing %s: %s", "testdata/conf.good.yml", err)
-	}
-
-	// String method must reveal authentication credentials.
-	s := c.String()
-	if strings.Count(s, "<secret>") > 0 || !strings.Contains(s, "mysecret") {
-		t.Fatal("config's String method must reveal authentication credentials when MarshalSecretValue = true.")
-	}
-}
-
 func TestJSONMarshal(t *testing.T) {
 	c, err := LoadFile("testdata/conf.good.yml")
 	if err != nil {
@@ -551,38 +535,6 @@ func TestJSONMarshal(t *testing.T) {
 	if err != nil {
 		t.Fatal("JSON Marshaling failed:", err)
 	}
-}
-
-func TestJSONMarshalHideSecret(t *testing.T) {
-	test := struct {
-		S Secret
-	}{
-		S: Secret("test"),
-	}
-
-	c, err := json.Marshal(test)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	require.JSONEq(t, `{"S":"<secret>"}`, string(c), "Secret not properly elided.")
-}
-
-func TestJSONMarshalShowSecret(t *testing.T) {
-	MarshalSecretValue = true
-	defer func() { MarshalSecretValue = false }()
-
-	test := struct {
-		S Secret
-	}{
-		S: Secret("test"),
-	}
-
-	c, err := json.Marshal(test)
-	if err != nil {
-		t.Fatal(err)
-	}
-	require.JSONEq(t, `{"S":"test"}`, string(c), "config's String method must reveal authentication credentials when MarshalSecretValue = true.")
 }
 
 func TestJSONMarshalHideSecretURL(t *testing.T) {
@@ -619,23 +571,6 @@ func TestJSONMarshalHideSecretURL(t *testing.T) {
 	}
 }
 
-func TestJSONMarshalShowSecretURL(t *testing.T) {
-	MarshalSecretValue = true
-	defer func() { MarshalSecretValue = false }()
-
-	urlp, err := url.Parse("http://example.com/")
-	if err != nil {
-		t.Fatal(err)
-	}
-	u := &SecretURL{urlp}
-
-	c, err := json.Marshal(u)
-	if err != nil {
-		t.Fatal(err)
-	}
-	require.Equal(t, "\"http://example.com/\"", string(c), "config's String method must reveal authentication credentials when MarshalSecretValue = true.")
-}
-
 func TestUnmarshalSecretURL(t *testing.T) {
 	b := []byte(`"http://example.com/se cret"`)
 	var u SecretURL
@@ -664,8 +599,8 @@ func TestHideSecretURL(t *testing.T) {
 }
 
 func TestShowMarshalSecretURL(t *testing.T) {
-	MarshalSecretValue = true
-	defer func() { MarshalSecretValue = false }()
+	commoncfg.MarshalSecretValue = true
+	defer func() { commoncfg.MarshalSecretValue = false }()
 
 	b := []byte(`"://wrongurl/"`)
 	var u SecretURL
@@ -1073,10 +1008,10 @@ func TestGlobalAndLocalSMTPPassword(t *testing.T) {
 	require.Equal(t, "/tmp/localuser1password", config.Receivers[0].EmailConfigs[1].AuthPasswordFile, "second email should use password file /tmp/localuser1password")
 	require.Emptyf(t, config.Receivers[0].EmailConfigs[1].AuthPassword, "password field should be empty when file provided")
 
-	require.Equal(t, Secret("mysecret"), config.Receivers[0].EmailConfigs[2].AuthPassword, "third email should use password mysecret")
+	require.Equal(t, commoncfg.Secret("mysecret"), config.Receivers[0].EmailConfigs[2].AuthPassword, "third email should use password mysecret")
 	require.Emptyf(t, config.Receivers[0].EmailConfigs[2].AuthPasswordFile, "file field should be empty when password provided")
 
-	require.Equal(t, Secret("myprecious"), config.Receivers[0].EmailConfigs[3].AuthSecret, "fourth email should use secret myprecious")
+	require.Equal(t, commoncfg.Secret("myprecious"), config.Receivers[0].EmailConfigs[3].AuthSecret, "fourth email should use secret myprecious")
 
 	require.Equal(t, "/tmp/localuser4secret", config.Receivers[0].EmailConfigs[4].AuthSecretFile, "fifth email should use secret file /tmp/localuser4secret")
 }
@@ -1099,7 +1034,7 @@ func TestVictorOpsDefaultAPIKey(t *testing.T) {
 	}
 
 	defaultKey := conf.Global.VictorOpsAPIKey
-	overrideKey := Secret("qwe456")
+	overrideKey := commoncfg.Secret("qwe456")
 	if defaultKey != conf.Receivers[0].VictorOpsConfigs[0].APIKey {
 		t.Fatalf("Invalid victorops key: %s\nExpected: %s", conf.Receivers[0].VictorOpsConfigs[0].APIKey, defaultKey)
 	}
@@ -1151,7 +1086,7 @@ func TestTelegramDefaultBotToken(t *testing.T) {
 	}
 
 	defaultBotToken := conf.Global.TelegramBotToken
-	overrideBotToken := Secret("qwe456")
+	overrideBotToken := commoncfg.Secret("qwe456")
 	if defaultBotToken != conf.Receivers[0].TelegramConfigs[0].BotToken {
 		t.Fatalf("Invalid telegram bot token: %s\nExpected: %s", conf.Receivers[0].TelegramConfigs[0].BotToken, defaultBotToken)
 	}
@@ -1335,7 +1270,7 @@ func TestSlackGlobalAppToken(t *testing.T) {
 		Credentials: commoncfg.Secret(inlineToken),
 	}
 	secondConfig := conf.Receivers[0].SlackConfigs[1]
-	if secondConfig.AppToken != Secret(inlineToken) {
+	if secondConfig.AppToken != commoncfg.Secret(inlineToken) {
 		t.Fatalf("Invalid Slack App token: %s\nExpected: %s", secondConfig.AppToken, inlineToken)
 	}
 	if secondConfig.HTTPConfig == nil || secondConfig.HTTPConfig.Authorization == nil {
@@ -1442,7 +1377,7 @@ func TestRocketchatDefaultToken(t *testing.T) {
 	}
 
 	defaultToken := conf.Global.RocketchatToken
-	overrideToken := Secret("token456")
+	overrideToken := commoncfg.Secret("token456")
 	if defaultToken != conf.Receivers[0].RocketchatConfigs[0].Token {
 		t.Fatalf("Invalid rocketchat key: %s\nExpected: %s", string(*conf.Receivers[0].RocketchatConfigs[0].Token), string(*defaultToken))
 	}
@@ -1458,7 +1393,7 @@ func TestRocketchatDefaultTokenID(t *testing.T) {
 	}
 
 	defaultTokenID := conf.Global.RocketchatTokenID
-	overrideTokenID := Secret("id456")
+	overrideTokenID := commoncfg.Secret("id456")
 	if defaultTokenID != conf.Receivers[0].RocketchatConfigs[0].TokenID {
 		t.Fatalf("Invalid rocketchat key: %s\nExpected: %s", string(*conf.Receivers[0].RocketchatConfigs[0].TokenID), string(*defaultTokenID))
 	}
@@ -1701,8 +1636,8 @@ func TestSecretTemplURLMarshaling(t *testing.T) {
 	})
 
 	t.Run("marshals actual value when MarshalSecretValue is true", func(t *testing.T) {
-		MarshalSecretValue = true
-		defer func() { MarshalSecretValue = false }()
+		commoncfg.MarshalSecretValue = true
+		defer func() { commoncfg.MarshalSecretValue = false }()
 
 		u := SecretTemplateURL("http://example.com/secret")
 

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -306,9 +306,9 @@ type EmailConfig struct {
 	Hello            string               `yaml:"hello,omitempty" json:"hello,omitempty"`
 	Smarthost        HostPort             `yaml:"smarthost,omitempty" json:"smarthost,omitempty"`
 	AuthUsername     string               `yaml:"auth_username,omitempty" json:"auth_username,omitempty"`
-	AuthPassword     Secret               `yaml:"auth_password,omitempty" json:"auth_password,omitempty"`
+	AuthPassword     commoncfg.Secret     `yaml:"auth_password,omitempty" json:"auth_password,omitempty"`
 	AuthPasswordFile string               `yaml:"auth_password_file,omitempty" json:"auth_password_file,omitempty"`
-	AuthSecret       Secret               `yaml:"auth_secret,omitempty" json:"auth_secret,omitempty"`
+	AuthSecret       commoncfg.Secret     `yaml:"auth_secret,omitempty" json:"auth_secret,omitempty"`
 	AuthSecretFile   string               `yaml:"auth_secret_file,omitempty" json:"auth_secret_file,omitempty"`
 	AuthIdentity     string               `yaml:"auth_identity,omitempty" json:"auth_identity,omitempty"`
 	Headers          map[string]string    `yaml:"headers,omitempty" json:"headers,omitempty"`
@@ -372,9 +372,9 @@ type PagerdutyConfig struct {
 
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
-	ServiceKey     Secret           `yaml:"service_key,omitempty" json:"service_key,omitempty"`
+	ServiceKey     commoncfg.Secret `yaml:"service_key,omitempty" json:"service_key,omitempty"`
 	ServiceKeyFile string           `yaml:"service_key_file,omitempty" json:"service_key_file,omitempty"`
-	RoutingKey     Secret           `yaml:"routing_key,omitempty" json:"routing_key,omitempty"`
+	RoutingKey     commoncfg.Secret `yaml:"routing_key,omitempty" json:"routing_key,omitempty"`
 	RoutingKeyFile string           `yaml:"routing_key_file,omitempty" json:"routing_key_file,omitempty"`
 	URL            *URL             `yaml:"url,omitempty" json:"url,omitempty"`
 	Client         string           `yaml:"client,omitempty" json:"client,omitempty"`
@@ -527,11 +527,11 @@ type SlackConfig struct {
 
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
-	APIURL       *SecretURL `yaml:"api_url,omitempty" json:"api_url,omitempty"`
-	APIURLFile   string     `yaml:"api_url_file,omitempty" json:"api_url_file,omitempty"`
-	AppToken     Secret     `yaml:"app_token,omitempty" json:"app_token,omitempty"`
-	AppTokenFile string     `yaml:"app_token_file,omitempty" json:"app_token_file,omitempty"`
-	AppURL       *URL       `yaml:"app_url,omitempty" json:"app_url,omitempty"`
+	APIURL       *SecretURL       `yaml:"api_url,omitempty" json:"api_url,omitempty"`
+	APIURLFile   string           `yaml:"api_url_file,omitempty" json:"api_url_file,omitempty"`
+	AppToken     commoncfg.Secret `yaml:"app_token,omitempty" json:"app_token,omitempty"`
+	AppTokenFile string           `yaml:"app_token_file,omitempty" json:"app_token_file,omitempty"`
+	AppURL       *URL             `yaml:"app_url,omitempty" json:"app_url,omitempty"`
 
 	// Slack channel override, (like #other-channel or @username).
 	Channel  string `yaml:"channel,omitempty" json:"channel,omitempty"`
@@ -592,8 +592,8 @@ type IncidentioConfig struct {
 	URLFile string `yaml:"url_file" json:"url_file"`
 
 	// AlertSourceToken is the key used to authenticate with the alert source in incident.io.
-	AlertSourceToken     Secret `yaml:"alert_source_token,omitempty" json:"alert_source_token,omitempty"`
-	AlertSourceTokenFile string `yaml:"alert_source_token_file,omitempty" json:"alert_source_token_file,omitempty"`
+	AlertSourceToken     commoncfg.Secret `yaml:"alert_source_token,omitempty" json:"alert_source_token,omitempty"`
+	AlertSourceTokenFile string           `yaml:"alert_source_token_file,omitempty" json:"alert_source_token_file,omitempty"`
 
 	// MaxAlerts is the maximum number of alerts to be sent per incident.io message.
 	// Alerts exceeding this threshold will be truncated. Setting this to 0
@@ -675,16 +675,16 @@ type WechatConfig struct {
 
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
-	APISecret     Secret `yaml:"api_secret,omitempty" json:"api_secret,omitempty"`
-	APISecretFile string `yaml:"api_secret_file,omitempty" json:"api_secret_file,omitempty"`
-	CorpID        string `yaml:"corp_id,omitempty" json:"corp_id,omitempty"`
-	Message       string `yaml:"message,omitempty" json:"message,omitempty"`
-	APIURL        *URL   `yaml:"api_url,omitempty" json:"api_url,omitempty"`
-	ToUser        string `yaml:"to_user,omitempty" json:"to_user,omitempty"`
-	ToParty       string `yaml:"to_party,omitempty" json:"to_party,omitempty"`
-	ToTag         string `yaml:"to_tag,omitempty" json:"to_tag,omitempty"`
-	AgentID       string `yaml:"agent_id,omitempty" json:"agent_id,omitempty"`
-	MessageType   string `yaml:"message_type,omitempty" json:"message_type,omitempty"`
+	APISecret     commoncfg.Secret `yaml:"api_secret,omitempty" json:"api_secret,omitempty"`
+	APISecretFile string           `yaml:"api_secret_file,omitempty" json:"api_secret_file,omitempty"`
+	CorpID        string           `yaml:"corp_id,omitempty" json:"corp_id,omitempty"`
+	Message       string           `yaml:"message,omitempty" json:"message,omitempty"`
+	APIURL        *URL             `yaml:"api_url,omitempty" json:"api_url,omitempty"`
+	ToUser        string           `yaml:"to_user,omitempty" json:"to_user,omitempty"`
+	ToParty       string           `yaml:"to_party,omitempty" json:"to_party,omitempty"`
+	ToTag         string           `yaml:"to_tag,omitempty" json:"to_tag,omitempty"`
+	AgentID       string           `yaml:"agent_id,omitempty" json:"agent_id,omitempty"`
+	MessageType   string           `yaml:"message_type,omitempty" json:"message_type,omitempty"`
 }
 
 const wechatValidTypesRe = `^(text|markdown)$`
@@ -720,7 +720,7 @@ type OpsGenieConfig struct {
 
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
-	APIKey       Secret                    `yaml:"api_key,omitempty" json:"api_key,omitempty"`
+	APIKey       commoncfg.Secret          `yaml:"api_key,omitempty" json:"api_key,omitempty"`
 	APIKeyFile   string                    `yaml:"api_key_file,omitempty" json:"api_key_file,omitempty"`
 	APIURL       *URL                      `yaml:"api_url,omitempty" json:"api_url,omitempty"`
 	Message      string                    `yaml:"message,omitempty" json:"message,omitempty"`
@@ -788,7 +788,7 @@ type VictorOpsConfig struct {
 
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
-	APIKey            Secret            `yaml:"api_key,omitempty" json:"api_key,omitempty"`
+	APIKey            commoncfg.Secret  `yaml:"api_key,omitempty" json:"api_key,omitempty"`
 	APIKeyFile        string            `yaml:"api_key_file,omitempty" json:"api_key_file,omitempty"`
 	APIURL            *URL              `yaml:"api_url" json:"api_url"`
 	RoutingKey        string            `yaml:"routing_key" json:"routing_key"`
@@ -843,22 +843,22 @@ type PushoverConfig struct {
 
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
-	UserKey     Secret   `yaml:"user_key,omitempty" json:"user_key,omitempty"`
-	UserKeyFile string   `yaml:"user_key_file,omitempty" json:"user_key_file,omitempty"`
-	Token       Secret   `yaml:"token,omitempty" json:"token,omitempty"`
-	TokenFile   string   `yaml:"token_file,omitempty" json:"token_file,omitempty"`
-	Title       string   `yaml:"title,omitempty" json:"title,omitempty"`
-	Message     string   `yaml:"message,omitempty" json:"message,omitempty"`
-	URL         string   `yaml:"url,omitempty" json:"url,omitempty"`
-	URLTitle    string   `yaml:"url_title,omitempty" json:"url_title,omitempty"`
-	Device      string   `yaml:"device,omitempty" json:"device,omitempty"`
-	Sound       string   `yaml:"sound,omitempty" json:"sound,omitempty"`
-	Priority    string   `yaml:"priority,omitempty" json:"priority,omitempty"`
-	Retry       duration `yaml:"retry,omitempty" json:"retry,omitempty"`
-	Expire      duration `yaml:"expire,omitempty" json:"expire,omitempty"`
-	TTL         duration `yaml:"ttl,omitempty" json:"ttl,omitempty"`
-	HTML        bool     `yaml:"html,omitempty" json:"html,omitempty"`
-	Monospace   bool     `yaml:"monospace,omitempty" json:"monospace,omitempty"`
+	UserKey     commoncfg.Secret `yaml:"user_key,omitempty" json:"user_key,omitempty"`
+	UserKeyFile string           `yaml:"user_key_file,omitempty" json:"user_key_file,omitempty"`
+	Token       commoncfg.Secret `yaml:"token,omitempty" json:"token,omitempty"`
+	TokenFile   string           `yaml:"token_file,omitempty" json:"token_file,omitempty"`
+	Title       string           `yaml:"title,omitempty" json:"title,omitempty"`
+	Message     string           `yaml:"message,omitempty" json:"message,omitempty"`
+	URL         string           `yaml:"url,omitempty" json:"url,omitempty"`
+	URLTitle    string           `yaml:"url_title,omitempty" json:"url_title,omitempty"`
+	Device      string           `yaml:"device,omitempty" json:"device,omitempty"`
+	Sound       string           `yaml:"sound,omitempty" json:"sound,omitempty"`
+	Priority    string           `yaml:"priority,omitempty" json:"priority,omitempty"`
+	Retry       duration         `yaml:"retry,omitempty" json:"retry,omitempty"`
+	Expire      duration         `yaml:"expire,omitempty" json:"expire,omitempty"`
+	TTL         duration         `yaml:"ttl,omitempty" json:"ttl,omitempty"`
+	HTML        bool             `yaml:"html,omitempty" json:"html,omitempty"`
+	Monospace   bool             `yaml:"monospace,omitempty" json:"monospace,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
@@ -920,15 +920,15 @@ type TelegramConfig struct {
 
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
-	APIUrl               *URL   `yaml:"api_url" json:"api_url,omitempty"`
-	BotToken             Secret `yaml:"bot_token,omitempty" json:"token,omitempty"`
-	BotTokenFile         string `yaml:"bot_token_file,omitempty" json:"token_file,omitempty"`
-	ChatID               int64  `yaml:"chat_id,omitempty" json:"chat,omitempty"`
-	ChatIDFile           string `yaml:"chat_id_file,omitempty" json:"chat_file,omitempty"`
-	MessageThreadID      int    `yaml:"message_thread_id,omitempty" json:"message_thread_id,omitempty"`
-	Message              string `yaml:"message,omitempty" json:"message,omitempty"`
-	DisableNotifications bool   `yaml:"disable_notifications,omitempty" json:"disable_notifications,omitempty"`
-	ParseMode            string `yaml:"parse_mode,omitempty" json:"parse_mode,omitempty"`
+	APIUrl               *URL             `yaml:"api_url" json:"api_url,omitempty"`
+	BotToken             commoncfg.Secret `yaml:"bot_token,omitempty" json:"token,omitempty"`
+	BotTokenFile         string           `yaml:"bot_token_file,omitempty" json:"token_file,omitempty"`
+	ChatID               int64            `yaml:"chat_id,omitempty" json:"chat,omitempty"`
+	ChatIDFile           string           `yaml:"chat_id_file,omitempty" json:"chat_file,omitempty"`
+	MessageThreadID      int              `yaml:"message_thread_id,omitempty" json:"message_thread_id,omitempty"`
+	Message              string           `yaml:"message,omitempty" json:"message,omitempty"`
+	DisableNotifications bool             `yaml:"disable_notifications,omitempty" json:"disable_notifications,omitempty"`
+	ParseMode            string           `yaml:"parse_mode,omitempty" json:"parse_mode,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
@@ -1114,11 +1114,11 @@ type RocketchatConfig struct {
 
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
-	APIURL      *URL    `yaml:"api_url,omitempty" json:"api_url,omitempty"`
-	TokenID     *Secret `yaml:"token_id,omitempty" json:"token_id,omitempty"`
-	TokenIDFile string  `yaml:"token_id_file,omitempty" json:"token_id_file,omitempty"`
-	Token       *Secret `yaml:"token,omitempty" json:"token,omitempty"`
-	TokenFile   string  `yaml:"token_file,omitempty" json:"token_file,omitempty"`
+	APIURL      *URL              `yaml:"api_url,omitempty" json:"api_url,omitempty"`
+	TokenID     *commoncfg.Secret `yaml:"token_id,omitempty" json:"token_id,omitempty"`
+	TokenIDFile string            `yaml:"token_id_file,omitempty" json:"token_id_file,omitempty"`
+	Token       *commoncfg.Secret `yaml:"token,omitempty" json:"token,omitempty"`
+	TokenFile   string            `yaml:"token_file,omitempty" json:"token_file,omitempty"`
 
 	// RocketChat channel override, (like #other-channel or @username).
 	Channel string `yaml:"channel,omitempty" json:"channel,omitempty"`

--- a/notify/email/email_test.go
+++ b/notify/email/email_test.go
@@ -477,7 +477,7 @@ func TestEmailNotifyWithAuthentication(t *testing.T) {
 			title: "email with authentication",
 			updateCfg: func(cfg *config.EmailConfig) {
 				cfg.AuthUsername = c.Username
-				cfg.AuthPassword = config.Secret(c.Password)
+				cfg.AuthPassword = commoncfg.Secret(c.Password)
 			},
 		},
 		{
@@ -491,7 +491,7 @@ func TestEmailNotifyWithAuthentication(t *testing.T) {
 			title: "HTML-only email",
 			updateCfg: func(cfg *config.EmailConfig) {
 				cfg.AuthUsername = c.Username
-				cfg.AuthPassword = config.Secret(c.Password)
+				cfg.AuthPassword = commoncfg.Secret(c.Password)
 				cfg.Text = ""
 			},
 		},
@@ -499,7 +499,7 @@ func TestEmailNotifyWithAuthentication(t *testing.T) {
 			title: "text-only email",
 			updateCfg: func(cfg *config.EmailConfig) {
 				cfg.AuthUsername = c.Username
-				cfg.AuthPassword = config.Secret(c.Password)
+				cfg.AuthPassword = commoncfg.Secret(c.Password)
 				cfg.HTML = ""
 			},
 		},
@@ -507,7 +507,7 @@ func TestEmailNotifyWithAuthentication(t *testing.T) {
 			title: "multiple To addresses",
 			updateCfg: func(cfg *config.EmailConfig) {
 				cfg.AuthUsername = c.Username
-				cfg.AuthPassword = config.Secret(c.Password)
+				cfg.AuthPassword = commoncfg.Secret(c.Password)
 				cfg.To = strings.Join([]string{emailTo, emailFrom}, ",")
 			},
 		},
@@ -515,7 +515,7 @@ func TestEmailNotifyWithAuthentication(t *testing.T) {
 			title: "no more than one From address",
 			updateCfg: func(cfg *config.EmailConfig) {
 				cfg.AuthUsername = c.Username
-				cfg.AuthPassword = config.Secret(c.Password)
+				cfg.AuthPassword = commoncfg.Secret(c.Password)
 				cfg.From = strings.Join([]string{emailFrom, emailTo}, ",")
 			},
 
@@ -526,7 +526,7 @@ func TestEmailNotifyWithAuthentication(t *testing.T) {
 			title: "wrong credentials",
 			updateCfg: func(cfg *config.EmailConfig) {
 				cfg.AuthUsername = c.Username
-				cfg.AuthPassword = config.Secret(c.Password + "wrong")
+				cfg.AuthPassword = commoncfg.Secret(c.Password + "wrong")
 			},
 
 			errMsg: "Invalid username or password",
@@ -571,7 +571,7 @@ func TestEmailNotifyWithAuthentication(t *testing.T) {
 			title: "invalid Hello string",
 			updateCfg: func(cfg *config.EmailConfig) {
 				cfg.AuthUsername = c.Username
-				cfg.AuthPassword = config.Secret(c.Password)
+				cfg.AuthPassword = commoncfg.Secret(c.Password)
 				cfg.Hello = "invalid hello string"
 			},
 

--- a/notify/opsgenie/opsgenie_test.go
+++ b/notify/opsgenie/opsgenie_test.go
@@ -59,7 +59,7 @@ func TestOpsGenieRedactedURL(t *testing.T) {
 	notifier, err := New(
 		&config.OpsGenieConfig{
 			APIURL:     &config.URL{URL: u},
-			APIKey:     config.Secret(key),
+			APIKey:     commoncfg.Secret(key),
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),

--- a/notify/pagerduty/pagerduty_test.go
+++ b/notify/pagerduty/pagerduty_test.go
@@ -41,7 +41,7 @@ import (
 func TestPagerDutyRetryV1(t *testing.T) {
 	notifier, err := New(
 		&config.PagerdutyConfig{
-			ServiceKey: config.Secret("01234567890123456789012345678901"),
+			ServiceKey: commoncfg.Secret("01234567890123456789012345678901"),
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),
@@ -59,7 +59,7 @@ func TestPagerDutyRetryV1(t *testing.T) {
 func TestPagerDutyRetryV2(t *testing.T) {
 	notifier, err := New(
 		&config.PagerdutyConfig{
-			RoutingKey: config.Secret("01234567890123456789012345678901"),
+			RoutingKey: commoncfg.Secret("01234567890123456789012345678901"),
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),
@@ -81,7 +81,7 @@ func TestPagerDutyRedactedURLV1(t *testing.T) {
 	key := "01234567890123456789012345678901"
 	notifier, err := New(
 		&config.PagerdutyConfig{
-			ServiceKey: config.Secret(key),
+			ServiceKey: commoncfg.Secret(key),
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),
@@ -101,7 +101,7 @@ func TestPagerDutyRedactedURLV2(t *testing.T) {
 	notifier, err := New(
 		&config.PagerdutyConfig{
 			URL:        &config.URL{URL: u},
-			RoutingKey: config.Secret(key),
+			RoutingKey: commoncfg.Secret(key),
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),
@@ -182,7 +182,7 @@ func TestPagerDutyTemplating(t *testing.T) {
 		{
 			title: "full-blown legacy message",
 			cfg: &config.PagerdutyConfig{
-				RoutingKey: config.Secret("01234567890123456789012345678901"),
+				RoutingKey: commoncfg.Secret("01234567890123456789012345678901"),
 				Images: []config.PagerdutyImage{
 					{
 						Src:  "{{ .Status }}",
@@ -207,7 +207,7 @@ func TestPagerDutyTemplating(t *testing.T) {
 		{
 			title: "full-blown legacy message",
 			cfg: &config.PagerdutyConfig{
-				RoutingKey: config.Secret("01234567890123456789012345678901"),
+				RoutingKey: commoncfg.Secret("01234567890123456789012345678901"),
 				Images: []config.PagerdutyImage{
 					{
 						Src:  "{{ .Status }}",
@@ -232,7 +232,7 @@ func TestPagerDutyTemplating(t *testing.T) {
 		{
 			title: "nested details",
 			cfg: &config.PagerdutyConfig{
-				RoutingKey: config.Secret("01234567890123456789012345678901"),
+				RoutingKey: commoncfg.Secret("01234567890123456789012345678901"),
 				Details: map[string]any{
 					"a": map[string]any{
 						"b": map[string]any{
@@ -250,7 +250,7 @@ func TestPagerDutyTemplating(t *testing.T) {
 		{
 			title: "nested details with template error",
 			cfg: &config.PagerdutyConfig{
-				RoutingKey: config.Secret("01234567890123456789012345678901"),
+				RoutingKey: commoncfg.Secret("01234567890123456789012345678901"),
 				Details: map[string]any{
 					"a": map[string]any{
 						"b": map[string]any{
@@ -266,7 +266,7 @@ func TestPagerDutyTemplating(t *testing.T) {
 		{
 			title: "details with templating errors",
 			cfg: &config.PagerdutyConfig{
-				RoutingKey: config.Secret("01234567890123456789012345678901"),
+				RoutingKey: commoncfg.Secret("01234567890123456789012345678901"),
 				Details: map[string]any{
 					"firing":       `{{ .Alerts.Firing | toJson`,
 					"resolved":     `{{ .Alerts.Resolved | toJson }}`,
@@ -279,7 +279,7 @@ func TestPagerDutyTemplating(t *testing.T) {
 		{
 			title: "v2 message with templating errors",
 			cfg: &config.PagerdutyConfig{
-				RoutingKey: config.Secret("01234567890123456789012345678901"),
+				RoutingKey: commoncfg.Secret("01234567890123456789012345678901"),
 				Severity:   "{{ ",
 			},
 			errMsg: "failed to template",
@@ -287,7 +287,7 @@ func TestPagerDutyTemplating(t *testing.T) {
 		{
 			title: "v1 message with templating errors",
 			cfg: &config.PagerdutyConfig{
-				ServiceKey: config.Secret("01234567890123456789012345678901"),
+				ServiceKey: commoncfg.Secret("01234567890123456789012345678901"),
 				Client:     "{{ ",
 			},
 			errMsg: "failed to template",
@@ -295,14 +295,14 @@ func TestPagerDutyTemplating(t *testing.T) {
 		{
 			title: "routing key cannot be empty",
 			cfg: &config.PagerdutyConfig{
-				RoutingKey: config.Secret(`{{ "" }}`),
+				RoutingKey: commoncfg.Secret(`{{ "" }}`),
 			},
 			errMsg: "routing key cannot be empty",
 		},
 		{
 			title: "service_key cannot be empty",
 			cfg: &config.PagerdutyConfig{
-				ServiceKey: config.Secret(`{{ "" }}`),
+				ServiceKey: commoncfg.Secret(`{{ "" }}`),
 			},
 			errMsg: "service key cannot be empty",
 		},
@@ -397,7 +397,7 @@ func TestEventSizeEnforcement(t *testing.T) {
 
 	notifierV1, err := New(
 		&config.PagerdutyConfig{
-			ServiceKey: config.Secret("01234567890123456789012345678901"),
+			ServiceKey: commoncfg.Secret("01234567890123456789012345678901"),
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),
@@ -420,7 +420,7 @@ func TestEventSizeEnforcement(t *testing.T) {
 
 	notifierV2, err := New(
 		&config.PagerdutyConfig{
-			RoutingKey: config.Secret("01234567890123456789012345678901"),
+			RoutingKey: commoncfg.Secret("01234567890123456789012345678901"),
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),
@@ -533,7 +533,7 @@ func TestPagerDutyEmptySrcHref(t *testing.T) {
 
 	pagerDutyConfig := config.PagerdutyConfig{
 		HTTPConfig: &commoncfg.HTTPClientConfig{},
-		RoutingKey: config.Secret("01234567890123456789012345678901"),
+		RoutingKey: commoncfg.Secret("01234567890123456789012345678901"),
 		URL:        &config.URL{URL: url},
 		Images:     images,
 		Links:      links,
@@ -601,7 +601,7 @@ func TestPagerDutyTimeout(t *testing.T) {
 
 			cfg := config.PagerdutyConfig{
 				HTTPConfig: &commoncfg.HTTPClientConfig{},
-				RoutingKey: config.Secret("01234567890123456789012345678901"),
+				RoutingKey: commoncfg.Secret("01234567890123456789012345678901"),
 				URL:        &config.URL{URL: u},
 				Timeout:    tt.timeout,
 			}

--- a/notify/pushover/pushover_test.go
+++ b/notify/pushover/pushover_test.go
@@ -50,8 +50,8 @@ func TestPushoverRedactedURL(t *testing.T) {
 	key, token := "user_key", "token"
 	notifier, err := New(
 		&config.PushoverConfig{
-			UserKey:    config.Secret(key),
-			Token:      config.Secret(token),
+			UserKey:    commoncfg.Secret(key),
+			Token:      commoncfg.Secret(token),
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),
@@ -76,7 +76,7 @@ func TestPushoverReadingUserKeyFromFile(t *testing.T) {
 	notifier, err := New(
 		&config.PushoverConfig{
 			UserKeyFile: f.Name(),
-			Token:       config.Secret("token"),
+			Token:       commoncfg.Secret("token"),
 			HTTPConfig:  &commoncfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),
@@ -100,7 +100,7 @@ func TestPushoverReadingTokenFromFile(t *testing.T) {
 
 	notifier, err := New(
 		&config.PushoverConfig{
-			UserKey:    config.Secret("user key"),
+			UserKey:    commoncfg.Secret("user key"),
 			TokenFile:  f.Name(),
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 		},
@@ -122,8 +122,8 @@ func TestPushoverMonospaceParameter(t *testing.T) {
 
 	notifier, err := New(
 		&config.PushoverConfig{
-			UserKey:    config.Secret("user_key"),
-			Token:      config.Secret("token"),
+			UserKey:    commoncfg.Secret("user_key"),
+			Token:      commoncfg.Secret("token"),
 			Monospace:  true,
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 		},

--- a/notify/rocketchat/rocketchat_test.go
+++ b/notify/rocketchat/rocketchat_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestRocketchatRetry(t *testing.T) {
-	secret := config.Secret("xxxxx")
+	secret := commoncfg.Secret("xxxxx")
 	notifier, err := New(
 		&config.RocketchatConfig{
 			HTTPConfig: &commoncfg.HTTPClientConfig{},

--- a/notify/telegram/telegram_test.go
+++ b/notify/telegram/telegram_test.go
@@ -55,7 +55,7 @@ receivers:
 	require.Len(t, c.Receivers[0].TelegramConfigs, 1)
 
 	require.Equal(t, "https://api.telegram.org", c.Receivers[0].TelegramConfigs[0].APIUrl.String())
-	require.Equal(t, config.Secret("secret"), c.Receivers[0].TelegramConfigs[0].BotToken)
+	require.Equal(t, commoncfg.Secret("secret"), c.Receivers[0].TelegramConfigs[0].BotToken)
 	require.Equal(t, int64(1234), c.Receivers[0].TelegramConfigs[0].ChatID)
 	require.Equal(t, 1357, c.Receivers[0].TelegramConfigs[0].MessageThreadID)
 	require.Equal(t, "HTML", c.Receivers[0].TelegramConfigs[0].ParseMode)
@@ -103,7 +103,7 @@ func TestTelegramNotify(t *testing.T) {
 			cfg: config.TelegramConfig{
 				Message:    "<code>x < y</code>",
 				HTTPConfig: &commoncfg.HTTPClientConfig{},
-				BotToken:   config.Secret(token),
+				BotToken:   commoncfg.Secret(token),
 			},
 			expText: "<code>x < y</code>",
 		},
@@ -113,7 +113,7 @@ func TestTelegramNotify(t *testing.T) {
 				ParseMode:  "HTML",
 				Message:    "<code>x < y</code>",
 				HTTPConfig: &commoncfg.HTTPClientConfig{},
-				BotToken:   config.Secret(token),
+				BotToken:   commoncfg.Secret(token),
 			},
 			expText: "<code>x &lt; y</code>",
 		},

--- a/notify/victorops/victorops_test.go
+++ b/notify/victorops/victorops_test.go
@@ -87,7 +87,7 @@ func TestVictorOpsCustomFields(t *testing.T) {
 func TestVictorOpsRetry(t *testing.T) {
 	notifier, err := New(
 		&config.VictorOpsConfig{
-			APIKey:     config.Secret("secret"),
+			APIKey:     commoncfg.Secret("secret"),
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),
@@ -108,7 +108,7 @@ func TestVictorOpsRedactedURL(t *testing.T) {
 	notifier, err := New(
 		&config.VictorOpsConfig{
 			APIURL:     &config.URL{URL: u},
-			APIKey:     config.Secret(secret),
+			APIKey:     commoncfg.Secret(secret),
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),

--- a/notify/wechat/wechat_test.go
+++ b/notify/wechat/wechat_test.go
@@ -37,7 +37,7 @@ func TestWechatRedactedURLOnInitialAuthentication(t *testing.T) {
 			APIURL:     &config.URL{URL: u},
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 			CorpID:     "corpid",
-			APISecret:  config.Secret(secret),
+			APISecret:  commoncfg.Secret(secret),
 		},
 		test.CreateTmpl(t),
 		promslog.NewNopLogger(),
@@ -59,7 +59,7 @@ func TestWechatRedactedURLOnNotify(t *testing.T) {
 			APIURL:     &config.URL{URL: u},
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 			CorpID:     "corpid",
-			APISecret:  config.Secret(secret),
+			APISecret:  commoncfg.Secret(secret),
 		},
 		test.CreateTmpl(t),
 		promslog.NewNopLogger(),
@@ -81,7 +81,7 @@ func TestWechatMessageTypeSelector(t *testing.T) {
 			APIURL:      &config.URL{URL: u},
 			HTTPConfig:  &commoncfg.HTTPClientConfig{},
 			CorpID:      "corpid",
-			APISecret:   config.Secret(secret),
+			APISecret:   commoncfg.Secret(secret),
 			MessageType: "markdown",
 		},
 		test.CreateTmpl(t),
@@ -93,7 +93,7 @@ func TestWechatMessageTypeSelector(t *testing.T) {
 }
 
 func TestGetApiSecretFromSecret(t *testing.T) {
-	n := &Notifier{conf: &config.WechatConfig{APISecret: config.Secret("shhh")}}
+	n := &Notifier{conf: &config.WechatConfig{APISecret: commoncfg.Secret("shhh")}}
 	s, err := n.getApiSecret()
 	require.NoError(t, err)
 	require.Equal(t, "shhh", s)


### PR DESCRIPTION
To be able to move notifier specific code out of the config and notify packages,
some shared code needs to be moved to other/new packages. Since commoncfg.Secret
already does what config.Secret does, this replaces all usages of config.Secret.
    
This requires external users of the config package to change their code if they used
config.MarshalSecretValue. This exported variable was added in
https://github.com/prometheus/alertmanager/pull/4158

