### PR TITLE
feat(notify): add notification logging for successfully sent notifications

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -174,6 +174,7 @@ func run() int {
 		allowInsecureAdvertise = kingpin.Flag("cluster.allow-insecure-public-advertise-address-discovery", "[EXPERIMENTAL] Allow alertmanager to discover and listen on a public IP address.").Bool()
 		label                  = kingpin.Flag("cluster.label", "The cluster label is an optional string to include on each packet and stream. It uniquely identifies the cluster and prevents cross-communication issues when sending gossip messages.").Default("").String()
 		featureFlags           = kingpin.Flag("enable-feature", fmt.Sprintf("Comma-separated experimental features to enable. Valid options: %s", strings.Join(featurecontrol.AllowedFlags, ", "))).Default("").String()
+		notificationLogFile    = kingpin.Flag("notification-log.file", "File to log all successfully sent notifications in JSON format. If empty, notification logging is disabled.").Default("").String()
 	)
 
 	prometheus.MustRegister(versioncollector.NewCollector("alertmanager"))
@@ -407,13 +408,25 @@ func run() int {
 
 	tracingManager := tracing.NewManager(logger.With("component", "tracing"))
 
+	var notificationLogger notify.NotificationLogger = notify.NoopNotificationLogger{}
+	if *notificationLogFile != "" {
+		nl, err := notify.NewFileNotificationLogger(*notificationLogFile)
+		if err != nil {
+			logger.Error("error creating notification log", "err", err)
+			return 1
+		}
+		defer nl.Close()
+		notificationLogger = nl
+		logger.Info("Notification logging enabled", "file", *notificationLogFile)
+	}
+
 	var (
 		inhibitor *inhibit.Inhibitor
 		tmpl      *template.Template
 	)
 
 	dispMetrics := dispatch.NewDispatcherMetrics(false, prometheus.DefaultRegisterer)
-	pipelineBuilder := notify.NewPipelineBuilder(prometheus.DefaultRegisterer, ff)
+	pipelineBuilder := notify.NewPipelineBuilder(prometheus.DefaultRegisterer, ff, notificationLogger)
 	configLogger := logger.With("component", "configuration")
 	configCoordinator := config.NewCoordinator(
 		*configFile,

--- a/notify/notification_log.go
+++ b/notify/notification_log.go
@@ -1,0 +1,147 @@
+// Copyright 2015 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package notify
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"sync"
+	"time"
+)
+
+// ErrNotificationLogClosed is returned when attempting to write to a closed notification log.
+var ErrNotificationLogClosed = errors.New("notification log is closed")
+
+// NotificationLogEntry represents a single notification log entry written to the
+// notification log file. Each entry captures metadata about a successfully sent
+// notification, including the integration type, receiver name, alert counts, and
+// group labels. The entry is serialized as a JSON object on a single line.
+//
+// Example JSON output:
+//
+//	{
+//	  "timestamp": "2024-01-15T10:30:00.123Z",
+//	  "integration": "slack",
+//	  "integrationIdx": 0,
+//	  "receiver": "team-alerts",
+//	  "groupKey": "{}:{alertname=\"HighMemory\"}",
+//	  "alertsCount": 3,
+//	  "firingCount": 2,
+//	  "resolvedCount": 1,
+//	  "groupLabels": {"alertname": "HighMemory"}
+//	}
+type NotificationLogEntry struct {
+	// Timestamp is the time when the notification was successfully sent.
+	Timestamp time.Time `json:"timestamp"`
+	// Integration is the type of notifier used (e.g., "slack", "webhook", "email").
+	Integration string `json:"integration"`
+	// IntegrationIdx is the index of the integration within the receiver configuration.
+	IntegrationIdx int `json:"integrationIdx"`
+	// Receiver is the name of the receiver that processed the notification.
+	Receiver string `json:"receiver"`
+	// GroupKey is the unique identifier for the alert group.
+	GroupKey string `json:"groupKey"`
+	// AlertsCount is the total number of alerts in the notification.
+	AlertsCount int `json:"alertsCount"`
+	// FiringCount is the number of firing alerts in the notification.
+	FiringCount int `json:"firingCount"`
+	// ResolvedCount is the number of resolved alerts in the notification.
+	ResolvedCount int `json:"resolvedCount"`
+	// GroupLabels contains the labels used for grouping alerts.
+	GroupLabels map[string]string `json:"groupLabels"`
+}
+
+// NotificationLogger is the interface for logging successfully sent notifications.
+// Implementations should be safe for concurrent use.
+type NotificationLogger interface {
+	// Log writes a notification entry to the log. It returns an error if the
+	// write fails, but implementations should not block notification delivery.
+	Log(entry *NotificationLogEntry) error
+}
+
+// FileNotificationLogger logs notifications to a file in JSON lines format.
+// Each notification is written as a single JSON object followed by a newline.
+// The logger is safe for concurrent use. Data is synced to disk when Close is called.
+type FileNotificationLogger struct {
+	mu     sync.Mutex
+	file   *os.File
+	closed bool
+}
+
+// NewFileNotificationLogger creates a new file-based notification logger that
+// writes to the specified path. The file is created if it doesn't exist, and
+// new entries are appended if it does. Returns an error if the file cannot be
+// opened or created.
+func NewFileNotificationLogger(path string) (*FileNotificationLogger, error) {
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return nil, err
+	}
+	return &FileNotificationLogger{
+		file: f,
+	}, nil
+}
+
+// Log writes a notification entry to the log file as a JSON line.
+// The data is buffered by the OS and synced to disk when Close is called.
+// Returns ErrNotificationLogClosed if the logger has been closed.
+func (l *FileNotificationLogger) Log(entry *NotificationLogEntry) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.closed {
+		return ErrNotificationLogClosed
+	}
+
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	_, err = l.file.Write(data)
+	return err
+}
+
+// Close syncs any buffered data to disk and closes the log file.
+// It is safe to call Close multiple times; subsequent calls will return nil.
+// After Close is called, any calls to Log will return ErrNotificationLogClosed.
+func (l *FileNotificationLogger) Close() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.closed {
+		return nil
+	}
+	l.closed = true
+
+	// Sync before closing to ensure all data is written to disk.
+	syncErr := l.file.Sync()
+	closeErr := l.file.Close()
+
+	// Return sync error if it occurred, otherwise return close error.
+	if syncErr != nil {
+		return syncErr
+	}
+	return closeErr
+}
+
+// NoopNotificationLogger is a no-op implementation of NotificationLogger
+// used when notification logging is disabled.
+type NoopNotificationLogger struct{}
+
+// Log is a no-op that always returns nil.
+func (n NoopNotificationLogger) Log(entry *NotificationLogEntry) error {
+	return nil
+}

