### PR TITLE
fix: force_implicit_tls config field name in docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -95,6 +95,8 @@ global:
   [ smtp_require_tls: <bool> | default = true ]
   # The default TLS configuration for SMTP receivers
   [ smtp_tls_config: <tls_config> ]
+  # Force implicit TLS regardless of SMTP port
+  [ smtp_force_implicit_tls: <bool>]
 
   # Default settings for the JIRA integration.
   [ jira_api_url: <string> ]
@@ -999,7 +1001,7 @@ to: <tmpl_string>
 # Force use of implicit TLS (direct TLS connection) for better security.
 # true: force use of implicit TLS (direct TLS connection on any port)
 # nil (default): auto-detect based on port (465=implicit, other=explicit) for backward compatibility
-[ implicit_tls: <bool> | default = nil ]
+[ force_implicit_tls: <bool> | default = nil ]
 
 # TLS configuration.
 tls_config:
@@ -1033,9 +1035,9 @@ receivers:
     email_configs:
       - to: alerts@example.com
         smarthost: smtp.example.com:8465
-        implicit_tls: true  # Use direct TLS connection on port 8465
+        force_implicit_tls: true  # Use direct TLS connection on port 8465
 
-# Example 2: Backward compatible (no implicit_tls specified)
+# Example 2: Backward compatible (no force_implicit_tls specified)
 receivers:
   - name: email-default
     email_configs:


### PR DESCRIPTION
#### Pull Request Checklist
Please check all the applicable boxes.
- [x] I have added/updated the required documentation
- [x] I have signed-off my commits
- [x] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/alertmanager/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[BUGFIX] fix the name of `force_implicit_tls` in the configuration docs and add global `smtp_force_implicit_tls` to the docs. Both fields already exist, but the documentation was incorrect.
```
#4818 added `force_implicit_tls` to the email receiver, but accidentally documented the field as `implicit_tls`. The documentation in that change also forgot to mention the `smpt_force_implicit_tls` filed in the the `global` section. This PR just modifies the docs to match the existing behavior.

See https://github.com/prometheus/alertmanager/blob/07e5b92accb143937340854bc40c086721dbf6a0/config/notifiers.go#L326 and https://github.com/prometheus/alertmanager/blob/07e5b92accb143937340854bc40c086721dbf6a0/config/config.go#L816

Thanks @nutmos for discovering this!