### PR TITLE
refactor: convert route groups to a sync map

### DIFF
--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -762,7 +762,9 @@ func (ag *aggrGroup) flush(notify func(...*types.Alert) bool) {
 		// and we don't want to send another one. However, we need to make sure
 		// that each resolved alert has not fired again during the flush as then
 		// we would delete an active alert thinking it was resolved.
-		if err := ag.alerts.DeleteIfNotModified(resolvedSlice); err != nil {
+		// Since we are passing DestroyIfEmpty=true the group will be marked as
+		// destroyed if there are no more alerts after the deletion.
+		if err := ag.alerts.DeleteIfNotModified(resolvedSlice, true); err != nil {
 			ag.logger.Error("error on delete alerts", "err", err)
 		} else {
 			// Delete markers for resolved alerts that are not in the store.

--- a/provider/mem/mem.go
+++ b/provider/mem/mem.go
@@ -136,7 +136,7 @@ func NewAlerts(
 	ctx, cancel := context.WithCancel(ctx)
 	a := &Alerts{
 		marker:     m,
-		alerts:     store.NewAlerts().WithDontDestroy().WithPerAlertLimit(perAlertNameLimit),
+		alerts:     store.NewAlerts().WithPerAlertLimit(perAlertNameLimit),
 		cancel:     cancel,
 		listeners:  map[int]listeningAlerts{},
 		next:       0,

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -51,7 +51,7 @@ func TestDeleteIfNotModified(t *testing.T) {
 		require.NoError(t, a.Set(a1))
 
 		// a1 should be deleted as it has not been modified.
-		a.DeleteIfNotModified(types.AlertSlice{a1})
+		a.DeleteIfNotModified(types.AlertSlice{a1}, false)
 		got, err := a.Get(a1.Fingerprint())
 		require.Equal(t, ErrNotFound, err)
 		require.Nil(t, got)
@@ -80,7 +80,7 @@ func TestDeleteIfNotModified(t *testing.T) {
 			UpdatedAt: time.Now().Add(-time.Second),
 		}
 		require.True(t, a2.UpdatedAt.Before(a1.UpdatedAt))
-		a.DeleteIfNotModified(types.AlertSlice{a2})
+		a.DeleteIfNotModified(types.AlertSlice{a2}, false)
 		// a1 should not be deleted.
 		got, err := a.Get(a1.Fingerprint())
 		require.NoError(t, err)
@@ -97,7 +97,7 @@ func TestDeleteIfNotModified(t *testing.T) {
 			UpdatedAt: time.Now().Add(time.Second),
 		}
 		require.True(t, a3.UpdatedAt.After(a1.UpdatedAt))
-		a.DeleteIfNotModified(types.AlertSlice{a3})
+		a.DeleteIfNotModified(types.AlertSlice{a3}, false)
 		// a1 should not be deleted.
 		got, err = a.Get(a1.Fingerprint())
 		require.NoError(t, err)
@@ -126,10 +126,11 @@ func TestDeleteIfNotModified(t *testing.T) {
 		require.NoError(t, a.Set(a2))
 
 		// Deleting a1 should not delete a2.
-		require.NoError(t, a.DeleteIfNotModified(types.AlertSlice{a1}))
+		require.NoError(t, a.DeleteIfNotModified(types.AlertSlice{a1}, true))
 		// a1 should be deleted.
 		got, err := a.Get(a1.Fingerprint())
 		require.Equal(t, ErrNotFound, err)
+		require.False(t, a.Destroyed())
 		require.Nil(t, got)
 		// a2 should not be deleted.
 		got, err = a.Get(a2.Fingerprint())


### PR DESCRIPTION
This allows us to avoid taking the lock in most cases.

The exception is that we still need it when adding an aggrgroup, as multiple goroutines might be otherwise trying to add theirs, for the same fp.
 
This applies on top of https://github.com/prometheus/alertmanager/pull/4958

