### PR TITLE
slack: retry on 429 and honor Retry-After header

### DIFF
--- a/notify/slack/slack.go
+++ b/notify/slack/slack.go
@@ -22,7 +22,9 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
+	"time"
 
 	commoncfg "github.com/prometheus/common/config"
 
@@ -59,7 +61,7 @@ func New(c *config.SlackConfig, t *template.Template, l *slog.Logger, httpOpts .
 		tmpl:         t,
 		logger:       l,
 		client:       client,
-		retrier:      &notify.Retrier{},
+		retrier:      &notify.Retrier{RetryCodes: []int{http.StatusTooManyRequests}},
 		postJSONFunc: notify.PostJSON,
 	}, nil
 }
@@ -256,6 +258,15 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	// classify them as retriable or not.
 	retry, err := n.retrier.Check(resp.StatusCode, resp.Body)
 	if err != nil {
+		if resp.StatusCode == http.StatusTooManyRequests {
+			if d := parseRetryAfter(resp.Header.Get("Retry-After")); d > 0 {
+				n.logger.Warn("Rate limited by Slack, waiting before retry", "retry_after_secs", d.Seconds())
+				select {
+				case <-time.After(d):
+				case <-ctx.Done():
+				}
+			}
+		}
 		err = fmt.Errorf("channel %q: %w", req.Channel, err)
 		return retry, notify.NewErrorWithReason(notify.GetFailureReasonFromStatusCode(resp.StatusCode), err)
 	}
@@ -292,6 +303,20 @@ func (n *Notifier) slackResponseHandler(resp *http.Response, store *nflog.Store)
 		n.logger.Debug("stored threadTs and channelId", "threadTs", data.Timestamp, "channelId", data.Channel)
 	}
 	return false, nil
+}
+
+// parseRetryAfter parses the Retry-After header value as integer seconds
+// and returns the corresponding duration. Returns 0 if the value is empty,
+// not a valid integer, or non-positive.
+func parseRetryAfter(val string) time.Duration {
+	if val == "" {
+		return 0
+	}
+	seconds, err := strconv.Atoi(val)
+	if err != nil || seconds <= 0 {
+		return 0
+	}
+	return time.Duration(seconds) * time.Second
 }
 
 // checkTextResponseError classifies plaintext responses from Slack.

--- a/notify/slack/slack.go
+++ b/notify/slack/slack.go
@@ -22,7 +22,9 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
+	"time"
 
 	commoncfg "github.com/prometheus/common/config"
 
@@ -48,7 +50,7 @@ func New(c *config.SlackConfig, t *template.Template, l *slog.Logger, httpOpts .
 		tmpl:         t,
 		logger:       l,
 		client:       client,
-		retrier:      &notify.Retrier{},
+		retrier:      &notify.Retrier{RetryCodes: []int{http.StatusTooManyRequests}},
 		postJSONFunc: notify.PostJSON,
 	}, nil
 }
@@ -208,6 +210,15 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	// classify them as retriable or not.
 	retry, err := n.retrier.Check(resp.StatusCode, resp.Body)
 	if err != nil {
+		if resp.StatusCode == http.StatusTooManyRequests {
+			if d := parseRetryAfter(resp.Header.Get("Retry-After")); d > 0 {
+				n.logger.Warn("Rate limited by Slack, waiting before retry", "retry_after_secs", d.Seconds())
+				select {
+				case <-time.After(d):
+				case <-ctx.Done():
+				}
+			}
+		}
 		err = fmt.Errorf("channel %q: %w", req.Channel, err)
 		return retry, notify.NewErrorWithReason(notify.GetFailureReasonFromStatusCode(resp.StatusCode), err)
 	}
@@ -244,6 +255,20 @@ func (n *Notifier) slackResponseHandler(resp *http.Response, store *nflog.Store)
 		n.logger.Debug("stored threadTs and channelId", "threadTs", data.Timestamp, "channelId", data.Channel)
 	}
 	return false, nil
+}
+
+// parseRetryAfter parses the Retry-After header value as integer seconds
+// and returns the corresponding duration. Returns 0 if the value is empty,
+// not a valid integer, or non-positive.
+func parseRetryAfter(val string) time.Duration {
+	if val == "" {
+		return 0
+	}
+	seconds, err := strconv.Atoi(val)
+	if err != nil || seconds <= 0 {
+		return 0
+	}
+	return time.Duration(seconds) * time.Second
 }
 
 // checkTextResponseError classifies plaintext responses from Slack.

