### PR TITLE
Add chat_id_file configuration parameter for Telegram

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -914,6 +914,7 @@ type TelegramConfig struct {
 	BotToken             Secret `yaml:"bot_token,omitempty" json:"token,omitempty"`
 	BotTokenFile         string `yaml:"bot_token_file,omitempty" json:"token_file,omitempty"`
 	ChatID               int64  `yaml:"chat_id,omitempty" json:"chat,omitempty"`
+	ChatIDFile           string `yaml:"chat_id_file,omitempty" json:"chat_file,omitempty"`
 	MessageThreadID      int    `yaml:"message_thread_id,omitempty" json:"message_thread_id,omitempty"`
 	Message              string `yaml:"message,omitempty" json:"message,omitempty"`
 	DisableNotifications bool   `yaml:"disable_notifications,omitempty" json:"disable_notifications,omitempty"`
@@ -933,8 +934,11 @@ func (c *TelegramConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	if c.BotToken != "" && c.BotTokenFile != "" {
 		return errors.New("at most one of bot_token & bot_token_file must be configured")
 	}
-	if c.ChatID == 0 {
-		return errors.New("missing chat_id on telegram_config")
+	if c.ChatID == 0 && c.ChatIDFile == "" {
+		return errors.New("missing chat_id or chat_id_file on telegram_config")
+	}
+	if c.ChatID != 0 && c.ChatIDFile != "" {
+		return errors.New("at most one of chat_id & chat_id_file must be configured")
 	}
 	if c.ParseMode != "" &&
 		c.ParseMode != "Markdown" &&

--- a/config/notifiers_test.go
+++ b/config/notifiers_test.go
@@ -1130,11 +1130,27 @@ chat_id: 123
 `,
 		},
 		{
+			name: "with bot_token_file and chat_id_file set - it succeeds",
+			in: `
+bot_token_file: /file
+chat_id_file: /chat_id_file
+`,
+		},
+		{
 			name: "with no chat_id set - it fails",
 			in: `
 bot_token: xyz
 `,
-			expected: errors.New("missing chat_id on telegram_config"),
+			expected: errors.New("missing chat_id or chat_id_file on telegram_config"),
+		},
+		{
+			name: "with both chat_id and chat_id_file - it fails",
+			in: `
+bot_token: xyz
+chat_id: 123
+chat_id_file: /file
+`,
+			expected: errors.New("at most one of chat_id & chat_id_file must be configured"),
 		},
 		{
 			name: "with unknown parse_mode - it fails",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1708,8 +1708,11 @@ attributes:
 # Read the Telegram bot token from a file. It is mutually exclusive with `bot_token`.
 [ bot_token_file: <filepath> ]
 
-# ID of the chat where to send the messages.
+# ID of the chat where to send the messages. It is mutually exclusive with `chat_id_file`.
 [ chat_id: <int> ]
+
+# Read the chat ID from a file. It is mutually exclusive with `chat_id`.
+[ chat_id_file: <filepath> ]
 
 # Optional ID of the message thread where to send the messages.
 [ message_thread_id: <int> ]


### PR DESCRIPTION
part of : #4672

### Description of change:

- This change adds support for the `chat_id_file` configuration parameter for Telegram notifications, allowing users to securely provide their chat ID via a file instead of embedding it directly in the config. This is similar to the existing `bot_token_file` parameter.
- Previously, users had to pass `chat_id` in clear text inside the config file. This feature allows passing a file path that contains the `chat_id` value, enabling more secure deployments using Docker secrets or Kubernetes volumes.

### Validation Rules:
- Either chat_id or chat_id_file must be provided (at least one required)
- chat_id and chat_id_file are mutually exclusive (cannot use both)
- Error messages:
    - "missing `chat_id` or `chat_id_file` on telegram_config" - when neither is provided
    -  "at most one of `chat_id` & `chat_id_file` must be configured" - when both are provided

### Fully backward compatible. Existing configurations using `chat_id` continue to work unchanged.