### PR TITLE
Add simple fuzzer for config deserialization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,10 @@ api/v2/models api/v2/restapi api/v2/client: api/v2/openapi.yaml
 	$(SWAGGER) generate server -f api/v2/openapi.yaml --copyright-file=COPYRIGHT.txt --exclude-main -A alertmanager --target api/v2/
 	$(SWAGGER) generate client -f api/v2/openapi.yaml --copyright-file=COPYRIGHT.txt --skip-models --target api/v2
 
+.PHONY: fuzz-config
+fuzz-config:
+	go test -fuzz=^Fuzz -fuzztime=5s ./config
+
 .PHONY: clean
 clean:
 	- @rm -rf asset/assets_vfsdata.go \

--- a/config/config_fuzz_test.go
+++ b/config/config_fuzz_test.go
@@ -1,0 +1,37 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import "testing"
+
+func FuzzLoad(f *testing.F) {
+	f.Add(`
+global:
+  resolve_timeout: 5m
+route:
+  group_by: ['alertname']
+  group_wait: 10s
+  group_interval: 10s
+  repeat_interval: 1h
+  receiver: 'web.hook'
+receivers:
+- name: 'web.hook'
+  webhook_configs:
+  - url: 'http://127.0.0.1:5001/'
+`)
+
+	f.Fuzz(func(t *testing.T, configText string) {
+		_, _ = Load(configText)
+	})
+}


### PR DESCRIPTION
This change does not include any fixes to `config.Load`. Those fixes should be handled separately, since a project is never completely fuzzed.

We also don't add any change to the `.github/workflows`. This fuzzer currently has findings, which it detects frequently. Thus, even a simple smoke test would be very noisy. Moreover, the goal is to use the infrastructure of the OSS-fuzz project rather than GitHubs.

`go` ensures that the fuzzer can pass at least once, with the default data provided. Therefore, `make test` treats `FuzzLoad` as a trivial unit-test. This avoids fuzzing targets becoming outdated.

Related to #4912