### PR TITLE
refactor: make the dispatcher ingestion concurrent

### DIFF
--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -144,8 +144,8 @@ func NewDispatcher(
 		limits = nilLimits{}
 	}
 
-	// Calculate concurrency: GOMAXPROC/2, minimum 4, maximum 64
-	concurrency := min(max(runtime.GOMAXPROCS(0)/2, 4), 64)
+	// Calculate concurrency for ingestion.
+	concurrency := min(max(runtime.GOMAXPROCS(0)/2, 2), 8)
 
 	disp := &Dispatcher{
 		alerts:              alerts,


### PR DESCRIPTION
Based on https://github.com/prometheus/alertmanager/pull/4958 and https://github.com/prometheus/alertmanager/pull/4966, we can now have multiple goroutines ingesting alerts.