--- a/notify/notification_log_test.go
+++ b/notify/notification_log_test.go
@@ -1,0 +1,436 @@
+// Copyright 2015 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package notify
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/common/promslog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/alertmanager/featurecontrol"
+	"github.com/prometheus/alertmanager/types"
+)
+
+func TestNotificationLogEntry_JSONSerialization(t *testing.T) {
+	entry := &NotificationLogEntry{
+		Timestamp:      time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC),
+		Integration:    "slack",
+		IntegrationIdx: 0,
+		Receiver:       "team-alerts",
+		GroupKey:       "{}:{alertname=\"HighMemory\"}",
+		AlertsCount:    3,
+		FiringCount:    2,
+		ResolvedCount:  1,
+		GroupLabels: map[string]string{
+			"alertname": "HighMemory",
+		},
+	}
+
+	data, err := json.Marshal(entry)
+	require.NoError(t, err)
+
+	var decoded NotificationLogEntry
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	require.Equal(t, entry.Integration, decoded.Integration)
+	require.Equal(t, entry.IntegrationIdx, decoded.IntegrationIdx)
+	require.Equal(t, entry.Receiver, decoded.Receiver)
+	require.Equal(t, entry.GroupKey, decoded.GroupKey)
+	require.Equal(t, entry.AlertsCount, decoded.AlertsCount)
+	require.Equal(t, entry.FiringCount, decoded.FiringCount)
+	require.Equal(t, entry.ResolvedCount, decoded.ResolvedCount)
+	require.Equal(t, entry.GroupLabels, decoded.GroupLabels)
+}
+
+func TestFileNotificationLogger(t *testing.T) {
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "notifications.log")
+
+	nl, err := NewFileNotificationLogger(logPath)
+	require.NoError(t, err)
+	defer nl.Close()
+
+	entry := &NotificationLogEntry{
+		Timestamp:      time.Now().UTC(),
+		Integration:    "webhook",
+		IntegrationIdx: 1,
+		Receiver:       "my-receiver",
+		GroupKey:       "{}:{alertname=\"TestAlert\"}",
+		AlertsCount:    2,
+		FiringCount:    1,
+		ResolvedCount:  1,
+		GroupLabels: map[string]string{
+			"alertname": "TestAlert",
+		},
+	}
+
+	err = nl.Log(entry)
+	require.NoError(t, err)
+
+	// Write another entry
+	entry2 := &NotificationLogEntry{
+		Timestamp:      time.Now().UTC(),
+		Integration:    "slack",
+		IntegrationIdx: 0,
+		Receiver:       "slack-channel",
+		GroupKey:       "{}:{alertname=\"AnotherAlert\"}",
+		AlertsCount:    5,
+		FiringCount:    5,
+		ResolvedCount:  0,
+		GroupLabels: map[string]string{
+			"alertname": "AnotherAlert",
+			"severity":  "critical",
+		},
+	}
+
+	err = nl.Log(entry2)
+	require.NoError(t, err)
+
+	// Close the file and read its contents
+	err = nl.Close()
+	require.NoError(t, err)
+
+	f, err := os.Open(logPath)
+	require.NoError(t, err)
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	var entries []NotificationLogEntry
+
+	for scanner.Scan() {
+		var e NotificationLogEntry
+		err := json.Unmarshal(scanner.Bytes(), &e)
+		require.NoError(t, err)
+		entries = append(entries, e)
+	}
+	require.NoError(t, scanner.Err())
+
+	require.Len(t, entries, 2)
+	require.Equal(t, "webhook", entries[0].Integration)
+	require.Equal(t, "my-receiver", entries[0].Receiver)
+	require.Equal(t, "slack", entries[1].Integration)
+	require.Equal(t, "slack-channel", entries[1].Receiver)
+}
+
+func TestFileNotificationLogger_ConcurrentWrites(t *testing.T) {
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "notifications_concurrent.log")
+
+	nl, err := NewFileNotificationLogger(logPath)
+	require.NoError(t, err)
+	defer nl.Close()
+
+	numGoroutines := 10
+	numEntriesPerGoroutine := 100
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		go func(goroutineID int) {
+			defer wg.Done()
+			for j := 0; j < numEntriesPerGoroutine; j++ {
+				entry := &NotificationLogEntry{
+					Timestamp:      time.Now().UTC(),
+					Integration:    "webhook",
+					IntegrationIdx: goroutineID,
+					Receiver:       "test-receiver",
+					GroupKey:       "{}:{alertname=\"Test\"}",
+					AlertsCount:    1,
+					FiringCount:    1,
+					ResolvedCount:  0,
+					GroupLabels: map[string]string{
+						"alertname": "Test",
+					},
+				}
+				err := nl.Log(entry)
+				require.NoError(t, err)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	err = nl.Close()
+	require.NoError(t, err)
+
+	// Verify all entries were written
+	f, err := os.Open(logPath)
+	require.NoError(t, err)
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	count := 0
+
+	for scanner.Scan() {
+		var e NotificationLogEntry
+		err := json.Unmarshal(scanner.Bytes(), &e)
+		require.NoError(t, err)
+		count++
+	}
+	require.NoError(t, scanner.Err())
+
+	require.Equal(t, numGoroutines*numEntriesPerGoroutine, count)
+}
+
+func TestNoopNotificationLogger(t *testing.T) {
+	nl := NoopNotificationLogger{}
+
+	entry := &NotificationLogEntry{
+		Timestamp:   time.Now().UTC(),
+		Integration: "test",
+		Receiver:    "test-receiver",
+	}
+
+	err := nl.Log(entry)
+	require.NoError(t, err)
+}
+
+func TestFileNotificationLogger_InvalidPath(t *testing.T) {
+	// Try to create a logger with an invalid path
+	_, err := NewFileNotificationLogger("/nonexistent/path/to/file.log")
+	require.Error(t, err)
+}
+
+func TestNotificationLogEntry_NilGroupLabels(t *testing.T) {
+	entry := &NotificationLogEntry{
+		Timestamp:      time.Now().UTC(),
+		Integration:    "slack",
+		IntegrationIdx: 0,
+		Receiver:       "test",
+		GroupKey:       "test-key",
+		AlertsCount:    1,
+		FiringCount:    1,
+		ResolvedCount:  0,
+		GroupLabels:    nil,
+	}
+
+	data, err := json.Marshal(entry)
+	require.NoError(t, err)
+
+	var decoded NotificationLogEntry
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	require.Nil(t, decoded.GroupLabels)
+}
+
+// mockNotificationLogger is a test implementation that captures logged entries.
+type mockNotificationLogger struct {
+	mu      sync.Mutex
+	entries []*NotificationLogEntry
+}
+
+func (m *mockNotificationLogger) Log(entry *NotificationLogEntry) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.entries = append(m.entries, entry)
+	return nil
+}
+
+func (m *mockNotificationLogger) getEntries() []*NotificationLogEntry {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.entries
+}
+
+func TestRetryStageWithNotificationLogger(t *testing.T) {
+	// Create a mock notification logger
+	mockLogger := &mockNotificationLogger{}
+
+	// Create a successful notifier
+	i := Integration{
+		name: "test-integration",
+		idx:  0,
+		notifier: notifierFunc(func(ctx context.Context, alerts ...*types.Alert) (bool, error) {
+			return false, nil // Success
+		}),
+		rs:           sendResolved(true),
+		receiverName: "test-receiver",
+	}
+
+	r := NewRetryStage(i, "test-receiver", NewMetrics(prometheus.NewRegistry(), featurecontrol.NoopFlags{}), mockLogger)
+
+	alerts := []*types.Alert{
+		{
+			Alert: model.Alert{
+				Labels:   model.LabelSet{"alertname": "TestAlert", "severity": "critical"},
+				EndsAt:   time.Now().Add(time.Hour),
+				StartsAt: time.Now(),
+			},
+		},
+	}
+
+	ctx := context.Background()
+	ctx = WithFiringAlerts(ctx, []uint64{1})
+	ctx = WithResolvedAlerts(ctx, []uint64{})
+	ctx = WithGroupKey(ctx, "{}:{alertname=\"TestAlert\"}")
+	ctx = WithGroupLabels(ctx, model.LabelSet{"alertname": "TestAlert"})
+
+	resctx, res, err := r.Exec(ctx, promslog.NewNopLogger(), alerts...)
+	require.NoError(t, err)
+	require.Equal(t, alerts, res)
+	require.NotNil(t, resctx)
+
+	// Verify the notification was logged
+	entries := mockLogger.getEntries()
+	require.Len(t, entries, 1)
+
+	entry := entries[0]
+	require.Equal(t, "test-integration", entry.Integration)
+	require.Equal(t, 0, entry.IntegrationIdx)
+	require.Equal(t, "test-receiver", entry.Receiver)
+	require.Equal(t, "{}:{alertname=\"TestAlert\"}", entry.GroupKey)
+	require.Equal(t, 1, entry.AlertsCount)
+	require.Equal(t, 1, entry.FiringCount)
+	require.Equal(t, 0, entry.ResolvedCount)
+	require.Equal(t, "TestAlert", entry.GroupLabels["alertname"])
+}
+
+func TestRetryStageWithNilNotificationLogger(t *testing.T) {
+	// Create a successful notifier with nil notification logger
+	i := Integration{
+		name: "test-integration",
+		idx:  0,
+		notifier: notifierFunc(func(ctx context.Context, alerts ...*types.Alert) (bool, error) {
+			return false, nil // Success
+		}),
+		rs:           sendResolved(true),
+		receiverName: "test-receiver",
+	}
+
+	// Pass nil for notification logger
+	r := NewRetryStage(i, "test-receiver", NewMetrics(prometheus.NewRegistry(), featurecontrol.NoopFlags{}), nil)
+
+	alerts := []*types.Alert{
+		{
+			Alert: model.Alert{
+				Labels:   model.LabelSet{"alertname": "TestAlert"},
+				EndsAt:   time.Now().Add(time.Hour),
+				StartsAt: time.Now(),
+			},
+		},
+	}
+
+	ctx := context.Background()
+	ctx = WithFiringAlerts(ctx, []uint64{1})
+	ctx = WithResolvedAlerts(ctx, []uint64{})
+
+	// Should not panic with nil notification logger
+	resctx, res, err := r.Exec(ctx, promslog.NewNopLogger(), alerts...)
+	require.NoError(t, err)
+	require.Equal(t, alerts, res)
+	require.NotNil(t, resctx)
+}
+
+// errorNotificationLogger is a test implementation that always returns an error.
+type errorNotificationLogger struct {
+	err error
+}
+
+func (e *errorNotificationLogger) Log(entry *NotificationLogEntry) error {
+	return e.err
+}
+
+func TestRetryStageWithNotificationLoggerError(t *testing.T) {
+	// Create a notification logger that always returns an error
+	errLogger := &errorNotificationLogger{err: errors.New("log write failed")}
+
+	// Create a successful notifier
+	i := Integration{
+		name: "test-integration",
+		idx:  0,
+		notifier: notifierFunc(func(ctx context.Context, alerts ...*types.Alert) (bool, error) {
+			return false, nil // Success
+		}),
+		rs:           sendResolved(true),
+		receiverName: "test-receiver",
+	}
+
+	r := NewRetryStage(i, "test-receiver", NewMetrics(prometheus.NewRegistry(), featurecontrol.NoopFlags{}), errLogger)
+
+	alerts := []*types.Alert{
+		{
+			Alert: model.Alert{
+				Labels:   model.LabelSet{"alertname": "TestAlert"},
+				EndsAt:   time.Now().Add(time.Hour),
+				StartsAt: time.Now(),
+			},
+		},
+	}
+
+	ctx := context.Background()
+	ctx = WithFiringAlerts(ctx, []uint64{1})
+	ctx = WithResolvedAlerts(ctx, []uint64{})
+	ctx = WithGroupKey(ctx, "{}:{alertname=\"TestAlert\"}")
+	ctx = WithGroupLabels(ctx, model.LabelSet{"alertname": "TestAlert"})
+
+	// Notification should still succeed even if logging fails
+	resctx, res, err := r.Exec(ctx, promslog.NewNopLogger(), alerts...)
+	require.NoError(t, err)
+	require.Equal(t, alerts, res)
+	require.NotNil(t, resctx)
+}
+
+func TestFileNotificationLogger_CloseIdempotent(t *testing.T) {
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "notifications_idempotent.log")
+
+	nl, err := NewFileNotificationLogger(logPath)
+	require.NoError(t, err)
+
+	// First close should succeed
+	err = nl.Close()
+	require.NoError(t, err)
+
+	// Second close should also succeed (idempotent)
+	err = nl.Close()
+	require.NoError(t, err)
+
+	// Third close should also succeed
+	err = nl.Close()
+	require.NoError(t, err)
+}
+
+func TestFileNotificationLogger_LogAfterClose(t *testing.T) {
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "notifications_after_close.log")
+
+	nl, err := NewFileNotificationLogger(logPath)
+	require.NoError(t, err)
+
+	// Close the logger
+	err = nl.Close()
+	require.NoError(t, err)
+
+	// Attempt to log after close should return ErrNotificationLogClosed
+	entry := &NotificationLogEntry{
+		Timestamp:   time.Now().UTC(),
+		Integration: "test",
+		Receiver:    "test-receiver",
+	}
+	err = nl.Log(entry)
+	require.ErrorIs(t, err, ErrNotificationLogClosed)
+}

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -399,14 +399,16 @@ func (m *Metrics) InitializeFor(receiver map[string][]Integration) {
 }
 
 type PipelineBuilder struct {
-	metrics *Metrics
-	ff      featurecontrol.Flagger
+	metrics            *Metrics
+	ff                 featurecontrol.Flagger
+	notificationLogger NotificationLogger
 }
 
