### PR TITLE
Add Rootly notification integration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -380,6 +380,9 @@ func resolveFilepaths(baseDir string, cfg *Config) {
 		for _, cfg := range receiver.RocketchatConfigs {
 			cfg.HTTPConfig.SetDirectory(baseDir)
 		}
+		for _, cfg := range receiver.RootlyConfigs {
+			cfg.HTTPConfig.SetDirectory(baseDir)
+		}
 		for _, cfg := range receiver.MattermostConfigs {
 			cfg.HTTPConfig.SetDirectory(baseDir)
 		}
@@ -595,6 +598,9 @@ func (c *Config) UnmarshalYAML(unmarshal func(any) error) error {
 		}
 		for _, iio := range rcv.IncidentioConfigs {
 			iio.HTTPConfig = cmp.Or(iio.HTTPConfig, c.Global.HTTPConfig)
+		}
+		for _, rootly := range rcv.RootlyConfigs {
+			rootly.HTTPConfig = cmp.Or(rootly.HTTPConfig, c.Global.HTTPConfig)
 		}
 		for _, ogc := range rcv.OpsGenieConfigs {
 			ogc.HTTPConfig = cmp.Or(ogc.HTTPConfig, c.Global.HTTPConfig)
@@ -1121,6 +1127,7 @@ type Receiver struct {
 	MSTeamsV2Configs  []*MSTeamsV2Config  `yaml:"msteamsv2_configs,omitempty" json:"msteamsv2_configs,omitempty"`
 	JiraConfigs       []*JiraConfig       `yaml:"jira_configs,omitempty" json:"jira_configs,omitempty"`
 	RocketchatConfigs []*RocketchatConfig `yaml:"rocketchat_configs,omitempty" json:"rocketchat_configs,omitempty"`
+	RootlyConfigs     []*RootlyConfig     `yaml:"rootly_configs,omitempty" json:"rootly_configs,omitempty"`
 	MattermostConfigs []*MattermostConfig `yaml:"mattermost_configs,omitempty" json:"mattermost_configs,omitempty"`
 }
 

--- a/config/receiver/receiver.go
+++ b/config/receiver/receiver.go
@@ -32,6 +32,7 @@ import (
 	"github.com/prometheus/alertmanager/notify/pagerduty"
 	"github.com/prometheus/alertmanager/notify/pushover"
 	"github.com/prometheus/alertmanager/notify/rocketchat"
+	"github.com/prometheus/alertmanager/notify/rootly"
 	"github.com/prometheus/alertmanager/notify/slack"
 	"github.com/prometheus/alertmanager/notify/sns"
 	"github.com/prometheus/alertmanager/notify/telegram"
@@ -113,6 +114,9 @@ func BuildReceiverIntegrations(nc config.Receiver, tmpl *template.Template, logg
 	}
 	for i, c := range nc.RocketchatConfigs {
 		add("rocketchat", i, c, func(l *slog.Logger) (notify.Notifier, error) { return rocketchat.New(c, tmpl, l, httpOpts...) })
+	}
+	for i, c := range nc.RootlyConfigs {
+		add("rootly", i, c, func(l *slog.Logger) (notify.Notifier, error) { return rootly.New(c, tmpl, l, httpOpts...) })
 	}
 	for i, c := range nc.MattermostConfigs {
 		add("mattermost", i, c, func(l *slog.Logger) (notify.Notifier, error) { return mattermost.New(c, tmpl, l, httpOpts...) })

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -395,6 +395,7 @@ func (m *Metrics) InitializeFor(receiver map[string][]Integration) {
 		"incidentio",
 		"jira",
 		"rocketchat",
+		"rootly",
 		"mattermost",
 	} {
 		m.numNotifications.WithLabelValues(integration)

--- a/notify/rootly/rootly.go
+++ b/notify/rootly/rootly.go
@@ -1,0 +1,241 @@
+// Copyright 2025 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rootly
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+
+	commoncfg "github.com/prometheus/common/config"
+
+	"github.com/prometheus/alertmanager/config"
+	"github.com/prometheus/alertmanager/notify"
+	"github.com/prometheus/alertmanager/template"
+	"github.com/prometheus/alertmanager/types"
+)
+
+const (
+	// MaxPayloadSize is the maximum size of the JSON payload Rootly accepts (256KB).
+	maxPayloadSize = 256 * 1024
+)
+
+// Notifier implements a Notifier for Rootly.
+type Notifier struct {
+	conf    *config.RootlyConfig
+	tmpl    *template.Template
+	logger  *slog.Logger
+	client  *http.Client
+	retrier *notify.Retrier
+}
+
+// New returns a new Rootly notifier.
+func New(conf *config.RootlyConfig, t *template.Template, l *slog.Logger, httpOpts ...commoncfg.HTTPClientOption) (*Notifier, error) {
+	// conf.HTTPConfig is likely to be the global shared HTTPConfig, so we take a
+	// copy to avoid modifying it.
+	httpConfig := *conf.HTTPConfig
+
+	// If a rootly token is provided, we use that one instead of whatever configuration is included in `http_config`.
+	var token string
+	if conf.RootlyToken != "" {
+		token = string(conf.RootlyToken)
+	}
+
+	if conf.RootlyTokenFile != "" {
+		content, err := os.ReadFile(conf.RootlyTokenFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read rootly_token_file: %w", err)
+		}
+		token = strings.TrimSpace(string(content))
+	}
+
+	if token != "" {
+		httpConfig.Authorization = &commoncfg.Authorization{
+			Type:        "Bearer",
+			Credentials: commoncfg.Secret(token),
+		}
+	}
+
+	client, err := notify.NewClientWithTracing(httpConfig, "rootly", httpOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Notifier{
+		conf:   conf,
+		tmpl:   t,
+		logger: l,
+		client: client,
+		// Always retry on 429 (rate limiting) and 5xx response codes.
+		retrier: &notify.Retrier{
+			RetryCodes:        []int{http.StatusTooManyRequests},
+			CustomDetailsFunc: errDetails,
+		},
+	}, nil
+}
+
+// Message defines the JSON object sent to Rootly endpoints.
+type Message struct {
+	*template.Data
+
+	// The protocol version.
+	Version         string `json:"version"`
+	GroupKey        string `json:"groupKey"`
+	TruncatedAlerts uint64 `json:"truncatedAlerts"`
+}
+
+func truncateAlerts(maxAlerts uint64, alerts []*types.Alert) ([]*types.Alert, uint64) {
+	if maxAlerts != 0 && uint64(len(alerts)) > maxAlerts {
+		return alerts[:maxAlerts], uint64(len(alerts)) - maxAlerts
+	}
+
+	return alerts, 0
+}
+
+// encodeMessage encodes the message and drops all alerts except the first one if it exceeds maxPayloadSize.
+func (n *Notifier) encodeMessage(msg *Message) (bytes.Buffer, error) {
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(msg); err != nil {
+		return buf, fmt.Errorf("failed to encode rootly message: %w", err)
+	}
+
+	if buf.Len() <= maxPayloadSize {
+		return buf, nil
+	}
+
+	originalSize := buf.Len()
+
+	// Drop all but the first alert in the message. For most use cases, a single
+	// alert will be created in Rootly for the group, so including more than
+	// one alert in that group is useful but non-essential.
+	msg.Alerts = msg.Alerts[:1]
+
+	// Re-encode after annotation truncation
+	buf.Reset()
+	if err := json.NewEncoder(&buf).Encode(msg); err != nil {
+		return buf, fmt.Errorf("failed to encode rootly message after annotation truncation: %w", err)
+	}
+
+	if buf.Len() <= maxPayloadSize {
+		n.logger.Warn("Truncated alert content due to rootly payload size limit",
+			"original_size", originalSize,
+			"final_size", buf.Len(),
+			"max_size", maxPayloadSize)
+
+		return buf, nil
+	}
+
+	// Still attempt to send the message even if it exceeds the limit, but log an
+	// error to explain why this is likely to fail.
+	n.logger.Error("Truncated alert content due to rootly payload size limit, but still exceeds limit",
+		"original_size", originalSize,
+		"final_size", buf.Len(),
+		"max_size", maxPayloadSize)
+
+	return buf, nil
+}
+
+// Notify implements the Notifier interface.
+func (n *Notifier) Notify(ctx context.Context, alerts ...*types.Alert) (bool, error) {
+	alerts, numTruncated := truncateAlerts(n.conf.MaxAlerts, alerts)
+	data := notify.GetTemplateData(ctx, n.tmpl, alerts, n.logger)
+
+	groupKey, err := notify.ExtractGroupKey(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	n.logger.Debug("rootly notification", "groupKey", groupKey)
+
+	msg := &Message{
+		Version:         "1",
+		Data:            data,
+		GroupKey:        groupKey.String(),
+		TruncatedAlerts: numTruncated,
+	}
+
+	buf, err := n.encodeMessage(msg)
+	if err != nil {
+		return false, err
+	}
+
+	var url string
+	if n.conf.URL != nil {
+		url = n.conf.URL.String()
+	} else {
+		content, err := os.ReadFile(n.conf.URLFile)
+		if err != nil {
+			return false, fmt.Errorf("read url_file: %w", err)
+		}
+		url = strings.TrimSpace(string(content))
+	}
+
+	if n.conf.Timeout > 0 {
+		ctxWithTimeout, cancel := context.WithTimeoutCause(ctx, n.conf.Timeout, fmt.Errorf("configured rootly timeout reached (%s)", n.conf.Timeout))
+		defer cancel()
+		ctx = ctxWithTimeout
+	}
+
+	resp, err := notify.PostJSON(ctx, n.client, url, &buf)
+	if err != nil {
+		if ctx.Err() != nil {
+			err = fmt.Errorf("%w: %w", err, context.Cause(ctx))
+		}
+		return true, notify.RedactURL(err)
+	}
+	defer notify.Drain(resp)
+
+	shouldRetry, err := n.retrier.Check(resp.StatusCode, resp.Body)
+	if err != nil {
+		return shouldRetry, notify.NewErrorWithReason(notify.GetFailureReasonFromStatusCode(resp.StatusCode), err)
+	}
+	return shouldRetry, err
+}
+
+// errDetails extracts error details from the response for better error messages.
+func errDetails(_ int, body io.Reader) string {
+	if body == nil {
+		return ""
+	}
+
+	// Try to decode the error message from JSON response
+	var errorResponse struct {
+		Message string   `json:"message"`
+		Errors  []string `json:"errors"`
+		Error   string   `json:"error"`
+	}
+
+	if err := json.NewDecoder(body).Decode(&errorResponse); err != nil {
+		return ""
+	}
+
+	var parts []string
+	if errorResponse.Message != "" {
+		parts = append(parts, errorResponse.Message)
+	}
+	if errorResponse.Error != "" {
+		parts = append(parts, errorResponse.Error)
+	}
+	if len(errorResponse.Errors) > 0 {
+		parts = append(parts, strings.Join(errorResponse.Errors, ", "))
+	}
+
+	return strings.Join(parts, ": ")
+}

--- a/notify/rootly/rootly_test.go
+++ b/notify/rootly/rootly_test.go
@@ -1,0 +1,401 @@
+// Copyright 2025 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rootly
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	commoncfg "github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/common/promslog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/alertmanager/config"
+	"github.com/prometheus/alertmanager/notify"
+	"github.com/prometheus/alertmanager/notify/test"
+	"github.com/prometheus/alertmanager/types"
+)
+
+func TestRootlyRetry(t *testing.T) {
+	notifier, err := New(
+		&config.RootlyConfig{
+			URL:         &config.URL{URL: &url.URL{Scheme: "https", Host: "example.com"}},
+			HTTPConfig:  &commoncfg.HTTPClientConfig{},
+			RootlyToken: "test-token",
+		},
+		test.CreateTmpl(t),
+		promslog.NewNopLogger(),
+	)
+	require.NoError(t, err)
+
+	retryCodes := append(test.DefaultRetryCodes(), http.StatusTooManyRequests)
+	for statusCode, expected := range test.RetryTests(retryCodes) {
+		actual, _ := notifier.retrier.Check(statusCode, nil)
+		require.Equal(t, expected, actual, "retry - error on status %d", statusCode)
+	}
+}
+
+func TestRootlyRedactedURL(t *testing.T) {
+	ctx, u, fn := test.GetContextWithCancelingURL()
+	defer fn()
+
+	notifier, err := New(
+		&config.RootlyConfig{
+			URL:         &config.URL{URL: u},
+			HTTPConfig:  &commoncfg.HTTPClientConfig{},
+			RootlyToken: "test-token",
+		},
+		test.CreateTmpl(t),
+		promslog.NewNopLogger(),
+	)
+	require.NoError(t, err)
+
+	test.AssertNotifyLeaksNoSecret(ctx, t, notifier, u.String())
+}
+
+func TestRootlyURLFromFile(t *testing.T) {
+	ctx, u, fn := test.GetContextWithCancelingURL()
+	defer fn()
+
+	f, err := os.CreateTemp(t.TempDir(), "rootly_test")
+	require.NoError(t, err, "creating temp file failed")
+	_, err = f.WriteString(u.String() + "\n")
+	require.NoError(t, err, "writing to temp file failed")
+
+	notifier, err := New(
+		&config.RootlyConfig{
+			URLFile:     f.Name(),
+			HTTPConfig:  &commoncfg.HTTPClientConfig{},
+			RootlyToken: "test-token",
+		},
+		test.CreateTmpl(t),
+		promslog.NewNopLogger(),
+	)
+	require.NoError(t, err)
+
+	test.AssertNotifyLeaksNoSecret(ctx, t, notifier, u.String())
+}
+
+func TestRootlyTokenFromFile(t *testing.T) {
+	ctx, u, fn := test.GetContextWithCancelingURL()
+	defer fn()
+
+	f, err := os.CreateTemp(t.TempDir(), "rootly_token_test")
+	require.NoError(t, err, "creating temp file failed")
+	_, err = f.WriteString("test-token-from-file\n")
+	require.NoError(t, err, "writing to temp file failed")
+
+	notifier, err := New(
+		&config.RootlyConfig{
+			URL:             &config.URL{URL: u},
+			HTTPConfig:      &commoncfg.HTTPClientConfig{},
+			RootlyTokenFile: f.Name(),
+		},
+		test.CreateTmpl(t),
+		promslog.NewNopLogger(),
+	)
+	require.NoError(t, err)
+
+	test.AssertNotifyLeaksNoSecret(ctx, t, notifier, u.String())
+}
+
+func TestRootlyTruncateAlerts(t *testing.T) {
+	alerts := make([]*types.Alert, 10)
+
+	truncatedAlerts, numTruncated := truncateAlerts(0, alerts)
+	require.Len(t, truncatedAlerts, 10)
+	require.EqualValues(t, 0, numTruncated)
+
+	truncatedAlerts, numTruncated = truncateAlerts(4, alerts)
+	require.Len(t, truncatedAlerts, 4)
+	require.EqualValues(t, 6, numTruncated)
+
+	truncatedAlerts, numTruncated = truncateAlerts(100, alerts)
+	require.Len(t, truncatedAlerts, 10)
+	require.EqualValues(t, 0, numTruncated)
+}
+
+func TestRootlyNotify(t *testing.T) {
+	// Test regular notifications are correctly sent
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			// Verify the content type header
+			contentType := r.Header.Get("Content-Type")
+			require.Equal(t, "application/json", contentType)
+
+			// Decode the webhook payload
+			var msg Message
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&msg))
+
+			// Verify required fields
+			require.Equal(t, "1", msg.Version)
+			require.NotEmpty(t, msg.GroupKey)
+			w.WriteHeader(http.StatusOK)
+		},
+	))
+	defer server.Close()
+
+	u, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	notifier, err := New(
+		&config.RootlyConfig{
+			URL:         &config.URL{URL: u},
+			HTTPConfig:  &commoncfg.HTTPClientConfig{},
+			RootlyToken: "test-token",
+		},
+		test.CreateTmpl(t),
+		promslog.NewNopLogger(),
+	)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	ctx = notify.WithGroupKey(ctx, "1")
+
+	alert := &types.Alert{
+		Alert: model.Alert{
+			Labels: model.LabelSet{
+				"alertname": "TestAlert",
+				"severity":  "critical",
+			},
+			StartsAt: time.Now(),
+			EndsAt:   time.Now().Add(time.Hour),
+		},
+	}
+
+	retry, err := notifier.Notify(ctx, alert)
+	require.NoError(t, err)
+	require.False(t, retry)
+}
+
+func TestRootlyRetryScenarios(t *testing.T) {
+	testCases := []struct {
+		name                   string
+		statusCode             int
+		responseBody           []byte
+		expectRetry            bool
+		expectErrorMsgContains string
+	}{
+		{
+			name:                   "success response",
+			statusCode:             http.StatusOK,
+			responseBody:           []byte(`{"status":"success"}`),
+			expectRetry:            false,
+			expectErrorMsgContains: "",
+		},
+		{
+			name:                   "rate limit response",
+			statusCode:             http.StatusTooManyRequests,
+			responseBody:           []byte(`{"error":"rate limit exceeded","message":"Too many requests"}`),
+			expectRetry:            true,
+			expectErrorMsgContains: "rate limit exceeded",
+		},
+		{
+			name:                   "server error response",
+			statusCode:             http.StatusInternalServerError,
+			responseBody:           []byte(`{"error":"internal error"}`),
+			expectRetry:            true,
+			expectErrorMsgContains: "internal error",
+		},
+		{
+			name:                   "client error response",
+			statusCode:             http.StatusBadRequest,
+			responseBody:           []byte(`{"error":"invalid request","message":"Invalid payload format"}`),
+			expectRetry:            false,
+			expectErrorMsgContains: "invalid request",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(
+				func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(tc.statusCode)
+					w.Write(tc.responseBody)
+				},
+			))
+			defer server.Close()
+
+			u, err := url.Parse(server.URL)
+			require.NoError(t, err)
+
+			notifier, err := New(
+				&config.RootlyConfig{
+					URL:         &config.URL{URL: u},
+					HTTPConfig:  &commoncfg.HTTPClientConfig{},
+					RootlyToken: "test-token",
+				},
+				test.CreateTmpl(t),
+				promslog.NewNopLogger(),
+			)
+			require.NoError(t, err)
+
+			ctx := context.Background()
+			ctx = notify.WithGroupKey(ctx, "1")
+
+			alert := &types.Alert{
+				Alert: model.Alert{
+					Labels: model.LabelSet{
+						"alertname": "TestAlert",
+						"severity":  "critical",
+					},
+					StartsAt: time.Now(),
+					EndsAt:   time.Now().Add(time.Hour),
+				},
+			}
+
+			retry, err := notifier.Notify(ctx, alert)
+			if tc.expectErrorMsgContains == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectErrorMsgContains)
+			}
+			require.Equal(t, tc.expectRetry, retry)
+		})
+	}
+}
+
+func TestRootlyErrDetails(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status int
+		body   io.Reader
+		expect string
+	}{
+		{
+			name:   "empty body",
+			status: http.StatusBadRequest,
+			body:   nil,
+			expect: "",
+		},
+		{
+			name:   "single error field",
+			status: http.StatusBadRequest,
+			body:   bytes.NewBufferString(`{"error":"Invalid request"}`),
+			expect: "Invalid request",
+		},
+		{
+			name:   "message and errors",
+			status: http.StatusBadRequest,
+			body:   bytes.NewBufferString(`{"message":"Validation failed","errors":["Field is required","Value too long"]}`),
+			expect: "Validation failed: Field is required, Value too long",
+		},
+		{
+			name:   "message and error",
+			status: http.StatusTooManyRequests,
+			body:   bytes.NewBufferString(`{"message":"Too many requests","error":"Rate limit exceeded"}`),
+			expect: "Too many requests: Rate limit exceeded",
+		},
+		{
+			name:   "invalid JSON",
+			status: http.StatusBadRequest,
+			body:   bytes.NewBufferString(`{invalid}`),
+			expect: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result := errDetails(tc.status, tc.body)
+			if tc.expect == "" {
+				require.Empty(t, result)
+			} else {
+				require.Contains(t, result, tc.expect)
+			}
+		})
+	}
+}
+
+func TestRootlyPayloadTruncation(t *testing.T) {
+	logger := promslog.NewNopLogger()
+
+	notifier, err := New(
+		&config.RootlyConfig{
+			URL:         &config.URL{URL: &url.URL{Scheme: "https", Host: "example.com"}},
+			HTTPConfig:  &commoncfg.HTTPClientConfig{},
+			RootlyToken: "test-token",
+		},
+		test.CreateTmpl(t),
+		logger,
+	)
+	require.NoError(t, err)
+
+	// Create a large annotation that will push payload over 256KB
+	largeAnnotation := make([]byte, 50*1024) // 50KB per annotation
+	for i := range largeAnnotation {
+		largeAnnotation[i] = 'a' + byte(i%26)
+	}
+	largeAnnotationStr := string(largeAnnotation)
+
+	// Create alerts with large annotations
+	var alerts []*types.Alert
+	for i := range 10 { // 10 alerts * 50KB = 500KB total in annotations alone
+		alert := &types.Alert{
+			Alert: model.Alert{
+				Labels: model.LabelSet{
+					"alertname": model.LabelValue("TestAlert" + string(rune('0'+i))),
+					"severity":  "critical",
+					"job":       "test-job",
+					"instance":  "test-instance",
+					"env":       "production",
+					"team":      "sre",
+				},
+				Annotations: model.LabelSet{
+					"description": model.LabelValue(largeAnnotationStr),
+					"runbook":     model.LabelValue(largeAnnotationStr),
+					"summary":     model.LabelValue("This is a test alert with very large annotations"),
+				},
+				StartsAt: time.Now(),
+				EndsAt:   time.Now().Add(time.Hour),
+			},
+		}
+		alerts = append(alerts, alert)
+	}
+
+	// Create template data
+	ctx := context.Background()
+	ctx = notify.WithGroupKey(ctx, "test-group")
+	data := notify.GetTemplateData(ctx, test.CreateTmpl(t), alerts, logger)
+
+	// Create message
+	msg := &Message{
+		Version:         "1",
+		Data:            data,
+		GroupKey:        "test-group",
+		TruncatedAlerts: 0,
+	}
+
+	// Test encoding with truncation
+	buf, err := notifier.encodeMessage(msg)
+	require.NoError(t, err)
+
+	// Verify the encoded message is under the size limit
+	require.LessOrEqual(t, buf.Len(), maxPayloadSize, "Encoded message should be under maxPayloadSize after truncation")
+
+	// Decode the message to verify truncation happened
+	var decodedMsg Message
+	err = json.NewDecoder(&buf).Decode(&decodedMsg)
+	require.NoError(t, err)
+
+	// Check that all but the first alert was dropped
+	require.Len(t, decodedMsg.Alerts, 1, "Only the first alert should be included after truncation")
+}


