### PR TITLE
refactor(config): move custom URL and SecretURL type to new package

### DIFF
--- a/config/common/url.go
+++ b/config/common/url.go
@@ -1,0 +1,254 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"html/template"
+	"net/url"
+	"strings"
+
+	commoncfg "github.com/prometheus/common/config"
+)
+
+const SecretToken = "<secret>"
+
+var SecretTokenJSON string
+
+func init() {
+	b, err := json.Marshal(SecretToken)
+	if err != nil {
+		panic(err)
+	}
+	SecretTokenJSON = string(b)
+}
+
+// URL is a custom type that represents an HTTP or HTTPS URL and allows validation at configuration load time.
+type URL struct {
+	*url.URL
+}
+
+// Copy makes a deep-copy of the struct.
+func (u *URL) Copy() *URL {
+	v := *u.URL
+	return &URL{&v}
+}
+
+// MarshalYAML implements the yaml.Marshaler interface for URL.
+func (u URL) MarshalYAML() (any, error) {
+	if u.URL != nil {
+		return u.String(), nil
+	}
+	return nil, nil
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface for URL.
+func (u *URL) UnmarshalYAML(unmarshal func(any) error) error {
+	var s string
+	if err := unmarshal(&s); err != nil {
+		return err
+	}
+	urlp, err := ParseURL(s)
+	if err != nil {
+		return err
+	}
+	u.URL = urlp.URL
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaler interface for URL.
+func (u URL) MarshalJSON() ([]byte, error) {
+	if u.URL != nil {
+		return json.Marshal(u.String())
+	}
+	return []byte("null"), nil
+}
+
+// UnmarshalJSON implements the json.Marshaler interface for URL.
+func (u *URL) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	urlp, err := ParseURL(s)
+	if err != nil {
+		return err
+	}
+	u.URL = urlp.URL
+	return nil
+}
+
+// SecretURL is a URL that must not be revealed on marshaling.
+type SecretURL URL
+
+// MarshalYAML implements the yaml.Marshaler interface for SecretURL.
+func (s SecretURL) MarshalYAML() (any, error) {
+	if s.URL != nil {
+		if commoncfg.MarshalSecretValue {
+			return s.String(), nil
+		}
+		return SecretToken, nil
+	}
+	return nil, nil
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface for SecretURL.
+func (s *SecretURL) UnmarshalYAML(unmarshal func(any) error) error {
+	var str string
+	if err := unmarshal(&str); err != nil {
+		return err
+	}
+	// In order to deserialize a previously serialized configuration (eg from
+	// the Alertmanager API with amtool), `<secret>` needs to be treated
+	// specially, as it isn't a valid URL.
+	if str == SecretToken {
+		s.URL = &url.URL{}
+		return nil
+	}
+	return unmarshal((*URL)(s))
+}
+
+// MarshalJSON implements the json.Marshaler interface for SecretURL.
+func (s SecretURL) MarshalJSON() ([]byte, error) {
+	if s.URL == nil {
+		return json.Marshal("")
+	}
+	if commoncfg.MarshalSecretValue {
+		return json.Marshal(s.String())
+	}
+	return json.Marshal(SecretToken)
+}
+
+// UnmarshalJSON implements the json.Marshaler interface for SecretURL.
+func (s *SecretURL) UnmarshalJSON(data []byte) error {
+	// In order to deserialize a previously serialized configuration (eg from
+	// the Alertmanager API with amtool), `<secret>` needs to be treated
+	// specially, as it isn't a valid URL.
+	if string(data) == SecretToken || string(data) == SecretTokenJSON {
+		s.URL = &url.URL{}
+		return nil
+	}
+	// Redact the secret URL in case of errors
+	if err := json.Unmarshal(data, (*URL)(s)); err != nil {
+		if commoncfg.MarshalSecretValue {
+			return err
+		}
+		return errors.New(strings.ReplaceAll(err.Error(), string(data), "[REDACTED]"))
+	}
+
+	return nil
+}
+
+// containsTemplating checks if the string contains template syntax.
+func containsTemplating(s string) (bool, error) {
+	if !strings.Contains(s, "{{") {
+		return false, nil
+	}
+	// If it contains template syntax, validate it's actually a valid templ.
+	_, err := template.New("").Parse(s)
+	if err != nil {
+		return true, err
+	}
+	return true, nil
+}
+
+// SecretTemplateURL is a Secret string that represents a URL which may contain
+// Go template syntax. Unlike SecretURL, it allows templated values and only
+// validates non-templated URLs at unmarshal time.
+type SecretTemplateURL commoncfg.Secret
+
+// MarshalYAML implements the yaml.Marshaler interface for SecretTemplateURL.
+func (s SecretTemplateURL) MarshalYAML() (any, error) {
+	if s != "" {
+		if commoncfg.MarshalSecretValue {
+			return string(s), nil
+		}
+		return SecretToken, nil
+	}
+	return nil, nil
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface for SecretTemplateURL.
+func (s *SecretTemplateURL) UnmarshalYAML(unmarshal func(any) error) error {
+	type plain commoncfg.Secret
+	if err := unmarshal((*plain)(s)); err != nil {
+		return err
+	}
+
+	urlStr := string(*s)
+
+	// Skip validation for empty strings or secret token
+	if urlStr == "" || urlStr == SecretToken {
+		return nil
+	}
+
+	// Check if the URL contains template syntax
+	isTemplated, err := containsTemplating(urlStr)
+	if err != nil {
+		return fmt.Errorf("invalid template syntax: %w", err)
+	}
+
+	// Only validate as URL if it's not templated
+	if !isTemplated {
+		if _, err := ParseURL(urlStr); err != nil {
+			return fmt.Errorf("invalid URL: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaler interface for SecretTemplateURL.
+func (s SecretTemplateURL) MarshalJSON() ([]byte, error) {
+	return commoncfg.Secret(s).MarshalJSON()
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface for SecretTemplateURL.
+func (s *SecretTemplateURL) UnmarshalJSON(data []byte) error {
+	if string(data) == SecretToken || string(data) == SecretTokenJSON {
+		*s = ""
+		return nil
+	}
+	// Just unmarshal as a string since Secret doesn't have UnmarshalJSON
+	var str string
+	if err := json.Unmarshal(data, &str); err != nil {
+		return err
+	}
+	*s = SecretTemplateURL(str)
+	return nil
+}
+
+func MustParseURL(s string) *URL {
+	u, err := ParseURL(s)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
+func ParseURL(s string) (*URL, error) {
+	u, err := url.Parse(s)
+	if err != nil {
+		return nil, err
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, fmt.Errorf("unsupported scheme %q for URL", u.Scheme)
+	}
+	if u.Host == "" {
+		return nil, errors.New("missing host for URL")
+	}
+	return &URL{u}, nil
+}

--- a/config/common/url_test.go
+++ b/config/common/url_test.go
@@ -1,0 +1,220 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"encoding/json"
+	"net/url"
+	"testing"
+
+	commoncfg "github.com/prometheus/common/config"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestJSONMarshalHideSecretURL(t *testing.T) {
+	urlp, err := url.Parse("http://example.com/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	u := &SecretURL{urlp}
+
+	c, err := json.Marshal(u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// u003c -> "<"
+	// u003e -> ">"
+	require.Equal(t, "\"\\u003csecret\\u003e\"", string(c), "SecretURL not properly elided in JSON.")
+	// Check that the marshaled data can be unmarshaled again.
+	out := &SecretURL{}
+	err = json.Unmarshal(c, out)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c, err = yaml.Marshal(u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	require.Equal(t, "<secret>\n", string(c), "SecretURL not properly elided in YAML.")
+	// Check that the marshaled data can be unmarshaled again.
+	out = &SecretURL{}
+	err = yaml.Unmarshal(c, &out)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUnmarshalSecretURL(t *testing.T) {
+	b := []byte(`"http://example.com/se cret"`)
+	var u SecretURL
+
+	err := json.Unmarshal(b, &u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	require.Equal(t, "http://example.com/se%20cret", u.String(), "SecretURL not properly unmarshaled in JSON.")
+
+	err = yaml.Unmarshal(b, &u)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	require.Equal(t, "http://example.com/se%20cret", u.String(), "SecretURL not properly unmarshaled in YAML.")
+}
+
+func TestHideSecretURL(t *testing.T) {
+	b := []byte(`"://wrongurl/"`)
+	var u SecretURL
+
+	err := json.Unmarshal(b, &u)
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "wrongurl")
+}
+
+func TestShowMarshalSecretURL(t *testing.T) {
+	commoncfg.MarshalSecretValue = true
+	defer func() { commoncfg.MarshalSecretValue = false }()
+
+	b := []byte(`"://wrongurl/"`)
+	var u SecretURL
+
+	err := json.Unmarshal(b, &u)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "wrongurl")
+}
+
+func TestMarshalURL(t *testing.T) {
+	for name, tc := range map[string]struct {
+		input        *URL
+		expectedJSON string
+		expectedYAML string
+	}{
+		"url": {
+			input:        MustParseURL("http://example.com/"),
+			expectedJSON: "\"http://example.com/\"",
+			expectedYAML: "http://example.com/\n",
+		},
+
+		"wrapped nil value": {
+			input:        &URL{},
+			expectedJSON: "null",
+			expectedYAML: "null\n",
+		},
+
+		"wrapped empty URL": {
+			input:        &URL{&url.URL{}},
+			expectedJSON: "\"\"",
+			expectedYAML: "\"\"\n",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			j, err := json.Marshal(tc.input)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedJSON, string(j), "URL not properly marshaled into JSON.")
+
+			y, err := yaml.Marshal(tc.input)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedYAML, string(y), "URL not properly marshaled into YAML.")
+		})
+	}
+}
+
+func TestUnmarshalNilURL(t *testing.T) {
+	b := []byte(`null`)
+
+	{
+		var u URL
+		err := json.Unmarshal(b, &u)
+		require.Error(t, err, "unsupported scheme \"\" for URL")
+	}
+
+	{
+		var u URL
+		err := yaml.Unmarshal(b, &u)
+		require.NoError(t, err)
+	}
+}
+
+func TestUnmarshalEmptyURL(t *testing.T) {
+	b := []byte(`""`)
+
+	{
+		var u URL
+		err := json.Unmarshal(b, &u)
+		require.Error(t, err, "unsupported scheme \"\" for URL")
+		require.Equal(t, (*url.URL)(nil), u.URL)
+	}
+
+	{
+		var u URL
+		err := yaml.Unmarshal(b, &u)
+		require.Error(t, err, "unsupported scheme \"\" for URL")
+		require.Equal(t, (*url.URL)(nil), u.URL)
+	}
+}
+
+func TestUnmarshalURL(t *testing.T) {
+	b := []byte(`"http://example.com/a b"`)
+	var u URL
+
+	err := json.Unmarshal(b, &u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	require.Equal(t, "http://example.com/a%20b", u.String(), "URL not properly unmarshaled in JSON.")
+
+	err = yaml.Unmarshal(b, &u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	require.Equal(t, "http://example.com/a%20b", u.String(), "URL not properly unmarshaled in YAML.")
+}
+
+func TestUnmarshalInvalidURL(t *testing.T) {
+	for _, b := range [][]byte{
+		[]byte(`"://example.com"`),
+		[]byte(`"http:example.com"`),
+		[]byte(`"telnet://example.com"`),
+	} {
+		var u URL
+
+		err := json.Unmarshal(b, &u)
+		if err == nil {
+			t.Errorf("Expected an error unmarshaling %q from JSON", string(b))
+		}
+
+		err = yaml.Unmarshal(b, &u)
+		if err == nil {
+			t.Errorf("Expected an error unmarshaling %q from YAML", string(b))
+		}
+		t.Logf("%s", err)
+	}
+}
+
+func TestUnmarshalRelativeURL(t *testing.T) {
+	b := []byte(`"/home"`)
+	var u URL
+
+	err := json.Unmarshal(b, &u)
+	if err == nil {
+		t.Errorf("Expected an error parsing URL")
+	}
+
+	err = yaml.Unmarshal(b, &u)
+	if err == nil {
+		t.Errorf("Expected an error parsing URL")
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -32,139 +31,12 @@ import (
 	"github.com/prometheus/common/model"
 	"gopkg.in/yaml.v2"
 
+	amcommoncfg "github.com/prometheus/alertmanager/config/common"
 	"github.com/prometheus/alertmanager/matcher/compat"
 	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/prometheus/alertmanager/timeinterval"
 	"github.com/prometheus/alertmanager/tracing"
 )
-
-const secretToken = "<secret>"
-
-var secretTokenJSON string
-
-func init() {
-	b, err := json.Marshal(secretToken)
-	if err != nil {
-		panic(err)
-	}
-	secretTokenJSON = string(b)
-}
-
-// URL is a custom type that represents an HTTP or HTTPS URL and allows validation at configuration load time.
-type URL struct {
-	*url.URL
-}
-
-// Copy makes a deep-copy of the struct.
-func (u *URL) Copy() *URL {
-	v := *u.URL
-	return &URL{&v}
-}
-
-// MarshalYAML implements the yaml.Marshaler interface for URL.
-func (u URL) MarshalYAML() (any, error) {
-	if u.URL != nil {
-		return u.String(), nil
-	}
-	return nil, nil
-}
-
-// UnmarshalYAML implements the yaml.Unmarshaler interface for URL.
-func (u *URL) UnmarshalYAML(unmarshal func(any) error) error {
-	var s string
-	if err := unmarshal(&s); err != nil {
-		return err
-	}
-	urlp, err := parseURL(s)
-	if err != nil {
-		return err
-	}
-	u.URL = urlp.URL
-	return nil
-}
-
-// MarshalJSON implements the json.Marshaler interface for URL.
-func (u URL) MarshalJSON() ([]byte, error) {
-	if u.URL != nil {
-		return json.Marshal(u.String())
-	}
-	return []byte("null"), nil
-}
-
-// UnmarshalJSON implements the json.Marshaler interface for URL.
-func (u *URL) UnmarshalJSON(data []byte) error {
-	var s string
-	if err := json.Unmarshal(data, &s); err != nil {
-		return err
-	}
-	urlp, err := parseURL(s)
-	if err != nil {
-		return err
-	}
-	u.URL = urlp.URL
-	return nil
-}
-
-// SecretURL is a URL that must not be revealed on marshaling.
-type SecretURL URL
-
-// MarshalYAML implements the yaml.Marshaler interface for SecretURL.
-func (s SecretURL) MarshalYAML() (any, error) {
-	if s.URL != nil {
-		if commoncfg.MarshalSecretValue {
-			return s.String(), nil
-		}
-		return secretToken, nil
-	}
-	return nil, nil
-}
-
-// UnmarshalYAML implements the yaml.Unmarshaler interface for SecretURL.
-func (s *SecretURL) UnmarshalYAML(unmarshal func(any) error) error {
-	var str string
-	if err := unmarshal(&str); err != nil {
-		return err
-	}
-	// In order to deserialize a previously serialized configuration (eg from
-	// the Alertmanager API with amtool), `<secret>` needs to be treated
-	// specially, as it isn't a valid URL.
-	if str == secretToken {
-		s.URL = &url.URL{}
-		return nil
-	}
-	return unmarshal((*URL)(s))
-}
-
-// MarshalJSON implements the json.Marshaler interface for SecretURL.
-func (s SecretURL) MarshalJSON() ([]byte, error) {
-	if s.URL == nil {
-		return json.Marshal("")
-	}
-	if commoncfg.MarshalSecretValue {
-		return json.Marshal(s.String())
-	}
-	return json.Marshal(secretToken)
-}
-
-// UnmarshalJSON implements the json.Marshaler interface for SecretURL.
-func (s *SecretURL) UnmarshalJSON(data []byte) error {
-	// In order to deserialize a previously serialized configuration (eg from
-	// the Alertmanager API with amtool), `<secret>` needs to be treated
-	// specially, as it isn't a valid URL.
-	if string(data) == secretToken || string(data) == secretTokenJSON {
-		s.URL = &url.URL{}
-		return nil
-	}
-	// Redact the secret URL in case of errors
-	if err := json.Unmarshal(data, (*URL)(s)); err != nil {
-		if commoncfg.MarshalSecretValue {
-			return err
-		}
-		return errors.New(strings.ReplaceAll(err.Error(), string(data), "[REDACTED]"))
-	}
-
-	return nil
-}
 
 // containsTemplating checks if the string contains template syntax.
 func containsTemplating(s string) (bool, error) {
@@ -190,7 +62,7 @@ func (s SecretTemplateURL) MarshalYAML() (any, error) {
 		if commoncfg.MarshalSecretValue {
 			return string(s), nil
 		}
-		return secretToken, nil
+		return amcommoncfg.SecretToken, nil
 	}
 	return nil, nil
 }
@@ -205,7 +77,7 @@ func (s *SecretTemplateURL) UnmarshalYAML(unmarshal func(any) error) error {
 	urlStr := string(*s)
 
 	// Skip validation for empty strings or secret token
-	if urlStr == "" || urlStr == secretToken {
+	if urlStr == "" || urlStr == amcommoncfg.SecretToken {
 		return nil
 	}
 
@@ -217,7 +89,7 @@ func (s *SecretTemplateURL) UnmarshalYAML(unmarshal func(any) error) error {
 
 	// Only validate as URL if it's not templated
 	if !isTemplated {
-		if _, err := parseURL(urlStr); err != nil {
+		if _, err := amcommoncfg.ParseURL(urlStr); err != nil {
 			return fmt.Errorf("invalid URL: %w", err)
 		}
 	}
@@ -232,7 +104,7 @@ func (s SecretTemplateURL) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements the json.Unmarshaler interface for SecretTemplateURL.
 func (s *SecretTemplateURL) UnmarshalJSON(data []byte) error {
-	if string(data) == secretToken || string(data) == secretTokenJSON {
+	if string(data) == amcommoncfg.SecretToken || string(data) == amcommoncfg.SecretTokenJSON {
 		*s = ""
 		return nil
 	}
@@ -557,7 +429,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(any) error) error {
 					Credentials:     commoncfg.Secret(sc.AppToken),
 					CredentialsFile: sc.AppTokenFile,
 				}
-				sc.APIURL = (*SecretURL)(sc.AppURL)
+				sc.APIURL = (*amcommoncfg.SecretURL)(sc.AppURL)
 			}
 		}
 		for _, poc := range rcv.PushoverConfigs {
@@ -842,37 +714,15 @@ func DefaultGlobalConfig() GlobalConfig {
 		SMTPHello:        "localhost",
 		SMTPRequireTLS:   true,
 		SMTPTLSConfig:    &defaultSMTPTLSConfig,
-		PagerdutyURL:     mustParseURL("https://events.pagerduty.com/v2/enqueue"),
-		OpsGenieAPIURL:   mustParseURL("https://api.opsgenie.com/"),
-		WeChatAPIURL:     mustParseURL("https://qyapi.weixin.qq.com/cgi-bin/"),
-		VictorOpsAPIURL:  mustParseURL("https://alert.victorops.com/integrations/generic/20131114/alert/"),
-		TelegramAPIUrl:   mustParseURL("https://api.telegram.org"),
-		WebexAPIURL:      mustParseURL("https://webexapis.com/v1/messages"),
-		RocketchatAPIURL: mustParseURL("https://open.rocket.chat/"),
-		SlackAppURL:      mustParseURL("https://slack.com/api/chat.postMessage"),
+		PagerdutyURL:     amcommoncfg.MustParseURL("https://events.pagerduty.com/v2/enqueue"),
+		OpsGenieAPIURL:   amcommoncfg.MustParseURL("https://api.opsgenie.com/"),
+		WeChatAPIURL:     amcommoncfg.MustParseURL("https://qyapi.weixin.qq.com/cgi-bin/"),
+		VictorOpsAPIURL:  amcommoncfg.MustParseURL("https://alert.victorops.com/integrations/generic/20131114/alert/"),
+		TelegramAPIUrl:   amcommoncfg.MustParseURL("https://api.telegram.org"),
+		WebexAPIURL:      amcommoncfg.MustParseURL("https://webexapis.com/v1/messages"),
+		RocketchatAPIURL: amcommoncfg.MustParseURL("https://open.rocket.chat/"),
+		SlackAppURL:      amcommoncfg.MustParseURL("https://slack.com/api/chat.postMessage"),
 	}
-}
-
-func mustParseURL(s string) *URL {
-	u, err := parseURL(s)
-	if err != nil {
-		panic(err)
-	}
-	return u
-}
-
-func parseURL(s string) (*URL, error) {
-	u, err := url.Parse(s)
-	if err != nil {
-		return nil, err
-	}
-	if u.Scheme != "http" && u.Scheme != "https" {
-		return nil, fmt.Errorf("unsupported scheme %q for URL", u.Scheme)
-	}
-	if u.Host == "" {
-		return nil, errors.New("missing host for URL")
-	}
-	return &URL{u}, nil
 }
 
 // HostPort represents a "host:port" network address.
@@ -951,46 +801,46 @@ type GlobalConfig struct {
 
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
-	JiraAPIURL               *URL                 `yaml:"jira_api_url,omitempty" json:"jira_api_url,omitempty"`
-	SMTPFrom                 string               `yaml:"smtp_from,omitempty" json:"smtp_from,omitempty"`
-	SMTPHello                string               `yaml:"smtp_hello,omitempty" json:"smtp_hello,omitempty"`
-	SMTPSmarthost            HostPort             `yaml:"smtp_smarthost,omitempty" json:"smtp_smarthost,omitempty"`
-	SMTPAuthUsername         string               `yaml:"smtp_auth_username,omitempty" json:"smtp_auth_username,omitempty"`
-	SMTPAuthPassword         commoncfg.Secret     `yaml:"smtp_auth_password,omitempty" json:"smtp_auth_password,omitempty"`
-	SMTPAuthPasswordFile     string               `yaml:"smtp_auth_password_file,omitempty" json:"smtp_auth_password_file,omitempty"`
-	SMTPAuthSecret           commoncfg.Secret     `yaml:"smtp_auth_secret,omitempty" json:"smtp_auth_secret,omitempty"`
-	SMTPAuthSecretFile       string               `yaml:"smtp_auth_secret_file,omitempty" json:"smtp_auth_secret_file,omitempty"`
-	SMTPAuthIdentity         string               `yaml:"smtp_auth_identity,omitempty" json:"smtp_auth_identity,omitempty"`
-	SMTPRequireTLS           bool                 `yaml:"smtp_require_tls" json:"smtp_require_tls,omitempty"`
-	SMTPTLSConfig            *commoncfg.TLSConfig `yaml:"smtp_tls_config,omitempty" json:"smtp_tls_config,omitempty"`
-	SMTPForceImplicitTLS     *bool                `yaml:"smtp_force_implicit_tls,omitempty" json:"smtp_force_implicit_tls,omitempty"`
-	SlackAPIURL              *SecretURL           `yaml:"slack_api_url,omitempty" json:"slack_api_url,omitempty"`
-	SlackAPIURLFile          string               `yaml:"slack_api_url_file,omitempty" json:"slack_api_url_file,omitempty"`
-	SlackAppToken            commoncfg.Secret     `yaml:"slack_app_token,omitempty" json:"slack_app_token,omitempty"`
-	SlackAppTokenFile        string               `yaml:"slack_app_token_file,omitempty" json:"slack_app_token_file,omitempty"`
-	SlackAppURL              *URL                 `yaml:"slack_app_url,omitempty" json:"slack_app_url,omitempty"`
-	PagerdutyURL             *URL                 `yaml:"pagerduty_url,omitempty" json:"pagerduty_url,omitempty"`
-	OpsGenieAPIURL           *URL                 `yaml:"opsgenie_api_url,omitempty" json:"opsgenie_api_url,omitempty"`
-	OpsGenieAPIKey           commoncfg.Secret     `yaml:"opsgenie_api_key,omitempty" json:"opsgenie_api_key,omitempty"`
-	OpsGenieAPIKeyFile       string               `yaml:"opsgenie_api_key_file,omitempty" json:"opsgenie_api_key_file,omitempty"`
-	WeChatAPIURL             *URL                 `yaml:"wechat_api_url,omitempty" json:"wechat_api_url,omitempty"`
-	WeChatAPISecret          commoncfg.Secret     `yaml:"wechat_api_secret,omitempty" json:"wechat_api_secret,omitempty"`
-	WeChatAPISecretFile      string               `yaml:"wechat_api_secret_file,omitempty" json:"wechat_api_secret_file,omitempty"`
-	WeChatAPICorpID          string               `yaml:"wechat_api_corp_id,omitempty" json:"wechat_api_corp_id,omitempty"`
-	VictorOpsAPIURL          *URL                 `yaml:"victorops_api_url,omitempty" json:"victorops_api_url,omitempty"`
-	VictorOpsAPIKey          commoncfg.Secret     `yaml:"victorops_api_key,omitempty" json:"victorops_api_key,omitempty"`
-	VictorOpsAPIKeyFile      string               `yaml:"victorops_api_key_file,omitempty" json:"victorops_api_key_file,omitempty"`
-	TelegramAPIUrl           *URL                 `yaml:"telegram_api_url,omitempty" json:"telegram_api_url,omitempty"`
-	TelegramBotToken         commoncfg.Secret     `yaml:"telegram_bot_token,omitempty" json:"telegram_bot_token,omitempty"`
-	TelegramBotTokenFile     string               `yaml:"telegram_bot_token_file,omitempty" json:"telegram_bot_token_file,omitempty"`
-	WebexAPIURL              *URL                 `yaml:"webex_api_url,omitempty" json:"webex_api_url,omitempty"`
-	RocketchatAPIURL         *URL                 `yaml:"rocketchat_api_url,omitempty" json:"rocketchat_api_url,omitempty"`
-	RocketchatToken          *commoncfg.Secret    `yaml:"rocketchat_token,omitempty" json:"rocketchat_token,omitempty"`
-	RocketchatTokenFile      string               `yaml:"rocketchat_token_file,omitempty" json:"rocketchat_token_file,omitempty"`
-	RocketchatTokenID        *commoncfg.Secret    `yaml:"rocketchat_token_id,omitempty" json:"rocketchat_token_id,omitempty"`
-	RocketchatTokenIDFile    string               `yaml:"rocketchat_token_id_file,omitempty" json:"rocketchat_token_id_file,omitempty"`
-	MattermostWebhookURL     *SecretURL           `yaml:"mattermost_webhook_url,omitempty" json:"mattermost_webhook_url,omitempty"`
-	MattermostWebhookURLFile string               `yaml:"mattermost_webhook_url_file,omitempty" json:"mattermost_webhook_url_file,omitempty"`
+	JiraAPIURL               *amcommoncfg.URL       `yaml:"jira_api_url,omitempty" json:"jira_api_url,omitempty"`
+	SMTPFrom                 string                 `yaml:"smtp_from,omitempty" json:"smtp_from,omitempty"`
+	SMTPHello                string                 `yaml:"smtp_hello,omitempty" json:"smtp_hello,omitempty"`
+	SMTPSmarthost            HostPort               `yaml:"smtp_smarthost,omitempty" json:"smtp_smarthost,omitempty"`
+	SMTPAuthUsername         string                 `yaml:"smtp_auth_username,omitempty" json:"smtp_auth_username,omitempty"`
+	SMTPAuthPassword         commoncfg.Secret       `yaml:"smtp_auth_password,omitempty" json:"smtp_auth_password,omitempty"`
+	SMTPAuthPasswordFile     string                 `yaml:"smtp_auth_password_file,omitempty" json:"smtp_auth_password_file,omitempty"`
+	SMTPAuthSecret           commoncfg.Secret       `yaml:"smtp_auth_secret,omitempty" json:"smtp_auth_secret,omitempty"`
+	SMTPAuthSecretFile       string                 `yaml:"smtp_auth_secret_file,omitempty" json:"smtp_auth_secret_file,omitempty"`
+	SMTPAuthIdentity         string                 `yaml:"smtp_auth_identity,omitempty" json:"smtp_auth_identity,omitempty"`
+	SMTPRequireTLS           bool                   `yaml:"smtp_require_tls" json:"smtp_require_tls,omitempty"`
+	SMTPTLSConfig            *commoncfg.TLSConfig   `yaml:"smtp_tls_config,omitempty" json:"smtp_tls_config,omitempty"`
+	SMTPForceImplicitTLS     *bool                  `yaml:"smtp_force_implicit_tls,omitempty" json:"smtp_force_implicit_tls,omitempty"`
+	SlackAPIURL              *amcommoncfg.SecretURL `yaml:"slack_api_url,omitempty" json:"slack_api_url,omitempty"`
+	SlackAPIURLFile          string                 `yaml:"slack_api_url_file,omitempty" json:"slack_api_url_file,omitempty"`
+	SlackAppToken            commoncfg.Secret       `yaml:"slack_app_token,omitempty" json:"slack_app_token,omitempty"`
+	SlackAppTokenFile        string                 `yaml:"slack_app_token_file,omitempty" json:"slack_app_token_file,omitempty"`
+	SlackAppURL              *amcommoncfg.URL       `yaml:"slack_app_url,omitempty" json:"slack_app_url,omitempty"`
+	PagerdutyURL             *amcommoncfg.URL       `yaml:"pagerduty_url,omitempty" json:"pagerduty_url,omitempty"`
+	OpsGenieAPIURL           *amcommoncfg.URL       `yaml:"opsgenie_api_url,omitempty" json:"opsgenie_api_url,omitempty"`
+	OpsGenieAPIKey           commoncfg.Secret       `yaml:"opsgenie_api_key,omitempty" json:"opsgenie_api_key,omitempty"`
+	OpsGenieAPIKeyFile       string                 `yaml:"opsgenie_api_key_file,omitempty" json:"opsgenie_api_key_file,omitempty"`
+	WeChatAPIURL             *amcommoncfg.URL       `yaml:"wechat_api_url,omitempty" json:"wechat_api_url,omitempty"`
+	WeChatAPISecret          commoncfg.Secret       `yaml:"wechat_api_secret,omitempty" json:"wechat_api_secret,omitempty"`
+	WeChatAPISecretFile      string                 `yaml:"wechat_api_secret_file,omitempty" json:"wechat_api_secret_file,omitempty"`
+	WeChatAPICorpID          string                 `yaml:"wechat_api_corp_id,omitempty" json:"wechat_api_corp_id,omitempty"`
+	VictorOpsAPIURL          *amcommoncfg.URL       `yaml:"victorops_api_url,omitempty" json:"victorops_api_url,omitempty"`
+	VictorOpsAPIKey          commoncfg.Secret       `yaml:"victorops_api_key,omitempty" json:"victorops_api_key,omitempty"`
+	VictorOpsAPIKeyFile      string                 `yaml:"victorops_api_key_file,omitempty" json:"victorops_api_key_file,omitempty"`
+	TelegramAPIUrl           *amcommoncfg.URL       `yaml:"telegram_api_url,omitempty" json:"telegram_api_url,omitempty"`
+	TelegramBotToken         commoncfg.Secret       `yaml:"telegram_bot_token,omitempty" json:"telegram_bot_token,omitempty"`
+	TelegramBotTokenFile     string                 `yaml:"telegram_bot_token_file,omitempty" json:"telegram_bot_token_file,omitempty"`
+	WebexAPIURL              *amcommoncfg.URL       `yaml:"webex_api_url,omitempty" json:"webex_api_url,omitempty"`
+	RocketchatAPIURL         *amcommoncfg.URL       `yaml:"rocketchat_api_url,omitempty" json:"rocketchat_api_url,omitempty"`
+	RocketchatToken          *commoncfg.Secret      `yaml:"rocketchat_token,omitempty" json:"rocketchat_token,omitempty"`
+	RocketchatTokenFile      string                 `yaml:"rocketchat_token_file,omitempty" json:"rocketchat_token_file,omitempty"`
+	RocketchatTokenID        *commoncfg.Secret      `yaml:"rocketchat_token_id,omitempty" json:"rocketchat_token_id,omitempty"`
+	RocketchatTokenIDFile    string                 `yaml:"rocketchat_token_id_file,omitempty" json:"rocketchat_token_id_file,omitempty"`
+	MattermostWebhookURL     *amcommoncfg.SecretURL `yaml:"mattermost_webhook_url,omitempty" json:"mattermost_webhook_url,omitempty"`
+	MattermostWebhookURLFile string                 `yaml:"mattermost_webhook_url_file,omitempty" json:"mattermost_webhook_url_file,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for GlobalConfig.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -16,7 +16,6 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"net/url"
 	"os"
 	"reflect"
 	"regexp"
@@ -30,6 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 
+	amcommoncfg "github.com/prometheus/alertmanager/config/common"
 	"github.com/prometheus/alertmanager/featurecontrol"
 	"github.com/prometheus/alertmanager/matcher/compat"
 )
@@ -538,202 +538,6 @@ func TestJSONMarshal(t *testing.T) {
 	}
 }
 
-func TestJSONMarshalHideSecretURL(t *testing.T) {
-	urlp, err := url.Parse("http://example.com/")
-	if err != nil {
-		t.Fatal(err)
-	}
-	u := &SecretURL{urlp}
-
-	c, err := json.Marshal(u)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// u003c -> "<"
-	// u003e -> ">"
-	require.Equal(t, "\"\\u003csecret\\u003e\"", string(c), "SecretURL not properly elided in JSON.")
-	// Check that the marshaled data can be unmarshaled again.
-	out := &SecretURL{}
-	err = json.Unmarshal(c, out)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	c, err = yaml.Marshal(u)
-	if err != nil {
-		t.Fatal(err)
-	}
-	require.Equal(t, "<secret>\n", string(c), "SecretURL not properly elided in YAML.")
-	// Check that the marshaled data can be unmarshaled again.
-	out = &SecretURL{}
-	err = yaml.Unmarshal(c, &out)
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestUnmarshalSecretURL(t *testing.T) {
-	b := []byte(`"http://example.com/se cret"`)
-	var u SecretURL
-
-	err := json.Unmarshal(b, &u)
-	if err != nil {
-		t.Fatal(err)
-	}
-	require.Equal(t, "http://example.com/se%20cret", u.String(), "SecretURL not properly unmarshaled in JSON.")
-
-	err = yaml.Unmarshal(b, &u)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	require.Equal(t, "http://example.com/se%20cret", u.String(), "SecretURL not properly unmarshaled in YAML.")
-}
-
-func TestHideSecretURL(t *testing.T) {
-	b := []byte(`"://wrongurl/"`)
-	var u SecretURL
-
-	err := json.Unmarshal(b, &u)
-	require.Error(t, err)
-	require.NotContains(t, err.Error(), "wrongurl")
-}
-
-func TestShowMarshalSecretURL(t *testing.T) {
-	commoncfg.MarshalSecretValue = true
-	defer func() { commoncfg.MarshalSecretValue = false }()
-
-	b := []byte(`"://wrongurl/"`)
-	var u SecretURL
-
-	err := json.Unmarshal(b, &u)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "wrongurl")
-}
-
-func TestMarshalURL(t *testing.T) {
-	for name, tc := range map[string]struct {
-		input        *URL
-		expectedJSON string
-		expectedYAML string
-	}{
-		"url": {
-			input:        mustParseURL("http://example.com/"),
-			expectedJSON: "\"http://example.com/\"",
-			expectedYAML: "http://example.com/\n",
-		},
-
-		"wrapped nil value": {
-			input:        &URL{},
-			expectedJSON: "null",
-			expectedYAML: "null\n",
-		},
-
-		"wrapped empty URL": {
-			input:        &URL{&url.URL{}},
-			expectedJSON: "\"\"",
-			expectedYAML: "\"\"\n",
-		},
-	} {
-		t.Run(name, func(t *testing.T) {
-			j, err := json.Marshal(tc.input)
-			require.NoError(t, err)
-			require.Equal(t, tc.expectedJSON, string(j), "URL not properly marshaled into JSON.")
-
-			y, err := yaml.Marshal(tc.input)
-			require.NoError(t, err)
-			require.Equal(t, tc.expectedYAML, string(y), "URL not properly marshaled into YAML.")
-		})
-	}
-}
-
-func TestUnmarshalNilURL(t *testing.T) {
-	b := []byte(`null`)
-
-	{
-		var u URL
-		err := json.Unmarshal(b, &u)
-		require.Error(t, err, "unsupported scheme \"\" for URL")
-	}
-
-	{
-		var u URL
-		err := yaml.Unmarshal(b, &u)
-		require.NoError(t, err)
-	}
-}
-
-func TestUnmarshalEmptyURL(t *testing.T) {
-	b := []byte(`""`)
-
-	{
-		var u URL
-		err := json.Unmarshal(b, &u)
-		require.Error(t, err, "unsupported scheme \"\" for URL")
-		require.Equal(t, (*url.URL)(nil), u.URL)
-	}
-
-	{
-		var u URL
-		err := yaml.Unmarshal(b, &u)
-		require.Error(t, err, "unsupported scheme \"\" for URL")
-		require.Equal(t, (*url.URL)(nil), u.URL)
-	}
-}
-
-func TestUnmarshalURL(t *testing.T) {
-	b := []byte(`"http://example.com/a b"`)
-	var u URL
-
-	err := json.Unmarshal(b, &u)
-	if err != nil {
-		t.Fatal(err)
-	}
-	require.Equal(t, "http://example.com/a%20b", u.String(), "URL not properly unmarshaled in JSON.")
-
-	err = yaml.Unmarshal(b, &u)
-	if err != nil {
-		t.Fatal(err)
-	}
-	require.Equal(t, "http://example.com/a%20b", u.String(), "URL not properly unmarshaled in YAML.")
-}
-
-func TestUnmarshalInvalidURL(t *testing.T) {
-	for _, b := range [][]byte{
-		[]byte(`"://example.com"`),
-		[]byte(`"http:example.com"`),
-		[]byte(`"telnet://example.com"`),
-	} {
-		var u URL
-
-		err := json.Unmarshal(b, &u)
-		if err == nil {
-			t.Errorf("Expected an error unmarshaling %q from JSON", string(b))
-		}
-
-		err = yaml.Unmarshal(b, &u)
-		if err == nil {
-			t.Errorf("Expected an error unmarshaling %q from YAML", string(b))
-		}
-		t.Logf("%s", err)
-	}
-}
-
-func TestUnmarshalRelativeURL(t *testing.T) {
-	b := []byte(`"/home"`)
-	var u URL
-
-	err := json.Unmarshal(b, &u)
-	if err == nil {
-		t.Errorf("Expected an error parsing URL")
-	}
-
-	err = yaml.Unmarshal(b, &u)
-	if err == nil {
-		t.Errorf("Expected an error parsing URL")
-	}
-}
-
 func TestMarshalRegexpWithNilValue(t *testing.T) {
 	r := &Regexp{}
 
@@ -869,16 +673,16 @@ func TestEmptyFieldsAndRegex(t *testing.T) {
 			SMTPTLSConfig: &commoncfg.TLSConfig{
 				InsecureSkipVerify: false,
 			},
-			SlackAPIURL:      (*SecretURL)(mustParseURL("http://slack.example.com/")),
-			SlackAppURL:      mustParseURL("https://slack.com/api/chat.postMessage"),
+			SlackAPIURL:      (*amcommoncfg.SecretURL)(amcommoncfg.MustParseURL("http://slack.example.com/")),
+			SlackAppURL:      amcommoncfg.MustParseURL("https://slack.com/api/chat.postMessage"),
 			SMTPRequireTLS:   true,
-			PagerdutyURL:     mustParseURL("https://events.pagerduty.com/v2/enqueue"),
-			OpsGenieAPIURL:   mustParseURL("https://api.opsgenie.com/"),
-			WeChatAPIURL:     mustParseURL("https://qyapi.weixin.qq.com/cgi-bin/"),
-			VictorOpsAPIURL:  mustParseURL("https://alert.victorops.com/integrations/generic/20131114/alert/"),
-			TelegramAPIUrl:   mustParseURL("https://api.telegram.org"),
-			WebexAPIURL:      mustParseURL("https://webexapis.com/v1/messages"),
-			RocketchatAPIURL: mustParseURL("https://open.rocket.chat/"),
+			PagerdutyURL:     amcommoncfg.MustParseURL("https://events.pagerduty.com/v2/enqueue"),
+			OpsGenieAPIURL:   amcommoncfg.MustParseURL("https://api.opsgenie.com/"),
+			WeChatAPIURL:     amcommoncfg.MustParseURL("https://qyapi.weixin.qq.com/cgi-bin/"),
+			VictorOpsAPIURL:  amcommoncfg.MustParseURL("https://alert.victorops.com/integrations/generic/20131114/alert/"),
+			TelegramAPIUrl:   amcommoncfg.MustParseURL("https://api.telegram.org"),
+			WebexAPIURL:      amcommoncfg.MustParseURL("https://webexapis.com/v1/messages"),
+			RocketchatAPIURL: amcommoncfg.MustParseURL("https://open.rocket.chat/"),
 		},
 
 		Templates: []string{

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -23,6 +23,9 @@ import (
 	"time"
 
 	commoncfg "github.com/prometheus/common/config"
+
+	amcommoncfg "github.com/prometheus/alertmanager/config/common"
+
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/sigv4"
 )
@@ -237,7 +240,7 @@ func (nc *NotifierConfig) SendResolved() bool {
 type WebexConfig struct {
 	NotifierConfig `yaml:",inline" json:",inline"`
 	HTTPConfig     *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
-	APIURL         *URL                        `yaml:"api_url,omitempty" json:"api_url,omitempty"`
+	APIURL         *amcommoncfg.URL            `yaml:"api_url,omitempty" json:"api_url,omitempty"`
 
 	Message string `yaml:"message,omitempty" json:"message,omitempty"`
 	RoomID  string `yaml:"room_id" json:"room_id"`
@@ -267,7 +270,7 @@ type DiscordConfig struct {
 	NotifierConfig `yaml:",inline" json:",inline"`
 
 	HTTPConfig     *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
-	WebhookURL     *SecretURL                  `yaml:"webhook_url,omitempty" json:"webhook_url,omitempty"`
+	WebhookURL     *amcommoncfg.SecretURL      `yaml:"webhook_url,omitempty" json:"webhook_url,omitempty"`
 	WebhookURLFile string                      `yaml:"webhook_url_file,omitempty" json:"webhook_url_file,omitempty"`
 
 	Content   string `yaml:"content,omitempty" json:"content,omitempty"`
@@ -376,7 +379,7 @@ type PagerdutyConfig struct {
 	ServiceKeyFile string           `yaml:"service_key_file,omitempty" json:"service_key_file,omitempty"`
 	RoutingKey     commoncfg.Secret `yaml:"routing_key,omitempty" json:"routing_key,omitempty"`
 	RoutingKeyFile string           `yaml:"routing_key_file,omitempty" json:"routing_key_file,omitempty"`
-	URL            *URL             `yaml:"url,omitempty" json:"url,omitempty"`
+	URL            *amcommoncfg.URL `yaml:"url,omitempty" json:"url,omitempty"`
 	Client         string           `yaml:"client,omitempty" json:"client,omitempty"`
 	ClientURL      string           `yaml:"client_url,omitempty" json:"client_url,omitempty"`
 	Description    string           `yaml:"description,omitempty" json:"description,omitempty"`
@@ -527,11 +530,11 @@ type SlackConfig struct {
 
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
-	APIURL       *SecretURL       `yaml:"api_url,omitempty" json:"api_url,omitempty"`
-	APIURLFile   string           `yaml:"api_url_file,omitempty" json:"api_url_file,omitempty"`
-	AppToken     commoncfg.Secret `yaml:"app_token,omitempty" json:"app_token,omitempty"`
-	AppTokenFile string           `yaml:"app_token_file,omitempty" json:"app_token_file,omitempty"`
-	AppURL       *URL             `yaml:"app_url,omitempty" json:"app_url,omitempty"`
+	APIURL       *amcommoncfg.SecretURL `yaml:"api_url,omitempty" json:"api_url,omitempty"`
+	APIURLFile   string                 `yaml:"api_url_file,omitempty" json:"api_url_file,omitempty"`
+	AppToken     commoncfg.Secret       `yaml:"app_token,omitempty" json:"app_token,omitempty"`
+	AppTokenFile string                 `yaml:"app_token_file,omitempty" json:"app_token_file,omitempty"`
+	AppURL       *amcommoncfg.URL       `yaml:"app_url,omitempty" json:"app_url,omitempty"`
 
 	// Slack channel override, (like #other-channel or @username).
 	Channel  string `yaml:"channel,omitempty" json:"channel,omitempty"`
@@ -588,8 +591,8 @@ type IncidentioConfig struct {
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
 	// URL to send POST request to.
-	URL     *URL   `yaml:"url" json:"url"`
-	URLFile string `yaml:"url_file" json:"url_file"`
+	URL     *amcommoncfg.URL `yaml:"url" json:"url"`
+	URLFile string           `yaml:"url_file" json:"url_file"`
 
 	// AlertSourceToken is the key used to authenticate with the alert source in incident.io.
 	AlertSourceToken     commoncfg.Secret `yaml:"alert_source_token,omitempty" json:"alert_source_token,omitempty"`
@@ -679,7 +682,7 @@ type WechatConfig struct {
 	APISecretFile string           `yaml:"api_secret_file,omitempty" json:"api_secret_file,omitempty"`
 	CorpID        string           `yaml:"corp_id,omitempty" json:"corp_id,omitempty"`
 	Message       string           `yaml:"message,omitempty" json:"message,omitempty"`
-	APIURL        *URL             `yaml:"api_url,omitempty" json:"api_url,omitempty"`
+	APIURL        *amcommoncfg.URL `yaml:"api_url,omitempty" json:"api_url,omitempty"`
 	ToUser        string           `yaml:"to_user,omitempty" json:"to_user,omitempty"`
 	ToParty       string           `yaml:"to_party,omitempty" json:"to_party,omitempty"`
 	ToTag         string           `yaml:"to_tag,omitempty" json:"to_tag,omitempty"`
@@ -722,7 +725,7 @@ type OpsGenieConfig struct {
 
 	APIKey       commoncfg.Secret          `yaml:"api_key,omitempty" json:"api_key,omitempty"`
 	APIKeyFile   string                    `yaml:"api_key_file,omitempty" json:"api_key_file,omitempty"`
-	APIURL       *URL                      `yaml:"api_url,omitempty" json:"api_url,omitempty"`
+	APIURL       *amcommoncfg.URL          `yaml:"api_url,omitempty" json:"api_url,omitempty"`
 	Message      string                    `yaml:"message,omitempty" json:"message,omitempty"`
 	Description  string                    `yaml:"description,omitempty" json:"description,omitempty"`
 	Source       string                    `yaml:"source,omitempty" json:"source,omitempty"`
@@ -790,7 +793,7 @@ type VictorOpsConfig struct {
 
 	APIKey            commoncfg.Secret  `yaml:"api_key,omitempty" json:"api_key,omitempty"`
 	APIKeyFile        string            `yaml:"api_key_file,omitempty" json:"api_key_file,omitempty"`
-	APIURL            *URL              `yaml:"api_url" json:"api_url"`
+	APIURL            *amcommoncfg.URL  `yaml:"api_url" json:"api_url"`
 	RoutingKey        string            `yaml:"routing_key" json:"routing_key"`
 	MessageType       string            `yaml:"message_type" json:"message_type"`
 	StateMessage      string            `yaml:"state_message" json:"state_message"`
@@ -920,7 +923,7 @@ type TelegramConfig struct {
 
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
-	APIUrl               *URL             `yaml:"api_url" json:"api_url,omitempty"`
+	APIUrl               *amcommoncfg.URL `yaml:"api_url" json:"api_url,omitempty"`
 	BotToken             commoncfg.Secret `yaml:"bot_token,omitempty" json:"token,omitempty"`
 	BotTokenFile         string           `yaml:"bot_token_file,omitempty" json:"token_file,omitempty"`
 	ChatID               int64            `yaml:"chat_id,omitempty" json:"chat,omitempty"`
@@ -959,7 +962,7 @@ func (c *TelegramConfig) UnmarshalYAML(unmarshal func(any) error) error {
 type MSTeamsConfig struct {
 	NotifierConfig `yaml:",inline" json:",inline"`
 	HTTPConfig     *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
-	WebhookURL     *SecretURL                  `yaml:"webhook_url,omitempty" json:"webhook_url,omitempty"`
+	WebhookURL     *amcommoncfg.SecretURL      `yaml:"webhook_url,omitempty" json:"webhook_url,omitempty"`
 	WebhookURLFile string                      `yaml:"webhook_url_file,omitempty" json:"webhook_url_file,omitempty"`
 
 	Title   string `yaml:"title,omitempty" json:"title,omitempty"`
@@ -988,7 +991,7 @@ func (c *MSTeamsConfig) UnmarshalYAML(unmarshal func(any) error) error {
 type MSTeamsV2Config struct {
 	NotifierConfig `yaml:",inline" json:",inline"`
 	HTTPConfig     *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
-	WebhookURL     *SecretURL                  `yaml:"webhook_url,omitempty" json:"webhook_url,omitempty"`
+	WebhookURL     *amcommoncfg.SecretURL      `yaml:"webhook_url,omitempty" json:"webhook_url,omitempty"`
 	WebhookURLFile string                      `yaml:"webhook_url_file,omitempty" json:"webhook_url_file,omitempty"`
 
 	Title string `yaml:"title,omitempty" json:"title,omitempty"`
@@ -1024,8 +1027,8 @@ type JiraConfig struct {
 	NotifierConfig `yaml:",inline" json:",inline"`
 	HTTPConfig     *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
-	APIURL  *URL   `yaml:"api_url,omitempty" json:"api_url,omitempty"`
-	APIType string `yaml:"api_type,omitempty" json:"api_type,omitempty"`
+	APIURL  *amcommoncfg.URL `yaml:"api_url,omitempty" json:"api_url,omitempty"`
+	APIType string           `yaml:"api_type,omitempty" json:"api_type,omitempty"`
 
 	Project     string          `yaml:"project,omitempty" json:"project,omitempty"`
 	Summary     JiraFieldConfig `yaml:"summary,omitempty" json:"summary,omitempty"`
@@ -1114,7 +1117,7 @@ type RocketchatConfig struct {
 
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
-	APIURL      *URL              `yaml:"api_url,omitempty" json:"api_url,omitempty"`
+	APIURL      *amcommoncfg.URL  `yaml:"api_url,omitempty" json:"api_url,omitempty"`
 	TokenID     *commoncfg.Secret `yaml:"token_id,omitempty" json:"token_id,omitempty"`
 	TokenIDFile string            `yaml:"token_id_file,omitempty" json:"token_id_file,omitempty"`
 	Token       *commoncfg.Secret `yaml:"token,omitempty" json:"token,omitempty"`
@@ -1214,7 +1217,7 @@ type MattermostConfig struct {
 	NotifierConfig `yaml:",inline" json:",inline"`
 
 	HTTPConfig     *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
-	WebhookURL     *SecretURL                  `yaml:"webhook_url,omitempty" json:"webhook_url,omitempty"`
+	WebhookURL     *amcommoncfg.SecretURL      `yaml:"webhook_url,omitempty" json:"webhook_url,omitempty"`
 	WebhookURLFile string                      `yaml:"webhook_url_file,omitempty" json:"webhook_url_file,omitempty"`
 
 	Channel  string `yaml:"channel,omitempty" json:"channel,omitempty"`

--- a/notify/discord/discord.go
+++ b/notify/discord/discord.go
@@ -27,6 +27,8 @@ import (
 	commoncfg "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 
+	amcommoncfg "github.com/prometheus/alertmanager/config/common"
+
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/template"
@@ -55,7 +57,7 @@ type Notifier struct {
 	logger     *slog.Logger
 	client     *http.Client
 	retrier    *notify.Retrier
-	webhookURL *config.SecretURL
+	webhookURL *amcommoncfg.SecretURL
 }
 
 // New returns a new Discord notifier.

--- a/notify/discord/discord_test.go
+++ b/notify/discord/discord_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 
+	amcommoncfg "github.com/prometheus/alertmanager/config/common"
+
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/notify/test"
@@ -41,7 +43,7 @@ var testWebhookURL, _ = url.Parse("https://discord.com/api/webhooks/971139602272
 func TestDiscordRetry(t *testing.T) {
 	notifier, err := New(
 		&config.DiscordConfig{
-			WebhookURL: &config.SecretURL{URL: testWebhookURL},
+			WebhookURL: &amcommoncfg.SecretURL{URL: testWebhookURL},
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),
@@ -99,7 +101,7 @@ func TestDiscordTemplating(t *testing.T) {
 		},
 	} {
 		t.Run(tc.title, func(t *testing.T) {
-			tc.cfg.WebhookURL = &config.SecretURL{URL: u}
+			tc.cfg.WebhookURL = &amcommoncfg.SecretURL{URL: u}
 			tc.cfg.HTTPConfig = &commoncfg.HTTPClientConfig{}
 			pd, err := New(tc.cfg, test.CreateTmpl(t), promslog.NewNopLogger())
 			require.NoError(t, err)
@@ -136,7 +138,7 @@ func TestDiscordRedactedURL(t *testing.T) {
 	secret := "secret"
 	notifier, err := New(
 		&config.DiscordConfig{
-			WebhookURL: &config.SecretURL{URL: u},
+			WebhookURL: &amcommoncfg.SecretURL{URL: u},
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),

--- a/notify/incidentio/incidentio_test.go
+++ b/notify/incidentio/incidentio_test.go
@@ -30,6 +30,8 @@ import (
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 
+	amcommoncfg "github.com/prometheus/alertmanager/config/common"
+
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/notify/test"
@@ -39,7 +41,7 @@ import (
 func TestIncidentIORetry(t *testing.T) {
 	notifier, err := New(
 		&config.IncidentioConfig{
-			URL:              &config.URL{URL: &url.URL{Scheme: "https", Host: "example.com"}},
+			URL:              &amcommoncfg.URL{URL: &url.URL{Scheme: "https", Host: "example.com"}},
 			HTTPConfig:       &commoncfg.HTTPClientConfig{},
 			AlertSourceToken: "test-token",
 		},
@@ -61,7 +63,7 @@ func TestIncidentIORedactedURL(t *testing.T) {
 
 	notifier, err := New(
 		&config.IncidentioConfig{
-			URL:              &config.URL{URL: u},
+			URL:              &amcommoncfg.URL{URL: u},
 			HTTPConfig:       &commoncfg.HTTPClientConfig{},
 			AlertSourceToken: "test-token",
 		},
@@ -137,7 +139,7 @@ func TestIncidentIONotify(t *testing.T) {
 
 	notifier, err := New(
 		&config.IncidentioConfig{
-			URL:              &config.URL{URL: u},
+			URL:              &amcommoncfg.URL{URL: u},
 			HTTPConfig:       &commoncfg.HTTPClientConfig{},
 			AlertSourceToken: "test-token",
 		},
@@ -218,7 +220,7 @@ func TestIncidentIORetryScenarios(t *testing.T) {
 
 			notifier, err := New(
 				&config.IncidentioConfig{
-					URL:              &config.URL{URL: u},
+					URL:              &amcommoncfg.URL{URL: u},
 					HTTPConfig:       &commoncfg.HTTPClientConfig{},
 					AlertSourceToken: "test-token",
 				},
@@ -307,7 +309,7 @@ func TestIncidentIOPayloadTruncation(t *testing.T) {
 
 	notifier, err := New(
 		&config.IncidentioConfig{
-			URL:              &config.URL{URL: &url.URL{Scheme: "https", Host: "example.com"}},
+			URL:              &amcommoncfg.URL{URL: &url.URL{Scheme: "https", Host: "example.com"}},
 			HTTPConfig:       &commoncfg.HTTPClientConfig{},
 			AlertSourceToken: "test-token",
 		},
@@ -383,7 +385,7 @@ func TestIncidentIOPayloadTruncationWithLabelTruncation(t *testing.T) {
 
 	notifier, err := New(
 		&config.IncidentioConfig{
-			URL:              &config.URL{URL: &url.URL{Scheme: "https", Host: "example.com"}},
+			URL:              &amcommoncfg.URL{URL: &url.URL{Scheme: "https", Host: "example.com"}},
 			HTTPConfig:       &commoncfg.HTTPClientConfig{},
 			AlertSourceToken: "test-token",
 		},

--- a/notify/jira/jira_test.go
+++ b/notify/jira/jira_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 
+	amcommoncfg "github.com/prometheus/alertmanager/config/common"
+
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/notify/test"
@@ -51,7 +53,7 @@ func boolPtr(v bool) *bool {
 func TestJiraRetry(t *testing.T) {
 	notifier, err := New(
 		&config.JiraConfig{
-			APIURL: &config.URL{
+			APIURL: &amcommoncfg.URL{
 				URL: &url.URL{
 					Scheme: "https",
 					Host:   "example.atlassian.net",
@@ -156,7 +158,7 @@ func TestSearchExistingIssue(t *testing.T) {
 	} {
 		t.Run(tc.title, func(t *testing.T) {
 			expectedJQL = tc.expectedJQL
-			tc.cfg.APIURL = &config.URL{URL: u}
+			tc.cfg.APIURL = &amcommoncfg.URL{URL: u}
 			tc.cfg.HTTPConfig = &commoncfg.HTTPClientConfig{}
 
 			as := []*types.Alert{
@@ -209,7 +211,7 @@ func TestPrepareSearchRequest(t *testing.T) {
 			title: "cloud API type",
 			cfg: &config.JiraConfig{
 				APIType: "cloud",
-				APIURL: &config.URL{
+				APIURL: &amcommoncfg.URL{
 					URL: &url.URL{
 						Scheme: "https",
 						Host:   "example.atlassian.net",
@@ -230,7 +232,7 @@ func TestPrepareSearchRequest(t *testing.T) {
 			title: "auto API type with atlassian.net url",
 			cfg: &config.JiraConfig{
 				APIType: "auto",
-				APIURL: &config.URL{
+				APIURL: &amcommoncfg.URL{
 					URL: &url.URL{
 						Scheme: "https",
 						Host:   "example.atlassian.net",
@@ -251,7 +253,7 @@ func TestPrepareSearchRequest(t *testing.T) {
 			title: "auto API type without atlassian.net url",
 			cfg: &config.JiraConfig{
 				APIType: "auto",
-				APIURL: &config.URL{
+				APIURL: &amcommoncfg.URL{
 					URL: &url.URL{
 						Scheme: "https",
 						Host:   "jira.example.com",
@@ -272,7 +274,7 @@ func TestPrepareSearchRequest(t *testing.T) {
 			title: "atlassian.net URL suffix but datacenter api type",
 			cfg: &config.JiraConfig{
 				APIType: "datacenter",
-				APIURL: &config.URL{
+				APIURL: &amcommoncfg.URL{
 					URL: &url.URL{
 						Scheme: "https",
 						Host:   "example.atlassian.net",
@@ -293,7 +295,7 @@ func TestPrepareSearchRequest(t *testing.T) {
 			title: "datacenter API type",
 			cfg: &config.JiraConfig{
 				APIType: "datacenter",
-				APIURL: &config.URL{
+				APIURL: &amcommoncfg.URL{
 					URL: &url.URL{
 						Scheme: "https",
 						Host:   "jira.example.com",
@@ -415,7 +417,7 @@ func TestJiraTemplating(t *testing.T) {
 		t.Run(tc.title, func(t *testing.T) {
 			capturedBody = nil
 
-			tc.cfg.APIURL = &config.URL{URL: u}
+			tc.cfg.APIURL = &amcommoncfg.URL{URL: u}
 			tc.cfg.HTTPConfig = &commoncfg.HTTPClientConfig{}
 			pd, err := New(tc.cfg, test.CreateTmpl(t), promslog.NewNopLogger())
 			require.NoError(t, err)
@@ -1014,7 +1016,7 @@ func TestJiraNotify(t *testing.T) {
 			defer srv.Close()
 			u, _ := url.Parse(srv.URL)
 
-			tc.cfg.APIURL = &config.URL{URL: u}
+			tc.cfg.APIURL = &amcommoncfg.URL{URL: u}
 			tc.cfg.HTTPConfig = &commoncfg.HTTPClientConfig{}
 
 			notifier, err := New(tc.cfg, test.CreateTmpl(t), promslog.NewNopLogger())
@@ -1270,7 +1272,7 @@ func TestPrepareIssueRequestBodyAPIv3DescriptionValidation(t *testing.T) {
 				Project:     "OPS",
 				Labels:      []string{"alertmanager"},
 				Priority:    `{{ template "jira.default.priority" . }}`,
-				APIURL: &config.URL{
+				APIURL: &amcommoncfg.URL{
 					URL: &url.URL{
 						Scheme: "https",
 						Host:   "example.atlassian.net",

--- a/notify/mattermost/mattermost_test.go
+++ b/notify/mattermost/mattermost_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 
+	amcommoncfg "github.com/prometheus/alertmanager/config/common"
+
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/notify/test"
@@ -40,7 +42,7 @@ var testWebhookURL, _ = url.Parse("https://mattermost.example.com/hooks/xxxxxxxx
 func TestMattermostRetry(t *testing.T) {
 	notifier, err := New(
 		&config.MattermostConfig{
-			WebhookURL: &config.SecretURL{URL: testWebhookURL},
+			WebhookURL: &amcommoncfg.SecretURL{URL: testWebhookURL},
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),
@@ -88,7 +90,7 @@ func TestMattermostTemplating(t *testing.T) {
 		},
 	} {
 		t.Run(tc.title, func(t *testing.T) {
-			tc.cfg.WebhookURL = &config.SecretURL{URL: u}
+			tc.cfg.WebhookURL = &amcommoncfg.SecretURL{URL: u}
 			tc.cfg.HTTPConfig = &commoncfg.HTTPClientConfig{}
 			pd, err := New(tc.cfg, test.CreateTmpl(t), promslog.NewNopLogger())
 			require.NoError(t, err)
@@ -125,7 +127,7 @@ func TestMattermostRedactedURL(t *testing.T) {
 	secret := "secret"
 	notifier, err := New(
 		&config.MattermostConfig{
-			WebhookURL: &config.SecretURL{URL: u},
+			WebhookURL: &amcommoncfg.SecretURL{URL: u},
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),

--- a/notify/msteams/msteams.go
+++ b/notify/msteams/msteams.go
@@ -27,6 +27,8 @@ import (
 	commoncfg "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 
+	amcommoncfg "github.com/prometheus/alertmanager/config/common"
+
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/template"
@@ -45,7 +47,7 @@ type Notifier struct {
 	logger       *slog.Logger
 	client       *http.Client
 	retrier      *notify.Retrier
-	webhookURL   *config.SecretURL
+	webhookURL   *amcommoncfg.SecretURL
 	postJSONFunc func(ctx context.Context, client *http.Client, url string, body io.Reader) (*http.Response, error)
 }
 

--- a/notify/msteams/msteams_test.go
+++ b/notify/msteams/msteams_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 
+	amcommoncfg "github.com/prometheus/alertmanager/config/common"
+
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/notify/test"
@@ -41,7 +43,7 @@ var testWebhookURL, _ = url.Parse("https://example.webhook.office.com/webhookb2/
 func TestMSTeamsRetry(t *testing.T) {
 	notifier, err := New(
 		&config.MSTeamsConfig{
-			WebhookURL: &config.SecretURL{URL: testWebhookURL},
+			WebhookURL: &amcommoncfg.SecretURL{URL: testWebhookURL},
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),
@@ -109,7 +111,7 @@ func TestMSTeamsTemplating(t *testing.T) {
 		},
 	} {
 		t.Run(tc.title, func(t *testing.T) {
-			tc.cfg.WebhookURL = &config.SecretURL{URL: u}
+			tc.cfg.WebhookURL = &amcommoncfg.SecretURL{URL: u}
 			tc.cfg.HTTPConfig = &commoncfg.HTTPClientConfig{}
 			pd, err := New(tc.cfg, test.CreateTmpl(t), promslog.NewNopLogger())
 			require.NoError(t, err)
@@ -158,7 +160,7 @@ func TestNotifier_Notify_WithReason(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			notifier, err := New(
 				&config.MSTeamsConfig{
-					WebhookURL: &config.SecretURL{URL: testWebhookURL},
+					WebhookURL: &amcommoncfg.SecretURL{URL: testWebhookURL},
 					HTTPConfig: &commoncfg.HTTPClientConfig{},
 				},
 				test.CreateTmpl(t),
@@ -200,7 +202,7 @@ func TestMSTeamsRedactedURL(t *testing.T) {
 	secret := "secret"
 	notifier, err := New(
 		&config.MSTeamsConfig{
-			WebhookURL: &config.SecretURL{URL: u},
+			WebhookURL: &amcommoncfg.SecretURL{URL: u},
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),

--- a/notify/msteamsv2/msteamsv2.go
+++ b/notify/msteamsv2/msteamsv2.go
@@ -27,6 +27,8 @@ import (
 	commoncfg "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 
+	amcommoncfg "github.com/prometheus/alertmanager/config/common"
+
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/template"
@@ -45,7 +47,7 @@ type Notifier struct {
 	logger       *slog.Logger
 	client       *http.Client
 	retrier      *notify.Retrier
-	webhookURL   *config.SecretURL
+	webhookURL   *amcommoncfg.SecretURL
 	postJSONFunc func(ctx context.Context, client *http.Client, url string, body io.Reader) (*http.Response, error)
 }
 

--- a/notify/msteamsv2/msteamsv2_test.go
+++ b/notify/msteamsv2/msteamsv2_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 
+	amcommoncfg "github.com/prometheus/alertmanager/config/common"
+
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/notify/test"
@@ -41,7 +43,7 @@ var testWebhookURL, _ = url.Parse("https://example.westeurope.logic.azure.com:44
 func TestMSTeamsV2Retry(t *testing.T) {
 	notifier, err := New(
 		&config.MSTeamsV2Config{
-			WebhookURL: &config.SecretURL{URL: testWebhookURL},
+			WebhookURL: &amcommoncfg.SecretURL{URL: testWebhookURL},
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),
@@ -74,7 +76,7 @@ func TestNotifier_Notify_WithReason(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			notifier, err := New(
 				&config.MSTeamsV2Config{
-					WebhookURL: &config.SecretURL{URL: testWebhookURL},
+					WebhookURL: &amcommoncfg.SecretURL{URL: testWebhookURL},
 					HTTPConfig: &commoncfg.HTTPClientConfig{},
 				},
 				test.CreateTmpl(t),
@@ -153,7 +155,7 @@ func TestMSTeamsV2Templating(t *testing.T) {
 		},
 	} {
 		t.Run(tc.title, func(t *testing.T) {
-			tc.cfg.WebhookURL = &config.SecretURL{URL: u}
+			tc.cfg.WebhookURL = &amcommoncfg.SecretURL{URL: u}
 			tc.cfg.HTTPConfig = &commoncfg.HTTPClientConfig{}
 			pd, err := New(tc.cfg, test.CreateTmpl(t), promslog.NewNopLogger())
 			require.NoError(t, err)
@@ -190,7 +192,7 @@ func TestMSTeamsV2RedactedURL(t *testing.T) {
 	secret := "secret"
 	notifier, err := New(
 		&config.MSTeamsV2Config{
-			WebhookURL: &config.SecretURL{URL: u},
+			WebhookURL: &amcommoncfg.SecretURL{URL: u},
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),

--- a/notify/opsgenie/opsgenie_test.go
+++ b/notify/opsgenie/opsgenie_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 
+	amcommoncfg "github.com/prometheus/alertmanager/config/common"
+
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/notify/test"
@@ -58,7 +60,7 @@ func TestOpsGenieRedactedURL(t *testing.T) {
 	key := "key"
 	notifier, err := New(
 		&config.OpsGenieConfig{
-			APIURL:     &config.URL{URL: u},
+			APIURL:     &amcommoncfg.URL{URL: u},
 			APIKey:     commoncfg.Secret(key),
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 		},
@@ -83,7 +85,7 @@ func TestGettingOpsGegineApikeyFromFile(t *testing.T) {
 
 	notifier, err := New(
 		&config.OpsGenieConfig{
-			APIURL:     &config.URL{URL: u},
+			APIURL:     &amcommoncfg.URL{URL: u},
 			APIKeyFile: f.Name(),
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 		},
@@ -135,7 +137,7 @@ func TestOpsGenie(t *testing.T) {
 				Entity:     `{{ .CommonLabels.Entity }}`,
 				Actions:    `{{ .CommonLabels.Actions }}`,
 				APIKey:     `{{ .ExternalURL }}`,
-				APIURL:     &config.URL{URL: u},
+				APIURL:     &amcommoncfg.URL{URL: u},
 				HTTPConfig: &commoncfg.HTTPClientConfig{},
 			},
 			expectedEmptyAlertBody: `{"alias":"6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b","message":"","details":{},"source":""}
@@ -171,7 +173,7 @@ func TestOpsGenie(t *testing.T) {
 				Entity:     `{{ .CommonLabels.Entity }}`,
 				Actions:    `{{ .CommonLabels.Actions }}`,
 				APIKey:     `{{ .ExternalURL }}`,
-				APIURL:     &config.URL{URL: u},
+				APIURL:     &amcommoncfg.URL{URL: u},
 				HTTPConfig: &commoncfg.HTTPClientConfig{},
 			},
 			expectedEmptyAlertBody: `{"alias":"6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b","message":"","details":{"Description":"adjusted "},"source":""}
@@ -201,7 +203,7 @@ func TestOpsGenie(t *testing.T) {
 				Note:       `{{ .CommonLabels.Note }}`,
 				Priority:   `{{ .CommonLabels.Priority }}`,
 				APIKey:     `{{ .ExternalURL }}`,
-				APIURL:     &config.URL{URL: u},
+				APIURL:     &amcommoncfg.URL{URL: u},
 				HTTPConfig: &commoncfg.HTTPClientConfig{},
 			},
 			expectedEmptyAlertBody: `{"alias":"6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b","message":"","details":{"Description":"adjusted "},"source":""}
@@ -284,7 +286,7 @@ func TestOpsGenieWithUpdate(t *testing.T) {
 		Description:  `{{ .CommonLabels.Description }}`,
 		UpdateAlerts: true,
 		APIKey:       "test-api-key",
-		APIURL:       &config.URL{URL: u},
+		APIURL:       &amcommoncfg.URL{URL: u},
 		HTTPConfig:   &commoncfg.HTTPClientConfig{},
 	}
 	notifierWithUpdate, err := New(&opsGenieConfigWithUpdate, tmpl, promslog.NewNopLogger())
@@ -327,7 +329,7 @@ func TestOpsGenieApiKeyFile(t *testing.T) {
 	ctx = notify.WithGroupKey(ctx, "1")
 	opsGenieConfigWithUpdate := config.OpsGenieConfig{
 		APIKeyFile: `./api_key_file`,
-		APIURL:     &config.URL{URL: u},
+		APIURL:     &amcommoncfg.URL{URL: u},
 		HTTPConfig: &commoncfg.HTTPClientConfig{},
 	}
 	notifierWithUpdate, err := New(&opsGenieConfigWithUpdate, tmpl, promslog.NewNopLogger())

--- a/notify/pagerduty/pagerduty_test.go
+++ b/notify/pagerduty/pagerduty_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 
+	amcommoncfg "github.com/prometheus/alertmanager/config/common"
+
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/notify/test"
@@ -100,7 +102,7 @@ func TestPagerDutyRedactedURLV2(t *testing.T) {
 	key := "01234567890123456789012345678901"
 	notifier, err := New(
 		&config.PagerdutyConfig{
-			URL:        &config.URL{URL: u},
+			URL:        &amcommoncfg.URL{URL: u},
 			RoutingKey: commoncfg.Secret(key),
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 		},
@@ -148,7 +150,7 @@ func TestPagerDutyV2RoutingKeyFromFile(t *testing.T) {
 
 	notifier, err := New(
 		&config.PagerdutyConfig{
-			URL:            &config.URL{URL: u},
+			URL:            &amcommoncfg.URL{URL: u},
 			RoutingKeyFile: f.Name(),
 			HTTPConfig:     &commoncfg.HTTPClientConfig{},
 		},
@@ -308,7 +310,7 @@ func TestPagerDutyTemplating(t *testing.T) {
 		},
 	} {
 		t.Run(tc.title, func(t *testing.T) {
-			tc.cfg.URL = &config.URL{URL: u}
+			tc.cfg.URL = &amcommoncfg.URL{URL: u}
 			tc.cfg.HTTPConfig = &commoncfg.HTTPClientConfig{}
 			pd, err := New(tc.cfg, test.CreateTmpl(t), promslog.NewNopLogger())
 			require.NoError(t, err)
@@ -534,7 +536,7 @@ func TestPagerDutyEmptySrcHref(t *testing.T) {
 	pagerDutyConfig := config.PagerdutyConfig{
 		HTTPConfig: &commoncfg.HTTPClientConfig{},
 		RoutingKey: commoncfg.Secret("01234567890123456789012345678901"),
-		URL:        &config.URL{URL: url},
+		URL:        &amcommoncfg.URL{URL: url},
 		Images:     images,
 		Links:      links,
 	}
@@ -602,7 +604,7 @@ func TestPagerDutyTimeout(t *testing.T) {
 			cfg := config.PagerdutyConfig{
 				HTTPConfig: &commoncfg.HTTPClientConfig{},
 				RoutingKey: commoncfg.Secret("01234567890123456789012345678901"),
-				URL:        &config.URL{URL: u},
+				URL:        &amcommoncfg.URL{URL: u},
 				Timeout:    tt.timeout,
 			}
 

--- a/notify/rocketchat/rocketchat_test.go
+++ b/notify/rocketchat/rocketchat_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 
+	amcommoncfg "github.com/prometheus/alertmanager/config/common"
+
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify/test"
 )
@@ -56,7 +58,7 @@ func TestGettingRocketchatTokenFromFile(t *testing.T) {
 			TokenFile:   f.Name(),
 			TokenIDFile: f.Name(),
 			HTTPConfig:  &commoncfg.HTTPClientConfig{},
-			APIURL:      &config.URL{URL: &url.URL{Scheme: "http", Host: "example.com", Path: "/api/v1/"}},
+			APIURL:      &amcommoncfg.URL{URL: &url.URL{Scheme: "http", Host: "example.com", Path: "/api/v1/"}},
 		},
 		test.CreateTmpl(t),
 		promslog.NewNopLogger(),

--- a/notify/slack/slack_test.go
+++ b/notify/slack/slack_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 
+	amcommoncfg "github.com/prometheus/alertmanager/config/common"
+
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/notify/test"
@@ -60,7 +62,7 @@ func TestSlackRedactedURL(t *testing.T) {
 
 	notifier, err := New(
 		&config.SlackConfig{
-			APIURL:     &config.SecretURL{URL: u},
+			APIURL:     &amcommoncfg.SecretURL{URL: u},
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),
@@ -197,7 +199,7 @@ func TestNotifier_Notify_WithReason(t *testing.T) {
 				&config.SlackConfig{
 					NotifierConfig: config.NotifierConfig{},
 					HTTPConfig:     &commoncfg.HTTPClientConfig{},
-					APIURL:         &config.SecretURL{URL: apiurl},
+					APIURL:         &amcommoncfg.SecretURL{URL: apiurl},
 					Channel:        "channelname",
 				},
 				test.CreateTmpl(t),
@@ -255,7 +257,7 @@ func TestSlackTimeout(t *testing.T) {
 				&config.SlackConfig{
 					NotifierConfig: config.NotifierConfig{},
 					HTTPConfig:     &commoncfg.HTTPClientConfig{},
-					APIURL:         &config.SecretURL{URL: u},
+					APIURL:         &amcommoncfg.SecretURL{URL: u},
 					Channel:        "channelname",
 					Timeout:        tt.timeout,
 				},
@@ -324,7 +326,7 @@ func TestSlackMessageField(t *testing.T) {
 	// 4. Configure Notifier with BOTH new and old fields
 	u, _ := url.Parse(server.URL)
 	conf := &config.SlackConfig{
-		APIURL:      &config.SecretURL{URL: u},
+		APIURL:      &amcommoncfg.SecretURL{URL: u},
 		MessageText: "My Top Level Message", // Your NEW field
 		Title:       "Old Attachment Title", // An OLD field
 		Channel:     "#test-channel",

--- a/notify/telegram/telegram_test.go
+++ b/notify/telegram/telegram_test.go
@@ -30,6 +30,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 
+	amcommoncfg "github.com/prometheus/alertmanager/config/common"
+
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/notify/test"
@@ -63,7 +65,7 @@ receivers:
 
 func TestTelegramRetry(t *testing.T) {
 	// Fake url for testing purposes
-	fakeURL := config.URL{
+	fakeURL := amcommoncfg.URL{
 		URL: &url.URL{
 			Scheme: "https",
 			Host:   "FAKE_API",
@@ -139,7 +141,7 @@ func TestTelegramNotify(t *testing.T) {
 			defer srv.Close()
 			u, _ := url.Parse(srv.URL)
 
-			tc.cfg.APIUrl = &config.URL{URL: u}
+			tc.cfg.APIUrl = &amcommoncfg.URL{URL: u}
 
 			notifier, err := New(&tc.cfg, test.CreateTmpl(t), promslog.NewNopLogger())
 			require.NoError(t, err)

--- a/notify/victorops/victorops_test.go
+++ b/notify/victorops/victorops_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 
+	amcommoncfg "github.com/prometheus/alertmanager/config/common"
+
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/notify/test"
@@ -44,7 +46,7 @@ func TestVictorOpsCustomFields(t *testing.T) {
 
 	conf := &config.VictorOpsConfig{
 		APIKey:            `12345`,
-		APIURL:            &config.URL{URL: url},
+		APIURL:            &amcommoncfg.URL{URL: url},
 		EntityDisplayName: `{{ .CommonLabels.Message }}`,
 		StateMessage:      `{{ .CommonLabels.Message }}`,
 		RoutingKey:        `test`,
@@ -107,7 +109,7 @@ func TestVictorOpsRedactedURL(t *testing.T) {
 	secret := "secret"
 	notifier, err := New(
 		&config.VictorOpsConfig{
-			APIURL:     &config.URL{URL: u},
+			APIURL:     &amcommoncfg.URL{URL: u},
 			APIKey:     commoncfg.Secret(secret),
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 		},
@@ -131,7 +133,7 @@ func TestVictorOpsReadingApiKeyFromFile(t *testing.T) {
 
 	notifier, err := New(
 		&config.VictorOpsConfig{
-			APIURL:     &config.URL{URL: u},
+			APIURL:     &amcommoncfg.URL{URL: u},
 			APIKeyFile: f.Name(),
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 		},
@@ -204,7 +206,7 @@ func TestVictorOpsTemplating(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.cfg.HTTPConfig = &commoncfg.HTTPClientConfig{}
-			tc.cfg.APIURL = &config.URL{URL: u}
+			tc.cfg.APIURL = &amcommoncfg.URL{URL: u}
 			tc.cfg.APIKey = "test"
 			vo, err := New(tc.cfg, test.CreateTmpl(t), promslog.NewNopLogger())
 			require.NoError(t, err)

--- a/notify/webex/webex_test.go
+++ b/notify/webex/webex_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 
+	amcommoncfg "github.com/prometheus/alertmanager/config/common"
+
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/notify/test"
@@ -40,7 +42,7 @@ func TestWebexRetry(t *testing.T) {
 	notifier, err := New(
 		&config.WebexConfig{
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
-			APIURL:     &config.URL{URL: testWebhookURL},
+			APIURL:     &amcommoncfg.URL{URL: testWebhookURL},
 		},
 		test.CreateTmpl(t),
 		promslog.NewNopLogger(),
@@ -120,7 +122,7 @@ func TestWebexTemplating(t *testing.T) {
 			defer srv.Close()
 			u, _ := url.Parse(srv.URL)
 
-			tt.cfg.APIURL = &config.URL{URL: u}
+			tt.cfg.APIURL = &amcommoncfg.URL{URL: u}
 			tt.cfg.HTTPConfig = tt.commonCfg
 			notifierWebex, err := New(tt.cfg, test.CreateTmpl(t), promslog.NewNopLogger())
 			require.NoError(t, err)

--- a/notify/wechat/wechat_test.go
+++ b/notify/wechat/wechat_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
 
+	amcommoncfg "github.com/prometheus/alertmanager/config/common"
+
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify/test"
 )
@@ -34,7 +36,7 @@ func TestWechatRedactedURLOnInitialAuthentication(t *testing.T) {
 	secret := "secret_key"
 	notifier, err := New(
 		&config.WechatConfig{
-			APIURL:     &config.URL{URL: u},
+			APIURL:     &amcommoncfg.URL{URL: u},
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 			CorpID:     "corpid",
 			APISecret:  commoncfg.Secret(secret),
@@ -56,7 +58,7 @@ func TestWechatRedactedURLOnNotify(t *testing.T) {
 
 	notifier, err := New(
 		&config.WechatConfig{
-			APIURL:     &config.URL{URL: u},
+			APIURL:     &amcommoncfg.URL{URL: u},
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 			CorpID:     "corpid",
 			APISecret:  commoncfg.Secret(secret),
@@ -78,7 +80,7 @@ func TestWechatMessageTypeSelector(t *testing.T) {
 
 	notifier, err := New(
 		&config.WechatConfig{
-			APIURL:      &config.URL{URL: u},
+			APIURL:      &amcommoncfg.URL{URL: u},
 			HTTPConfig:  &commoncfg.HTTPClientConfig{},
 			CorpID:      "corpid",
 			APISecret:   commoncfg.Secret(secret),


### PR DESCRIPTION
This commit adds a new package `config/common` and moves the custom `URL` and `SecretURL` types to it. It allows to reuse these types in the notify package without creating circular dependencies between the notify and config packages. This is a preparation to further separate notifier specific code from the config package and move it to the notify sub packages.

The new package is also the future target for other common config types like `InhibitRule` and `MatchRegexps`