### PR TITLE
Support global Mattermost webhook url

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -477,6 +477,10 @@ func (c *Config) UnmarshalYAML(unmarshal func(any) error) error {
 		return errors.New("at most one of wechat_api_secret & wechat_api_secret_file must be configured")
 	}
 
+	if c.Global.MattermostWebhookURL != nil && len(c.Global.MattermostWebhookURLFile) > 0 {
+		return errors.New("at most one of mattermost_webhook_url & mattermost_webhook_url_file must be configured")
+	}
+
 	names := map[string]struct{}{}
 
 	for _, rcv := range c.Receivers {
@@ -679,6 +683,13 @@ func (c *Config) UnmarshalYAML(unmarshal func(any) error) error {
 		}
 		for _, mattermost := range rcv.MattermostConfigs {
 			mattermost.HTTPConfig = cmp.Or(mattermost.HTTPConfig, c.Global.HTTPConfig)
+			if mattermost.WebhookURL == nil && len(mattermost.WebhookURLFile) == 0 {
+				if c.Global.MattermostWebhookURL == nil && len(c.Global.MattermostWebhookURLFile) == 0 {
+					return errors.New("missing webhook_url or webhook_url_file on mattermost_config")
+				}
+				mattermost.WebhookURL = c.Global.MattermostWebhookURL
+				mattermost.WebhookURLFile = c.Global.MattermostWebhookURLFile
+			}
 		}
 
 		names[rcv.Name] = struct{}{}
@@ -886,44 +897,46 @@ type GlobalConfig struct {
 
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
-	JiraAPIURL            *URL                 `yaml:"jira_api_url,omitempty" json:"jira_api_url,omitempty"`
-	SMTPFrom              string               `yaml:"smtp_from,omitempty" json:"smtp_from,omitempty"`
-	SMTPHello             string               `yaml:"smtp_hello,omitempty" json:"smtp_hello,omitempty"`
-	SMTPSmarthost         HostPort             `yaml:"smtp_smarthost,omitempty" json:"smtp_smarthost,omitempty"`
-	SMTPAuthUsername      string               `yaml:"smtp_auth_username,omitempty" json:"smtp_auth_username,omitempty"`
-	SMTPAuthPassword      commoncfg.Secret     `yaml:"smtp_auth_password,omitempty" json:"smtp_auth_password,omitempty"`
-	SMTPAuthPasswordFile  string               `yaml:"smtp_auth_password_file,omitempty" json:"smtp_auth_password_file,omitempty"`
-	SMTPAuthSecret        commoncfg.Secret     `yaml:"smtp_auth_secret,omitempty" json:"smtp_auth_secret,omitempty"`
-	SMTPAuthSecretFile    string               `yaml:"smtp_auth_secret_file,omitempty" json:"smtp_auth_secret_file,omitempty"`
-	SMTPAuthIdentity      string               `yaml:"smtp_auth_identity,omitempty" json:"smtp_auth_identity,omitempty"`
-	SMTPRequireTLS        bool                 `yaml:"smtp_require_tls" json:"smtp_require_tls,omitempty"`
-	SMTPTLSConfig         *commoncfg.TLSConfig `yaml:"smtp_tls_config,omitempty" json:"smtp_tls_config,omitempty"`
-	SMTPForceImplicitTLS  *bool                `yaml:"smtp_force_implicit_tls,omitempty" json:"smtp_force_implicit_tls,omitempty"`
-	SlackAPIURL           *SecretURL           `yaml:"slack_api_url,omitempty" json:"slack_api_url,omitempty"`
-	SlackAPIURLFile       string               `yaml:"slack_api_url_file,omitempty" json:"slack_api_url_file,omitempty"`
-	SlackAppToken         commoncfg.Secret     `yaml:"slack_app_token,omitempty" json:"slack_app_token,omitempty"`
-	SlackAppTokenFile     string               `yaml:"slack_app_token_file,omitempty" json:"slack_app_token_file,omitempty"`
-	SlackAppURL           *URL                 `yaml:"slack_app_url,omitempty" json:"slack_app_url,omitempty"`
-	PagerdutyURL          *URL                 `yaml:"pagerduty_url,omitempty" json:"pagerduty_url,omitempty"`
-	OpsGenieAPIURL        *URL                 `yaml:"opsgenie_api_url,omitempty" json:"opsgenie_api_url,omitempty"`
-	OpsGenieAPIKey        commoncfg.Secret     `yaml:"opsgenie_api_key,omitempty" json:"opsgenie_api_key,omitempty"`
-	OpsGenieAPIKeyFile    string               `yaml:"opsgenie_api_key_file,omitempty" json:"opsgenie_api_key_file,omitempty"`
-	WeChatAPIURL          *URL                 `yaml:"wechat_api_url,omitempty" json:"wechat_api_url,omitempty"`
-	WeChatAPISecret       commoncfg.Secret     `yaml:"wechat_api_secret,omitempty" json:"wechat_api_secret,omitempty"`
-	WeChatAPISecretFile   string               `yaml:"wechat_api_secret_file,omitempty" json:"wechat_api_secret_file,omitempty"`
-	WeChatAPICorpID       string               `yaml:"wechat_api_corp_id,omitempty" json:"wechat_api_corp_id,omitempty"`
-	VictorOpsAPIURL       *URL                 `yaml:"victorops_api_url,omitempty" json:"victorops_api_url,omitempty"`
-	VictorOpsAPIKey       commoncfg.Secret     `yaml:"victorops_api_key,omitempty" json:"victorops_api_key,omitempty"`
-	VictorOpsAPIKeyFile   string               `yaml:"victorops_api_key_file,omitempty" json:"victorops_api_key_file,omitempty"`
-	TelegramAPIUrl        *URL                 `yaml:"telegram_api_url,omitempty" json:"telegram_api_url,omitempty"`
-	TelegramBotToken      commoncfg.Secret     `yaml:"telegram_bot_token,omitempty" json:"telegram_bot_token,omitempty"`
-	TelegramBotTokenFile  string               `yaml:"telegram_bot_token_file,omitempty" json:"telegram_bot_token_file,omitempty"`
-	WebexAPIURL           *URL                 `yaml:"webex_api_url,omitempty" json:"webex_api_url,omitempty"`
-	RocketchatAPIURL      *URL                 `yaml:"rocketchat_api_url,omitempty" json:"rocketchat_api_url,omitempty"`
-	RocketchatToken       *commoncfg.Secret    `yaml:"rocketchat_token,omitempty" json:"rocketchat_token,omitempty"`
-	RocketchatTokenFile   string               `yaml:"rocketchat_token_file,omitempty" json:"rocketchat_token_file,omitempty"`
-	RocketchatTokenID     *commoncfg.Secret    `yaml:"rocketchat_token_id,omitempty" json:"rocketchat_token_id,omitempty"`
-	RocketchatTokenIDFile string               `yaml:"rocketchat_token_id_file,omitempty" json:"rocketchat_token_id_file,omitempty"`
+	JiraAPIURL               *URL                 `yaml:"jira_api_url,omitempty" json:"jira_api_url,omitempty"`
+	SMTPFrom                 string               `yaml:"smtp_from,omitempty" json:"smtp_from,omitempty"`
+	SMTPHello                string               `yaml:"smtp_hello,omitempty" json:"smtp_hello,omitempty"`
+	SMTPSmarthost            HostPort             `yaml:"smtp_smarthost,omitempty" json:"smtp_smarthost,omitempty"`
+	SMTPAuthUsername         string               `yaml:"smtp_auth_username,omitempty" json:"smtp_auth_username,omitempty"`
+	SMTPAuthPassword         commoncfg.Secret     `yaml:"smtp_auth_password,omitempty" json:"smtp_auth_password,omitempty"`
+	SMTPAuthPasswordFile     string               `yaml:"smtp_auth_password_file,omitempty" json:"smtp_auth_password_file,omitempty"`
+	SMTPAuthSecret           commoncfg.Secret     `yaml:"smtp_auth_secret,omitempty" json:"smtp_auth_secret,omitempty"`
+	SMTPAuthSecretFile       string               `yaml:"smtp_auth_secret_file,omitempty" json:"smtp_auth_secret_file,omitempty"`
+	SMTPAuthIdentity         string               `yaml:"smtp_auth_identity,omitempty" json:"smtp_auth_identity,omitempty"`
+	SMTPRequireTLS           bool                 `yaml:"smtp_require_tls" json:"smtp_require_tls,omitempty"`
+	SMTPTLSConfig            *commoncfg.TLSConfig `yaml:"smtp_tls_config,omitempty" json:"smtp_tls_config,omitempty"`
+	SMTPForceImplicitTLS     *bool                `yaml:"smtp_force_implicit_tls,omitempty" json:"smtp_force_implicit_tls,omitempty"`
+	SlackAPIURL              *SecretURL           `yaml:"slack_api_url,omitempty" json:"slack_api_url,omitempty"`
+	SlackAPIURLFile          string               `yaml:"slack_api_url_file,omitempty" json:"slack_api_url_file,omitempty"`
+	SlackAppToken            commoncfg.Secret     `yaml:"slack_app_token,omitempty" json:"slack_app_token,omitempty"`
+	SlackAppTokenFile        string               `yaml:"slack_app_token_file,omitempty" json:"slack_app_token_file,omitempty"`
+	SlackAppURL              *URL                 `yaml:"slack_app_url,omitempty" json:"slack_app_url,omitempty"`
+	PagerdutyURL             *URL                 `yaml:"pagerduty_url,omitempty" json:"pagerduty_url,omitempty"`
+	OpsGenieAPIURL           *URL                 `yaml:"opsgenie_api_url,omitempty" json:"opsgenie_api_url,omitempty"`
+	OpsGenieAPIKey           commoncfg.Secret     `yaml:"opsgenie_api_key,omitempty" json:"opsgenie_api_key,omitempty"`
+	OpsGenieAPIKeyFile       string               `yaml:"opsgenie_api_key_file,omitempty" json:"opsgenie_api_key_file,omitempty"`
+	WeChatAPIURL             *URL                 `yaml:"wechat_api_url,omitempty" json:"wechat_api_url,omitempty"`
+	WeChatAPISecret          commoncfg.Secret     `yaml:"wechat_api_secret,omitempty" json:"wechat_api_secret,omitempty"`
+	WeChatAPISecretFile      string               `yaml:"wechat_api_secret_file,omitempty" json:"wechat_api_secret_file,omitempty"`
+	WeChatAPICorpID          string               `yaml:"wechat_api_corp_id,omitempty" json:"wechat_api_corp_id,omitempty"`
+	VictorOpsAPIURL          *URL                 `yaml:"victorops_api_url,omitempty" json:"victorops_api_url,omitempty"`
+	VictorOpsAPIKey          commoncfg.Secret     `yaml:"victorops_api_key,omitempty" json:"victorops_api_key,omitempty"`
+	VictorOpsAPIKeyFile      string               `yaml:"victorops_api_key_file,omitempty" json:"victorops_api_key_file,omitempty"`
+	TelegramAPIUrl           *URL                 `yaml:"telegram_api_url,omitempty" json:"telegram_api_url,omitempty"`
+	TelegramBotToken         commoncfg.Secret     `yaml:"telegram_bot_token,omitempty" json:"telegram_bot_token,omitempty"`
+	TelegramBotTokenFile     string               `yaml:"telegram_bot_token_file,omitempty" json:"telegram_bot_token_file,omitempty"`
+	WebexAPIURL              *URL                 `yaml:"webex_api_url,omitempty" json:"webex_api_url,omitempty"`
+	RocketchatAPIURL         *URL                 `yaml:"rocketchat_api_url,omitempty" json:"rocketchat_api_url,omitempty"`
+	RocketchatToken          *commoncfg.Secret    `yaml:"rocketchat_token,omitempty" json:"rocketchat_token,omitempty"`
+	RocketchatTokenFile      string               `yaml:"rocketchat_token_file,omitempty" json:"rocketchat_token_file,omitempty"`
+	RocketchatTokenID        *commoncfg.Secret    `yaml:"rocketchat_token_id,omitempty" json:"rocketchat_token_id,omitempty"`
+	RocketchatTokenIDFile    string               `yaml:"rocketchat_token_id_file,omitempty" json:"rocketchat_token_id_file,omitempty"`
+	MattermostWebhookURL     *SecretURL           `yaml:"mattermost_webhook_url,omitempty" json:"mattermost_webhook_url,omitempty"`
+	MattermostWebhookURLFile string               `yaml:"mattermost_webhook_url_file,omitempty" json:"mattermost_webhook_url_file,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for GlobalConfig.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1767,3 +1767,65 @@ func TestWechatGlobalAPISecretFile(t *testing.T) {
 		t.Fatalf("Invalid Wechat API Secret: %s\nExpected: %s", string(thirdConfig.APISecret), "my_inline_secret")
 	}
 }
+
+func TestMattermostDefaultWebhookURL(t *testing.T) {
+	conf, err := LoadFile("testdata/conf.mattermost-default-webhook-url.yml")
+	if err != nil {
+		t.Fatalf("Error parsing %s: %s", "testdata/conf.mattermost-default-webhook-url.yml", err)
+	}
+
+	defaultWebhookURL := conf.Global.MattermostWebhookURL
+	overrideWebhookURL := "https://fakemattermost.example.com/hooks/xxxxxxxxxxxxxxxxxxxxxxxxxx"
+	if defaultWebhookURL != conf.Receivers[0].MattermostConfigs[0].WebhookURL {
+		t.Fatalf("Invalid mattermost webhook url: %s\nExpected: %s", conf.Receivers[0].MattermostConfigs[0].WebhookURL, defaultWebhookURL)
+	}
+	if overrideWebhookURL != conf.Receivers[1].MattermostConfigs[0].WebhookURL.String() {
+		t.Errorf("Invalid mattermost webhook url: %s\nExpected: %s", conf.Receivers[1].MattermostConfigs[0].WebhookURL, overrideWebhookURL)
+	}
+}
+
+func TestMattermostDefaultWebhookURLFile(t *testing.T) {
+	conf, err := LoadFile("testdata/conf.mattermost-default-webhook-url-file.yml")
+	if err != nil {
+		t.Fatalf("Error parsing %s: %s", "testdata/conf.mattermost-default-webhook-url-file.yml", err)
+	}
+
+	defaultWebhookURLFile := conf.Global.MattermostWebhookURLFile
+	overrideWebhookURLFile := "/override_file"
+	if defaultWebhookURLFile != conf.Receivers[0].MattermostConfigs[0].WebhookURLFile {
+		t.Fatalf("Invalid mattermost webhook url file: %s\nExpected: %s", conf.Receivers[0].MattermostConfigs[0].WebhookURLFile, defaultWebhookURLFile)
+	}
+	if overrideWebhookURLFile != conf.Receivers[1].MattermostConfigs[0].WebhookURLFile {
+		t.Errorf("Invalid mattermost webhook url file: %s\nExpected: %s", conf.Receivers[1].MattermostConfigs[0].WebhookURLFile, overrideWebhookURLFile)
+	}
+}
+
+func TestMattermostBothWebhookURLAndFile(t *testing.T) {
+	_, err := LoadFile("testdata/conf.mattermost-both-webhook-url-and-file.yml")
+	if err == nil {
+		t.Fatalf("Expected an error parsing %s: %s", "testdata/conf.mattermost-both-webhook-url-and-file.yml", err)
+	}
+	if err.Error() != "at most one of mattermost_webhook_url & mattermost_webhook_url_file must be configured" {
+		t.Errorf("Expected: %s\nGot: %s", "at most one of mattermost_webhook_url & mattermost_webhook_url_file must be configured", err.Error())
+	}
+}
+
+func TestMattermostValidReceiverBothWebhookURLAndFile(t *testing.T) {
+	_, err := LoadFile("testdata/conf.mattermost-valid-receiver-both-webhook-url-and-file.yml")
+	if err == nil {
+		t.Fatalf("Expected an error parsing %s: %s", "testdata/conf.mattermost-valid-receiver-both-webhook-url-and-file.yml", err)
+	}
+	if err.Error() != "at most one of mattermost_webhook_url & mattermost_webhook_url_file must be configured" {
+		t.Errorf("Expected: %s\nGot: %s", "at most one of mattermost_webhook_url & mattermost_webhook_url_file must be configured", err.Error())
+	}
+}
+
+func TestMattermostNoWebhookURL(t *testing.T) {
+	_, err := LoadFile("testdata/conf.mattermost-no-webhook-url.yml")
+	if err == nil {
+		t.Fatalf("Expected an error parsing %s: %s", "testdata/conf.mattermost-no-webhook-url.yml", err)
+	}
+	if err.Error() != "missing webhook_url or webhook_url_file on mattermost_config" {
+		t.Errorf("Expected: %s\nGot: %s", "missing webhook_url or webhook_url_file on mattermost_config", err.Error())
+	}
+}

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -1237,10 +1237,6 @@ func (c *MattermostConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		return err
 	}
 
-	if c.WebhookURL == nil && c.WebhookURLFile == "" {
-		return errors.New("one of webhook_url or webhook_url_file must be configured")
-	}
-
 	if c.WebhookURL != nil && len(c.WebhookURLFile) > 0 {
 		return errors.New("at most one of webhook_url & webhook_url_file must be configured")
 	}

--- a/config/testdata/conf.mattermost-both-webhook-url-and-file.yml
+++ b/config/testdata/conf.mattermost-both-webhook-url-and-file.yml
@@ -1,0 +1,14 @@
+global:
+  mattermost_webhook_url: https://mattermost.example.com/hooks/xxxxxxxxxxxxxxxxxxxxxxxxxx
+  mattermost_webhook_url_file: /global_file
+route:
+  receiver: team-X-mattermost
+
+receivers:
+  - name: team-X-mattermost
+    mattermost_configs:
+      - channel: team-X
+  - name: team-Y-mattermost
+    mattermost_configs:
+      - channel: team-Y
+        webhook_url: https://fakemattermost.example.com/hooks/xxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/config/testdata/conf.mattermost-default-webhook-url-file.yml
+++ b/config/testdata/conf.mattermost-default-webhook-url-file.yml
@@ -1,0 +1,13 @@
+global:
+  mattermost_webhook_url_file: /global_file
+route:
+  receiver: team-X-mattermost
+
+receivers:
+  - name: team-X-mattermost
+    mattermost_configs:
+      - channel: team-X
+  - name: team-Y-mattermost
+    mattermost_configs:
+      - channel: team-Y
+        webhook_url_file: /override_file

--- a/config/testdata/conf.mattermost-default-webhook-url.yml
+++ b/config/testdata/conf.mattermost-default-webhook-url.yml
@@ -1,0 +1,13 @@
+global:
+  mattermost_webhook_url: https://mattermost.example.com/hooks/xxxxxxxxxxxxxxxxxxxxxxxxxx
+route:
+  receiver: team-X-mattermost
+
+receivers:
+  - name: team-X-mattermost
+    mattermost_configs:
+      - channel: team-X
+  - name: team-Y-mattermost
+    mattermost_configs:
+      - channel: team-Y
+        webhook_url: https://fakemattermost.example.com/hooks/xxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/config/testdata/conf.mattermost-no-webhook-url.yml
+++ b/config/testdata/conf.mattermost-no-webhook-url.yml
@@ -1,0 +1,7 @@
+route:
+  receiver: team-X-mattermost
+
+receivers:
+  - name: team-X-mattermost
+    mattermost_configs:
+      - channel: team-X

--- a/config/testdata/conf.mattermost-valid-receiver-both-webhook-url-and-file.yml
+++ b/config/testdata/conf.mattermost-valid-receiver-both-webhook-url-and-file.yml
@@ -1,0 +1,11 @@
+global:
+  mattermost_webhook_url: https://mattermost.example.com/hooks/xxxxxxxxxxxxxxxxxxxxxxxxxx
+  mattermost_webhook_url_file: /global_file
+route:
+  receiver: team-X-mattermost
+
+receivers:
+  - name: team-X-mattermost
+    mattermost_configs:
+      - channel: team-X
+        webhook_url_file: /override_file

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -124,6 +124,8 @@ global:
   [ wechat_api_corp_id: <string> ]
   [ telegram_api_url: <string> | default = "https://api.telegram.org" ]
   [ webex_api_url: <string> | default = "https://webexapis.com/v1/messages" ]
+  [ mattermost_webhook_url: <secret> ]
+  [ mattermost_webhook_url_file: <string> ]
   # The default HTTP client configuration
   [ http_config: <http_config> ]
 


### PR DESCRIPTION
This PR adds global configuration support for Mattermost webhook url in Alertmanager.

Until now, `mattermost_webhook_url` and `mattermost_webhook_url_file` could only be set per receiver, which could lead to redundant configuration when multiple receivers used the same webhook.