### PR TITLE
[dispatcher] benchmark suite

### DIFF
--- a/dispatch/dispatch_bench_test.go
+++ b/dispatch/dispatch_bench_test.go
@@ -200,7 +200,7 @@ func BenchmarkGroups(b *testing.B) {
 	b.Run("500 routes, 5000 groups", func(b *testing.B) {
 		benchmarkGroups(b, 5000, 3, 25, 4, 5)
 	})
-	b.Run("120 routes, 10000 groups", func(b *testing.B) {
+	b.Run("400 routes, 10000 groups", func(b *testing.B) {
 		benchmarkGroups(b, 10000, 3, 20, 4, 5)
 	})
 }


### PR DESCRIPTION
Simple benchmark testing the dispatcher Groups() call, and the dispatcher ingestion, indirectly via the mem alert provider.

While the mem alert provider takes a lock and then puts the alerts into a channel, it does block if the dispatcher is not processing the alerts, so this way we measure the backpressure and how much we can ingest alerts with concurrency.

This is the result of these patches on main, and after all the concurrent dispatcher series:

```go
goos: linux
goarch: amd64
pkg: github.com/prometheus/alertmanager/dispatch
cpu: AMD EPYC Processor (with IBPB)
                                                                 │ bench_dispatch_main.txt │    bench_dispatch_concurrent.txt    │
                                                                 │         sec/op          │    sec/op     vs base               │
Groups/500_routes,_5000_groups-40                                             47.34m ±  4%   47.66m ±  3%        ~ (p=0.394 n=6)
Groups/400_routes,_10000_groups-40                                            116.4m ±  1%   117.3m ±  3%   +0.79% (p=0.026 n=6)
IngestionUnderGroupsLoad/500_routes,_0/s_Groups()_callers-40                  5.495m ± 57%   2.290m ± 54%  -58.33% (p=0.002 n=6)
IngestionUnderGroupsLoad/500_routes,_1_10/s_Groups()_callers-40               5.591m ±  5%   2.291m ± 17%  -59.02% (p=0.002 n=6)
IngestionUnderGroupsLoad/500_routes,_10_10/s_Groups()_callers-40              6.760m ±  7%   3.117m ± 38%  -53.90% (p=0.002 n=6)
IngestionUnderGroupsLoad/500_routes,_25_10/s_Groups()_callers-40              12.47m ± 15%   17.70m ± 70%        ~ (p=0.394 n=6)
IngestionUnderGroupsLoad/500_routes,_25_20/s_Groups()_callers-40             11.872m ± 33%   7.978m ± 76%  -32.80% (p=0.041 n=6)
geomean                                                                       14.98m         10.37m        -30.77%

                                                                 │ bench_dispatch_main.txt │    bench_dispatch_concurrent.txt     │
                                                                 │          B/op           │     B/op       vs base               │
Groups/500_routes,_5000_groups-40                                            9.275Mi ±  0%   9.132Mi ±  1%   -1.54% (p=0.002 n=6)
Groups/400_routes,_10000_groups-40                                           18.98Mi ±  0%   18.76Mi ±  0%   -1.15% (p=0.002 n=6)
IngestionUnderGroupsLoad/500_routes,_0/s_Groups()_callers-40                 4.604Mi ±  1%   4.614Mi ±  1%        ~ (p=0.240 n=6)
IngestionUnderGroupsLoad/500_routes,_1_10/s_Groups()_callers-40              5.197Mi ±  4%   4.831Mi ±  3%   -7.04% (p=0.004 n=6)
IngestionUnderGroupsLoad/500_routes,_10_10/s_Groups()_callers-40            10.414Mi ± 14%   6.856Mi ± 16%  -34.16% (p=0.002 n=6)
IngestionUnderGroupsLoad/500_routes,_25_10/s_Groups()_callers-40             27.43Mi ± 11%   27.38Mi ± 63%        ~ (p=0.937 n=6)
IngestionUnderGroupsLoad/500_routes,_25_20/s_Groups()_callers-40             27.21Mi ± 33%   12.93Mi ± 85%  -52.49% (p=0.002 n=6)
geomean                                                                      11.85Mi         9.892Mi        -16.50%

                                                                 │ bench_dispatch_main.txt │    bench_dispatch_concurrent.txt     │
                                                                 │        allocs/op        │   allocs/op    vs base               │
Groups/500_routes,_5000_groups-40                                             210.7k ±  0%   209.2k ±   2%        ~ (p=0.065 n=6)
Groups/400_routes,_10000_groups-40                                            440.8k ±  0%   437.5k ±   1%   -0.77% (p=0.002 n=6)
IngestionUnderGroupsLoad/500_routes,_0/s_Groups()_callers-40                  18.89k ±  0%   19.13k ±   1%   +1.30% (p=0.002 n=6)
IngestionUnderGroupsLoad/500_routes,_1_10/s_Groups()_callers-40               36.70k ± 21%   25.07k ±  23%  -31.67% (p=0.004 n=6)
IngestionUnderGroupsLoad/500_routes,_10_10/s_Groups()_callers-40             189.57k ± 22%   85.69k ±  38%  -54.79% (p=0.002 n=6)
IngestionUnderGroupsLoad/500_routes,_25_10/s_Groups()_callers-40              660.1k ± 12%   692.4k ±  73%        ~ (p=0.937 n=6)
IngestionUnderGroupsLoad/500_routes,_25_20/s_Groups()_callers-40              657.4k ± 37%   259.0k ± 123%  -60.61% (p=0.002 n=6)
geomean                                                                       176.3k         131.4k         -25.50%