### PR TITLE
fix: omit empty text field in Mattermost notifications

### DIFF
--- a/notify/mattermost/mattermost.go
+++ b/notify/mattermost/mattermost.go
@@ -68,7 +68,7 @@ func New(c *config.MattermostConfig, t *template.Template, l *slog.Logger, httpO
 // request is the request for sending a Mattermost notification.
 // https://developers.mattermost.com/integrate/webhooks/incoming/#parameters
 type request struct {
-	Text        string                     `json:"text"`
+	Text        string                     `json:"text,omitempty"`
 	Channel     string                     `json:"channel,omitempty"`
 	Username    string                     `json:"username,omitempty"`
 	IconURL     string                     `json:"icon_url,omitempty"`

--- a/notify/mattermost/mattermost_test.go
+++ b/notify/mattermost/mattermost_test.go
@@ -195,11 +195,12 @@ func TestMattermost_Notify(t *testing.T) {
 	}
 
 	type testcase struct {
-		name     string
-		text     string
-		props    *config.MattermostProps
-		priority *config.MattermostPriority
-		result   string
+		name        string
+		text        string
+		props       *config.MattermostProps
+		priority    *config.MattermostPriority
+		attachments []*config.MattermostAttachment
+		result      string
 	}
 	tests := []testcase{
 		{
@@ -228,6 +229,22 @@ func TestMattermost_Notify(t *testing.T) {
 			priority: &config.MattermostPriority{Priority: "urgent"},
 			result:   "{\"text\":\"Test Text\",\"props\":{\"card\":\"Test Card\"},\"priority\":{\"priority\":\"urgent\"}}\n",
 		},
+		{
+			name:   "with empty text - should omit text field",
+			text:   "",
+			result: "{}\n",
+		},
+		{
+			name: "with empty text and attachments - should omit text field",
+			text: "",
+			attachments: []*config.MattermostAttachment{
+				{
+					Title: "Test Attachment",
+					Text:  "Attachment Text",
+				},
+			},
+			result: "{\"attachments\":[{\"text\":\"Attachment Text\",\"title\":\"Test Attachment\"}]}\n",
+		},
 	}
 
 	for _, tc := range tests {
@@ -239,6 +256,7 @@ func TestMattermost_Notify(t *testing.T) {
 				Text:           tc.text,
 				Props:          tc.props,
 				Priority:       tc.priority,
+				Attachments:    tc.attachments,
 			}
 
 			// Create a new Mattermost notifier


### PR DESCRIPTION
Add omitempty tag to Text field to prevent sending empty text values to Mattermost, which causes 400 errors. Per the Mattermost API spec, text is only required if attachments are not set.

Related to prometheus-operator/prometheus-operator#8363