### PR TITLE
feat: Add silence annotation to web UI

### DIFF
--- a/ui/app/src/Utils/Views.elm
+++ b/ui/app/src/Utils/Views.elm
@@ -1,5 +1,6 @@
 module Utils.Views exposing
-    ( apiData
+    ( annotationButton
+    , apiData
     , checkbox
     , error
     , labelButton
@@ -47,7 +48,7 @@ labelButton maybeMsg labelText =
                 , style "-moz-user-select" "text"
                 , style "-webkit-user-select" "text"
                 ]
-                [ text labelText ]
+                [ span [ class "text-muted" ] [ text labelText ] ]
 
         Just msg ->
             button
@@ -55,6 +56,11 @@ labelButton maybeMsg labelText =
                 , onClick msg
                 ]
                 [ span [ class "text-muted" ] [ text labelText ] ]
+
+
+annotationButton : ( String, String ) -> Html msg
+annotationButton ( key, value ) =
+    labelButton Nothing (key ++ "=" ++ value)
 
 
 linkifyText : String -> List (Html msg)

--- a/ui/app/src/Views/SilenceForm/Views.elm
+++ b/ui/app/src/Views/SilenceForm/Views.elm
@@ -1,22 +1,23 @@
 module Views.SilenceForm.Views exposing (view)
 
 import Data.GettableAlert exposing (GettableAlert)
-import Html exposing (Html, button, div, h1, i, input, label, strong, text)
-import Html.Attributes exposing (class, style)
-import Html.Events exposing (onClick)
+import Html exposing (Html, button, div, h1, i, input, label, small, strong, text)
+import Html.Attributes exposing (class, placeholder, style, value)
+import Html.Events exposing (onClick, onInput)
 import Utils.DateTimePicker.Views exposing (viewDateTimePicker)
 import Utils.Filter exposing (SilenceFormGetParams)
 import Utils.FormValidation exposing (ValidatedField, ValidationState(..))
+import Utils.Keyboard exposing (keys, onKeyDown)
 import Utils.Types exposing (ApiData)
 import Utils.Views exposing (loading, validatedField, validatedTextareaField)
 import Views.FilterBar.Types as FilterBar
 import Views.FilterBar.Views as FilterBar
 import Views.Shared.SilencePreview
-import Views.SilenceForm.Types exposing (Model, SilenceForm, SilenceFormFieldMsg(..), SilenceFormMsg(..))
+import Views.SilenceForm.Types exposing (Model, SilenceForm, SilenceFormFieldMsg(..), SilenceFormMsg(..), hasAnnotationKey, parseAnnotation)
 
 
 view : Maybe String -> SilenceFormGetParams -> String -> Model -> Html SilenceFormMsg
-view maybeId silenceFormGetParams defaultCreator { form, filterBar, filterBarValid, silenceId, alerts, activeAlertId } =
+view maybeId silenceFormGetParams defaultCreator { form, filterBar, filterBarValid, annotationsValid, silenceId, alerts, activeAlertId } =
     let
         ( title, resetClick ) =
             case maybeId of