--- a/notify/slack/slack_test.go
+++ b/notify/slack/slack_test.go
@@ -50,7 +50,8 @@ func TestSlackRetry(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	for statusCode, expected := range test.RetryTests(test.DefaultRetryCodes()) {
+	retryCodes := append(test.DefaultRetryCodes(), http.StatusTooManyRequests)
+	for statusCode, expected := range test.RetryTests(retryCodes) {
 		actual, _ := notifier.retrier.Check(statusCode, nil)
 		require.Equal(t, expected, actual, "error on status %d", statusCode)
 	}
@@ -178,6 +179,13 @@ func TestNotifier_Notify_WithReason(t *testing.T) {
 			expectedReason: notify.ClientErrorReason,
 			expectedRetry:  false,
 			expectedErr:    "error response from Slack: no_channel",
+		},
+		{
+			name:           "with a 429 status code",
+			statusCode:     http.StatusTooManyRequests,
+			expectedReason: notify.ClientErrorReason,
+			expectedRetry:  true,
+			expectedErr:    "unexpected status code 429",
 		},
 		{
 			name:         "successful JSON response",
@@ -351,4 +359,110 @@ func TestSlackMessageField(t *testing.T) {
 	if _, err := notifier.Notify(ctx); err != nil {
 		t.Fatal("Notify failed:", err)
 	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected time.Duration
+	}{
+		{name: "valid integer", value: "30", expected: 30 * time.Second},
+		{name: "empty string", value: "", expected: 0},
+		{name: "non-integer", value: "abc", expected: 0},
+		{name: "negative", value: "-5", expected: 0},
+		{name: "zero", value: "0", expected: 0},
+		{name: "float value", value: "1.5", expected: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, parseRetryAfter(tt.value))
+		})
+	}
+}
+
+func TestNotifier_Notify_RetryAfterSleep(t *testing.T) {
+	apiurl, _ := url.Parse("https://slack.com/post.Message")
+	notifier, err := New(
+		&config.SlackConfig{
+			NotifierConfig: config.NotifierConfig{},
+			HTTPConfig:     &commoncfg.HTTPClientConfig{},
+			APIURL:         &amcommoncfg.SecretURL{URL: apiurl},
+			Channel:        "channelname",
+		},
+		test.CreateTmpl(t),
+		promslog.NewNopLogger(),
+	)
+	require.NoError(t, err)
+
+	notifier.postJSONFunc = func(ctx context.Context, client *http.Client, url string, body io.Reader) (*http.Response, error) {
+		resp := httptest.NewRecorder()
+		resp.Header().Set("Retry-After", "1")
+		resp.WriteHeader(http.StatusTooManyRequests)
+		return resp.Result(), nil
+	}
+
+	ctx := context.Background()
+	ctx = notify.WithGroupKey(ctx, "1")
+
+	alert1 := &types.Alert{
+		Alert: model.Alert{
+			StartsAt: time.Now(),
+			EndsAt:   time.Now().Add(time.Hour),
+		},
+	}
+
+	start := time.Now()
+	retry, err := notifier.Notify(ctx, alert1)
+	elapsed := time.Since(start)
+
+	require.True(t, retry)
+	require.Error(t, err)
+	require.GreaterOrEqual(t, elapsed, 1*time.Second, "should have waited at least 1 second for Retry-After")
+}
+
+func TestNotifier_Notify_RetryAfterContextCancelled(t *testing.T) {
+	apiurl, _ := url.Parse("https://slack.com/post.Message")
+	notifier, err := New(
+		&config.SlackConfig{
+			NotifierConfig: config.NotifierConfig{},
+			HTTPConfig:     &commoncfg.HTTPClientConfig{},
+			APIURL:         &amcommoncfg.SecretURL{URL: apiurl},
+			Channel:        "channelname",
+		},
+		test.CreateTmpl(t),
+		promslog.NewNopLogger(),
+	)
+	require.NoError(t, err)
+
+	notifier.postJSONFunc = func(ctx context.Context, client *http.Client, url string, body io.Reader) (*http.Response, error) {
+		resp := httptest.NewRecorder()
+		resp.Header().Set("Retry-After", "2")
+		resp.WriteHeader(http.StatusTooManyRequests)
+		return resp.Result(), nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx = notify.WithGroupKey(ctx, "1")
+
+	// Cancel context after a short delay to interrupt the Retry-After sleep.
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	alert1 := &types.Alert{
+		Alert: model.Alert{
+			StartsAt: time.Now(),
+			EndsAt:   time.Now().Add(time.Hour),
+		},
+	}
+
+	start := time.Now()
+	retry, err := notifier.Notify(ctx, alert1)
+	elapsed := time.Since(start)
+
+	require.True(t, retry)
+	require.Error(t, err)
+	require.Less(t, elapsed, 2*time.Second, "should not have waited the full Retry-After duration")
 }

--- a/notify/slack/slack_test.go
+++ b/notify/slack/slack_test.go
@@ -183,7 +183,7 @@ func TestNotifier_Notify_WithReason(t *testing.T) {
 		{
 			name:           "with a 429 status code",
 			statusCode:     http.StatusTooManyRequests,
-			expectedReason: notify.ClientErrorReason,
+			expectedReason: notify.RateLimitedReason,
 			expectedRetry:  true,
 			expectedErr:    "unexpected status code 429",
 		},
@@ -385,7 +385,7 @@ func TestNotifier_Notify_RetryAfterSleep(t *testing.T) {
 	apiurl, _ := url.Parse("https://slack.com/post.Message")
 	notifier, err := New(
 		&config.SlackConfig{
-			NotifierConfig: config.NotifierConfig{},
+			NotifierConfig: amcommoncfg.NotifierConfig{},
 			HTTPConfig:     &commoncfg.HTTPClientConfig{},
 			APIURL:         &amcommoncfg.SecretURL{URL: apiurl},
 			Channel:        "channelname",
@@ -425,7 +425,7 @@ func TestNotifier_Notify_RetryAfterContextCancelled(t *testing.T) {
 	apiurl, _ := url.Parse("https://slack.com/post.Message")
 	notifier, err := New(
 		&config.SlackConfig{
-			NotifierConfig: config.NotifierConfig{},
+			NotifierConfig: amcommoncfg.NotifierConfig{},
 			HTTPConfig:     &commoncfg.HTTPClientConfig{},
 			APIURL:         &amcommoncfg.SecretURL{URL: apiurl},
 			Channel:        "channelname",


### PR DESCRIPTION
Make HTTP 429 (Too Many Requests) retryable for the Slack notifier by adding http.StatusTooManyRequests to the retrier's RetryCodes, matching the pattern already used by PagerDuty, OpsGenie, Jira, and incident.io.

Additionally, parse the Retry-After response header on 429 responses and sleep for the indicated duration before returning. This addresses the concern raised when a similar change was reverted in #2128: simply retrying 429 without honoring Retry-After causes rapid-fire retries that risk getting apps permanently disabled by Slack. The sleep respects context cancellation.

Fixes #2111
Ref #2205

<!--
    - Please give your PR a title in the form "area: short description".  For example "dispatcher: improve performance"

    - Please sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Pull Request Checklist
Please check all the applicable boxes.

- Please list all open issue(s) discussed with maintainers related to this change
    - Fixes #<issue number>
    <!--
    If it applies.
    Automatically closes linked issue when PR is merged.
    Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
    More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
    -->
- Is this a new Receiver integration?
    - [ ] I have already tried to use the [Webhook Receiver Integration](https://prometheus.io/docs/alerting/latest/configuration/#webhook_config) and [3rd party integrations](https://prometheus.io/docs/operating/integrations/#alertmanager-webhook-receiver) before adding this new Receiver Integration
- Is this a bugfix?
    - [ ] I have added tests that can reproduce the bug which pass with this bugfix applied
- Is this a new feature?
    - [x] I have added tests that test the new feature's functionality
- Does this change affect performance?
    - [ ] I have provided benchmarks comparison that shows performance is improved or is not degraded
        - You can use [`benchstat`](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat) to compare benchmarks
    - [x] I have added new benchmarks if required or requested by maintainers
- Is this a breaking change?
    - [x] My changes do not break the existing cluster messages
    - [x] My changes do not break the existing api
- [x] I have added/updated the required documentation
- [x] I have signed-off my commits
- [x] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/alertmanager/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[ENHANCEMENT] slack: retry on 429 honoring Retry-After header
```
