### PR TITLE
config: fix IPv6 address handling in HostPort.String()

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -789,7 +789,7 @@ func (hp HostPort) String() string {
 	if hp.Host == "" && hp.Port == "" {
 		return ""
 	}
-	return fmt.Sprintf("%s:%s", hp.Host, hp.Port)
+	return net.JoinHostPort(hp.Host, hp.Port)
 }
 
 // GlobalConfig defines configuration parameters that are valid globally

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1406,6 +1406,13 @@ func TestUnmarshalHostPort(t *testing.T) {
 			in:  `"localhost:"`,
 			err: true,
 		},
+		{
+			in:  `"[fd12:3456:789a::1]:25"`,
+			exp: HostPort{Host: "fd12:3456:789a::1", Port: "25"},
+			yamlOut: `'[fd12:3456:789a::1]:25'
+`,
+			jsonOut: `"[fd12:3456:789a::1]:25"`,
+		},
 	} {
 		t.Run(tc.in, func(t *testing.T) {
 			hp := HostPort{}


### PR DESCRIPTION
`HostPort.String()` was using `fmt.Sprintf("%s:%s", hp.Host, hp.Port)` which doesn't wrap IPv6 addresses in brackets. This caused marshaled configs to produce invalid addresses like:
  fd12:3456:789a::1:25
instead of:
  [fd12:3456:789a::1]:25

This fix uses `net.JoinHostPort()` which correctly handles IPv6.

Added testcases, which would fail without the fix.
<!--
    - Please give your PR a title in the form "area: short description".  For example "dispatcher: improve performance"

    - Please sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Pull Request Checklist
Please check all the applicable boxes.

- Please list all open issue(s) discussed with maintainers related to this change
    - Fixes #5039 
    <!--
    If it applies.
    Automatically closes linked issue when PR is merged.
    Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
    More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
    -->
- Is this a new Receiver integration?
- Is this a bugfix?
    - [x] I have added tests that can reproduce the bug which pass with this bugfix applied
- [x] I have signed-off my commits
- [x] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/alertmanager/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```