-func NewPipelineBuilder(r prometheus.Registerer, ff featurecontrol.Flagger) *PipelineBuilder {
+func NewPipelineBuilder(r prometheus.Registerer, ff featurecontrol.Flagger, nl NotificationLogger) *PipelineBuilder {
 	return &PipelineBuilder{
-		metrics: NewMetrics(r, ff),
-		ff:      ff,
+		metrics:            NewMetrics(r, ff),
+		ff:                 ff,
+		notificationLogger: nl,
 	}
 }
 
@@ -430,7 +432,7 @@ func (pb *PipelineBuilder) New(
 	ss := NewMuteStage(silencer, pb.metrics)
 
 	for name := range receivers {
-		st := createReceiverStage(name, receivers[name], wait, notificationLog, pb.metrics)
+		st := createReceiverStage(name, receivers[name], wait, notificationLog, pb.metrics, pb.notificationLogger)
 		rs[name] = MultiStage{ms, is, tas, tms, ss, st}
 	}
 
@@ -446,6 +448,7 @@ func createReceiverStage(
 	wait func() time.Duration,
 	notificationLog NotificationLog,
 	metrics *Metrics,
+	notificationLogger NotificationLogger,
 ) Stage {
 	var fs FanoutStage
 	for i := range integrations {
@@ -457,7 +460,7 @@ func createReceiverStage(
 		var s MultiStage
 		s = append(s, NewWaitStage(wait))
 		s = append(s, NewDedupStage(&integrations[i], notificationLog, recv))
-		s = append(s, NewRetryStage(integrations[i], name, metrics))
+		s = append(s, NewRetryStage(integrations[i], name, metrics, notificationLogger))
 		s = append(s, NewSetNotifiesStage(notificationLog, recv))
 
 		fs = append(fs, s)
@@ -798,14 +801,15 @@ func (n *DedupStage) Exec(ctx context.Context, _ *slog.Logger, alerts ...*types.
 // RetryStage notifies via passed integration with exponential backoff until it
 // succeeds. It aborts if the context is canceled or timed out.
 type RetryStage struct {
-	integration Integration
-	groupName   string
-	metrics     *Metrics
-	labelValues []string
+	integration        Integration
+	groupName          string
+	metrics            *Metrics
+	labelValues        []string
+	notificationLogger NotificationLogger
 }
 
 // NewRetryStage returns a new instance of a RetryStage.
-func NewRetryStage(i Integration, groupName string, metrics *Metrics) *RetryStage {
+func NewRetryStage(i Integration, groupName string, metrics *Metrics, nl NotificationLogger) *RetryStage {
 	labelValues := []string{i.Name()}
 
 	if metrics.ff.EnableReceiverNamesInMetrics() {
@@ -813,10 +817,11 @@ func NewRetryStage(i Integration, groupName string, metrics *Metrics) *RetryStag
 	}
 
 	return &RetryStage{
-		integration: i,
-		groupName:   groupName,
-		metrics:     metrics,
-		labelValues: labelValues,
+		integration:        i,
+		groupName:          groupName,
+		metrics:            metrics,
+		labelValues:        labelValues,
+		notificationLogger: nl,
 	}
 }
 
@@ -937,6 +942,28 @@ func (r RetryStage) exec(ctx context.Context, l *slog.Logger, alerts ...*types.A
 					l.Debug("Notify success")
 				} else {
 					l.Info("Notify success")
+				}
+
+				if r.notificationLogger != nil {
+					gkey, _ := GroupKey(ctx)
+					firing, _ := FiringAlerts(ctx)
+					resolved, _ := ResolvedAlerts(ctx)
+					groupLabels, _ := GroupLabels(ctx)
+
+					entry := &NotificationLogEntry{
+						Timestamp:      time.Now().UTC(),
+						Integration:    r.integration.Name(),
+						IntegrationIdx: r.integration.Index(),
+						Receiver:       r.groupName,
+						GroupKey:       gkey,
+						AlertsCount:    len(sent),
+						FiringCount:    len(firing),
+						ResolvedCount:  len(resolved),
+						GroupLabels:    labelSetToMap(groupLabels),
+					}
+					if err := r.notificationLogger.Log(entry); err != nil {
+						l.Warn("Failed to log notification", "err", err)
+					}
 				}
 
 				return ctx, alerts, nil
@@ -1145,4 +1172,18 @@ func (tas TimeActiveStage) Exec(ctx context.Context, l *slog.Logger, alerts ...*
 	}
 
 	return ctx, alerts, nil
+}
+
+// labelSetToMap converts a Prometheus model.LabelSet into a map[string]string.
+// If the provided label set is nil, labelSetToMap returns nil without
+// allocating a new map.
+func labelSetToMap(ls model.LabelSet) map[string]string {
+	if ls == nil {
+		return nil
+	}
+	m := make(map[string]string, len(ls))
+	for k, v := range ls {
+		m[string(k)] = string(v)
+	}
+	return m
 }

--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -394,7 +394,7 @@ func TestRetryStageWithError(t *testing.T) {
 		}),
 		rs: sendResolved(false),
 	}
-	r := NewRetryStage(i, "", NewMetrics(prometheus.NewRegistry(), featurecontrol.NoopFlags{}))
+	r := NewRetryStage(i, "", NewMetrics(prometheus.NewRegistry(), featurecontrol.NoopFlags{}), nil)
 
 	alerts := []*types.Alert{
 		{
@@ -447,7 +447,7 @@ func TestRetryStageWithErrorCode(t *testing.T) {
 			}),
 			rs: sendResolved(false),
 		}
-		r := NewRetryStage(i, "", NewMetrics(prometheus.NewRegistry(), featurecontrol.NoopFlags{}))
+		r := NewRetryStage(i, "", NewMetrics(prometheus.NewRegistry(), featurecontrol.NoopFlags{}), nil)
 
 		alerts := []*types.Alert{
 			{
@@ -482,7 +482,7 @@ func TestRetryStageWithContextCanceled(t *testing.T) {
 		}),
 		rs: sendResolved(false),
 	}
-	r := NewRetryStage(i, "", NewMetrics(prometheus.NewRegistry(), featurecontrol.NoopFlags{}))
+	r := NewRetryStage(i, "", NewMetrics(prometheus.NewRegistry(), featurecontrol.NoopFlags{}), nil)
 
 	alerts := []*types.Alert{
 		{
@@ -514,7 +514,7 @@ func TestRetryStageNoResolved(t *testing.T) {
 		}),
 		rs: sendResolved(false),
 	}
-	r := NewRetryStage(i, "", NewMetrics(prometheus.NewRegistry(), featurecontrol.NoopFlags{}))
+	r := NewRetryStage(i, "", NewMetrics(prometheus.NewRegistry(), featurecontrol.NoopFlags{}), nil)
 
 	alerts := []*types.Alert{
 		{
@@ -565,7 +565,7 @@ func TestRetryStageSendResolved(t *testing.T) {
 		}),
 		rs: sendResolved(true),
 	}
-	r := NewRetryStage(i, "", NewMetrics(prometheus.NewRegistry(), featurecontrol.NoopFlags{}))
+	r := NewRetryStage(i, "", NewMetrics(prometheus.NewRegistry(), featurecontrol.NoopFlags{}), nil)
 
 	alerts := []*types.Alert{
 		{
@@ -1078,5 +1078,59 @@ func BenchmarkHashAlert(b *testing.B) {
 	}
 	for b.Loop() {
 		hashAlert(alert)
+	}
+}
+
+func TestLabelSetToMap(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    model.LabelSet
+		expected map[string]string
+	}{
+		{
+			name:     "nil LabelSet",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:     "empty LabelSet",
+			input:    model.LabelSet{},
+			expected: map[string]string{},
+		},
+		{
+			name:     "single label",
+			input:    model.LabelSet{"alertname": "TestAlert"},
+			expected: map[string]string{"alertname": "TestAlert"},
+		},
+		{
+			name: "multiple labels",
+			input: model.LabelSet{
+				"alertname": "TestAlert",
+				"severity":  "critical",
+				"instance":  "localhost:9090",
+			},
+			expected: map[string]string{
+				"alertname": "TestAlert",
+				"severity":  "critical",
+				"instance":  "localhost:9090",
+			},
+		},
+		{
+			name:     "empty label value",
+			input:    model.LabelSet{"alertname": ""},
+			expected: map[string]string{"alertname": ""},
+		},
+		{
+			name:     "special characters in values",
+			input:    model.LabelSet{"path": "/api/v1/query?query=up{job=\"prometheus\"}"},
+			expected: map[string]string{"path": "/api/v1/query?query=up{job=\"prometheus\"}"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := labelSetToMap(tt.input)
+			require.Equal(t, tt.expected, result)
+		})
 	}
 }


### PR DESCRIPTION
This PR implements notification logging for Alertmanager.

- Add `--notification-log.file` CLI flag to enable JSON-formatted notification logging
- Log successful notifications with rich metadata (receiver, integration, group key, alert counts, group labels)
- Follow the pattern established by Prometheus query logging

## Motivation

Users need visibility into which notifications were successfully sent for auditing and analytics purposes. The current workaround of using a webhook receiver with `continue: true` has limitations around destination visibility and routing behavior.

## Implementation Details

### New Files
- `notify/notification_log.go` - Notification logger implementation
- `notify/notification_log_test.go` - Unit tests

### Modified Files
- `notify/notify.go` - Integrate NotificationLogger into the pipeline
- `cmd/alertmanager/main.go` - Add CLI flag and initialization
- `notify/notify_test.go` - Update existing tests for new function signature

### Log Entry Format

Each line in the notification log file is a JSON object:

```json
{
  "timestamp": "2024-01-15T10:30:00.123Z",
  "integration": "slack",
  "integrationIdx": 0,
  "receiver": "team-alerts",
  "groupKey": "{}:{alertname=\"HighMemory\"}",
  "alertsCount": 3,
  "firingCount": 2,
  "resolvedCount": 1,
  "groupLabels": {
    "alertname": "HighMemory"
  }
}
```

### Design Decisions

1. **Metadata only**: Log receiver, integration, group key, counts, and group labels. Avoids sensitive alert data and keeps log files manageable.
2. **Success only**: Only log successful notifications. Failures are already visible in standard logs and metrics.
3. **JSON lines format**: Easy to parse, grep, and integrate with log aggregation systems.
4. **No built-in rotation**: Users can use logrotate or similar tools, following Prometheus conventions.

## Usage

```bash
alertmanager --notification-log.file=/var/log/alertmanager/notifications.log
```

When the flag is not set or empty, notification logging is disabled (default behavior).

## Test Plan

- [x] Unit tests for JSON serialization
- [x] Unit tests for file writing
- [x] Unit tests for concurrent write safety
- [x] Unit tests for noop logger
- [x] Existing notify package tests pass
- [x] Build succeeds
- [ ] Manual integration test: start Alertmanager with flag, send alerts, verify JSON entries in log file

## Future Considerations (Out of Scope)

- Log rotation (users can use logrotate)
- Logging failures (could add with `status: "failure"` in future PR)
- Configurable fields to include/exclude
- Metrics for notification logging

Fixes #2304