### PR TITLE
incident.io notifier: add metadata field with templating support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2037,6 +2037,10 @@ url_file: <filepath>
 # Timeout is the maximum time allowed to invoke incident.io. Setting this to 0
 # does not impose a timeout.
 [ timeout: <duration> | default = 0s ]
+
+# A set of arbitrary key/value pairs to include with alerts.
+# Values support Go template syntax.
+[ metadata: { <string>: <tmpl_string>, ... } ]
 ```
 
 ### `<wechat_config>`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2067,6 +2067,10 @@ url_file: <filepath>
 # Timeout is the maximum time allowed to invoke incident.io. Setting this to 0
 # does not impose a timeout.
 [ timeout: <duration> | default = 0s ]
+
+# A set of arbitrary key/value pairs to include with alerts.
+# Values support Go template syntax.
+[ metadata: { <string>: <tmpl_string>, ... } ]
 ```
 
 ### `<wechat_config>`

--- a/notify/incidentio/config.go
+++ b/notify/incidentio/config.go
@@ -53,6 +53,10 @@ type IncidentioConfig struct {
 	// Timeout is the maximum time allowed to invoke incident.io. Setting this to 0
 	// does not impose a timeout.
 	Timeout time.Duration `yaml:"timeout" json:"timeout"`
+
+	// Metadata is a set of arbitrary key/value pairs to include with alerts.
+	// Values support Go template syntax.
+	Metadata map[string]string `yaml:"metadata,omitempty" json:"metadata,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/notify/incidentio/incidentio.go
+++ b/notify/incidentio/incidentio.go
@@ -173,10 +173,9 @@ func (n *Notifier) Notify(ctx context.Context, alerts ...*types.Alert) (bool, er
 		metadata = make(map[string]string, len(n.conf.Metadata))
 		for k, v := range n.conf.Metadata {
 			metadata[k] = tmpl(v)
-		}
-
-		if tmplErr != nil {
-			return false, fmt.Errorf("failed to render metadata templates: %w", tmplErr)
+			if tmplErr != nil {
+				return false, fmt.Errorf("failed to render metadata templates: %w", tmplErr)
+			}
 		}
 	}
 

--- a/notify/incidentio/incidentio.go
+++ b/notify/incidentio/incidentio.go
@@ -95,9 +95,10 @@ type Message struct {
 	*template.Data
 
 	// The protocol version.
-	Version         string `json:"version"`
-	GroupKey        string `json:"groupKey"`
-	TruncatedAlerts uint64 `json:"truncatedAlerts"`
+	Version         string            `json:"version"`
+	GroupKey        string            `json:"groupKey"`
+	TruncatedAlerts uint64            `json:"truncatedAlerts"`
+	Metadata        map[string]string `json:"metadata,omitempty"`
 }
 
 func truncateAlerts(maxAlerts uint64, alerts []*types.Alert) ([]*types.Alert, uint64) {
@@ -163,11 +164,27 @@ func (n *Notifier) Notify(ctx context.Context, alerts ...*types.Alert) (bool, er
 
 	n.logger.Debug("incident.io notification", "groupKey", groupKey)
 
+	// Render metadata templates
+	var metadata map[string]string
+	if len(n.conf.Metadata) > 0 {
+		var tmplErr error
+		tmpl := notify.TmplText(n.tmpl, data, &tmplErr)
+
+		metadata = make(map[string]string, len(n.conf.Metadata))
+		for k, v := range n.conf.Metadata {
+			metadata[k] = tmpl(v)
+			if tmplErr != nil {
+				return false, fmt.Errorf("failed to render metadata templates: %w", tmplErr)
+			}
+		}
+	}
+
 	msg := &Message{
 		Version:         "1",
 		Data:            data,
 		GroupKey:        groupKey.String(),
 		TruncatedAlerts: numTruncated,
+		Metadata:        metadata,
 	}
 
 	buf, err := n.encodeMessage(msg)

--- a/notify/incidentio/incidentio.go
+++ b/notify/incidentio/incidentio.go
@@ -95,9 +95,10 @@ type Message struct {
 	*template.Data
 
 	// The protocol version.
-	Version         string `json:"version"`
-	GroupKey        string `json:"groupKey"`
-	TruncatedAlerts uint64 `json:"truncatedAlerts"`
+	Version         string            `json:"version"`
+	GroupKey        string            `json:"groupKey"`
+	TruncatedAlerts uint64            `json:"truncatedAlerts"`
+	Metadata        map[string]string `json:"metadata,omitempty"`
 }
 
 func truncateAlerts(maxAlerts uint64, alerts []*types.Alert) ([]*types.Alert, uint64) {
@@ -163,11 +164,28 @@ func (n *Notifier) Notify(ctx context.Context, alerts ...*types.Alert) (bool, er
 
 	n.logger.Debug("incident.io notification", "groupKey", groupKey)
 
+	// Render metadata templates
+	var metadata map[string]string
+	if len(n.conf.Metadata) > 0 {
+		var tmplErr error
+		tmpl := notify.TmplText(n.tmpl, data, &tmplErr)
+
+		metadata = make(map[string]string, len(n.conf.Metadata))
+		for k, v := range n.conf.Metadata {
+			metadata[k] = tmpl(v)
+		}
+
+		if tmplErr != nil {
+			return false, fmt.Errorf("failed to render metadata templates: %w", tmplErr)
+		}
+	}
+
 	msg := &Message{
 		Version:         "1",
 		Data:            data,
 		GroupKey:        groupKey.String(),
 		TruncatedAlerts: numTruncated,
+		Metadata:        metadata,
 	}
 
 	buf, err := n.encodeMessage(msg)

--- a/notify/incidentio/incidentio_test.go
+++ b/notify/incidentio/incidentio_test.go
@@ -475,3 +475,207 @@ func TestIncidentIOPayloadTruncationWithLabelTruncation(t *testing.T) {
 		}
 	}
 }
+
+func TestIncidentIOMetadataEmpty(t *testing.T) {
+	// When no metadata is configured, the field should be omitted from JSON.
+	var receivedBody []byte
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			var err error
+			receivedBody, err = io.ReadAll(r.Body)
+			require.NoError(t, err)
+			w.WriteHeader(http.StatusOK)
+		},
+	))
+	defer server.Close()
+
+	u, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	notifier, err := New(
+		&IncidentioConfig{
+			URL:              &amcommoncfg.URL{URL: u},
+			HTTPConfig:       &commoncfg.HTTPClientConfig{},
+			AlertSourceToken: "test-token",
+		},
+		test.CreateTmpl(t),
+		promslog.NewNopLogger(),
+	)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	ctx = notify.WithGroupKey(ctx, "1")
+
+	alert := &types.Alert{
+		Alert: model.Alert{
+			Labels:   model.LabelSet{"alertname": "TestAlert"},
+			StartsAt: time.Now(),
+			EndsAt:   time.Now().Add(time.Hour),
+		},
+	}
+
+	retry, err := notifier.Notify(ctx, alert)
+	require.NoError(t, err)
+	require.False(t, retry)
+
+	// Verify metadata field is not present in JSON
+	var rawMsg map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(receivedBody, &rawMsg))
+	_, hasMetadata := rawMsg["metadata"]
+	require.False(t, hasMetadata, "metadata field should be omitted when not configured")
+}
+
+func TestIncidentIOMetadataStatic(t *testing.T) {
+	// Static metadata values (no templates) should be passed through as-is.
+	var receivedMsg Message
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&receivedMsg))
+			w.WriteHeader(http.StatusOK)
+		},
+	))
+	defer server.Close()
+
+	u, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	notifier, err := New(
+		&IncidentioConfig{
+			URL:              &amcommoncfg.URL{URL: u},
+			HTTPConfig:       &commoncfg.HTTPClientConfig{},
+			AlertSourceToken: "test-token",
+			Metadata: map[string]string{
+				"environment": "production",
+				"team":        "sre",
+				"region":      "us-east-1",
+			},
+		},
+		test.CreateTmpl(t),
+		promslog.NewNopLogger(),
+	)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	ctx = notify.WithGroupKey(ctx, "1")
+
+	alert := &types.Alert{
+		Alert: model.Alert{
+			Labels:   model.LabelSet{"alertname": "TestAlert"},
+			StartsAt: time.Now(),
+			EndsAt:   time.Now().Add(time.Hour),
+		},
+	}
+
+	retry, err := notifier.Notify(ctx, alert)
+	require.NoError(t, err)
+	require.False(t, retry)
+
+	require.Equal(t, map[string]string{
+		"environment": "production",
+		"team":        "sre",
+		"region":      "us-east-1",
+	}, receivedMsg.Metadata)
+}
+
+func TestIncidentIOMetadataTemplated(t *testing.T) {
+	// Metadata values using Go templates should be rendered with alert data.
+	var receivedMsg Message
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&receivedMsg))
+			w.WriteHeader(http.StatusOK)
+		},
+	))
+	defer server.Close()
+
+	u, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	notifier, err := New(
+		&IncidentioConfig{
+			URL:              &amcommoncfg.URL{URL: u},
+			HTTPConfig:       &commoncfg.HTTPClientConfig{},
+			AlertSourceToken: "test-token",
+			Metadata: map[string]string{
+				"severity":    "{{ .CommonLabels.severity }}",
+				"alert_name":  "{{ .CommonLabels.alertname }}",
+				"alert_count": "{{ len .Alerts }}",
+				"status":      "{{ .Status }}",
+			},
+		},
+		test.CreateTmpl(t),
+		promslog.NewNopLogger(),
+	)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	ctx = notify.WithGroupKey(ctx, "1")
+
+	alerts := []*types.Alert{
+		{
+			Alert: model.Alert{
+				Labels: model.LabelSet{
+					"alertname": "HighLatency",
+					"severity":  "critical",
+				},
+				StartsAt: time.Now(),
+				EndsAt:   time.Now().Add(time.Hour),
+			},
+		},
+		{
+			Alert: model.Alert{
+				Labels: model.LabelSet{
+					"alertname": "HighLatency",
+					"severity":  "critical",
+				},
+				StartsAt: time.Now(),
+				EndsAt:   time.Now().Add(time.Hour),
+			},
+		},
+	}
+
+	retry, err := notifier.Notify(ctx, alerts...)
+	require.NoError(t, err)
+	require.False(t, retry)
+
+	require.Equal(t, "critical", receivedMsg.Metadata["severity"])
+	require.Equal(t, "HighLatency", receivedMsg.Metadata["alert_name"])
+	require.Equal(t, "2", receivedMsg.Metadata["alert_count"])
+	require.Equal(t, "firing", receivedMsg.Metadata["status"])
+}
+
+func TestIncidentIOMetadataTemplateError(t *testing.T) {
+	// Invalid template references should return an error with no retry.
+	u, err := url.Parse("https://example.com")
+	require.NoError(t, err)
+
+	notifier, err := New(
+		&IncidentioConfig{
+			URL:              &amcommoncfg.URL{URL: u},
+			HTTPConfig:       &commoncfg.HTTPClientConfig{},
+			AlertSourceToken: "test-token",
+			Metadata: map[string]string{
+				"bad": "{{ .NonExistentMethod }}",
+			},
+		},
+		test.CreateTmpl(t),
+		promslog.NewNopLogger(),
+	)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	ctx = notify.WithGroupKey(ctx, "1")
+
+	alert := &types.Alert{
+		Alert: model.Alert{
+			Labels:   model.LabelSet{"alertname": "TestAlert"},
+			StartsAt: time.Now(),
+			EndsAt:   time.Now().Add(time.Hour),
+		},
+	}
+
+	retry, err := notifier.Notify(ctx, alert)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to render metadata templates")
+	require.False(t, retry, "should not retry on template rendering errors")
+}


### PR DESCRIPTION
Allow users to send custom key-value metadata with alerts, with full Go template rendering support (e.g. {{ .CommonLabels.severity }}). This mirrors the approach to the Opsgenie `Details` attribute.

#### Pull Request Checklist
Please check all the applicable boxes.

- Please list all open issue(s) discussed with maintainers related to this change
    - There is no issue where this is formally requested, but it was mentioned [here](https://github.com/prometheus/alertmanager/pull/4372#discussion_r2067916290), and through other threads.
- Is this a new Receiver integration?
    - [x] I have already tried to use the [Webhook Receiver Integration](https://prometheus.io/docs/alerting/latest/configuration/#webhook_config) and [3rd party integrations](https://prometheus.io/docs/operating/integrations/#alertmanager-webhook-receiver) before adding this new Receiver Integration
- Is this a bugfix?
    - [ ] I have added tests that can reproduce the bug which pass with this bugfix applied
- Is this a new feature?
    - [x] I have added tests that test the new feature's functionality
- Does this change affect performance?
    - [ ] I have provided benchmarks comparison that shows performance is improved or is not degraded
        - You can use [`benchstat`](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat) to compare benchmarks
    - [ ] I have added new benchmarks if required or requested by maintainers
- Is this a breaking change?
    - [x] My changes do not break the existing cluster messages
    - [x] My changes do not break the existing api
- [x] I have added/updated the required documentation
- [x] I have signed-off my commits
- [x] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/alertmanager/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[ENHANCEMENT] The incident.io notifier now supports metadata with templating. 
```