### PR TITLE
Add telegram bot token options to global config docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -123,6 +123,8 @@ global:
   [ wechat_api_secret_file: <string> ]
   [ wechat_api_corp_id: <string> ]
   [ telegram_api_url: <string> | default = "https://api.telegram.org" ]
+  [ telegram_bot_token: <secret> ]
+  [ telegram_bot_token_file: <string> ]
   [ webex_api_url: <string> | default = "https://webexapis.com/v1/messages" ]
   # The default HTTP client configuration
   [ http_config: <http_config> ]


### PR DESCRIPTION
The `telegram_bot_token` and `telegram_bot_token_file` options were introduced in #4823 but were not documented.