### PR TITLE
fix: Send fallback message when Telegram notification exceeds character limit

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1791,6 +1791,7 @@ attributes:
 [ disable_notifications: <boolean> | default = false ]
 
 # Parse mode for telegram message, supported values are MarkdownV2, Markdown, HTML and empty string for plain text.
+# If the message exceeds Telegram's character limit, it will be truncated or replaced with a fallback message if parse_mode is set to HTML.
 [ parse_mode: <string> | default = "HTML" ]
 
 # The HTTP client's configuration.

--- a/notify/telegram/telegram.go
+++ b/notify/telegram/telegram.go
@@ -74,21 +74,32 @@ func (n *Notifier) Notify(ctx context.Context, alert ...*types.Alert) (bool, err
 	logger.Debug("extracted group key")
 
 	var (
-		err  error
-		data = notify.GetTemplateData(ctx, n.tmpl, alert, logger)
-		tmpl = notify.TmplText(n.tmpl, data, &err)
+		err         error
+		data        = notify.GetTemplateData(ctx, n.tmpl, alert, logger)
+		tmpl        = notify.TmplText(n.tmpl, data, &err)
+		messageText string
+		truncated   bool
 	)
 
-	if n.conf.ParseMode == "HTML" {
+	switch n.conf.ParseMode {
+	case "HTML":
 		tmpl = notify.TmplHTML(n.tmpl, data, &err)
-	}
-
-	messageText, truncated := notify.TruncateInRunes(tmpl(n.conf.Message), maxMessageLenRunes)
-	if err != nil {
-		return false, err
-	}
-	if truncated {
-		logger.Warn("Truncated message", "max_runes", maxMessageLenRunes)
+		messageText = tmpl(n.conf.Message)
+		if err != nil {
+			return false, err
+		}
+		if len([]rune(messageText)) > maxMessageLenRunes {
+			messageText = `Alertmanager notification could not be sent: message length exceeds Telegram limits.
+			Please check the template used for producing the message content.`
+		}
+	default:
+		messageText, truncated = notify.TruncateInRunes(tmpl(n.conf.Message), maxMessageLenRunes)
+		if err != nil {
+			return false, err
+		}
+		if truncated {
+			logger.Warn("Truncated message", "max_runes", maxMessageLenRunes)
+		}
 	}
 
 	n.client.Token, err = n.getBotToken()

--- a/notify/telegram/telegram_test.go
+++ b/notify/telegram/telegram_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -127,6 +128,45 @@ func TestTelegramNotify(t *testing.T) {
 				BotTokenFile: fileWithToken.Name(),
 			},
 			expText: "test",
+		},
+		{
+			name: "HTML mode with too-large message",
+			cfg: config.TelegramConfig{
+				ParseMode:  "HTML",
+				Message:    strings.Repeat("x", 5000),
+				HTTPConfig: &commoncfg.HTTPClientConfig{},
+				BotToken:   commoncfg.Secret(token),
+			},
+			expText: `Alertmanager notification could not be sent: message length exceeds Telegram limits.
+			Please check the template used for producing the message content.`,
+		},
+		{
+			name: "Default mode with too-large message",
+			cfg: config.TelegramConfig{
+				Message:    strings.Repeat("y", 5000),
+				HTTPConfig: &commoncfg.HTTPClientConfig{},
+				BotToken:   commoncfg.Secret(token),
+			},
+			expText: strings.Repeat("y", maxMessageLenRunes-1) + "…",
+		},
+		{
+			name: "HTML mode with message smaller than limit",
+			cfg: config.TelegramConfig{
+				ParseMode:  "HTML",
+				Message:    strings.Repeat("a", 100),
+				HTTPConfig: &commoncfg.HTTPClientConfig{},
+				BotToken:   commoncfg.Secret(token),
+			},
+			expText: strings.Repeat("a", 100),
+		},
+		{
+			name: "Default mode with message smaller than limit",
+			cfg: config.TelegramConfig{
+				Message:    strings.Repeat("b", 100),
+				HTTPConfig: &commoncfg.HTTPClientConfig{},
+				BotToken:   commoncfg.Secret(token),
+			},
+			expText: strings.Repeat("b", 100),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
When parse_mode is set to HTML, Telegram notifications that exceed the character limit will now be replaced with a fallback message instead of being truncated. This ensures that recipients receive a clear notification about the issue with the message size, rather than receiving no notification at all.

<!--
    - Please give your PR a title in the form "area: short description".  For example "dispatcher: improve performance"

    - Please sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Pull Request Checklist
Please check all the applicable boxes.

- Please list all open issue(s) discussed with maintainers related to this change
    - Fixes #2923
    <!--
    If it applies.
    Automatically closes linked issue when PR is merged.
    Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
    More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
    -->
- Is this a new Receiver integration?
    - [ ] I have already tried to use the [Webhook Receiver Integration](https://prometheus.io/docs/alerting/latest/configuration/#webhook_config) and [3rd party integrations](https://prometheus.io/docs/operating/integrations/#alertmanager-webhook-receiver) before adding this new Receiver Integration
- Is this a bugfix?
    - [x] I have added tests that can reproduce the bug which pass with this bugfix applied
- Is this a new feature?
    - [x] I have added tests that test the new feature's functionality
- Does this change affect performance?
    - [ ] I have provided benchmarks comparison that shows performance is improved or is not degraded
        - You can use [`benchstat`](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat) to compare benchmarks
    - [ ] I have added new benchmarks if required or requested by maintainers
- Is this a breaking change?
    - [ ] My changes do not break the existing cluster messages
    - [ ] My changes do not break the existing api
- [ ] I have added/updated the required documentation
- [x] I have signed-off my commits
- [x] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/alertmanager/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[FIX] NOTIFIY: Send fallback massage if telegram payload is to big
```
