### PR TITLE
Fix/4973 json error responses

### DIFF
--- a/api/v2/client/alert/get_alerts_responses.go
+++ b/api/v2/client/alert/get_alerts_responses.go
@@ -20,12 +20,16 @@ package alert
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 
+	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 
 	"github.com/prometheus/alertmanager/api/v2/models"
 )
@@ -140,7 +144,7 @@ GetAlertsBadRequest describes a response with status code 400, with default head
 Bad request
 */
 type GetAlertsBadRequest struct {
-	Payload string
+	Payload *GetAlertsBadRequestBody
 }
 
 // IsSuccess returns true when this get alerts bad request response has a 2xx status code
@@ -183,14 +187,16 @@ func (o *GetAlertsBadRequest) String() string {
 	return fmt.Sprintf("[GET /alerts][%d] getAlertsBadRequest %s", 400, payload)
 }
 
-func (o *GetAlertsBadRequest) GetPayload() string {
+func (o *GetAlertsBadRequest) GetPayload() *GetAlertsBadRequestBody {
 	return o.Payload
 }
 
 func (o *GetAlertsBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(GetAlertsBadRequestBody)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
@@ -208,7 +214,7 @@ GetAlertsInternalServerError describes a response with status code 500, with def
 Internal server error
 */
 type GetAlertsInternalServerError struct {
-	Payload string
+	Payload *GetAlertsInternalServerErrorBody
 }
 
 // IsSuccess returns true when this get alerts internal server error response has a 2xx status code
@@ -251,16 +257,236 @@ func (o *GetAlertsInternalServerError) String() string {
 	return fmt.Sprintf("[GET /alerts][%d] getAlertsInternalServerError %s", 500, payload)
 }
 
-func (o *GetAlertsInternalServerError) GetPayload() string {
+func (o *GetAlertsInternalServerError) GetPayload() *GetAlertsInternalServerErrorBody {
 	return o.Payload
 }
 
 func (o *GetAlertsInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(GetAlertsInternalServerErrorBody)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
+	return nil
+}
+
+/*
+GetAlertsBadRequestBody get alerts bad request body
+swagger:model GetAlertsBadRequestBody
+*/
+type GetAlertsBadRequestBody struct {
+
+	// error
+	// Required: true
+	Error *string `json:"error"`
+
+	// error type
+	ErrorType string `json:"errorType,omitempty"`
+
+	// status
+	// Required: true
+	// Enum: ["error"]
+	Status *string `json:"status"`
+}
+
+// Validate validates this get alerts bad request body
+func (o *GetAlertsBadRequestBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateError(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateStatus(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *GetAlertsBadRequestBody) validateError(formats strfmt.Registry) error {
+
+	if err := validate.Required("getAlertsBadRequest"+"."+"error", "body", o.Error); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var getAlertsBadRequestBodyTypeStatusPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["error"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		getAlertsBadRequestBodyTypeStatusPropEnum = append(getAlertsBadRequestBodyTypeStatusPropEnum, v)
+	}
+}
+
+const (
+
+	// GetAlertsBadRequestBodyStatusError captures enum value "error"
+	GetAlertsBadRequestBodyStatusError string = "error"
+)
+
+// prop value enum
+func (o *GetAlertsBadRequestBody) validateStatusEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, getAlertsBadRequestBodyTypeStatusPropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *GetAlertsBadRequestBody) validateStatus(formats strfmt.Registry) error {
+
+	if err := validate.Required("getAlertsBadRequest"+"."+"status", "body", o.Status); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := o.validateStatusEnum("getAlertsBadRequest"+"."+"status", "body", *o.Status); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validates this get alerts bad request body based on context it is used
+func (o *GetAlertsBadRequestBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *GetAlertsBadRequestBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *GetAlertsBadRequestBody) UnmarshalBinary(b []byte) error {
+	var res GetAlertsBadRequestBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
+	return nil
+}
+
+/*
+GetAlertsInternalServerErrorBody get alerts internal server error body
+swagger:model GetAlertsInternalServerErrorBody
+*/
+type GetAlertsInternalServerErrorBody struct {
+
+	// error
+	// Required: true
+	Error *string `json:"error"`
+
+	// error type
+	ErrorType string `json:"errorType,omitempty"`
+
+	// status
+	// Required: true
+	// Enum: ["error"]
+	Status *string `json:"status"`
+}
+
+// Validate validates this get alerts internal server error body
+func (o *GetAlertsInternalServerErrorBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateError(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateStatus(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *GetAlertsInternalServerErrorBody) validateError(formats strfmt.Registry) error {
+
+	if err := validate.Required("getAlertsInternalServerError"+"."+"error", "body", o.Error); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var getAlertsInternalServerErrorBodyTypeStatusPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["error"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		getAlertsInternalServerErrorBodyTypeStatusPropEnum = append(getAlertsInternalServerErrorBodyTypeStatusPropEnum, v)
+	}
+}
+
+const (
+
+	// GetAlertsInternalServerErrorBodyStatusError captures enum value "error"
+	GetAlertsInternalServerErrorBodyStatusError string = "error"
+)
+
+// prop value enum
+func (o *GetAlertsInternalServerErrorBody) validateStatusEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, getAlertsInternalServerErrorBodyTypeStatusPropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *GetAlertsInternalServerErrorBody) validateStatus(formats strfmt.Registry) error {
+
+	if err := validate.Required("getAlertsInternalServerError"+"."+"status", "body", o.Status); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := o.validateStatusEnum("getAlertsInternalServerError"+"."+"status", "body", *o.Status); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validates this get alerts internal server error body based on context it is used
+func (o *GetAlertsInternalServerErrorBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *GetAlertsInternalServerErrorBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *GetAlertsInternalServerErrorBody) UnmarshalBinary(b []byte) error {
+	var res GetAlertsInternalServerErrorBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
 	return nil
 }

--- a/api/v2/client/alert/post_alerts_responses.go
+++ b/api/v2/client/alert/post_alerts_responses.go
@@ -20,12 +20,16 @@ package alert
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 
+	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 )
 
 // PostAlertsReader is a Reader for the PostAlerts structure.
@@ -126,7 +130,7 @@ PostAlertsBadRequest describes a response with status code 400, with default hea
 Bad request
 */
 type PostAlertsBadRequest struct {
-	Payload string
+	Payload *PostAlertsBadRequestBody
 }
 
 // IsSuccess returns true when this post alerts bad request response has a 2xx status code
@@ -169,14 +173,16 @@ func (o *PostAlertsBadRequest) String() string {
 	return fmt.Sprintf("[POST /alerts][%d] postAlertsBadRequest %s", 400, payload)
 }
 
-func (o *PostAlertsBadRequest) GetPayload() string {
+func (o *PostAlertsBadRequest) GetPayload() *PostAlertsBadRequestBody {
 	return o.Payload
 }
 
 func (o *PostAlertsBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(PostAlertsBadRequestBody)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
@@ -194,7 +200,7 @@ PostAlertsInternalServerError describes a response with status code 500, with de
 Internal server error
 */
 type PostAlertsInternalServerError struct {
-	Payload string
+	Payload *PostAlertsInternalServerErrorBody
 }
 
 // IsSuccess returns true when this post alerts internal server error response has a 2xx status code
@@ -237,16 +243,236 @@ func (o *PostAlertsInternalServerError) String() string {
 	return fmt.Sprintf("[POST /alerts][%d] postAlertsInternalServerError %s", 500, payload)
 }
 
-func (o *PostAlertsInternalServerError) GetPayload() string {
+func (o *PostAlertsInternalServerError) GetPayload() *PostAlertsInternalServerErrorBody {
 	return o.Payload
 }
 
 func (o *PostAlertsInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(PostAlertsInternalServerErrorBody)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
+	return nil
+}
+
+/*
+PostAlertsBadRequestBody post alerts bad request body
+swagger:model PostAlertsBadRequestBody
+*/
+type PostAlertsBadRequestBody struct {
+
+	// error
+	// Required: true
+	Error *string `json:"error"`
+
+	// error type
+	ErrorType string `json:"errorType,omitempty"`
+
+	// status
+	// Required: true
+	// Enum: ["error"]
+	Status *string `json:"status"`
+}
+
+// Validate validates this post alerts bad request body
+func (o *PostAlertsBadRequestBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateError(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateStatus(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *PostAlertsBadRequestBody) validateError(formats strfmt.Registry) error {
+
+	if err := validate.Required("postAlertsBadRequest"+"."+"error", "body", o.Error); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var postAlertsBadRequestBodyTypeStatusPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["error"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		postAlertsBadRequestBodyTypeStatusPropEnum = append(postAlertsBadRequestBodyTypeStatusPropEnum, v)
+	}
+}
+
+const (
+
+	// PostAlertsBadRequestBodyStatusError captures enum value "error"
+	PostAlertsBadRequestBodyStatusError string = "error"
+)
+
+// prop value enum
+func (o *PostAlertsBadRequestBody) validateStatusEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, postAlertsBadRequestBodyTypeStatusPropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *PostAlertsBadRequestBody) validateStatus(formats strfmt.Registry) error {
+
+	if err := validate.Required("postAlertsBadRequest"+"."+"status", "body", o.Status); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := o.validateStatusEnum("postAlertsBadRequest"+"."+"status", "body", *o.Status); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validates this post alerts bad request body based on context it is used
+func (o *PostAlertsBadRequestBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *PostAlertsBadRequestBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *PostAlertsBadRequestBody) UnmarshalBinary(b []byte) error {
+	var res PostAlertsBadRequestBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
+	return nil
+}
+
+/*
+PostAlertsInternalServerErrorBody post alerts internal server error body
+swagger:model PostAlertsInternalServerErrorBody
+*/
+type PostAlertsInternalServerErrorBody struct {
+
+	// error
+	// Required: true
+	Error *string `json:"error"`
+
+	// error type
+	ErrorType string `json:"errorType,omitempty"`
+
+	// status
+	// Required: true
+	// Enum: ["error"]
+	Status *string `json:"status"`
+}
+
+// Validate validates this post alerts internal server error body
+func (o *PostAlertsInternalServerErrorBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateError(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateStatus(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *PostAlertsInternalServerErrorBody) validateError(formats strfmt.Registry) error {
+
+	if err := validate.Required("postAlertsInternalServerError"+"."+"error", "body", o.Error); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var postAlertsInternalServerErrorBodyTypeStatusPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["error"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		postAlertsInternalServerErrorBodyTypeStatusPropEnum = append(postAlertsInternalServerErrorBodyTypeStatusPropEnum, v)
+	}
+}
+
+const (
+
+	// PostAlertsInternalServerErrorBodyStatusError captures enum value "error"
+	PostAlertsInternalServerErrorBodyStatusError string = "error"
+)
+
+// prop value enum
+func (o *PostAlertsInternalServerErrorBody) validateStatusEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, postAlertsInternalServerErrorBodyTypeStatusPropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *PostAlertsInternalServerErrorBody) validateStatus(formats strfmt.Registry) error {
+
+	if err := validate.Required("postAlertsInternalServerError"+"."+"status", "body", o.Status); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := o.validateStatusEnum("postAlertsInternalServerError"+"."+"status", "body", *o.Status); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validates this post alerts internal server error body based on context it is used
+func (o *PostAlertsInternalServerErrorBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *PostAlertsInternalServerErrorBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *PostAlertsInternalServerErrorBody) UnmarshalBinary(b []byte) error {
+	var res PostAlertsInternalServerErrorBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
 	return nil
 }

--- a/api/v2/client/alertgroup/get_alert_groups_responses.go
+++ b/api/v2/client/alertgroup/get_alert_groups_responses.go
@@ -20,12 +20,16 @@ package alertgroup
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 
+	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 
 	"github.com/prometheus/alertmanager/api/v2/models"
 )
@@ -140,7 +144,7 @@ GetAlertGroupsBadRequest describes a response with status code 400, with default
 Bad request
 */
 type GetAlertGroupsBadRequest struct {
-	Payload string
+	Payload *GetAlertGroupsBadRequestBody
 }
 
 // IsSuccess returns true when this get alert groups bad request response has a 2xx status code
@@ -183,14 +187,16 @@ func (o *GetAlertGroupsBadRequest) String() string {
 	return fmt.Sprintf("[GET /alerts/groups][%d] getAlertGroupsBadRequest %s", 400, payload)
 }
 
-func (o *GetAlertGroupsBadRequest) GetPayload() string {
+func (o *GetAlertGroupsBadRequest) GetPayload() *GetAlertGroupsBadRequestBody {
 	return o.Payload
 }
 
 func (o *GetAlertGroupsBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(GetAlertGroupsBadRequestBody)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
@@ -208,7 +214,7 @@ GetAlertGroupsInternalServerError describes a response with status code 500, wit
 Internal server error
 */
 type GetAlertGroupsInternalServerError struct {
-	Payload string
+	Payload *GetAlertGroupsInternalServerErrorBody
 }
 
 // IsSuccess returns true when this get alert groups internal server error response has a 2xx status code
@@ -251,16 +257,236 @@ func (o *GetAlertGroupsInternalServerError) String() string {
 	return fmt.Sprintf("[GET /alerts/groups][%d] getAlertGroupsInternalServerError %s", 500, payload)
 }
 
-func (o *GetAlertGroupsInternalServerError) GetPayload() string {
+func (o *GetAlertGroupsInternalServerError) GetPayload() *GetAlertGroupsInternalServerErrorBody {
 	return o.Payload
 }
 
 func (o *GetAlertGroupsInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(GetAlertGroupsInternalServerErrorBody)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
+	return nil
+}
+
+/*
+GetAlertGroupsBadRequestBody get alert groups bad request body
+swagger:model GetAlertGroupsBadRequestBody
+*/
+type GetAlertGroupsBadRequestBody struct {
+
+	// error
+	// Required: true
+	Error *string `json:"error"`
+
+	// error type
+	ErrorType string `json:"errorType,omitempty"`
+
+	// status
+	// Required: true
+	// Enum: ["error"]
+	Status *string `json:"status"`
+}
+
+// Validate validates this get alert groups bad request body
+func (o *GetAlertGroupsBadRequestBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateError(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateStatus(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *GetAlertGroupsBadRequestBody) validateError(formats strfmt.Registry) error {
+
+	if err := validate.Required("getAlertGroupsBadRequest"+"."+"error", "body", o.Error); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var getAlertGroupsBadRequestBodyTypeStatusPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["error"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		getAlertGroupsBadRequestBodyTypeStatusPropEnum = append(getAlertGroupsBadRequestBodyTypeStatusPropEnum, v)
+	}
+}
+
+const (
+
+	// GetAlertGroupsBadRequestBodyStatusError captures enum value "error"
+	GetAlertGroupsBadRequestBodyStatusError string = "error"
+)
+
+// prop value enum
+func (o *GetAlertGroupsBadRequestBody) validateStatusEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, getAlertGroupsBadRequestBodyTypeStatusPropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *GetAlertGroupsBadRequestBody) validateStatus(formats strfmt.Registry) error {
+
+	if err := validate.Required("getAlertGroupsBadRequest"+"."+"status", "body", o.Status); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := o.validateStatusEnum("getAlertGroupsBadRequest"+"."+"status", "body", *o.Status); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validates this get alert groups bad request body based on context it is used
+func (o *GetAlertGroupsBadRequestBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *GetAlertGroupsBadRequestBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *GetAlertGroupsBadRequestBody) UnmarshalBinary(b []byte) error {
+	var res GetAlertGroupsBadRequestBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
+	return nil
+}
+
+/*
+GetAlertGroupsInternalServerErrorBody get alert groups internal server error body
+swagger:model GetAlertGroupsInternalServerErrorBody
+*/
+type GetAlertGroupsInternalServerErrorBody struct {
+
+	// error
+	// Required: true
+	Error *string `json:"error"`
+
+	// error type
+	ErrorType string `json:"errorType,omitempty"`
+
+	// status
+	// Required: true
+	// Enum: ["error"]
+	Status *string `json:"status"`
+}
+
+// Validate validates this get alert groups internal server error body
+func (o *GetAlertGroupsInternalServerErrorBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateError(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateStatus(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *GetAlertGroupsInternalServerErrorBody) validateError(formats strfmt.Registry) error {
+
+	if err := validate.Required("getAlertGroupsInternalServerError"+"."+"error", "body", o.Error); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var getAlertGroupsInternalServerErrorBodyTypeStatusPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["error"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		getAlertGroupsInternalServerErrorBodyTypeStatusPropEnum = append(getAlertGroupsInternalServerErrorBodyTypeStatusPropEnum, v)
+	}
+}
+
+const (
+
+	// GetAlertGroupsInternalServerErrorBodyStatusError captures enum value "error"
+	GetAlertGroupsInternalServerErrorBodyStatusError string = "error"
+)
+
+// prop value enum
+func (o *GetAlertGroupsInternalServerErrorBody) validateStatusEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, getAlertGroupsInternalServerErrorBodyTypeStatusPropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *GetAlertGroupsInternalServerErrorBody) validateStatus(formats strfmt.Registry) error {
+
+	if err := validate.Required("getAlertGroupsInternalServerError"+"."+"status", "body", o.Status); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := o.validateStatusEnum("getAlertGroupsInternalServerError"+"."+"status", "body", *o.Status); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validates this get alert groups internal server error body based on context it is used
+func (o *GetAlertGroupsInternalServerErrorBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *GetAlertGroupsInternalServerErrorBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *GetAlertGroupsInternalServerErrorBody) UnmarshalBinary(b []byte) error {
+	var res GetAlertGroupsInternalServerErrorBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
 	return nil
 }

--- a/api/v2/client/silence/delete_silence_responses.go
+++ b/api/v2/client/silence/delete_silence_responses.go
@@ -20,12 +20,16 @@ package silence
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 
+	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 )
 
 // DeleteSilenceReader is a Reader for the DeleteSilence structure.
@@ -123,9 +127,10 @@ func NewDeleteSilenceNotFound() *DeleteSilenceNotFound {
 /*
 DeleteSilenceNotFound describes a response with status code 404, with default header values.
 
-A silence with the specified ID was not found
+Resource not found
 */
 type DeleteSilenceNotFound struct {
+	Payload *DeleteSilenceNotFoundBody
 }
 
 // IsSuccess returns true when this delete silence not found response has a 2xx status code
@@ -159,14 +164,27 @@ func (o *DeleteSilenceNotFound) Code() int {
 }
 
 func (o *DeleteSilenceNotFound) Error() string {
-	return fmt.Sprintf("[DELETE /silence/{silenceID}][%d] deleteSilenceNotFound", 404)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /silence/{silenceID}][%d] deleteSilenceNotFound %s", 404, payload)
 }
 
 func (o *DeleteSilenceNotFound) String() string {
-	return fmt.Sprintf("[DELETE /silence/{silenceID}][%d] deleteSilenceNotFound", 404)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /silence/{silenceID}][%d] deleteSilenceNotFound %s", 404, payload)
+}
+
+func (o *DeleteSilenceNotFound) GetPayload() *DeleteSilenceNotFoundBody {
+	return o.Payload
 }
 
 func (o *DeleteSilenceNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(DeleteSilenceNotFoundBody)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
 
 	return nil
 }
@@ -182,7 +200,7 @@ DeleteSilenceInternalServerError describes a response with status code 500, with
 Internal server error
 */
 type DeleteSilenceInternalServerError struct {
-	Payload string
+	Payload *DeleteSilenceInternalServerErrorBody
 }
 
 // IsSuccess returns true when this delete silence internal server error response has a 2xx status code
@@ -225,16 +243,236 @@ func (o *DeleteSilenceInternalServerError) String() string {
 	return fmt.Sprintf("[DELETE /silence/{silenceID}][%d] deleteSilenceInternalServerError %s", 500, payload)
 }
 
-func (o *DeleteSilenceInternalServerError) GetPayload() string {
+func (o *DeleteSilenceInternalServerError) GetPayload() *DeleteSilenceInternalServerErrorBody {
 	return o.Payload
 }
 
 func (o *DeleteSilenceInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(DeleteSilenceInternalServerErrorBody)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
+	return nil
+}
+
+/*
+DeleteSilenceInternalServerErrorBody delete silence internal server error body
+swagger:model DeleteSilenceInternalServerErrorBody
+*/
+type DeleteSilenceInternalServerErrorBody struct {
+
+	// error
+	// Required: true
+	Error *string `json:"error"`
+
+	// error type
+	ErrorType string `json:"errorType,omitempty"`
+
+	// status
+	// Required: true
+	// Enum: ["error"]
+	Status *string `json:"status"`
+}
+
+// Validate validates this delete silence internal server error body
+func (o *DeleteSilenceInternalServerErrorBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateError(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateStatus(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *DeleteSilenceInternalServerErrorBody) validateError(formats strfmt.Registry) error {
+
+	if err := validate.Required("deleteSilenceInternalServerError"+"."+"error", "body", o.Error); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var deleteSilenceInternalServerErrorBodyTypeStatusPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["error"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		deleteSilenceInternalServerErrorBodyTypeStatusPropEnum = append(deleteSilenceInternalServerErrorBodyTypeStatusPropEnum, v)
+	}
+}
+
+const (
+
+	// DeleteSilenceInternalServerErrorBodyStatusError captures enum value "error"
+	DeleteSilenceInternalServerErrorBodyStatusError string = "error"
+)
+
+// prop value enum
+func (o *DeleteSilenceInternalServerErrorBody) validateStatusEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, deleteSilenceInternalServerErrorBodyTypeStatusPropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *DeleteSilenceInternalServerErrorBody) validateStatus(formats strfmt.Registry) error {
+
+	if err := validate.Required("deleteSilenceInternalServerError"+"."+"status", "body", o.Status); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := o.validateStatusEnum("deleteSilenceInternalServerError"+"."+"status", "body", *o.Status); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validates this delete silence internal server error body based on context it is used
+func (o *DeleteSilenceInternalServerErrorBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *DeleteSilenceInternalServerErrorBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *DeleteSilenceInternalServerErrorBody) UnmarshalBinary(b []byte) error {
+	var res DeleteSilenceInternalServerErrorBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
+	return nil
+}
+
+/*
+DeleteSilenceNotFoundBody delete silence not found body
+swagger:model DeleteSilenceNotFoundBody
+*/
+type DeleteSilenceNotFoundBody struct {
+
+	// error
+	// Required: true
+	Error *string `json:"error"`
+
+	// error type
+	ErrorType string `json:"errorType,omitempty"`
+
+	// status
+	// Required: true
+	// Enum: ["error"]
+	Status *string `json:"status"`
+}
+
+// Validate validates this delete silence not found body
+func (o *DeleteSilenceNotFoundBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateError(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateStatus(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *DeleteSilenceNotFoundBody) validateError(formats strfmt.Registry) error {
+
+	if err := validate.Required("deleteSilenceNotFound"+"."+"error", "body", o.Error); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var deleteSilenceNotFoundBodyTypeStatusPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["error"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		deleteSilenceNotFoundBodyTypeStatusPropEnum = append(deleteSilenceNotFoundBodyTypeStatusPropEnum, v)
+	}
+}
+
+const (
+
+	// DeleteSilenceNotFoundBodyStatusError captures enum value "error"
+	DeleteSilenceNotFoundBodyStatusError string = "error"
+)
+
+// prop value enum
+func (o *DeleteSilenceNotFoundBody) validateStatusEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, deleteSilenceNotFoundBodyTypeStatusPropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *DeleteSilenceNotFoundBody) validateStatus(formats strfmt.Registry) error {
+
+	if err := validate.Required("deleteSilenceNotFound"+"."+"status", "body", o.Status); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := o.validateStatusEnum("deleteSilenceNotFound"+"."+"status", "body", *o.Status); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validates this delete silence not found body based on context it is used
+func (o *DeleteSilenceNotFoundBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *DeleteSilenceNotFoundBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *DeleteSilenceNotFoundBody) UnmarshalBinary(b []byte) error {
+	var res DeleteSilenceNotFoundBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
 	return nil
 }

--- a/api/v2/client/silence/get_silence_responses.go
+++ b/api/v2/client/silence/get_silence_responses.go
@@ -20,12 +20,16 @@ package silence
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 
+	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 
 	"github.com/prometheus/alertmanager/api/v2/models"
 )
@@ -139,9 +143,10 @@ func NewGetSilenceNotFound() *GetSilenceNotFound {
 /*
 GetSilenceNotFound describes a response with status code 404, with default header values.
 
-A silence with the specified ID was not found
+Resource not found
 */
 type GetSilenceNotFound struct {
+	Payload *GetSilenceNotFoundBody
 }
 
 // IsSuccess returns true when this get silence not found response has a 2xx status code
@@ -175,14 +180,27 @@ func (o *GetSilenceNotFound) Code() int {
 }
 
 func (o *GetSilenceNotFound) Error() string {
-	return fmt.Sprintf("[GET /silence/{silenceID}][%d] getSilenceNotFound", 404)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /silence/{silenceID}][%d] getSilenceNotFound %s", 404, payload)
 }
 
 func (o *GetSilenceNotFound) String() string {
-	return fmt.Sprintf("[GET /silence/{silenceID}][%d] getSilenceNotFound", 404)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /silence/{silenceID}][%d] getSilenceNotFound %s", 404, payload)
+}
+
+func (o *GetSilenceNotFound) GetPayload() *GetSilenceNotFoundBody {
+	return o.Payload
 }
 
 func (o *GetSilenceNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(GetSilenceNotFoundBody)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
 
 	return nil
 }
@@ -198,7 +216,7 @@ GetSilenceInternalServerError describes a response with status code 500, with de
 Internal server error
 */
 type GetSilenceInternalServerError struct {
-	Payload string
+	Payload *GetSilenceInternalServerErrorBody
 }
 
 // IsSuccess returns true when this get silence internal server error response has a 2xx status code
@@ -241,16 +259,236 @@ func (o *GetSilenceInternalServerError) String() string {
 	return fmt.Sprintf("[GET /silence/{silenceID}][%d] getSilenceInternalServerError %s", 500, payload)
 }
 
-func (o *GetSilenceInternalServerError) GetPayload() string {
+func (o *GetSilenceInternalServerError) GetPayload() *GetSilenceInternalServerErrorBody {
 	return o.Payload
 }
 
 func (o *GetSilenceInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(GetSilenceInternalServerErrorBody)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
+	return nil
+}
+
+/*
+GetSilenceInternalServerErrorBody get silence internal server error body
+swagger:model GetSilenceInternalServerErrorBody
+*/
+type GetSilenceInternalServerErrorBody struct {
+
+	// error
+	// Required: true
+	Error *string `json:"error"`
+
+	// error type
+	ErrorType string `json:"errorType,omitempty"`
+
+	// status
+	// Required: true
+	// Enum: ["error"]
+	Status *string `json:"status"`
+}
+
+// Validate validates this get silence internal server error body
+func (o *GetSilenceInternalServerErrorBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateError(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateStatus(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *GetSilenceInternalServerErrorBody) validateError(formats strfmt.Registry) error {
+
+	if err := validate.Required("getSilenceInternalServerError"+"."+"error", "body", o.Error); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var getSilenceInternalServerErrorBodyTypeStatusPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["error"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		getSilenceInternalServerErrorBodyTypeStatusPropEnum = append(getSilenceInternalServerErrorBodyTypeStatusPropEnum, v)
+	}
+}
+
+const (
+
+	// GetSilenceInternalServerErrorBodyStatusError captures enum value "error"
+	GetSilenceInternalServerErrorBodyStatusError string = "error"
+)
+
+// prop value enum
+func (o *GetSilenceInternalServerErrorBody) validateStatusEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, getSilenceInternalServerErrorBodyTypeStatusPropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *GetSilenceInternalServerErrorBody) validateStatus(formats strfmt.Registry) error {
+
+	if err := validate.Required("getSilenceInternalServerError"+"."+"status", "body", o.Status); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := o.validateStatusEnum("getSilenceInternalServerError"+"."+"status", "body", *o.Status); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validates this get silence internal server error body based on context it is used
+func (o *GetSilenceInternalServerErrorBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *GetSilenceInternalServerErrorBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *GetSilenceInternalServerErrorBody) UnmarshalBinary(b []byte) error {
+	var res GetSilenceInternalServerErrorBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
+	return nil
+}
+
+/*
+GetSilenceNotFoundBody get silence not found body
+swagger:model GetSilenceNotFoundBody
+*/
+type GetSilenceNotFoundBody struct {
+
+	// error
+	// Required: true
+	Error *string `json:"error"`
+
+	// error type
+	ErrorType string `json:"errorType,omitempty"`
+
+	// status
+	// Required: true
+	// Enum: ["error"]
+	Status *string `json:"status"`
+}
+
+// Validate validates this get silence not found body
+func (o *GetSilenceNotFoundBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateError(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateStatus(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *GetSilenceNotFoundBody) validateError(formats strfmt.Registry) error {
+
+	if err := validate.Required("getSilenceNotFound"+"."+"error", "body", o.Error); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var getSilenceNotFoundBodyTypeStatusPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["error"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		getSilenceNotFoundBodyTypeStatusPropEnum = append(getSilenceNotFoundBodyTypeStatusPropEnum, v)
+	}
+}
+
+const (
+
+	// GetSilenceNotFoundBodyStatusError captures enum value "error"
+	GetSilenceNotFoundBodyStatusError string = "error"
+)
+
+// prop value enum
+func (o *GetSilenceNotFoundBody) validateStatusEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, getSilenceNotFoundBodyTypeStatusPropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *GetSilenceNotFoundBody) validateStatus(formats strfmt.Registry) error {
+
+	if err := validate.Required("getSilenceNotFound"+"."+"status", "body", o.Status); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := o.validateStatusEnum("getSilenceNotFound"+"."+"status", "body", *o.Status); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validates this get silence not found body based on context it is used
+func (o *GetSilenceNotFoundBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *GetSilenceNotFoundBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *GetSilenceNotFoundBody) UnmarshalBinary(b []byte) error {
+	var res GetSilenceNotFoundBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
 	return nil
 }

--- a/api/v2/client/silence/get_silences_responses.go
+++ b/api/v2/client/silence/get_silences_responses.go
@@ -20,12 +20,16 @@ package silence
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 
+	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 
 	"github.com/prometheus/alertmanager/api/v2/models"
 )
@@ -140,7 +144,7 @@ GetSilencesBadRequest describes a response with status code 400, with default he
 Bad request
 */
 type GetSilencesBadRequest struct {
-	Payload string
+	Payload *GetSilencesBadRequestBody
 }
 
 // IsSuccess returns true when this get silences bad request response has a 2xx status code
@@ -183,14 +187,16 @@ func (o *GetSilencesBadRequest) String() string {
 	return fmt.Sprintf("[GET /silences][%d] getSilencesBadRequest %s", 400, payload)
 }
 
-func (o *GetSilencesBadRequest) GetPayload() string {
+func (o *GetSilencesBadRequest) GetPayload() *GetSilencesBadRequestBody {
 	return o.Payload
 }
 
 func (o *GetSilencesBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(GetSilencesBadRequestBody)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
@@ -208,7 +214,7 @@ GetSilencesInternalServerError describes a response with status code 500, with d
 Internal server error
 */
 type GetSilencesInternalServerError struct {
-	Payload string
+	Payload *GetSilencesInternalServerErrorBody
 }
 
 // IsSuccess returns true when this get silences internal server error response has a 2xx status code
@@ -251,16 +257,236 @@ func (o *GetSilencesInternalServerError) String() string {
 	return fmt.Sprintf("[GET /silences][%d] getSilencesInternalServerError %s", 500, payload)
 }
 
-func (o *GetSilencesInternalServerError) GetPayload() string {
+func (o *GetSilencesInternalServerError) GetPayload() *GetSilencesInternalServerErrorBody {
 	return o.Payload
 }
 
 func (o *GetSilencesInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(GetSilencesInternalServerErrorBody)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
+	return nil
+}
+
+/*
+GetSilencesBadRequestBody get silences bad request body
+swagger:model GetSilencesBadRequestBody
+*/
+type GetSilencesBadRequestBody struct {
+
+	// error
+	// Required: true
+	Error *string `json:"error"`
+
+	// error type
+	ErrorType string `json:"errorType,omitempty"`
+
+	// status
+	// Required: true
+	// Enum: ["error"]
+	Status *string `json:"status"`
+}
+
+// Validate validates this get silences bad request body
+func (o *GetSilencesBadRequestBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateError(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateStatus(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *GetSilencesBadRequestBody) validateError(formats strfmt.Registry) error {
+
+	if err := validate.Required("getSilencesBadRequest"+"."+"error", "body", o.Error); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var getSilencesBadRequestBodyTypeStatusPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["error"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		getSilencesBadRequestBodyTypeStatusPropEnum = append(getSilencesBadRequestBodyTypeStatusPropEnum, v)
+	}
+}
+
+const (
+
+	// GetSilencesBadRequestBodyStatusError captures enum value "error"
+	GetSilencesBadRequestBodyStatusError string = "error"
+)
+
+// prop value enum
+func (o *GetSilencesBadRequestBody) validateStatusEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, getSilencesBadRequestBodyTypeStatusPropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *GetSilencesBadRequestBody) validateStatus(formats strfmt.Registry) error {
+
+	if err := validate.Required("getSilencesBadRequest"+"."+"status", "body", o.Status); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := o.validateStatusEnum("getSilencesBadRequest"+"."+"status", "body", *o.Status); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validates this get silences bad request body based on context it is used
+func (o *GetSilencesBadRequestBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *GetSilencesBadRequestBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *GetSilencesBadRequestBody) UnmarshalBinary(b []byte) error {
+	var res GetSilencesBadRequestBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
+	return nil
+}
+
+/*
+GetSilencesInternalServerErrorBody get silences internal server error body
+swagger:model GetSilencesInternalServerErrorBody
+*/
+type GetSilencesInternalServerErrorBody struct {
+
+	// error
+	// Required: true
+	Error *string `json:"error"`
+
+	// error type
+	ErrorType string `json:"errorType,omitempty"`
+
+	// status
+	// Required: true
+	// Enum: ["error"]
+	Status *string `json:"status"`
+}
+
+// Validate validates this get silences internal server error body
+func (o *GetSilencesInternalServerErrorBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateError(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateStatus(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *GetSilencesInternalServerErrorBody) validateError(formats strfmt.Registry) error {
+
+	if err := validate.Required("getSilencesInternalServerError"+"."+"error", "body", o.Error); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var getSilencesInternalServerErrorBodyTypeStatusPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["error"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		getSilencesInternalServerErrorBodyTypeStatusPropEnum = append(getSilencesInternalServerErrorBodyTypeStatusPropEnum, v)
+	}
+}
+
+const (
+
+	// GetSilencesInternalServerErrorBodyStatusError captures enum value "error"
+	GetSilencesInternalServerErrorBodyStatusError string = "error"
+)
+
+// prop value enum
+func (o *GetSilencesInternalServerErrorBody) validateStatusEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, getSilencesInternalServerErrorBodyTypeStatusPropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *GetSilencesInternalServerErrorBody) validateStatus(formats strfmt.Registry) error {
+
+	if err := validate.Required("getSilencesInternalServerError"+"."+"status", "body", o.Status); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := o.validateStatusEnum("getSilencesInternalServerError"+"."+"status", "body", *o.Status); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validates this get silences internal server error body based on context it is used
+func (o *GetSilencesInternalServerErrorBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *GetSilencesInternalServerErrorBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *GetSilencesInternalServerErrorBody) UnmarshalBinary(b []byte) error {
+	var res GetSilencesInternalServerErrorBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
 	return nil
 }

--- a/api/v2/client/silence/post_silences_responses.go
+++ b/api/v2/client/silence/post_silences_responses.go
@@ -25,9 +25,11 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 )
 
 // PostSilencesReader is a Reader for the PostSilences structure.
@@ -52,6 +54,12 @@ func (o *PostSilencesReader) ReadResponse(response runtime.ClientResponse, consu
 		return nil, result
 	case 404:
 		result := NewPostSilencesNotFound()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
+	case 500:
+		result := NewPostSilencesInternalServerError()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
 			return nil, err
 		}
@@ -142,7 +150,7 @@ PostSilencesBadRequest describes a response with status code 400, with default h
 Bad request
 */
 type PostSilencesBadRequest struct {
-	Payload string
+	Payload *PostSilencesBadRequestBody
 }
 
 // IsSuccess returns true when this post silences bad request response has a 2xx status code
@@ -185,14 +193,16 @@ func (o *PostSilencesBadRequest) String() string {
 	return fmt.Sprintf("[POST /silences][%d] postSilencesBadRequest %s", 400, payload)
 }
 
-func (o *PostSilencesBadRequest) GetPayload() string {
+func (o *PostSilencesBadRequest) GetPayload() *PostSilencesBadRequestBody {
 	return o.Payload
 }
 
 func (o *PostSilencesBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(PostSilencesBadRequestBody)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
@@ -207,10 +217,10 @@ func NewPostSilencesNotFound() *PostSilencesNotFound {
 /*
 PostSilencesNotFound describes a response with status code 404, with default header values.
 
-A silence with the specified ID was not found
+Resource not found
 */
 type PostSilencesNotFound struct {
-	Payload string
+	Payload *PostSilencesNotFoundBody
 }
 
 // IsSuccess returns true when this post silences not found response has a 2xx status code
@@ -253,17 +263,416 @@ func (o *PostSilencesNotFound) String() string {
 	return fmt.Sprintf("[POST /silences][%d] postSilencesNotFound %s", 404, payload)
 }
 
-func (o *PostSilencesNotFound) GetPayload() string {
+func (o *PostSilencesNotFound) GetPayload() *PostSilencesNotFoundBody {
 	return o.Payload
 }
 
 func (o *PostSilencesNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(PostSilencesNotFoundBody)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
+	return nil
+}
+
+// NewPostSilencesInternalServerError creates a PostSilencesInternalServerError with default headers values
+func NewPostSilencesInternalServerError() *PostSilencesInternalServerError {
+	return &PostSilencesInternalServerError{}
+}
+
+/*
+PostSilencesInternalServerError describes a response with status code 500, with default header values.
+
+Internal server error
+*/
+type PostSilencesInternalServerError struct {
+	Payload *PostSilencesInternalServerErrorBody
+}
+
+// IsSuccess returns true when this post silences internal server error response has a 2xx status code
+func (o *PostSilencesInternalServerError) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this post silences internal server error response has a 3xx status code
+func (o *PostSilencesInternalServerError) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this post silences internal server error response has a 4xx status code
+func (o *PostSilencesInternalServerError) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this post silences internal server error response has a 5xx status code
+func (o *PostSilencesInternalServerError) IsServerError() bool {
+	return true
+}
+
+// IsCode returns true when this post silences internal server error response a status code equal to that given
+func (o *PostSilencesInternalServerError) IsCode(code int) bool {
+	return code == 500
+}
+
+// Code gets the status code for the post silences internal server error response
+func (o *PostSilencesInternalServerError) Code() int {
+	return 500
+}
+
+func (o *PostSilencesInternalServerError) Error() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /silences][%d] postSilencesInternalServerError %s", 500, payload)
+}
+
+func (o *PostSilencesInternalServerError) String() string {
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /silences][%d] postSilencesInternalServerError %s", 500, payload)
+}
+
+func (o *PostSilencesInternalServerError) GetPayload() *PostSilencesInternalServerErrorBody {
+	return o.Payload
+}
+
+func (o *PostSilencesInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(PostSilencesInternalServerErrorBody)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+/*
+PostSilencesBadRequestBody post silences bad request body
+swagger:model PostSilencesBadRequestBody
+*/
+type PostSilencesBadRequestBody struct {
+
+	// error
+	// Required: true
+	Error *string `json:"error"`
+
+	// error type
+	ErrorType string `json:"errorType,omitempty"`
+
+	// status
+	// Required: true
+	// Enum: ["error"]
+	Status *string `json:"status"`
+}
+
+// Validate validates this post silences bad request body
+func (o *PostSilencesBadRequestBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateError(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateStatus(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *PostSilencesBadRequestBody) validateError(formats strfmt.Registry) error {
+
+	if err := validate.Required("postSilencesBadRequest"+"."+"error", "body", o.Error); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var postSilencesBadRequestBodyTypeStatusPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["error"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		postSilencesBadRequestBodyTypeStatusPropEnum = append(postSilencesBadRequestBodyTypeStatusPropEnum, v)
+	}
+}
+
+const (
+
+	// PostSilencesBadRequestBodyStatusError captures enum value "error"
+	PostSilencesBadRequestBodyStatusError string = "error"
+)
+
+// prop value enum
+func (o *PostSilencesBadRequestBody) validateStatusEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, postSilencesBadRequestBodyTypeStatusPropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *PostSilencesBadRequestBody) validateStatus(formats strfmt.Registry) error {
+
+	if err := validate.Required("postSilencesBadRequest"+"."+"status", "body", o.Status); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := o.validateStatusEnum("postSilencesBadRequest"+"."+"status", "body", *o.Status); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validates this post silences bad request body based on context it is used
+func (o *PostSilencesBadRequestBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *PostSilencesBadRequestBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *PostSilencesBadRequestBody) UnmarshalBinary(b []byte) error {
+	var res PostSilencesBadRequestBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
+	return nil
+}
+
+/*
+PostSilencesInternalServerErrorBody post silences internal server error body
+swagger:model PostSilencesInternalServerErrorBody
+*/
+type PostSilencesInternalServerErrorBody struct {
+
+	// error
+	// Required: true
+	Error *string `json:"error"`
+
+	// error type
+	ErrorType string `json:"errorType,omitempty"`
+
+	// status
+	// Required: true
+	// Enum: ["error"]
+	Status *string `json:"status"`
+}
+
+// Validate validates this post silences internal server error body
+func (o *PostSilencesInternalServerErrorBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateError(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateStatus(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *PostSilencesInternalServerErrorBody) validateError(formats strfmt.Registry) error {
+
+	if err := validate.Required("postSilencesInternalServerError"+"."+"error", "body", o.Error); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var postSilencesInternalServerErrorBodyTypeStatusPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["error"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		postSilencesInternalServerErrorBodyTypeStatusPropEnum = append(postSilencesInternalServerErrorBodyTypeStatusPropEnum, v)
+	}
+}
+
+const (
+
+	// PostSilencesInternalServerErrorBodyStatusError captures enum value "error"
+	PostSilencesInternalServerErrorBodyStatusError string = "error"
+)
+
+// prop value enum
+func (o *PostSilencesInternalServerErrorBody) validateStatusEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, postSilencesInternalServerErrorBodyTypeStatusPropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *PostSilencesInternalServerErrorBody) validateStatus(formats strfmt.Registry) error {
+
+	if err := validate.Required("postSilencesInternalServerError"+"."+"status", "body", o.Status); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := o.validateStatusEnum("postSilencesInternalServerError"+"."+"status", "body", *o.Status); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validates this post silences internal server error body based on context it is used
+func (o *PostSilencesInternalServerErrorBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *PostSilencesInternalServerErrorBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *PostSilencesInternalServerErrorBody) UnmarshalBinary(b []byte) error {
+	var res PostSilencesInternalServerErrorBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
+	return nil
+}
+
+/*
+PostSilencesNotFoundBody post silences not found body
+swagger:model PostSilencesNotFoundBody
+*/
+type PostSilencesNotFoundBody struct {
+
+	// error
+	// Required: true
+	Error *string `json:"error"`
+
+	// error type
+	ErrorType string `json:"errorType,omitempty"`
+
+	// status
+	// Required: true
+	// Enum: ["error"]
+	Status *string `json:"status"`
+}
+
+// Validate validates this post silences not found body
+func (o *PostSilencesNotFoundBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateError(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateStatus(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *PostSilencesNotFoundBody) validateError(formats strfmt.Registry) error {
+
+	if err := validate.Required("postSilencesNotFound"+"."+"error", "body", o.Error); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var postSilencesNotFoundBodyTypeStatusPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["error"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		postSilencesNotFoundBodyTypeStatusPropEnum = append(postSilencesNotFoundBodyTypeStatusPropEnum, v)
+	}
+}
+
+const (
+
+	// PostSilencesNotFoundBodyStatusError captures enum value "error"
+	PostSilencesNotFoundBodyStatusError string = "error"
+)
+
+// prop value enum
+func (o *PostSilencesNotFoundBody) validateStatusEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, postSilencesNotFoundBodyTypeStatusPropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *PostSilencesNotFoundBody) validateStatus(formats strfmt.Registry) error {
+
+	if err := validate.Required("postSilencesNotFound"+"."+"status", "body", o.Status); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := o.validateStatusEnum("postSilencesNotFound"+"."+"status", "body", *o.Status); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validates this post silences not found body based on context it is used
+func (o *PostSilencesNotFoundBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *PostSilencesNotFoundBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *PostSilencesNotFoundBody) UnmarshalBinary(b []byte) error {
+	var res PostSilencesNotFoundBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
 	return nil
 }
 

--- a/api/v2/openapi.yaml
+++ b/api/v2/openapi.yaml
@@ -89,9 +89,9 @@ paths:
         '400':
           $ref: '#/responses/BadRequest'
         '404':
-          description: A silence with the specified ID was not found
-          schema:
-            type: string
+          $ref: '#/responses/NotFound'
+        '500':
+          $ref: '#/responses/InternalServerError'
   /silence/{silenceID}:
     parameters:
       - in: path
@@ -111,7 +111,7 @@ paths:
           schema:
             $ref: '#/definitions/gettableSilence'
         '404':
-          description: A silence with the specified ID was not found
+          $ref: '#/responses/NotFound'
         '500':
           $ref: '#/responses/InternalServerError'
     delete:
@@ -130,7 +130,7 @@ paths:
         '200':
           description: Delete silence response
         '404':
-          description: A silence with the specified ID was not found
+          $ref: '#/responses/NotFound'
         '500':
           $ref: '#/responses/InternalServerError'
   /alerts:
@@ -255,11 +255,48 @@ responses:
   BadRequest:
     description: Bad request
     schema:
-      type: string
+      type: object
+      properties:
+        status:
+          type: string
+          enum: ["error"]
+        errorType:
+          type: string
+        error:
+          type: string
+      required:
+        - status
+        - error
   InternalServerError:
     description: Internal server error
     schema:
-      type: string
+      type: object
+      properties:
+        status:
+          type: string
+          enum: ["error"]
+        errorType:
+          type: string
+        error:
+          type: string
+      required:
+        - status
+        - error
+  NotFound:
+    description: Resource not found
+    schema:
+      type: object
+      properties:
+        status:
+          type: string
+          enum: ["error"]
+        errorType:
+          type: string
+        error:
+          type: string
+      required:
+        - status
+        - error
 
 
 definitions:

--- a/api/v2/restapi/embedded_spec.go
+++ b/api/v2/restapi/embedded_spec.go
@@ -252,7 +252,7 @@ func init() {
             }
           },
           "404": {
-            "description": "A silence with the specified ID was not found"
+            "$ref": "#/responses/NotFound"
           },
           "500": {
             "$ref": "#/responses/InternalServerError"
@@ -280,7 +280,7 @@ func init() {
             "description": "Delete silence response"
           },
           "404": {
-            "description": "A silence with the specified ID was not found"
+            "$ref": "#/responses/NotFound"
           },
           "500": {
             "$ref": "#/responses/InternalServerError"
@@ -365,10 +365,10 @@ func init() {
             "$ref": "#/responses/BadRequest"
           },
           "404": {
-            "description": "A silence with the specified ID was not found",
-            "schema": {
-              "type": "string"
-            }
+            "$ref": "#/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/responses/InternalServerError"
           }
         }
       }
@@ -806,13 +806,73 @@ func init() {
     "BadRequest": {
       "description": "Bad request",
       "schema": {
-        "type": "string"
+        "type": "object",
+        "required": [
+          "status",
+          "error"
+        ],
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "errorType": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "error"
+            ]
+          }
+        }
       }
     },
     "InternalServerError": {
       "description": "Internal server error",
       "schema": {
-        "type": "string"
+        "type": "object",
+        "required": [
+          "status",
+          "error"
+        ],
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "errorType": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "error"
+            ]
+          }
+        }
+      }
+    },
+    "NotFound": {
+      "description": "Resource not found",
+      "schema": {
+        "type": "object",
+        "required": [
+          "status",
+          "error"
+        ],
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "errorType": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "error"
+            ]
+          }
+        }
       }
     }
   },
@@ -917,13 +977,49 @@ func init() {
           "400": {
             "description": "Bad request",
             "schema": {
-              "type": "string"
+              "type": "object",
+              "required": [
+                "status",
+                "error"
+              ],
+              "properties": {
+                "error": {
+                  "type": "string"
+                },
+                "errorType": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "error"
+                  ]
+                }
+              }
             }
           },
           "500": {
             "description": "Internal server error",
             "schema": {
-              "type": "string"
+              "type": "object",
+              "required": [
+                "status",
+                "error"
+              ],
+              "properties": {
+                "error": {
+                  "type": "string"
+                },
+                "errorType": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "error"
+                  ]
+                }
+              }
             }
           }
         }
@@ -952,13 +1048,49 @@ func init() {
           "400": {
             "description": "Bad request",
             "schema": {
-              "type": "string"
+              "type": "object",
+              "required": [
+                "status",
+                "error"
+              ],
+              "properties": {
+                "error": {
+                  "type": "string"
+                },
+                "errorType": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "error"
+                  ]
+                }
+              }
             }
           },
           "500": {
             "description": "Internal server error",
             "schema": {
-              "type": "string"
+              "type": "object",
+              "required": [
+                "status",
+                "error"
+              ],
+              "properties": {
+                "error": {
+                  "type": "string"
+                },
+                "errorType": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "error"
+                  ]
+                }
+              }
             }
           }
         }
@@ -1027,13 +1159,49 @@ func init() {
           "400": {
             "description": "Bad request",
             "schema": {
-              "type": "string"
+              "type": "object",
+              "required": [
+                "status",
+                "error"
+              ],
+              "properties": {
+                "error": {
+                  "type": "string"
+                },
+                "errorType": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "error"
+                  ]
+                }
+              }
             }
           },
           "500": {
             "description": "Internal server error",
             "schema": {
-              "type": "string"
+              "type": "object",
+              "required": [
+                "status",
+                "error"
+              ],
+              "properties": {
+                "error": {
+                  "type": "string"
+                },
+                "errorType": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "error"
+                  ]
+                }
+              }
             }
           }
         }
@@ -1074,12 +1242,51 @@ func init() {
             }
           },
           "404": {
-            "description": "A silence with the specified ID was not found"
+            "description": "Resource not found",
+            "schema": {
+              "type": "object",
+              "required": [
+                "status",
+                "error"
+              ],
+              "properties": {
+                "error": {
+                  "type": "string"
+                },
+                "errorType": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "error"
+                  ]
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal server error",
             "schema": {
-              "type": "string"
+              "type": "object",
+              "required": [
+                "status",
+                "error"
+              ],
+              "properties": {
+                "error": {
+                  "type": "string"
+                },
+                "errorType": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "error"
+                  ]
+                }
+              }
             }
           }
         }
@@ -1105,12 +1312,51 @@ func init() {
             "description": "Delete silence response"
           },
           "404": {
-            "description": "A silence with the specified ID was not found"
+            "description": "Resource not found",
+            "schema": {
+              "type": "object",
+              "required": [
+                "status",
+                "error"
+              ],
+              "properties": {
+                "error": {
+                  "type": "string"
+                },
+                "errorType": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "error"
+                  ]
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal server error",
             "schema": {
-              "type": "string"
+              "type": "object",
+              "required": [
+                "status",
+                "error"
+              ],
+              "properties": {
+                "error": {
+                  "type": "string"
+                },
+                "errorType": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "error"
+                  ]
+                }
+              }
             }
           }
         }
@@ -1155,13 +1401,49 @@ func init() {
           "400": {
             "description": "Bad request",
             "schema": {
-              "type": "string"
+              "type": "object",
+              "required": [
+                "status",
+                "error"
+              ],
+              "properties": {
+                "error": {
+                  "type": "string"
+                },
+                "errorType": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "error"
+                  ]
+                }
+              }
             }
           },
           "500": {
             "description": "Internal server error",
             "schema": {
-              "type": "string"
+              "type": "object",
+              "required": [
+                "status",
+                "error"
+              ],
+              "properties": {
+                "error": {
+                  "type": "string"
+                },
+                "errorType": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "error"
+                  ]
+                }
+              }
             }
           }
         }
@@ -1198,13 +1480,73 @@ func init() {
           "400": {
             "description": "Bad request",
             "schema": {
-              "type": "string"
+              "type": "object",
+              "required": [
+                "status",
+                "error"
+              ],
+              "properties": {
+                "error": {
+                  "type": "string"
+                },
+                "errorType": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "error"
+                  ]
+                }
+              }
             }
           },
           "404": {
-            "description": "A silence with the specified ID was not found",
+            "description": "Resource not found",
             "schema": {
-              "type": "string"
+              "type": "object",
+              "required": [
+                "status",
+                "error"
+              ],
+              "properties": {
+                "error": {
+                  "type": "string"
+                },
+                "errorType": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "schema": {
+              "type": "object",
+              "required": [
+                "status",
+                "error"
+              ],
+              "properties": {
+                "error": {
+                  "type": "string"
+                },
+                "errorType": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "error"
+                  ]
+                }
+              }
             }
           }
         }
@@ -1643,13 +1985,73 @@ func init() {
     "BadRequest": {
       "description": "Bad request",
       "schema": {
-        "type": "string"
+        "type": "object",
+        "required": [
+          "status",
+          "error"
+        ],
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "errorType": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "error"
+            ]
+          }
+        }
       }
     },
     "InternalServerError": {
       "description": "Internal server error",
       "schema": {
-        "type": "string"
+        "type": "object",
+        "required": [
+          "status",
+          "error"
+        ],
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "errorType": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "error"
+            ]
+          }
+        }
+      }
+    },
+    "NotFound": {
+      "description": "Resource not found",
+      "schema": {
+        "type": "object",
+        "required": [
+          "status",
+          "error"
+        ],
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "errorType": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "error"
+            ]
+          }
+        }
       }
     }
   },

