### PR TITLE
refactor(config): move NotifierConfig to config/common

### DIFF
--- a/config/common/notifierconfig.go
+++ b/config/common/notifierconfig.go
@@ -1,0 +1,23 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+// NotifierConfig contains base options common across all notifier configurations.
+type NotifierConfig struct {
+	VSendResolved bool `yaml:"send_resolved" json:"send_resolved"`
+}
+
+func (nc *NotifierConfig) SendResolved() bool {
+	return nc.VSendResolved
+}

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -1,4 +1,4 @@
-// Copyright 2015 Prometheus Team
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -33,21 +33,21 @@ import (
 var (
 	// DefaultIncidentioConfig defines default values for Incident.io configurations.
 	DefaultIncidentioConfig = IncidentioConfig{
-		NotifierConfig: NotifierConfig{
+		NotifierConfig: amcommoncfg.NotifierConfig{
 			VSendResolved: true,
 		},
 	}
 
 	// DefaultWebhookConfig defines default values for Webhook configurations.
 	DefaultWebhookConfig = WebhookConfig{
-		NotifierConfig: NotifierConfig{
+		NotifierConfig: amcommoncfg.NotifierConfig{
 			VSendResolved: true,
 		},
 	}
 
 	// DefaultWebexConfig defines default values for Webex configurations.
 	DefaultWebexConfig = WebexConfig{
-		NotifierConfig: NotifierConfig{
+		NotifierConfig: amcommoncfg.NotifierConfig{
 			VSendResolved: true,
 		},
 		Message: `{{ template "webex.default.message" . }}`,
@@ -55,7 +55,7 @@ var (
 
 	// DefaultDiscordConfig defines default values for Discord configurations.
 	DefaultDiscordConfig = DiscordConfig{
-		NotifierConfig: NotifierConfig{
+		NotifierConfig: amcommoncfg.NotifierConfig{
 			VSendResolved: true,
 		},
 		Title:   `{{ template "discord.default.title" . }}`,
@@ -64,7 +64,7 @@ var (
 
 	// DefaultEmailConfig defines default values for Email configurations.
 	DefaultEmailConfig = EmailConfig{
-		NotifierConfig: NotifierConfig{
+		NotifierConfig: amcommoncfg.NotifierConfig{
 			VSendResolved: false,
 		},
 		HTML: `{{ template "email.default.html" . }}`,
@@ -84,7 +84,7 @@ var (
 
 	// DefaultPagerdutyConfig defines default values for PagerDuty configurations.
 	DefaultPagerdutyConfig = PagerdutyConfig{
-		NotifierConfig: NotifierConfig{
+		NotifierConfig: amcommoncfg.NotifierConfig{
 			VSendResolved: true,
 		},
 		Description: `{{ template "pagerduty.default.description" .}}`,
@@ -94,7 +94,7 @@ var (
 
 	// DefaultSlackConfig defines default values for Slack configurations.
 	DefaultSlackConfig = SlackConfig{
-		NotifierConfig: NotifierConfig{
+		NotifierConfig: amcommoncfg.NotifierConfig{
 			VSendResolved: false,
 		},
 		Color:      `{{ if eq .Status "firing" }}danger{{ else }}good{{ end }}`,
@@ -111,7 +111,7 @@ var (
 	}
 	// DefaultRocketchatConfig defines default values for Rocketchat configurations.
 	DefaultRocketchatConfig = RocketchatConfig{
-		NotifierConfig: NotifierConfig{
+		NotifierConfig: amcommoncfg.NotifierConfig{
 			VSendResolved: false,
 		},
 		Color:     `{{ if eq .Status "firing" }}red{{ else }}green{{ end }}`,
@@ -124,7 +124,7 @@ var (
 
 	// DefaultOpsGenieConfig defines default values for OpsGenie configurations.
 	DefaultOpsGenieConfig = OpsGenieConfig{
-		NotifierConfig: NotifierConfig{
+		NotifierConfig: amcommoncfg.NotifierConfig{
 			VSendResolved: true,
 		},
 		Message:     `{{ template "opsgenie.default.message" . }}`,
@@ -135,7 +135,7 @@ var (
 
 	// DefaultWechatConfig defines default values for wechat configurations.
 	DefaultWechatConfig = WechatConfig{
-		NotifierConfig: NotifierConfig{
+		NotifierConfig: amcommoncfg.NotifierConfig{
 			VSendResolved: false,
 		},
 		Message: `{{ template "wechat.default.message" . }}`,
@@ -147,7 +147,7 @@ var (
 
 	// DefaultVictorOpsConfig defines default values for VictorOps configurations.
 	DefaultVictorOpsConfig = VictorOpsConfig{
-		NotifierConfig: NotifierConfig{
+		NotifierConfig: amcommoncfg.NotifierConfig{
 			VSendResolved: true,
 		},
 		MessageType:       `CRITICAL`,
@@ -158,7 +158,7 @@ var (
 
 	// DefaultPushoverConfig defines default values for Pushover configurations.
 	DefaultPushoverConfig = PushoverConfig{
-		NotifierConfig: NotifierConfig{
+		NotifierConfig: amcommoncfg.NotifierConfig{
 			VSendResolved: true,
 		},
 		Title:    `{{ template "pushover.default.title" . }}`,
@@ -172,7 +172,7 @@ var (
 
 	// DefaultSNSConfig defines default values for SNS configurations.
 	DefaultSNSConfig = SNSConfig{
-		NotifierConfig: NotifierConfig{
+		NotifierConfig: amcommoncfg.NotifierConfig{
 			VSendResolved: true,
 		},
 		Subject: `{{ template "sns.default.subject" . }}`,
@@ -180,7 +180,7 @@ var (
 	}
 
 	DefaultTelegramConfig = TelegramConfig{
-		NotifierConfig: NotifierConfig{
+		NotifierConfig: amcommoncfg.NotifierConfig{
 			VSendResolved: true,
 		},
 		DisableNotifications: false,
@@ -189,7 +189,7 @@ var (
 	}
 
 	DefaultMSTeamsConfig = MSTeamsConfig{
-		NotifierConfig: NotifierConfig{
+		NotifierConfig: amcommoncfg.NotifierConfig{
 			VSendResolved: true,
 		},
 		Title:   `{{ template "msteams.default.title" . }}`,
@@ -198,7 +198,7 @@ var (
 	}
 
 	DefaultMSTeamsV2Config = MSTeamsV2Config{
-		NotifierConfig: NotifierConfig{
+		NotifierConfig: amcommoncfg.NotifierConfig{
 			VSendResolved: true,
 		},
 		Title: `{{ template "msteamsv2.default.title" . }}`,
@@ -206,7 +206,7 @@ var (
 	}
 
 	DefaultJiraConfig = JiraConfig{
-		NotifierConfig: NotifierConfig{
+		NotifierConfig: amcommoncfg.NotifierConfig{
 			VSendResolved: true,
 		},
 		APIType: "auto",
@@ -220,7 +220,7 @@ var (
 	}
 
 	DefaultMattermostConfig = MattermostConfig{
-		NotifierConfig: NotifierConfig{
+		NotifierConfig: amcommoncfg.NotifierConfig{
 			VSendResolved: true,
 		},
 		Username:  `{{ template "mattermost.default.username" . }}`,
@@ -232,20 +232,11 @@ var (
 	}
 )
 
-// NotifierConfig contains base options common across all notifier configurations.
-type NotifierConfig struct {
-	VSendResolved bool `yaml:"send_resolved" json:"send_resolved"`
-}
-
-func (nc *NotifierConfig) SendResolved() bool {
-	return nc.VSendResolved
-}
-
 // WebexConfig configures notifications via Webex.
 type WebexConfig struct {
-	NotifierConfig `yaml:",inline" json:",inline"`
-	HTTPConfig     *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
-	APIURL         *amcommoncfg.URL            `yaml:"api_url,omitempty" json:"api_url,omitempty"`
+	amcommoncfg.NotifierConfig `yaml:",inline" json:",inline"`
+	HTTPConfig                 *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
+	APIURL                     *amcommoncfg.URL            `yaml:"api_url,omitempty" json:"api_url,omitempty"`
 
 	Message string `yaml:"message,omitempty" json:"message,omitempty"`
 	RoomID  string `yaml:"room_id" json:"room_id"`
@@ -272,7 +263,7 @@ func (c *WebexConfig) UnmarshalYAML(unmarshal func(any) error) error {
 
 // DiscordConfig configures notifications via Discord.
 type DiscordConfig struct {
-	NotifierConfig `yaml:",inline" json:",inline"`
+	amcommoncfg.NotifierConfig `yaml:",inline" json:",inline"`
 
 	HTTPConfig     *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 	WebhookURL     *amcommoncfg.SecretURL      `yaml:"webhook_url,omitempty" json:"webhook_url,omitempty"`
@@ -306,7 +297,7 @@ func (c *DiscordConfig) UnmarshalYAML(unmarshal func(any) error) error {
 
 // EmailConfig configures notifications via mail.
 type EmailConfig struct {
-	NotifierConfig `yaml:",inline" json:",inline"`
+	amcommoncfg.NotifierConfig `yaml:",inline" json:",inline"`
 
 	// Email address to notify.
 	To               string               `yaml:"to,omitempty" json:"to,omitempty"`
@@ -376,7 +367,7 @@ func (c *EmailConfig) UnmarshalYAML(unmarshal func(any) error) error {
 
 // PagerdutyConfig configures notifications via PagerDuty.
 type PagerdutyConfig struct {
-	NotifierConfig `yaml:",inline" json:",inline"`
+	amcommoncfg.NotifierConfig `yaml:",inline" json:",inline"`
 
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
@@ -531,7 +522,7 @@ func (c *SlackField) UnmarshalYAML(unmarshal func(any) error) error {
 
 // SlackConfig configures notifications via Slack.
 type SlackConfig struct {
-	NotifierConfig `yaml:",inline" json:",inline"`
+	amcommoncfg.NotifierConfig `yaml:",inline" json:",inline"`
 
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
@@ -600,7 +591,7 @@ func (c *SlackConfig) UnmarshalYAML(unmarshal func(any) error) error {
 
 // IncidentioConfig configures notifications via incident.io.
 type IncidentioConfig struct {
-	NotifierConfig `yaml:",inline" json:",inline"`
+	amcommoncfg.NotifierConfig `yaml:",inline" json:",inline"`
 
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
@@ -652,7 +643,7 @@ func (c *IncidentioConfig) UnmarshalYAML(unmarshal func(any) error) error {
 
 // WebhookConfig configures notifications via a generic webhook.
 type WebhookConfig struct {
-	NotifierConfig `yaml:",inline" json:",inline"`
+	amcommoncfg.NotifierConfig `yaml:",inline" json:",inline"`
 
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
@@ -689,7 +680,7 @@ func (c *WebhookConfig) UnmarshalYAML(unmarshal func(any) error) error {
 
 // WechatConfig configures notifications via Wechat.
 type WechatConfig struct {
-	NotifierConfig `yaml:",inline" json:",inline"`
+	amcommoncfg.NotifierConfig `yaml:",inline" json:",inline"`
 
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
@@ -734,7 +725,7 @@ func (c *WechatConfig) UnmarshalYAML(unmarshal func(any) error) error {
 
 // OpsGenieConfig configures notifications via OpsGenie.
 type OpsGenieConfig struct {
-	NotifierConfig `yaml:",inline" json:",inline"`
+	amcommoncfg.NotifierConfig `yaml:",inline" json:",inline"`
 
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
@@ -802,7 +793,7 @@ type OpsGenieConfigResponder struct {
 
 // VictorOpsConfig configures notifications via VictorOps.
 type VictorOpsConfig struct {
-	NotifierConfig `yaml:",inline" json:",inline"`
+	amcommoncfg.NotifierConfig `yaml:",inline" json:",inline"`
 
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
@@ -857,7 +848,7 @@ func (d duration) MarshalText() ([]byte, error) {
 }
 
 type PushoverConfig struct {
-	NotifierConfig `yaml:",inline" json:",inline"`
+	amcommoncfg.NotifierConfig `yaml:",inline" json:",inline"`
 
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
@@ -905,7 +896,7 @@ func (c *PushoverConfig) UnmarshalYAML(unmarshal func(any) error) error {
 }
 
 type SNSConfig struct {
-	NotifierConfig `yaml:",inline" json:",inline"`
+	amcommoncfg.NotifierConfig `yaml:",inline" json:",inline"`
 
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
@@ -934,7 +925,7 @@ func (c *SNSConfig) UnmarshalYAML(unmarshal func(any) error) error {
 
 // TelegramConfig configures notifications via Telegram.
 type TelegramConfig struct {
-	NotifierConfig `yaml:",inline" json:",inline"`
+	amcommoncfg.NotifierConfig `yaml:",inline" json:",inline"`
 
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
@@ -975,10 +966,10 @@ func (c *TelegramConfig) UnmarshalYAML(unmarshal func(any) error) error {
 }
 
 type MSTeamsConfig struct {
-	NotifierConfig `yaml:",inline" json:",inline"`
-	HTTPConfig     *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
-	WebhookURL     *amcommoncfg.SecretURL      `yaml:"webhook_url,omitempty" json:"webhook_url,omitempty"`
-	WebhookURLFile string                      `yaml:"webhook_url_file,omitempty" json:"webhook_url_file,omitempty"`
+	amcommoncfg.NotifierConfig `yaml:",inline" json:",inline"`
+	HTTPConfig                 *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
+	WebhookURL                 *amcommoncfg.SecretURL      `yaml:"webhook_url,omitempty" json:"webhook_url,omitempty"`
+	WebhookURLFile             string                      `yaml:"webhook_url_file,omitempty" json:"webhook_url_file,omitempty"`
 
 	Title   string `yaml:"title,omitempty" json:"title,omitempty"`
 	Summary string `yaml:"summary,omitempty" json:"summary,omitempty"`
@@ -1004,10 +995,10 @@ func (c *MSTeamsConfig) UnmarshalYAML(unmarshal func(any) error) error {
 }
 
 type MSTeamsV2Config struct {
-	NotifierConfig `yaml:",inline" json:",inline"`
-	HTTPConfig     *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
-	WebhookURL     *amcommoncfg.SecretURL      `yaml:"webhook_url,omitempty" json:"webhook_url,omitempty"`
-	WebhookURLFile string                      `yaml:"webhook_url_file,omitempty" json:"webhook_url_file,omitempty"`
+	amcommoncfg.NotifierConfig `yaml:",inline" json:",inline"`
+	HTTPConfig                 *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
+	WebhookURL                 *amcommoncfg.SecretURL      `yaml:"webhook_url,omitempty" json:"webhook_url,omitempty"`
+	WebhookURLFile             string                      `yaml:"webhook_url_file,omitempty" json:"webhook_url_file,omitempty"`
 
 	Title string `yaml:"title,omitempty" json:"title,omitempty"`
 	Text  string `yaml:"text,omitempty" json:"text,omitempty"`
@@ -1039,8 +1030,8 @@ type JiraFieldConfig struct {
 }
 
 type JiraConfig struct {
-	NotifierConfig `yaml:",inline" json:",inline"`
-	HTTPConfig     *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
+	amcommoncfg.NotifierConfig `yaml:",inline" json:",inline"`
+	HTTPConfig                 *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
 	APIURL  *amcommoncfg.URL `yaml:"api_url,omitempty" json:"api_url,omitempty"`
 	APIType string           `yaml:"api_type,omitempty" json:"api_type,omitempty"`
@@ -1128,7 +1119,7 @@ type RocketchatAttachmentAction struct {
 
 // RocketchatConfig configures notifications via Rocketchat.
 type RocketchatConfig struct {
-	NotifierConfig `yaml:",inline" json:",inline"`
+	amcommoncfg.NotifierConfig `yaml:",inline" json:",inline"`
 
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
@@ -1229,7 +1220,7 @@ type MattermostAttachment struct {
 // MattermostConfig configures notifications via Mattermost.
 // See https://developers.mattermost.com/integrate/webhooks/incoming/ for more information.
 type MattermostConfig struct {
-	NotifierConfig `yaml:",inline" json:",inline"`
+	amcommoncfg.NotifierConfig `yaml:",inline" json:",inline"`
 
 	HTTPConfig     *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 	WebhookURL     *amcommoncfg.SecretURL      `yaml:"webhook_url,omitempty" json:"webhook_url,omitempty"`

--- a/config/receiver/receiver_test.go
+++ b/config/receiver/receiver_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Prometheus Team
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -18,6 +18,8 @@ import (
 
 	commoncfg "github.com/prometheus/common/config"
 	"github.com/stretchr/testify/require"
+
+	amcommoncfg "github.com/prometheus/alertmanager/config/common"
 
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
@@ -42,7 +44,7 @@ func TestBuildReceiverIntegrations(t *testing.T) {
 					},
 					{
 						HTTPConfig: &commoncfg.HTTPClientConfig{},
-						NotifierConfig: config.NotifierConfig{
+						NotifierConfig: amcommoncfg.NotifierConfig{
 							VSendResolved: true,
 						},
 					},

--- a/notify/opsgenie/opsgenie_test.go
+++ b/notify/opsgenie/opsgenie_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Prometheus Team
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -115,7 +115,7 @@ func TestOpsGenie(t *testing.T) {
 		{
 			title: "config without details",
 			cfg: &config.OpsGenieConfig{
-				NotifierConfig: config.NotifierConfig{
+				NotifierConfig: amcommoncfg.NotifierConfig{
 					VSendResolved: true,
 				},
 				Message:     `{{ .CommonLabels.Message }}`,
@@ -148,7 +148,7 @@ func TestOpsGenie(t *testing.T) {
 		{
 			title: "config with details",
 			cfg: &config.OpsGenieConfig{
-				NotifierConfig: config.NotifierConfig{
+				NotifierConfig: amcommoncfg.NotifierConfig{
 					VSendResolved: true,
 				},
 				Message:     `{{ .CommonLabels.Message }}`,
@@ -184,7 +184,7 @@ func TestOpsGenie(t *testing.T) {
 		{
 			title: "config with multiple teams",
 			cfg: &config.OpsGenieConfig{
-				NotifierConfig: config.NotifierConfig{
+				NotifierConfig: amcommoncfg.NotifierConfig{
 					VSendResolved: true,
 				},
 				Message:     `{{ .CommonLabels.Message }}`,

--- a/notify/slack/slack_test.go
+++ b/notify/slack/slack_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Prometheus Team
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -197,7 +197,7 @@ func TestNotifier_Notify_WithReason(t *testing.T) {
 			apiurl, _ := url.Parse("https://slack.com/post.Message")
 			notifier, err := New(
 				&config.SlackConfig{
-					NotifierConfig: config.NotifierConfig{},
+					NotifierConfig: amcommoncfg.NotifierConfig{},
 					HTTPConfig:     &commoncfg.HTTPClientConfig{},
 					APIURL:         &amcommoncfg.SecretURL{URL: apiurl},
 					Channel:        "channelname",
@@ -255,7 +255,7 @@ func TestSlackTimeout(t *testing.T) {
 			u, _ := url.Parse("https://slack.com/post.Message")
 			notifier, err := New(
 				&config.SlackConfig{
-					NotifierConfig: config.NotifierConfig{},
+					NotifierConfig: amcommoncfg.NotifierConfig{},
 					HTTPConfig:     &commoncfg.HTTPClientConfig{},
 					APIURL:         &amcommoncfg.SecretURL{URL: u},
 					Channel:        "channelname",


### PR DESCRIPTION
This moves NotifierConfig to config/common. It allows to reuse this type in the notify package without creating circular dependencies between the notify and config packages. This is a preparation to further separate notifier specific code from the config package and move it to the notify sub packages.

<!--
    - Please give your PR a title in the form "area: short description".  For example "dispatcher: improve performance"

    - Please sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Pull Request Checklist
Please check all the applicable boxes.

- Please list all open issue(s) discussed with maintainers related to this change
    - Fixes #<issue number>
    <!--
    If it applies.
    Automatically closes linked issue when PR is merged.
    Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
    More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
    -->
- Is this a new Receiver integration?
    - [ ] I have already tried to use the [Webhook Receiver Integration](https://prometheus.io/docs/alerting/latest/configuration/#webhook_config) and [3rd party integrations](https://prometheus.io/docs/operating/integrations/#alertmanager-webhook-receiver) before adding this new Receiver Integration
- Is this a bugfix?
    - [ ] I have added tests that can reproduce the bug which pass with this bugfix applied
- Is this a new feature?
    - [ ] I have added tests that test the new feature's functionality
- Does this change affect performance?
    - [ ] I have provided benchmarks comparison that shows performance is improved or is not degraded
        - You can use [`benchstat`](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat) to compare benchmarks
    - [ ] I have added new benchmarks if required or requested by maintainers
- Is this a breaking change?
    - [ ] My changes do not break the existing cluster messages
    - [ ] My changes do not break the existing api
- [ ] I have added/updated the required documentation
- [x] I have signed-off my commits
- [x] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/alertmanager/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
