### PR TITLE
chore: drop multi error

### DIFF
--- a/notify/email/email_test.go
+++ b/notify/email/email_test.go
@@ -660,7 +660,7 @@ func TestEmailConfigMissingAuthParam(t *testing.T) {
 
 	_, err = email.auth("PLAIN LOGIN")
 	require.Error(t, err)
-	require.Equal(t, "missing password for PLAIN auth mechanism; missing password for LOGIN auth mechanism", err.Error())
+	require.Equal(t, "missing password for PLAIN auth mechanism\nmissing password for LOGIN auth mechanism", err.Error())
 }
 
 func TestEmailNoUsernameStillOk(t *testing.T) {

--- a/types/types.go
+++ b/types/types.go
@@ -15,7 +15,6 @@ package types
 
 import (
 	"context"
-	"strings"
 	"sync"
 	"time"
 
@@ -300,49 +299,6 @@ func (m *MemMarker) Silenced(alert model.Fingerprint) (activeIDs []string, silen
 	s := m.Status(alert)
 	return s.SilencedBy,
 		s.State == AlertStateSuppressed && len(s.SilencedBy) > 0
-}
-
-// MultiError contains multiple errors and implements the error interface. Its
-// zero value is ready to use. All its methods are goroutine safe.
-type MultiError struct {
-	mtx    sync.Mutex
-	errors []error
-}
-
-// Add adds an error to the MultiError.
-func (e *MultiError) Add(err error) {
-	e.mtx.Lock()
-	defer e.mtx.Unlock()
-
-	e.errors = append(e.errors, err)
-}
-
-// Len returns the number of errors added to the MultiError.
-func (e *MultiError) Len() int {
-	e.mtx.Lock()
-	defer e.mtx.Unlock()
-
-	return len(e.errors)
-}
-
-// Errors returns the errors added to the MuliError. The returned slice is a
-// copy of the internal slice of errors.
-func (e *MultiError) Errors() []error {
-	e.mtx.Lock()
-	defer e.mtx.Unlock()
-
-	return append(make([]error, 0, len(e.errors)), e.errors...)
-}
-
-func (e *MultiError) Error() string {
-	e.mtx.Lock()
-	defer e.mtx.Unlock()
-
-	es := make([]string, 0, len(e.errors))
-	for _, err := range e.errors {
-		es = append(es, err.Error())
-	}
-	return strings.Join(es, "; ")
 }
 
 // A Muter determines whether a given label set is muted. Implementers that


### PR DESCRIPTION
Drop `MultiError` in favor of `errors.Join()` from Go 1.20+

<!--
    - Please give your PR a title in the form "area: short description".  For example "dispatcher: improve performance"

    - Please sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Pull Request Checklist
Please check all the applicable boxes.

- [x] I have signed-off my commits
- [x] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/alertmanager/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[CHANGE] Breaking: remove types.MultiError
```