@@ -42,6 +43,7 @@ view maybeId silenceFormGetParams defaultCreator { form, filterBar, filterBarVal
             (UpdateComment >> UpdateField)
             (ValidateComment |> UpdateField)
             form.comment
+        , annotationsInput annotationsValid form
         , div [ class inputSectionPadding ]
             [ informationBlock activeAlertId silenceId alerts
             , silenceActionButtons maybeId resetClick
@@ -158,6 +160,100 @@ matchersInput filterBarValid filterBar =
 
             _ ->
                 text ""
+        ]
+
+
+annotationsInput : Utils.FormValidation.ValidationState -> SilenceForm -> Html SilenceFormMsg
+annotationsInput annotationsValid form =
+    let
+        errorClass =
+            case annotationsValid of
+                Invalid _ ->
+                    " has-danger"
+
+                _ ->
+                    ""
+
+        isValid =
+            if form.annotationText == "" then
+                True
+
+            else
+                case parseAnnotation form.annotationText of
+                    Just ( key, _ ) ->
+                        not (hasAnnotationKey key form.annotations)
+
+                    Nothing ->
+                        False
+
+        addButtonEnabled =
+            form.annotationText /= "" && isValid
+
+        keyDown key =
+            if key == keys.enter then
+                -- Enter key
+                if addButtonEnabled then
+                    AddAnnotation |> UpdateField
+
+                else
+                    UpdateField Noop
+
+            else
+                UpdateField Noop
+    in
+    div [ class inputSectionPadding ]
+        [ label []
+            [ strong [] [ text "Annotations (Optional) " ]
+            , small [ class "text-muted" ] [ text "key=value pairs" ]
+            ]
+        , div [ class ("row no-gutters align-items-start" ++ errorClass) ]
+            (List.map viewAnnotation form.annotations
+                ++ [ div [ class "col" ]
+                        [ div [ class "input-group" ]
+                            [ input
+                                [ class "form-control"
+                                , placeholder "key=value"
+                                , value form.annotationText
+                                , onInput (UpdateAnnotationText >> UpdateField)
+                                , onKeyDown keyDown
+                                ]
+                                []
+                            , div [ class "input-group-append" ]
+                                [ button
+                                    [ class "btn btn-primary"
+                                    , onClick (AddAnnotation |> UpdateField)
+                                    , Html.Attributes.disabled (not addButtonEnabled)
+                                    ]
+                                    [ text "+" ]
+                                ]
+                            ]
+                        ]
+                   ]
+            )
+        , case annotationsValid of
+            Invalid error ->
+                div [ class "form-control-feedback" ] [ text error ]
+
+            _ ->
+                text ""
+        ]
+
+
+viewAnnotation : ( String, String ) -> Html SilenceFormMsg
+viewAnnotation annotation =
+    div [ class "col col-auto" ]
+        [ div [ class "btn-group mr-2 mb-2" ]
+            [ button
+                [ class "btn btn-outline-info"
+                , onClick (DeleteAnnotation True annotation |> UpdateField)
+                ]
+                [ text (Tuple.first annotation ++ "=" ++ Tuple.second annotation) ]
+            , button
+                [ class "btn btn-outline-danger"
+                , onClick (DeleteAnnotation False annotation |> UpdateField)
+                ]
+                [ text "×" ]
+            ]
         ]
 
 

--- a/ui/app/src/Views/SilenceList/SilenceView.elm
+++ b/ui/app/src/Views/SilenceList/SilenceView.elm
@@ -3,6 +3,7 @@ module Views.SilenceList.SilenceView exposing (editButton, view)
 import Data.GettableSilence exposing (GettableSilence)
 import Data.Matcher exposing (Matcher)
 import Data.SilenceStatus exposing (State(..))
+import Dict
 import Html exposing (Html, a, button, div, li, span, text)
 import Html.Attributes exposing (class, href, style)
 import Html.Events exposing (onClick)
@@ -40,7 +41,23 @@ view showConfirmationDialog silence =
             , editButton silence
             , deleteButton silence
             ]
