### PR TITLE
refactor: move tracing config into tracing package

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -548,7 +548,7 @@ func run() int {
 		newDisp.WaitForLoading()
 		disp = newDisp
 
-		err = tracingManager.ApplyConfig(conf)
+		err = tracingManager.ApplyConfig(conf.TracingConfig)
 		if err != nil {
 			return fmt.Errorf("failed to apply tracing config: %w", err)
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,7 @@ import (
 	"github.com/prometheus/alertmanager/matcher/compat"
 	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/prometheus/alertmanager/timeinterval"
+	"github.com/prometheus/alertmanager/tracing"
 )
 
 const secretToken = "<secret>"
@@ -432,7 +433,7 @@ type Config struct {
 	MuteTimeIntervals []MuteTimeInterval `yaml:"mute_time_intervals,omitempty" json:"mute_time_intervals,omitempty"`
 	TimeIntervals     []TimeInterval     `yaml:"time_intervals,omitempty" json:"time_intervals,omitempty"`
 
-	TracingConfig TracingConfig `yaml:"tracing,omitempty" json:"tracing,omitempty"`
+	TracingConfig tracing.TracingConfig `yaml:"tracing,omitempty" json:"tracing,omitempty"`
 
 	// original is the input from which the config was parsed.
 	original string

--- a/tracing/config.go
+++ b/tracing/config.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package tracing
 
 import (
 	"errors"


### PR DESCRIPTION
While experimenting to move notifier specifcs from the config package to their respective notfier packages and untangling import cycles I figured this might be a good place to start. 

I was at this point experimenting with the webhook notifier:
```
package github.com/prometheus/alertmanager/cmd/alertmanager
	imports github.com/prometheus/alertmanager/api from main.go
	imports github.com/prometheus/alertmanager/api/v2 from api.go
	imports github.com/prometheus/alertmanager/config from api.go
	imports github.com/prometheus/alertmanager/notify/webhook from config.go
	imports github.com/prometheus/alertmanager/notify from webhook.go
	imports github.com/prometheus/alertmanager/tracing from util.go
	imports github.com/prometheus/alertmanager/config from tracing.go: import cycle not allowed
```

There is plenty more to be moved around, eg in my experiments I used a new `amcommoncfg` package holding a couple of types that currently live in config package (e.g. type SecretURL)