### PR DESCRIPTION
## Summary

Add native [Rootly](https://rootly.com) receiver for Alertmanager, enabling users to configure `rootly_configs` directly in `alertmanager.yml` instead of using generic webhooks.

The implementation follows the established integration pattern and includes configuration, notifier, wiring, and comprehensive tests.

## Changes

**Configuration** (`config/notifiers.go`, `config/config.go`)
- `RootlyConfig` struct with `url`/`url_file`, `rootly_token`/`rootly_token_file`, `max_alerts`, `timeout`, and `http_config` fields
- `UnmarshalYAML` validation for mutual exclusivity and required fields
- `send_resolved` enabled by default
- `RootlyConfigs` field on `Receiver` struct with `HTTPConfig` inheritance

**Notifier** (`notify/rootly/rootly.go`)
- JSON payload with `version`, `groupKey`, `truncatedAlerts`, and alert data
- Bearer token authentication via `rootly_token` or `rootly_token_file`
- All alerts in a group are sent in full — Rootly processes each alert individually
- Retry on 429/5xx, no retry on other 4xx
- Error response parsing from Rootly API
- Secret redaction via `notify.RedactURL()`

**Wiring** (`config/receiver/receiver.go`, `notify/notify.go`)
- Import and builder loop in `BuildReceiverIntegrations()`
- `"rootly"` registered in notification metrics

**Tests** (`notify/rootly/rootly_test.go`)
- 9 test functions covering retry logic, secret redaction, file-based URL/token loading, alert truncation, notification flow, retry scenarios, error detail parsing, and multi-alert delivery
- Uses `require` (not `assert`), follows Prometheus testing conventions

## Example configuration

```yaml
receivers:
  - name: rootly
    rootly_configs:
      - url: https://rootly.com/webhooks/incoming/alertmanager_webhooks
        rootly_token: <token>
```

## Checklist

- [x] Tests pass (`go test ./notify/rootly/`)
- [x] Linter passes (`make lint`)
- [x] Apache 2.0 license headers on all new files
- [x] DCO sign-off on commits

Signed-off-by: Quentin Rousseau <contact@quent.in>