-        , div [ class "" ] (List.map matcherButton silence.matchers)
+        , div [ class "d-flex align-items-center" ]
+            [ span [ class "mr-2" ] [ text "Matchers:" ]
+            , div [ class "" ] (List.map matcherButton silence.matchers)
+            ]
+        , case silence.annotations of
+            Just annotations ->
+                if Dict.isEmpty annotations then
+                    text ""
+
+                else
+                    div [ class "d-flex align-items-center" ]
+                        [ span [ class "mr-2" ] [ text "Annotations:" ]
+                        , div [ class "" ] (List.map Utils.Views.annotationButton (Dict.toList annotations))
+                        ]
+
+            Nothing ->
+                text ""
         , Dialog.view
             (if showConfirmationDialog then
                 Just (confirmSilenceDeleteView silence False)

--- a/ui/app/src/Views/SilenceView/Views.elm
+++ b/ui/app/src/Views/SilenceView/Views.elm
@@ -3,6 +3,7 @@ module Views.SilenceView.Views exposing (view)
 import Data.GettableAlert exposing (GettableAlert)
 import Data.GettableSilence exposing (GettableSilence)
 import Data.SilenceStatus
+import Dict
 import Html exposing (Html, b, button, div, h1, label, span, text)
 import Html.Attributes exposing (class)
 import Html.Events exposing (onClick)
@@ -11,7 +12,7 @@ import Types exposing (Msg(..))
 import Utils.Date exposing (dateTimeFormat)
 import Utils.List
 import Utils.Types exposing (ApiData(..))
-import Utils.Views exposing (error, loading)
+import Utils.Views exposing (annotationButton, error, labelButton, loading)
 import Views.Shared.Dialog as Dialog
 import Views.Shared.SilencePreview
 import Views.SilenceList.SilenceView exposing (editButton)
@@ -64,7 +65,21 @@ viewSilence activeAlertId alerts silence showPromptDialog =
         , formGroup "State" <| text <| stateToString silence.status.state
         , formGroup "Matchers" <|
             div [] <|
-                List.map (Utils.List.mstring >> Utils.Views.labelButton Nothing) silence.matchers
+                List.map
+                    (\matcher -> labelButton Nothing (Utils.List.mstring matcher))
+                    silence.matchers
+        , case silence.annotations of
+            Just annotations ->
+                if Dict.isEmpty annotations then
+                    text ""
+
+                else
+                    formGroup "Annotations" <|
+                        div [] <|
+                            List.map annotationButton (Dict.toList annotations)
+
+            Nothing ->
+                text ""
         , affectedAlerts
         , Dialog.view
             (if showPromptDialog then

--- a/ui/app/tests/SilenceForm.elm
+++ b/ui/app/tests/SilenceForm.elm
@@ -1,0 +1,79 @@
+module SilenceForm exposing (parseAnnotation)
+
+import Expect
+import Test exposing (..)
+import Views.SilenceForm.Types
+
+
+parseAnnotation : Test
+parseAnnotation =
+    describe "parseAnnotation"
+        [ describe "valid inputs"
+            [ test "should parse basic key=value" <|
+                \() ->
+                    Expect.equal (Just ( "key", "value" ))
+                        (Views.SilenceForm.Types.parseAnnotation "key=value")
+            , test "should parse value containing equals signs" <|
+                \() ->
+                    Expect.equal (Just ( "key", "value=extra" ))
+                        (Views.SilenceForm.Types.parseAnnotation "key=value=extra")
+            , test "should parse value with multiple equals signs" <|
+                \() ->
+                    Expect.equal (Just ( "key", "a=b=c=d" ))
+                        (Views.SilenceForm.Types.parseAnnotation "key=a=b=c=d")
+            , test "should trim whitespace from key and value" <|
+                \() ->
+                    Expect.equal (Just ( "key", "value" ))
+                        (Views.SilenceForm.Types.parseAnnotation " key = value ")
+            , test "should trim whitespace with equals in value" <|
+                \() ->
+                    Expect.equal (Just ( "key", "value=extra" ))
+                        (Views.SilenceForm.Types.parseAnnotation " key = value=extra ")
+            , test "should parse value with leading/trailing spaces" <|
+                \() ->
+                    Expect.equal (Just ( "key", "value with spaces" ))
+                        (Views.SilenceForm.Types.parseAnnotation "key= value with spaces ")
+            , test "should parse key with underscores and numbers" <|
+                \() ->
+                    Expect.equal (Just ( "annotation_key_1", "value123" ))
+                        (Views.SilenceForm.Types.parseAnnotation "annotation_key_1=value123")
+            , test "should parse value containing URL with query parameters" <|
+                \() ->
+                    Expect.equal (Just ( "key", "http://example.com?foo=bar&baz=qux" ))
+                        (Views.SilenceForm.Types.parseAnnotation "key=http://example.com?foo=bar&baz=qux")
+            ]
+        , describe "invalid inputs"
+            [ test "should reject empty string" <|
+                \() ->
+                    Expect.equal Nothing
+                        (Views.SilenceForm.Types.parseAnnotation "")
+            , test "should reject string without equals sign" <|
+                \() ->
+                    Expect.equal Nothing
+                        (Views.SilenceForm.Types.parseAnnotation "noequals")
+            , test "should reject empty key" <|
+                \() ->
+                    Expect.equal Nothing
+                        (Views.SilenceForm.Types.parseAnnotation "=value")
+            , test "should reject empty value" <|
+                \() ->
+                    Expect.equal Nothing
+                        (Views.SilenceForm.Types.parseAnnotation "key=")
+            , test "should reject whitespace-only key" <|
+                \() ->
+                    Expect.equal Nothing
+                        (Views.SilenceForm.Types.parseAnnotation "  =value")
+            , test "should reject whitespace-only value" <|
+                \() ->
+                    Expect.equal Nothing
+                        (Views.SilenceForm.Types.parseAnnotation "key=  ")
+            , test "should reject both key and value as whitespace" <|
+                \() ->
+                    Expect.equal Nothing
+                        (Views.SilenceForm.Types.parseAnnotation " = ")
+            , test "should reject only whitespace" <|
+                \() ->
+                    Expect.equal Nothing
+                        (Views.SilenceForm.Types.parseAnnotation "   ")
+            ]
+        ]


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "dispatcher: improve performance"

    - Please sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Pull Request Checklist
Please check all the applicable boxes.

- Please list all open issue(s) discussed with maintainers related to this change
    - Fixes #<issue number>
    <!--
    If it applies.
    Automatically closes linked issue when PR is merged.
    Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
    More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
    -->
- Is this a new Receiver integration?
    - [ ] I have already tried to use the [Webhook Receiver Integration](https://prometheus.io/docs/alerting/latest/configuration/#webhook_config) and [3rd party integrations](https://prometheus.io/docs/operating/integrations/#alertmanager-webhook-receiver) before adding this new Receiver Integration
- Is this a bugfix?
    - [ ] I have added tests that can reproduce the bug which pass with this bugfix applied
- Is this a new feature?
    - [ ] I have added tests that test the new feature's functionality
- Does this change affect performance?
    - [ ] I have provided benchmarks comparison that shows performance is improved or is not degraded
        - You can use [`benchstat`](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat) to compare benchmarks
    - [ ] I have added new benchmarks if required or requested by maintainers
- Is this a breaking change?
    - [ ] My changes do not break the existing cluster messages
    - [ ] My changes do not break the existing api
- [ ] I have added/updated the required documentation
- [x] I have signed-off my commits
- [x] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/alertmanager/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[FEATURE] UI: Add support for silence annotations
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add/manage key=value annotations when creating or editing silences (add, delete, edit via input with Enter support).
  * Annotations shown on silence list and detail views.
  * Inline validation prevents malformed entries and duplicate keys, with real-time enable/disable of the add action.

* **Tests**
  * Added tests covering valid and invalid annotation parsing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->