--- a/api/v2/restapi/operations/alert/get_alerts.go
+++ b/api/v2/restapi/operations/alert/get_alerts.go
@@ -20,9 +20,15 @@ package alert
 // Editing this file might prove futile when you re-run the generate command
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
 
+	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 )
 
 // GetAlertsHandlerFunc turns a function with the right signature into a get alerts handler
@@ -67,4 +73,220 @@ func (o *GetAlerts) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	res := o.Handler.Handle(Params) // actually handle the request
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
+}
+
+// GetAlertsBadRequestBody get alerts bad request body
+//
+// swagger:model GetAlertsBadRequestBody
+type GetAlertsBadRequestBody struct {
+
+	// error
+	// Required: true
+	Error *string `json:"error"`
+
+	// error type
+	ErrorType string `json:"errorType,omitempty"`
+
+	// status
+	// Required: true
+	// Enum: ["error"]
+	Status *string `json:"status"`
+}
+
+// Validate validates this get alerts bad request body
+func (o *GetAlertsBadRequestBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateError(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateStatus(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *GetAlertsBadRequestBody) validateError(formats strfmt.Registry) error {
+
+	if err := validate.Required("getAlertsBadRequest"+"."+"error", "body", o.Error); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var getAlertsBadRequestBodyTypeStatusPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["error"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		getAlertsBadRequestBodyTypeStatusPropEnum = append(getAlertsBadRequestBodyTypeStatusPropEnum, v)
+	}
+}
+
+const (
+
+	// GetAlertsBadRequestBodyStatusError captures enum value "error"
+	GetAlertsBadRequestBodyStatusError string = "error"
+)
+
+// prop value enum
+func (o *GetAlertsBadRequestBody) validateStatusEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, getAlertsBadRequestBodyTypeStatusPropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *GetAlertsBadRequestBody) validateStatus(formats strfmt.Registry) error {
+
+	if err := validate.Required("getAlertsBadRequest"+"."+"status", "body", o.Status); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := o.validateStatusEnum("getAlertsBadRequest"+"."+"status", "body", *o.Status); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validates this get alerts bad request body based on context it is used
+func (o *GetAlertsBadRequestBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *GetAlertsBadRequestBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *GetAlertsBadRequestBody) UnmarshalBinary(b []byte) error {
+	var res GetAlertsBadRequestBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
+	return nil
+}
+
+// GetAlertsInternalServerErrorBody get alerts internal server error body
+//
+// swagger:model GetAlertsInternalServerErrorBody
+type GetAlertsInternalServerErrorBody struct {
+
+	// error
+	// Required: true
+	Error *string `json:"error"`
+
+	// error type
+	ErrorType string `json:"errorType,omitempty"`
+
+	// status
+	// Required: true
+	// Enum: ["error"]
+	Status *string `json:"status"`
+}
+
+// Validate validates this get alerts internal server error body
+func (o *GetAlertsInternalServerErrorBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateError(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateStatus(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *GetAlertsInternalServerErrorBody) validateError(formats strfmt.Registry) error {
+
+	if err := validate.Required("getAlertsInternalServerError"+"."+"error", "body", o.Error); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var getAlertsInternalServerErrorBodyTypeStatusPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["error"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		getAlertsInternalServerErrorBodyTypeStatusPropEnum = append(getAlertsInternalServerErrorBodyTypeStatusPropEnum, v)
+	}
+}
+
+const (
+
+	// GetAlertsInternalServerErrorBodyStatusError captures enum value "error"
+	GetAlertsInternalServerErrorBodyStatusError string = "error"
+)
+
+// prop value enum
+func (o *GetAlertsInternalServerErrorBody) validateStatusEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, getAlertsInternalServerErrorBodyTypeStatusPropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *GetAlertsInternalServerErrorBody) validateStatus(formats strfmt.Registry) error {
+
+	if err := validate.Required("getAlertsInternalServerError"+"."+"status", "body", o.Status); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := o.validateStatusEnum("getAlertsInternalServerError"+"."+"status", "body", *o.Status); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validates this get alerts internal server error body based on context it is used
+func (o *GetAlertsInternalServerErrorBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *GetAlertsInternalServerErrorBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *GetAlertsInternalServerErrorBody) UnmarshalBinary(b []byte) error {
+	var res GetAlertsInternalServerErrorBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
+	return nil
 }

--- a/api/v2/restapi/operations/alert/get_alerts_responses.go
+++ b/api/v2/restapi/operations/alert/get_alerts_responses.go
@@ -88,7 +88,7 @@ type GetAlertsBadRequest struct {
 	/*
 	  In: Body
 	*/
-	Payload string `json:"body,omitempty"`
+	Payload *GetAlertsBadRequestBody `json:"body,omitempty"`
 }
 
 // NewGetAlertsBadRequest creates GetAlertsBadRequest with default headers values
@@ -98,13 +98,13 @@ func NewGetAlertsBadRequest() *GetAlertsBadRequest {
 }
 
 // WithPayload adds the payload to the get alerts bad request response
-func (o *GetAlertsBadRequest) WithPayload(payload string) *GetAlertsBadRequest {
+func (o *GetAlertsBadRequest) WithPayload(payload *GetAlertsBadRequestBody) *GetAlertsBadRequest {
 	o.Payload = payload
 	return o
 }
 
 // SetPayload sets the payload to the get alerts bad request response
-func (o *GetAlertsBadRequest) SetPayload(payload string) {
+func (o *GetAlertsBadRequest) SetPayload(payload *GetAlertsBadRequestBody) {
 	o.Payload = payload
 }
 
@@ -112,9 +112,11 @@ func (o *GetAlertsBadRequest) SetPayload(payload string) {
 func (o *GetAlertsBadRequest) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
 	rw.WriteHeader(400)
-	payload := o.Payload
-	if err := producer.Produce(rw, payload); err != nil {
-		panic(err) // let the recovery middleware deal with this
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
 	}
 }
 
@@ -131,7 +133,7 @@ type GetAlertsInternalServerError struct {
 	/*
 	  In: Body
 	*/
-	Payload string `json:"body,omitempty"`
+	Payload *GetAlertsInternalServerErrorBody `json:"body,omitempty"`
 }
 
 // NewGetAlertsInternalServerError creates GetAlertsInternalServerError with default headers values
@@ -141,13 +143,13 @@ func NewGetAlertsInternalServerError() *GetAlertsInternalServerError {
 }
 
 // WithPayload adds the payload to the get alerts internal server error response
-func (o *GetAlertsInternalServerError) WithPayload(payload string) *GetAlertsInternalServerError {
+func (o *GetAlertsInternalServerError) WithPayload(payload *GetAlertsInternalServerErrorBody) *GetAlertsInternalServerError {
 	o.Payload = payload
 	return o
 }
 
 // SetPayload sets the payload to the get alerts internal server error response
-func (o *GetAlertsInternalServerError) SetPayload(payload string) {
+func (o *GetAlertsInternalServerError) SetPayload(payload *GetAlertsInternalServerErrorBody) {
 	o.Payload = payload
 }
 
@@ -155,8 +157,10 @@ func (o *GetAlertsInternalServerError) SetPayload(payload string) {
 func (o *GetAlertsInternalServerError) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
 	rw.WriteHeader(500)
-	payload := o.Payload
-	if err := producer.Produce(rw, payload); err != nil {
-		panic(err) // let the recovery middleware deal with this
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
 	}
 }

--- a/api/v2/restapi/operations/alert/post_alerts.go
+++ b/api/v2/restapi/operations/alert/post_alerts.go
@@ -20,9 +20,15 @@ package alert
 // Editing this file might prove futile when you re-run the generate command
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
 
+	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 )
 
 // PostAlertsHandlerFunc turns a function with the right signature into a post alerts handler
@@ -67,4 +73,220 @@ func (o *PostAlerts) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	res := o.Handler.Handle(Params) // actually handle the request
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
+}
+
+// PostAlertsBadRequestBody post alerts bad request body
+//
+// swagger:model PostAlertsBadRequestBody
+type PostAlertsBadRequestBody struct {
+
+	// error
+	// Required: true
+	Error *string `json:"error"`
+
+	// error type
+	ErrorType string `json:"errorType,omitempty"`
+
+	// status
+	// Required: true
+	// Enum: ["error"]
+	Status *string `json:"status"`
+}
+
+// Validate validates this post alerts bad request body
+func (o *PostAlertsBadRequestBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateError(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateStatus(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *PostAlertsBadRequestBody) validateError(formats strfmt.Registry) error {
+
+	if err := validate.Required("postAlertsBadRequest"+"."+"error", "body", o.Error); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var postAlertsBadRequestBodyTypeStatusPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["error"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		postAlertsBadRequestBodyTypeStatusPropEnum = append(postAlertsBadRequestBodyTypeStatusPropEnum, v)
+	}
+}
+
+const (
+
+	// PostAlertsBadRequestBodyStatusError captures enum value "error"
+	PostAlertsBadRequestBodyStatusError string = "error"
+)
+
+// prop value enum
+func (o *PostAlertsBadRequestBody) validateStatusEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, postAlertsBadRequestBodyTypeStatusPropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *PostAlertsBadRequestBody) validateStatus(formats strfmt.Registry) error {
+
+	if err := validate.Required("postAlertsBadRequest"+"."+"status", "body", o.Status); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := o.validateStatusEnum("postAlertsBadRequest"+"."+"status", "body", *o.Status); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validates this post alerts bad request body based on context it is used
+func (o *PostAlertsBadRequestBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *PostAlertsBadRequestBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *PostAlertsBadRequestBody) UnmarshalBinary(b []byte) error {
+	var res PostAlertsBadRequestBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
+	return nil
+}
+
+// PostAlertsInternalServerErrorBody post alerts internal server error body
+//
+// swagger:model PostAlertsInternalServerErrorBody
+type PostAlertsInternalServerErrorBody struct {
+
+	// error
+	// Required: true
+	Error *string `json:"error"`
+
+	// error type
+	ErrorType string `json:"errorType,omitempty"`
+
+	// status
+	// Required: true
+	// Enum: ["error"]
+	Status *string `json:"status"`
+}
+
+// Validate validates this post alerts internal server error body
+func (o *PostAlertsInternalServerErrorBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateError(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateStatus(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *PostAlertsInternalServerErrorBody) validateError(formats strfmt.Registry) error {
+
+	if err := validate.Required("postAlertsInternalServerError"+"."+"error", "body", o.Error); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var postAlertsInternalServerErrorBodyTypeStatusPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["error"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		postAlertsInternalServerErrorBodyTypeStatusPropEnum = append(postAlertsInternalServerErrorBodyTypeStatusPropEnum, v)
+	}
+}
+
+const (
+
+	// PostAlertsInternalServerErrorBodyStatusError captures enum value "error"
+	PostAlertsInternalServerErrorBodyStatusError string = "error"
+)
+
+// prop value enum
+func (o *PostAlertsInternalServerErrorBody) validateStatusEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, postAlertsInternalServerErrorBodyTypeStatusPropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *PostAlertsInternalServerErrorBody) validateStatus(formats strfmt.Registry) error {
+
+	if err := validate.Required("postAlertsInternalServerError"+"."+"status", "body", o.Status); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := o.validateStatusEnum("postAlertsInternalServerError"+"."+"status", "body", *o.Status); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validates this post alerts internal server error body based on context it is used
+func (o *PostAlertsInternalServerErrorBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *PostAlertsInternalServerErrorBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *PostAlertsInternalServerErrorBody) UnmarshalBinary(b []byte) error {
+	var res PostAlertsInternalServerErrorBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
+	return nil
 }

--- a/api/v2/restapi/operations/alert/post_alerts_responses.go
+++ b/api/v2/restapi/operations/alert/post_alerts_responses.go
@@ -63,7 +63,7 @@ type PostAlertsBadRequest struct {
 	/*
 	  In: Body
 	*/
-	Payload string `json:"body,omitempty"`
+	Payload *PostAlertsBadRequestBody `json:"body,omitempty"`
 }
 
 // NewPostAlertsBadRequest creates PostAlertsBadRequest with default headers values
@@ -73,13 +73,13 @@ func NewPostAlertsBadRequest() *PostAlertsBadRequest {
 }
 
 // WithPayload adds the payload to the post alerts bad request response
-func (o *PostAlertsBadRequest) WithPayload(payload string) *PostAlertsBadRequest {
+func (o *PostAlertsBadRequest) WithPayload(payload *PostAlertsBadRequestBody) *PostAlertsBadRequest {
 	o.Payload = payload
 	return o
 }
 
 // SetPayload sets the payload to the post alerts bad request response
-func (o *PostAlertsBadRequest) SetPayload(payload string) {
+func (o *PostAlertsBadRequest) SetPayload(payload *PostAlertsBadRequestBody) {
 	o.Payload = payload
 }
 
@@ -87,9 +87,11 @@ func (o *PostAlertsBadRequest) SetPayload(payload string) {
 func (o *PostAlertsBadRequest) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
 	rw.WriteHeader(400)
-	payload := o.Payload
-	if err := producer.Produce(rw, payload); err != nil {
-		panic(err) // let the recovery middleware deal with this
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
 	}
 }
 
@@ -106,7 +108,7 @@ type PostAlertsInternalServerError struct {
 	/*
 	  In: Body
 	*/
-	Payload string `json:"body,omitempty"`
+	Payload *PostAlertsInternalServerErrorBody `json:"body,omitempty"`
 }
 
 // NewPostAlertsInternalServerError creates PostAlertsInternalServerError with default headers values
@@ -116,13 +118,13 @@ func NewPostAlertsInternalServerError() *PostAlertsInternalServerError {
 }
 
 // WithPayload adds the payload to the post alerts internal server error response
-func (o *PostAlertsInternalServerError) WithPayload(payload string) *PostAlertsInternalServerError {
+func (o *PostAlertsInternalServerError) WithPayload(payload *PostAlertsInternalServerErrorBody) *PostAlertsInternalServerError {
 	o.Payload = payload
 	return o
 }
 
 // SetPayload sets the payload to the post alerts internal server error response
-func (o *PostAlertsInternalServerError) SetPayload(payload string) {
+func (o *PostAlertsInternalServerError) SetPayload(payload *PostAlertsInternalServerErrorBody) {
 	o.Payload = payload
 }
 
@@ -130,8 +132,10 @@ func (o *PostAlertsInternalServerError) SetPayload(payload string) {
 func (o *PostAlertsInternalServerError) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
 	rw.WriteHeader(500)
-	payload := o.Payload
-	if err := producer.Produce(rw, payload); err != nil {
-		panic(err) // let the recovery middleware deal with this
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
 	}
 }

--- a/api/v2/restapi/operations/alertgroup/get_alert_groups.go
+++ b/api/v2/restapi/operations/alertgroup/get_alert_groups.go
@@ -20,9 +20,15 @@ package alertgroup
 // Editing this file might prove futile when you re-run the generate command
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
 
+	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 )
 
 // GetAlertGroupsHandlerFunc turns a function with the right signature into a get alert groups handler
@@ -67,4 +73,220 @@ func (o *GetAlertGroups) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	res := o.Handler.Handle(Params) // actually handle the request
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
+}
+
+// GetAlertGroupsBadRequestBody get alert groups bad request body
+//
+// swagger:model GetAlertGroupsBadRequestBody
+type GetAlertGroupsBadRequestBody struct {
+
+	// error
+	// Required: true
+	Error *string `json:"error"`
+
+	// error type
+	ErrorType string `json:"errorType,omitempty"`
+
+	// status
+	// Required: true
+	// Enum: ["error"]
+	Status *string `json:"status"`
+}
+
+// Validate validates this get alert groups bad request body
+func (o *GetAlertGroupsBadRequestBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateError(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateStatus(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *GetAlertGroupsBadRequestBody) validateError(formats strfmt.Registry) error {
+
+	if err := validate.Required("getAlertGroupsBadRequest"+"."+"error", "body", o.Error); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var getAlertGroupsBadRequestBodyTypeStatusPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["error"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		getAlertGroupsBadRequestBodyTypeStatusPropEnum = append(getAlertGroupsBadRequestBodyTypeStatusPropEnum, v)
+	}
+}
+
+const (
+
+	// GetAlertGroupsBadRequestBodyStatusError captures enum value "error"
+	GetAlertGroupsBadRequestBodyStatusError string = "error"
+)
+
+// prop value enum
+func (o *GetAlertGroupsBadRequestBody) validateStatusEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, getAlertGroupsBadRequestBodyTypeStatusPropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *GetAlertGroupsBadRequestBody) validateStatus(formats strfmt.Registry) error {
+
+	if err := validate.Required("getAlertGroupsBadRequest"+"."+"status", "body", o.Status); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := o.validateStatusEnum("getAlertGroupsBadRequest"+"."+"status", "body", *o.Status); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validates this get alert groups bad request body based on context it is used
+func (o *GetAlertGroupsBadRequestBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *GetAlertGroupsBadRequestBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *GetAlertGroupsBadRequestBody) UnmarshalBinary(b []byte) error {
+	var res GetAlertGroupsBadRequestBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
+	return nil
+}
+
+// GetAlertGroupsInternalServerErrorBody get alert groups internal server error body
+//
+// swagger:model GetAlertGroupsInternalServerErrorBody
+type GetAlertGroupsInternalServerErrorBody struct {
+
+	// error
+	// Required: true
+	Error *string `json:"error"`
+
+	// error type
+	ErrorType string `json:"errorType,omitempty"`
+
+	// status
+	// Required: true
+	// Enum: ["error"]
+	Status *string `json:"status"`
+}
+
+// Validate validates this get alert groups internal server error body
+func (o *GetAlertGroupsInternalServerErrorBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateError(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateStatus(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *GetAlertGroupsInternalServerErrorBody) validateError(formats strfmt.Registry) error {
+
+	if err := validate.Required("getAlertGroupsInternalServerError"+"."+"error", "body", o.Error); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var getAlertGroupsInternalServerErrorBodyTypeStatusPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["error"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		getAlertGroupsInternalServerErrorBodyTypeStatusPropEnum = append(getAlertGroupsInternalServerErrorBodyTypeStatusPropEnum, v)
+	}
+}
+
+const (
+
+	// GetAlertGroupsInternalServerErrorBodyStatusError captures enum value "error"
+	GetAlertGroupsInternalServerErrorBodyStatusError string = "error"
+)
+
+// prop value enum
+func (o *GetAlertGroupsInternalServerErrorBody) validateStatusEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, getAlertGroupsInternalServerErrorBodyTypeStatusPropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *GetAlertGroupsInternalServerErrorBody) validateStatus(formats strfmt.Registry) error {
+
+	if err := validate.Required("getAlertGroupsInternalServerError"+"."+"status", "body", o.Status); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := o.validateStatusEnum("getAlertGroupsInternalServerError"+"."+"status", "body", *o.Status); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validates this get alert groups internal server error body based on context it is used
+func (o *GetAlertGroupsInternalServerErrorBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *GetAlertGroupsInternalServerErrorBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *GetAlertGroupsInternalServerErrorBody) UnmarshalBinary(b []byte) error {
+	var res GetAlertGroupsInternalServerErrorBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
+	return nil
 }

--- a/api/v2/restapi/operations/alertgroup/get_alert_groups_responses.go
+++ b/api/v2/restapi/operations/alertgroup/get_alert_groups_responses.go
@@ -88,7 +88,7 @@ type GetAlertGroupsBadRequest struct {
 	/*
 	  In: Body
 	*/
-	Payload string `json:"body,omitempty"`
+	Payload *GetAlertGroupsBadRequestBody `json:"body,omitempty"`
 }
 
 // NewGetAlertGroupsBadRequest creates GetAlertGroupsBadRequest with default headers values
@@ -98,13 +98,13 @@ func NewGetAlertGroupsBadRequest() *GetAlertGroupsBadRequest {
 }
 
 // WithPayload adds the payload to the get alert groups bad request response
-func (o *GetAlertGroupsBadRequest) WithPayload(payload string) *GetAlertGroupsBadRequest {
+func (o *GetAlertGroupsBadRequest) WithPayload(payload *GetAlertGroupsBadRequestBody) *GetAlertGroupsBadRequest {
 	o.Payload = payload
 	return o
 }
 
 // SetPayload sets the payload to the get alert groups bad request response
-func (o *GetAlertGroupsBadRequest) SetPayload(payload string) {
+func (o *GetAlertGroupsBadRequest) SetPayload(payload *GetAlertGroupsBadRequestBody) {
 	o.Payload = payload
 }
 
@@ -112,9 +112,11 @@ func (o *GetAlertGroupsBadRequest) SetPayload(payload string) {
 func (o *GetAlertGroupsBadRequest) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
 	rw.WriteHeader(400)
-	payload := o.Payload
-	if err := producer.Produce(rw, payload); err != nil {
-		panic(err) // let the recovery middleware deal with this
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
 	}
 }
 
@@ -131,7 +133,7 @@ type GetAlertGroupsInternalServerError struct {
 	/*
 	  In: Body
 	*/
-	Payload string `json:"body,omitempty"`
+	Payload *GetAlertGroupsInternalServerErrorBody `json:"body,omitempty"`
 }
 
 // NewGetAlertGroupsInternalServerError creates GetAlertGroupsInternalServerError with default headers values
@@ -141,13 +143,13 @@ func NewGetAlertGroupsInternalServerError() *GetAlertGroupsInternalServerError {
 }
 
 // WithPayload adds the payload to the get alert groups internal server error response
-func (o *GetAlertGroupsInternalServerError) WithPayload(payload string) *GetAlertGroupsInternalServerError {
+func (o *GetAlertGroupsInternalServerError) WithPayload(payload *GetAlertGroupsInternalServerErrorBody) *GetAlertGroupsInternalServerError {
 	o.Payload = payload
 	return o
 }
 
 // SetPayload sets the payload to the get alert groups internal server error response
-func (o *GetAlertGroupsInternalServerError) SetPayload(payload string) {
+func (o *GetAlertGroupsInternalServerError) SetPayload(payload *GetAlertGroupsInternalServerErrorBody) {
 	o.Payload = payload
 }
 
@@ -155,8 +157,10 @@ func (o *GetAlertGroupsInternalServerError) SetPayload(payload string) {
 func (o *GetAlertGroupsInternalServerError) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
 	rw.WriteHeader(500)
-	payload := o.Payload
-	if err := producer.Produce(rw, payload); err != nil {
-		panic(err) // let the recovery middleware deal with this
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
 	}
 }

--- a/api/v2/restapi/operations/silence/delete_silence.go
+++ b/api/v2/restapi/operations/silence/delete_silence.go
@@ -20,9 +20,15 @@ package silence
 // Editing this file might prove futile when you re-run the generate command
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
 
+	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 )
 
 // DeleteSilenceHandlerFunc turns a function with the right signature into a delete silence handler
@@ -67,4 +73,220 @@ func (o *DeleteSilence) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	res := o.Handler.Handle(Params) // actually handle the request
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
+}
+
+// DeleteSilenceInternalServerErrorBody delete silence internal server error body
+//
+// swagger:model DeleteSilenceInternalServerErrorBody
+type DeleteSilenceInternalServerErrorBody struct {
+
+	// error
+	// Required: true
+	Error *string `json:"error"`
+
+	// error type
+	ErrorType string `json:"errorType,omitempty"`
+
+	// status
+	// Required: true
+	// Enum: ["error"]
+	Status *string `json:"status"`
+}
+
+// Validate validates this delete silence internal server error body
+func (o *DeleteSilenceInternalServerErrorBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateError(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateStatus(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *DeleteSilenceInternalServerErrorBody) validateError(formats strfmt.Registry) error {
+
+	if err := validate.Required("deleteSilenceInternalServerError"+"."+"error", "body", o.Error); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var deleteSilenceInternalServerErrorBodyTypeStatusPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["error"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		deleteSilenceInternalServerErrorBodyTypeStatusPropEnum = append(deleteSilenceInternalServerErrorBodyTypeStatusPropEnum, v)
+	}
+}
+
+const (
+
+	// DeleteSilenceInternalServerErrorBodyStatusError captures enum value "error"
+	DeleteSilenceInternalServerErrorBodyStatusError string = "error"
+)
+
+// prop value enum
+func (o *DeleteSilenceInternalServerErrorBody) validateStatusEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, deleteSilenceInternalServerErrorBodyTypeStatusPropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *DeleteSilenceInternalServerErrorBody) validateStatus(formats strfmt.Registry) error {
+
+	if err := validate.Required("deleteSilenceInternalServerError"+"."+"status", "body", o.Status); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := o.validateStatusEnum("deleteSilenceInternalServerError"+"."+"status", "body", *o.Status); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validates this delete silence internal server error body based on context it is used
+func (o *DeleteSilenceInternalServerErrorBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *DeleteSilenceInternalServerErrorBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *DeleteSilenceInternalServerErrorBody) UnmarshalBinary(b []byte) error {
+	var res DeleteSilenceInternalServerErrorBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
+	return nil
+}
+
+// DeleteSilenceNotFoundBody delete silence not found body
+//
+// swagger:model DeleteSilenceNotFoundBody
+type DeleteSilenceNotFoundBody struct {
+
+	// error
+	// Required: true
+	Error *string `json:"error"`
+
+	// error type
+	ErrorType string `json:"errorType,omitempty"`
+
+	// status
+	// Required: true
+	// Enum: ["error"]
+	Status *string `json:"status"`
+}
+
+// Validate validates this delete silence not found body
+func (o *DeleteSilenceNotFoundBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateError(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateStatus(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *DeleteSilenceNotFoundBody) validateError(formats strfmt.Registry) error {
+
+	if err := validate.Required("deleteSilenceNotFound"+"."+"error", "body", o.Error); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var deleteSilenceNotFoundBodyTypeStatusPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["error"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		deleteSilenceNotFoundBodyTypeStatusPropEnum = append(deleteSilenceNotFoundBodyTypeStatusPropEnum, v)
+	}
+}
+
+const (
+
+	// DeleteSilenceNotFoundBodyStatusError captures enum value "error"
+	DeleteSilenceNotFoundBodyStatusError string = "error"
+)
+
+// prop value enum
+func (o *DeleteSilenceNotFoundBody) validateStatusEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, deleteSilenceNotFoundBodyTypeStatusPropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *DeleteSilenceNotFoundBody) validateStatus(formats strfmt.Registry) error {
+
+	if err := validate.Required("deleteSilenceNotFound"+"."+"status", "body", o.Status); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := o.validateStatusEnum("deleteSilenceNotFound"+"."+"status", "body", *o.Status); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validates this delete silence not found body based on context it is used
+func (o *DeleteSilenceNotFoundBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *DeleteSilenceNotFoundBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *DeleteSilenceNotFoundBody) UnmarshalBinary(b []byte) error {
+	var res DeleteSilenceNotFoundBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
+	return nil
 }

--- a/api/v2/restapi/operations/silence/delete_silence_responses.go
+++ b/api/v2/restapi/operations/silence/delete_silence_responses.go
@@ -54,11 +54,16 @@ func (o *DeleteSilenceOK) WriteResponse(rw http.ResponseWriter, producer runtime
 const DeleteSilenceNotFoundCode int = 404
 
 /*
-DeleteSilenceNotFound A silence with the specified ID was not found
+DeleteSilenceNotFound Resource not found
 
 swagger:response deleteSilenceNotFound
 */
 type DeleteSilenceNotFound struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *DeleteSilenceNotFoundBody `json:"body,omitempty"`
 }
 
 // NewDeleteSilenceNotFound creates DeleteSilenceNotFound with default headers values
@@ -67,12 +72,27 @@ func NewDeleteSilenceNotFound() *DeleteSilenceNotFound {
 	return &DeleteSilenceNotFound{}
 }
 
+// WithPayload adds the payload to the delete silence not found response
+func (o *DeleteSilenceNotFound) WithPayload(payload *DeleteSilenceNotFoundBody) *DeleteSilenceNotFound {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the delete silence not found response
+func (o *DeleteSilenceNotFound) SetPayload(payload *DeleteSilenceNotFoundBody) {
+	o.Payload = payload
+}
+
 // WriteResponse to the client
 func (o *DeleteSilenceNotFound) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
-	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
-
 	rw.WriteHeader(404)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
 }
 
 // DeleteSilenceInternalServerErrorCode is the HTTP code returned for type DeleteSilenceInternalServerError
@@ -88,7 +108,7 @@ type DeleteSilenceInternalServerError struct {
 	/*
 	  In: Body
 	*/
-	Payload string `json:"body,omitempty"`
+	Payload *DeleteSilenceInternalServerErrorBody `json:"body,omitempty"`
 }
 
 // NewDeleteSilenceInternalServerError creates DeleteSilenceInternalServerError with default headers values
@@ -98,13 +118,13 @@ func NewDeleteSilenceInternalServerError() *DeleteSilenceInternalServerError {
 }
 
 // WithPayload adds the payload to the delete silence internal server error response
-func (o *DeleteSilenceInternalServerError) WithPayload(payload string) *DeleteSilenceInternalServerError {
+func (o *DeleteSilenceInternalServerError) WithPayload(payload *DeleteSilenceInternalServerErrorBody) *DeleteSilenceInternalServerError {
 	o.Payload = payload
 	return o
 }
 
 // SetPayload sets the payload to the delete silence internal server error response
-func (o *DeleteSilenceInternalServerError) SetPayload(payload string) {
+func (o *DeleteSilenceInternalServerError) SetPayload(payload *DeleteSilenceInternalServerErrorBody) {
 	o.Payload = payload
 }
 
@@ -112,8 +132,10 @@ func (o *DeleteSilenceInternalServerError) SetPayload(payload string) {
 func (o *DeleteSilenceInternalServerError) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
 	rw.WriteHeader(500)
-	payload := o.Payload
-	if err := producer.Produce(rw, payload); err != nil {
-		panic(err) // let the recovery middleware deal with this
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
 	}
 }

--- a/api/v2/restapi/operations/silence/get_silence.go
+++ b/api/v2/restapi/operations/silence/get_silence.go
@@ -20,9 +20,15 @@ package silence
 // Editing this file might prove futile when you re-run the generate command
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
 
+	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 )
 
 // GetSilenceHandlerFunc turns a function with the right signature into a get silence handler
@@ -67,4 +73,220 @@ func (o *GetSilence) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	res := o.Handler.Handle(Params) // actually handle the request
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
+}
+
+// GetSilenceInternalServerErrorBody get silence internal server error body
+//
+// swagger:model GetSilenceInternalServerErrorBody
+type GetSilenceInternalServerErrorBody struct {
+
+	// error
+	// Required: true
+	Error *string `json:"error"`
+
+	// error type
+	ErrorType string `json:"errorType,omitempty"`
+
+	// status
+	// Required: true
+	// Enum: ["error"]
+	Status *string `json:"status"`
+}
+
+// Validate validates this get silence internal server error body
+func (o *GetSilenceInternalServerErrorBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateError(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateStatus(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *GetSilenceInternalServerErrorBody) validateError(formats strfmt.Registry) error {
+
+	if err := validate.Required("getSilenceInternalServerError"+"."+"error", "body", o.Error); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var getSilenceInternalServerErrorBodyTypeStatusPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["error"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		getSilenceInternalServerErrorBodyTypeStatusPropEnum = append(getSilenceInternalServerErrorBodyTypeStatusPropEnum, v)
+	}
+}
+
+const (
+
+	// GetSilenceInternalServerErrorBodyStatusError captures enum value "error"
+	GetSilenceInternalServerErrorBodyStatusError string = "error"
+)
+
+// prop value enum
+func (o *GetSilenceInternalServerErrorBody) validateStatusEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, getSilenceInternalServerErrorBodyTypeStatusPropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *GetSilenceInternalServerErrorBody) validateStatus(formats strfmt.Registry) error {
+
+	if err := validate.Required("getSilenceInternalServerError"+"."+"status", "body", o.Status); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := o.validateStatusEnum("getSilenceInternalServerError"+"."+"status", "body", *o.Status); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validates this get silence internal server error body based on context it is used
+func (o *GetSilenceInternalServerErrorBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *GetSilenceInternalServerErrorBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *GetSilenceInternalServerErrorBody) UnmarshalBinary(b []byte) error {
+	var res GetSilenceInternalServerErrorBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
+	return nil
+}
+
+// GetSilenceNotFoundBody get silence not found body
+//
+// swagger:model GetSilenceNotFoundBody
+type GetSilenceNotFoundBody struct {
+
+	// error
+	// Required: true
+	Error *string `json:"error"`
+
+	// error type
+	ErrorType string `json:"errorType,omitempty"`
+
+	// status
+	// Required: true
+	// Enum: ["error"]
+	Status *string `json:"status"`
+}
+
+// Validate validates this get silence not found body
+func (o *GetSilenceNotFoundBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateError(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateStatus(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *GetSilenceNotFoundBody) validateError(formats strfmt.Registry) error {
+
+	if err := validate.Required("getSilenceNotFound"+"."+"error", "body", o.Error); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var getSilenceNotFoundBodyTypeStatusPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["error"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		getSilenceNotFoundBodyTypeStatusPropEnum = append(getSilenceNotFoundBodyTypeStatusPropEnum, v)
+	}
+}
+
+const (
+
+	// GetSilenceNotFoundBodyStatusError captures enum value "error"
+	GetSilenceNotFoundBodyStatusError string = "error"
+)
+
+// prop value enum
+func (o *GetSilenceNotFoundBody) validateStatusEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, getSilenceNotFoundBodyTypeStatusPropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *GetSilenceNotFoundBody) validateStatus(formats strfmt.Registry) error {
+
+	if err := validate.Required("getSilenceNotFound"+"."+"status", "body", o.Status); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := o.validateStatusEnum("getSilenceNotFound"+"."+"status", "body", *o.Status); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validates this get silence not found body based on context it is used
+func (o *GetSilenceNotFoundBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *GetSilenceNotFoundBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *GetSilenceNotFoundBody) UnmarshalBinary(b []byte) error {
+	var res GetSilenceNotFoundBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
+	return nil
 }

--- a/api/v2/restapi/operations/silence/get_silence_responses.go
+++ b/api/v2/restapi/operations/silence/get_silence_responses.go
@@ -76,11 +76,16 @@ func (o *GetSilenceOK) WriteResponse(rw http.ResponseWriter, producer runtime.Pr
 const GetSilenceNotFoundCode int = 404
 
 /*
-GetSilenceNotFound A silence with the specified ID was not found
+GetSilenceNotFound Resource not found
 
 swagger:response getSilenceNotFound
 */
 type GetSilenceNotFound struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *GetSilenceNotFoundBody `json:"body,omitempty"`
 }
 
 // NewGetSilenceNotFound creates GetSilenceNotFound with default headers values
@@ -89,12 +94,27 @@ func NewGetSilenceNotFound() *GetSilenceNotFound {
 	return &GetSilenceNotFound{}
 }
 
+// WithPayload adds the payload to the get silence not found response
+func (o *GetSilenceNotFound) WithPayload(payload *GetSilenceNotFoundBody) *GetSilenceNotFound {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the get silence not found response
+func (o *GetSilenceNotFound) SetPayload(payload *GetSilenceNotFoundBody) {
+	o.Payload = payload
+}
+
 // WriteResponse to the client
 func (o *GetSilenceNotFound) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
-	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
-
 	rw.WriteHeader(404)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
 }
 
 // GetSilenceInternalServerErrorCode is the HTTP code returned for type GetSilenceInternalServerError
@@ -110,7 +130,7 @@ type GetSilenceInternalServerError struct {
 	/*
 	  In: Body
 	*/
-	Payload string `json:"body,omitempty"`
+	Payload *GetSilenceInternalServerErrorBody `json:"body,omitempty"`
 }
 
 // NewGetSilenceInternalServerError creates GetSilenceInternalServerError with default headers values
@@ -120,13 +140,13 @@ func NewGetSilenceInternalServerError() *GetSilenceInternalServerError {
 }
 
 // WithPayload adds the payload to the get silence internal server error response
-func (o *GetSilenceInternalServerError) WithPayload(payload string) *GetSilenceInternalServerError {
+func (o *GetSilenceInternalServerError) WithPayload(payload *GetSilenceInternalServerErrorBody) *GetSilenceInternalServerError {
 	o.Payload = payload
 	return o
 }
 
 // SetPayload sets the payload to the get silence internal server error response
-func (o *GetSilenceInternalServerError) SetPayload(payload string) {
+func (o *GetSilenceInternalServerError) SetPayload(payload *GetSilenceInternalServerErrorBody) {
 	o.Payload = payload
 }
 
@@ -134,8 +154,10 @@ func (o *GetSilenceInternalServerError) SetPayload(payload string) {
 func (o *GetSilenceInternalServerError) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
 	rw.WriteHeader(500)
-	payload := o.Payload
-	if err := producer.Produce(rw, payload); err != nil {
-		panic(err) // let the recovery middleware deal with this
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
 	}
 }

--- a/api/v2/restapi/operations/silence/get_silences.go
+++ b/api/v2/restapi/operations/silence/get_silences.go
@@ -20,9 +20,15 @@ package silence
 // Editing this file might prove futile when you re-run the generate command
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
 
+	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 )
 
 // GetSilencesHandlerFunc turns a function with the right signature into a get silences handler
@@ -67,4 +73,220 @@ func (o *GetSilences) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	res := o.Handler.Handle(Params) // actually handle the request
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
+}
+
+// GetSilencesBadRequestBody get silences bad request body
+//
+// swagger:model GetSilencesBadRequestBody
+type GetSilencesBadRequestBody struct {
+
+	// error
+	// Required: true
+	Error *string `json:"error"`
+
+	// error type
+	ErrorType string `json:"errorType,omitempty"`
+
+	// status
+	// Required: true
+	// Enum: ["error"]
+	Status *string `json:"status"`
+}
+
+// Validate validates this get silences bad request body
+func (o *GetSilencesBadRequestBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateError(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateStatus(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *GetSilencesBadRequestBody) validateError(formats strfmt.Registry) error {
+
+	if err := validate.Required("getSilencesBadRequest"+"."+"error", "body", o.Error); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var getSilencesBadRequestBodyTypeStatusPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["error"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		getSilencesBadRequestBodyTypeStatusPropEnum = append(getSilencesBadRequestBodyTypeStatusPropEnum, v)
+	}
+}
+
+const (
+
+	// GetSilencesBadRequestBodyStatusError captures enum value "error"
+	GetSilencesBadRequestBodyStatusError string = "error"
+)
+
+// prop value enum
+func (o *GetSilencesBadRequestBody) validateStatusEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, getSilencesBadRequestBodyTypeStatusPropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *GetSilencesBadRequestBody) validateStatus(formats strfmt.Registry) error {
+
+	if err := validate.Required("getSilencesBadRequest"+"."+"status", "body", o.Status); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := o.validateStatusEnum("getSilencesBadRequest"+"."+"status", "body", *o.Status); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validates this get silences bad request body based on context it is used
+func (o *GetSilencesBadRequestBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *GetSilencesBadRequestBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *GetSilencesBadRequestBody) UnmarshalBinary(b []byte) error {
+	var res GetSilencesBadRequestBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
+	return nil
+}
+
+// GetSilencesInternalServerErrorBody get silences internal server error body
+//
+// swagger:model GetSilencesInternalServerErrorBody
+type GetSilencesInternalServerErrorBody struct {
+
+	// error
+	// Required: true
+	Error *string `json:"error"`
+
+	// error type
+	ErrorType string `json:"errorType,omitempty"`
+
+	// status
+	// Required: true
+	// Enum: ["error"]
+	Status *string `json:"status"`
+}
+
+// Validate validates this get silences internal server error body
+func (o *GetSilencesInternalServerErrorBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateError(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateStatus(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *GetSilencesInternalServerErrorBody) validateError(formats strfmt.Registry) error {
+
+	if err := validate.Required("getSilencesInternalServerError"+"."+"error", "body", o.Error); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var getSilencesInternalServerErrorBodyTypeStatusPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["error"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		getSilencesInternalServerErrorBodyTypeStatusPropEnum = append(getSilencesInternalServerErrorBodyTypeStatusPropEnum, v)
+	}
+}
+
+const (
+
+	// GetSilencesInternalServerErrorBodyStatusError captures enum value "error"
+	GetSilencesInternalServerErrorBodyStatusError string = "error"
+)
+
+// prop value enum
+func (o *GetSilencesInternalServerErrorBody) validateStatusEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, getSilencesInternalServerErrorBodyTypeStatusPropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *GetSilencesInternalServerErrorBody) validateStatus(formats strfmt.Registry) error {
+
+	if err := validate.Required("getSilencesInternalServerError"+"."+"status", "body", o.Status); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := o.validateStatusEnum("getSilencesInternalServerError"+"."+"status", "body", *o.Status); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validates this get silences internal server error body based on context it is used
+func (o *GetSilencesInternalServerErrorBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *GetSilencesInternalServerErrorBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *GetSilencesInternalServerErrorBody) UnmarshalBinary(b []byte) error {
+	var res GetSilencesInternalServerErrorBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
+	return nil
 }

--- a/api/v2/restapi/operations/silence/get_silences_responses.go
+++ b/api/v2/restapi/operations/silence/get_silences_responses.go
@@ -88,7 +88,7 @@ type GetSilencesBadRequest struct {
 	/*
 	  In: Body
 	*/
-	Payload string `json:"body,omitempty"`
+	Payload *GetSilencesBadRequestBody `json:"body,omitempty"`
 }
 
 // NewGetSilencesBadRequest creates GetSilencesBadRequest with default headers values
@@ -98,13 +98,13 @@ func NewGetSilencesBadRequest() *GetSilencesBadRequest {
 }
 
 // WithPayload adds the payload to the get silences bad request response
-func (o *GetSilencesBadRequest) WithPayload(payload string) *GetSilencesBadRequest {
+func (o *GetSilencesBadRequest) WithPayload(payload *GetSilencesBadRequestBody) *GetSilencesBadRequest {
 	o.Payload = payload
 	return o
 }
 
 // SetPayload sets the payload to the get silences bad request response
-func (o *GetSilencesBadRequest) SetPayload(payload string) {
+func (o *GetSilencesBadRequest) SetPayload(payload *GetSilencesBadRequestBody) {
 	o.Payload = payload
 }
 
@@ -112,9 +112,11 @@ func (o *GetSilencesBadRequest) SetPayload(payload string) {
 func (o *GetSilencesBadRequest) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
 	rw.WriteHeader(400)
-	payload := o.Payload
-	if err := producer.Produce(rw, payload); err != nil {
-		panic(err) // let the recovery middleware deal with this
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
 	}
 }
 
@@ -131,7 +133,7 @@ type GetSilencesInternalServerError struct {
 	/*
 	  In: Body
 	*/
-	Payload string `json:"body,omitempty"`
+	Payload *GetSilencesInternalServerErrorBody `json:"body,omitempty"`
 }
 
 // NewGetSilencesInternalServerError creates GetSilencesInternalServerError with default headers values
@@ -141,13 +143,13 @@ func NewGetSilencesInternalServerError() *GetSilencesInternalServerError {
 }
 
 // WithPayload adds the payload to the get silences internal server error response
-func (o *GetSilencesInternalServerError) WithPayload(payload string) *GetSilencesInternalServerError {
+func (o *GetSilencesInternalServerError) WithPayload(payload *GetSilencesInternalServerErrorBody) *GetSilencesInternalServerError {
 	o.Payload = payload
 	return o
 }
 
 // SetPayload sets the payload to the get silences internal server error response
-func (o *GetSilencesInternalServerError) SetPayload(payload string) {
+func (o *GetSilencesInternalServerError) SetPayload(payload *GetSilencesInternalServerErrorBody) {
 	o.Payload = payload
 }
 
@@ -155,8 +157,10 @@ func (o *GetSilencesInternalServerError) SetPayload(payload string) {
 func (o *GetSilencesInternalServerError) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
 	rw.WriteHeader(500)
-	payload := o.Payload
-	if err := producer.Produce(rw, payload); err != nil {
-		panic(err) // let the recovery middleware deal with this
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
 	}
 }

--- a/api/v2/restapi/operations/silence/post_silences.go
+++ b/api/v2/restapi/operations/silence/post_silences.go
@@ -21,11 +21,14 @@ package silence
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 
+	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 )
 
 // PostSilencesHandlerFunc turns a function with the right signature into a post silences handler
@@ -70,6 +73,330 @@ func (o *PostSilences) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	res := o.Handler.Handle(Params) // actually handle the request
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
+}
+
+// PostSilencesBadRequestBody post silences bad request body
+//
+// swagger:model PostSilencesBadRequestBody
+type PostSilencesBadRequestBody struct {
+
+	// error
+	// Required: true
+	Error *string `json:"error"`
+
+	// error type
+	ErrorType string `json:"errorType,omitempty"`
+
+	// status
+	// Required: true
+	// Enum: ["error"]
+	Status *string `json:"status"`
+}
+
+// Validate validates this post silences bad request body
+func (o *PostSilencesBadRequestBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateError(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateStatus(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *PostSilencesBadRequestBody) validateError(formats strfmt.Registry) error {
+
+	if err := validate.Required("postSilencesBadRequest"+"."+"error", "body", o.Error); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var postSilencesBadRequestBodyTypeStatusPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["error"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		postSilencesBadRequestBodyTypeStatusPropEnum = append(postSilencesBadRequestBodyTypeStatusPropEnum, v)
+	}
+}
+
+const (
+
+	// PostSilencesBadRequestBodyStatusError captures enum value "error"
+	PostSilencesBadRequestBodyStatusError string = "error"
+)
+
+// prop value enum
+func (o *PostSilencesBadRequestBody) validateStatusEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, postSilencesBadRequestBodyTypeStatusPropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *PostSilencesBadRequestBody) validateStatus(formats strfmt.Registry) error {
+
+	if err := validate.Required("postSilencesBadRequest"+"."+"status", "body", o.Status); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := o.validateStatusEnum("postSilencesBadRequest"+"."+"status", "body", *o.Status); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validates this post silences bad request body based on context it is used
+func (o *PostSilencesBadRequestBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *PostSilencesBadRequestBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *PostSilencesBadRequestBody) UnmarshalBinary(b []byte) error {
+	var res PostSilencesBadRequestBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
+	return nil
+}
+
+// PostSilencesInternalServerErrorBody post silences internal server error body
+//
+// swagger:model PostSilencesInternalServerErrorBody
+type PostSilencesInternalServerErrorBody struct {
+
+	// error
+	// Required: true
+	Error *string `json:"error"`
+
+	// error type
+	ErrorType string `json:"errorType,omitempty"`
+
+	// status
+	// Required: true
+	// Enum: ["error"]
+	Status *string `json:"status"`
+}
+
+// Validate validates this post silences internal server error body
+func (o *PostSilencesInternalServerErrorBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateError(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateStatus(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *PostSilencesInternalServerErrorBody) validateError(formats strfmt.Registry) error {
+
+	if err := validate.Required("postSilencesInternalServerError"+"."+"error", "body", o.Error); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var postSilencesInternalServerErrorBodyTypeStatusPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["error"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		postSilencesInternalServerErrorBodyTypeStatusPropEnum = append(postSilencesInternalServerErrorBodyTypeStatusPropEnum, v)
+	}
+}
+
+const (
+
+	// PostSilencesInternalServerErrorBodyStatusError captures enum value "error"
+	PostSilencesInternalServerErrorBodyStatusError string = "error"
+)
+
+// prop value enum
+func (o *PostSilencesInternalServerErrorBody) validateStatusEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, postSilencesInternalServerErrorBodyTypeStatusPropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *PostSilencesInternalServerErrorBody) validateStatus(formats strfmt.Registry) error {
+
+	if err := validate.Required("postSilencesInternalServerError"+"."+"status", "body", o.Status); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := o.validateStatusEnum("postSilencesInternalServerError"+"."+"status", "body", *o.Status); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validates this post silences internal server error body based on context it is used
+func (o *PostSilencesInternalServerErrorBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *PostSilencesInternalServerErrorBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *PostSilencesInternalServerErrorBody) UnmarshalBinary(b []byte) error {
+	var res PostSilencesInternalServerErrorBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
+	return nil
+}
+
+// PostSilencesNotFoundBody post silences not found body
+//
+// swagger:model PostSilencesNotFoundBody
+type PostSilencesNotFoundBody struct {
+
+	// error
+	// Required: true
+	Error *string `json:"error"`
+
+	// error type
+	ErrorType string `json:"errorType,omitempty"`
+
+	// status
+	// Required: true
+	// Enum: ["error"]
+	Status *string `json:"status"`
+}
+
+// Validate validates this post silences not found body
+func (o *PostSilencesNotFoundBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateError(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateStatus(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *PostSilencesNotFoundBody) validateError(formats strfmt.Registry) error {
+
+	if err := validate.Required("postSilencesNotFound"+"."+"error", "body", o.Error); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var postSilencesNotFoundBodyTypeStatusPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["error"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		postSilencesNotFoundBodyTypeStatusPropEnum = append(postSilencesNotFoundBodyTypeStatusPropEnum, v)
+	}
+}
+
+const (
+
+	// PostSilencesNotFoundBodyStatusError captures enum value "error"
+	PostSilencesNotFoundBodyStatusError string = "error"
+)
+
+// prop value enum
+func (o *PostSilencesNotFoundBody) validateStatusEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, postSilencesNotFoundBodyTypeStatusPropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *PostSilencesNotFoundBody) validateStatus(formats strfmt.Registry) error {
+
+	if err := validate.Required("postSilencesNotFound"+"."+"status", "body", o.Status); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := o.validateStatusEnum("postSilencesNotFound"+"."+"status", "body", *o.Status); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validates this post silences not found body based on context it is used
+func (o *PostSilencesNotFoundBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *PostSilencesNotFoundBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *PostSilencesNotFoundBody) UnmarshalBinary(b []byte) error {
+	var res PostSilencesNotFoundBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
+	return nil
 }
 
 // PostSilencesOKBody post silences o k body

--- a/api/v2/restapi/operations/silence/post_silences_responses.go
+++ b/api/v2/restapi/operations/silence/post_silences_responses.go
@@ -83,7 +83,7 @@ type PostSilencesBadRequest struct {
 	/*
 	  In: Body
 	*/
-	Payload string `json:"body,omitempty"`
+	Payload *PostSilencesBadRequestBody `json:"body,omitempty"`
 }
 
 // NewPostSilencesBadRequest creates PostSilencesBadRequest with default headers values
@@ -93,13 +93,13 @@ func NewPostSilencesBadRequest() *PostSilencesBadRequest {
 }
 
 // WithPayload adds the payload to the post silences bad request response
-func (o *PostSilencesBadRequest) WithPayload(payload string) *PostSilencesBadRequest {
+func (o *PostSilencesBadRequest) WithPayload(payload *PostSilencesBadRequestBody) *PostSilencesBadRequest {
 	o.Payload = payload
 	return o
 }
 
 // SetPayload sets the payload to the post silences bad request response
-func (o *PostSilencesBadRequest) SetPayload(payload string) {
+func (o *PostSilencesBadRequest) SetPayload(payload *PostSilencesBadRequestBody) {
 	o.Payload = payload
 }
 
@@ -107,9 +107,11 @@ func (o *PostSilencesBadRequest) SetPayload(payload string) {
 func (o *PostSilencesBadRequest) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
 	rw.WriteHeader(400)
-	payload := o.Payload
-	if err := producer.Produce(rw, payload); err != nil {
-		panic(err) // let the recovery middleware deal with this
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
 	}
 }
 
@@ -117,7 +119,7 @@ func (o *PostSilencesBadRequest) WriteResponse(rw http.ResponseWriter, producer 
 const PostSilencesNotFoundCode int = 404
 
 /*
-PostSilencesNotFound A silence with the specified ID was not found
+PostSilencesNotFound Resource not found
 
 swagger:response postSilencesNotFound
 */
@@ -126,7 +128,7 @@ type PostSilencesNotFound struct {
 	/*
 	  In: Body
 	*/
-	Payload string `json:"body,omitempty"`
+	Payload *PostSilencesNotFoundBody `json:"body,omitempty"`
 }
 
 // NewPostSilencesNotFound creates PostSilencesNotFound with default headers values
@@ -136,13 +138,13 @@ func NewPostSilencesNotFound() *PostSilencesNotFound {
 }
 
 // WithPayload adds the payload to the post silences not found response
-func (o *PostSilencesNotFound) WithPayload(payload string) *PostSilencesNotFound {
+func (o *PostSilencesNotFound) WithPayload(payload *PostSilencesNotFoundBody) *PostSilencesNotFound {
 	o.Payload = payload
 	return o
 }
 
 // SetPayload sets the payload to the post silences not found response
-func (o *PostSilencesNotFound) SetPayload(payload string) {
+func (o *PostSilencesNotFound) SetPayload(payload *PostSilencesNotFoundBody) {
 	o.Payload = payload
 }
 
@@ -150,8 +152,55 @@ func (o *PostSilencesNotFound) SetPayload(payload string) {
 func (o *PostSilencesNotFound) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
 	rw.WriteHeader(404)
-	payload := o.Payload
-	if err := producer.Produce(rw, payload); err != nil {
-		panic(err) // let the recovery middleware deal with this
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
+// PostSilencesInternalServerErrorCode is the HTTP code returned for type PostSilencesInternalServerError
+const PostSilencesInternalServerErrorCode int = 500
+
+/*
+PostSilencesInternalServerError Internal server error
+
+swagger:response postSilencesInternalServerError
+*/
+type PostSilencesInternalServerError struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *PostSilencesInternalServerErrorBody `json:"body,omitempty"`
+}
+
+// NewPostSilencesInternalServerError creates PostSilencesInternalServerError with default headers values
+func NewPostSilencesInternalServerError() *PostSilencesInternalServerError {
+
+	return &PostSilencesInternalServerError{}
+}
+
+// WithPayload adds the payload to the post silences internal server error response
+func (o *PostSilencesInternalServerError) WithPayload(payload *PostSilencesInternalServerErrorBody) *PostSilencesInternalServerError {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the post silences internal server error response
+func (o *PostSilencesInternalServerError) SetPayload(payload *PostSilencesInternalServerErrorBody) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *PostSilencesInternalServerError) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(500)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
 	}
 }


### PR DESCRIPTION
Fix #4973: Return JSON error responses instead of plain text
## Problem
The Alertmanager API was returning error responses as plain text strings with incorrect Content-Type header:
- **Content-Type:** `application/json`
- **Response Body:** `"bad matcher format: invalidfilter"` (plain text string)
This violates the JSON API specification as the response body is a quoted string, not a JSON object.
## Solution
Updated the API to return proper JSON error responses with an `error` field:
- **Content-Type:** `application/json`
- **Response Body:** `{"error":"bad matcher format: invalidfilter"}` (valid JSON object)
### Changes Made
1. **OpenAPI Spec (`api/v2/openapi.yaml`)**
   - Changed all error response schemas from `type: string` to JSON objects with `error` field
   - Added proper error body types for all error responses (400, 404, 500)
   
2. **Swagger Code Generation**
   - Regenerated REST API code with new error body types
   - Created proper error response structs:
     - `GetAlertsBadRequestBody`, `GetAlertsInternalServerErrorBody`
     - `GetAlertGroupsBadRequestBody`, `GetAlertGroupsInternalServerErrorBody`
     - `GetSilencesBadRequestBody`, `GetSilencesInternalServerErrorBody`
     - `GetSilenceInternalServerErrorBody`
     - `DeleteSilenceInternalServerErrorBody`
     - `PostAlertsBadRequestBody`, `PostAlertsInternalServerErrorBody`
     - `PostSilencesBadRequestBody`
3. **API Handlers (`api/v2/api.go`)**
   - Updated all error handlers to create error body objects instead of passing raw strings
   - Fixed the following endpoints:
     - GET /api/v2/alerts
     - POST /api/v2/alerts
     - GET /api/v2/alerts/groups
     - GET /api/v2/silences
     - GET /api/v2/silences/:silence_id
     - DELETE /api/v2/silences/:silence_id
     - POST /api/v2/silences
## Example
### Before
```bash
$ curl -v "http://localhost:9093/api/v2/alerts/groups?filter=invalidfilter"
< HTTP/1.1 400 Bad Request
< Content-Type: application/json
"bad matcher format: invalidfilter"