### PR TITLE
refactor(config): move matcher/regex types to config/common

### DIFF
--- a/config/common/matchers.go
+++ b/config/common/matchers.go
@@ -1,0 +1,157 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+
+	"github.com/prometheus/common/model"
+
+	"github.com/prometheus/alertmanager/matcher/compat"
+	"github.com/prometheus/alertmanager/pkg/labels"
+)
+
+// MatchRegexps represents a map of Regexp.
+type MatchRegexps map[string]Regexp
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface for MatchRegexps.
+func (m *MatchRegexps) UnmarshalYAML(unmarshal func(any) error) error {
+	type plain MatchRegexps
+	if err := unmarshal((*plain)(m)); err != nil {
+		return err
+	}
+	for k, v := range *m {
+		if !model.LabelNameRE.MatchString(k) {
+			return fmt.Errorf("invalid label name %q", k)
+		}
+		if v.Regexp == nil {
+			return fmt.Errorf("invalid regexp value for %q", k)
+		}
+	}
+	return nil
+}
+
+// Regexp encapsulates a regexp.Regexp and makes it YAML marshalable.
+type Regexp struct {
+	*regexp.Regexp
+	Original string
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface for Regexp.
+func (re *Regexp) UnmarshalYAML(unmarshal func(any) error) error {
+	var s string
+	if err := unmarshal(&s); err != nil {
+		return err
+	}
+	regex, err := regexp.Compile("^(?:" + s + ")$")
+	if err != nil {
+		return err
+	}
+	re.Regexp = regex
+	re.Original = s
+	return nil
+}
+
+// MarshalYAML implements the yaml.Marshaler interface for Regexp.
+func (re Regexp) MarshalYAML() (any, error) {
+	if re.Original != "" {
+		return re.Original, nil
+	}
+	return nil, nil
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface for Regexp.
+func (re *Regexp) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	regex, err := regexp.Compile("^(?:" + s + ")$")
+	if err != nil {
+		return err
+	}
+	re.Regexp = regex
+	re.Original = s
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaler interface for Regexp.
+func (re Regexp) MarshalJSON() ([]byte, error) {
+	if re.Original != "" {
+		return json.Marshal(re.Original)
+	}
+	return []byte("null"), nil
+}
+
+// Matchers is label.Matchers with an added UnmarshalYAML method to implement the yaml.Unmarshaler interface
+// and MarshalYAML to implement the yaml.Marshaler interface.
+type Matchers labels.Matchers
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface for Matchers.
+func (m *Matchers) UnmarshalYAML(unmarshal func(any) error) error {
+	var lines []string
+	if err := unmarshal(&lines); err != nil {
+		return err
+	}
+	for _, line := range lines {
+		pm, err := compat.Matchers(line, "config")
+		if err != nil {
+			return err
+		}
+		*m = append(*m, pm...)
+	}
+	sort.Sort(labels.Matchers(*m))
+	return nil
+}
+
+// MarshalYAML implements the yaml.Marshaler interface for Matchers.
+func (m Matchers) MarshalYAML() (any, error) {
+	result := make([]string, len(m))
+	for i, matcher := range m {
+		result[i] = matcher.String()
+	}
+	return result, nil
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface for Matchers.
+func (m *Matchers) UnmarshalJSON(data []byte) error {
+	var lines []string
+	if err := json.Unmarshal(data, &lines); err != nil {
+		return err
+	}
+	for _, line := range lines {
+		pm, err := compat.Matchers(line, "config")
+		if err != nil {
+			return err
+		}
+		*m = append(*m, pm...)
+	}
+	sort.Sort(labels.Matchers(*m))
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaler interface for Matchers.
+func (m Matchers) MarshalJSON() ([]byte, error) {
+	if len(m) == 0 {
+		return []byte("[]"), nil
+	}
+	result := make([]string, len(m))
+	for i, matcher := range m {
+		result[i] = matcher.String()
+	}
+	return json.Marshal(result)
+}

--- a/config/common/matchers_test.go
+++ b/config/common/matchers_test.go
@@ -1,0 +1,86 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"encoding/json"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestMarshalRegexpWithNilValue(t *testing.T) {
+	r := &Regexp{}
+
+	out, err := json.Marshal(r)
+	require.NoError(t, err)
+	require.Equal(t, "null", string(out))
+
+	out, err = yaml.Marshal(r)
+	require.NoError(t, err)
+	require.Equal(t, "null\n", string(out))
+}
+
+func TestUnmarshalEmptyRegexp(t *testing.T) {
+	b := []byte(`""`)
+
+	{
+		var re Regexp
+		err := json.Unmarshal(b, &re)
+		require.NoError(t, err)
+		require.Equal(t, regexp.MustCompile("^(?:)$"), re.Regexp)
+		require.Empty(t, re.Original)
+	}
+
+	{
+		var re Regexp
+		err := yaml.Unmarshal(b, &re)
+		require.NoError(t, err)
+		require.Equal(t, regexp.MustCompile("^(?:)$"), re.Regexp)
+		require.Empty(t, re.Original)
+	}
+}
+
+func TestUnmarshalNullRegexp(t *testing.T) {
+	input := []byte(`null`)
+
+	{
+		var re Regexp
+		err := json.Unmarshal(input, &re)
+		require.NoError(t, err)
+		require.Empty(t, re.Original)
+	}
+
+	{
+		var re Regexp
+		err := yaml.Unmarshal(input, &re) // Interestingly enough, unmarshalling `null` in YAML doesn't even call UnmarshalYAML.
+		require.NoError(t, err)
+		require.Nil(t, re.Regexp)
+		require.Empty(t, re.Original)
+	}
+}
+
+func TestMarshalEmptyMatchers(t *testing.T) {
+	r := Matchers{}
+
+	out, err := json.Marshal(r)
+	require.NoError(t, err)
+	require.Equal(t, "[]", string(out))
+
+	out, err = yaml.Marshal(r)
+	require.NoError(t, err)
+	require.Equal(t, "[]\n", string(out))
+}

--- a/config/config.go
+++ b/config/config.go
@@ -21,8 +21,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"regexp"
-	"sort"
 	"strings"
 	"text/template"
 	"time"
@@ -33,7 +31,6 @@ import (
 
 	amcommoncfg "github.com/prometheus/alertmanager/config/common"
 	"github.com/prometheus/alertmanager/matcher/compat"
-	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/prometheus/alertmanager/timeinterval"
 	"github.com/prometheus/alertmanager/tracing"
 )
@@ -860,12 +857,12 @@ type Route struct {
 	// Deprecated. Remove before v1.0 release.
 	Match map[string]string `yaml:"match,omitempty" json:"match,omitempty"`
 	// Deprecated. Remove before v1.0 release.
-	MatchRE             MatchRegexps `yaml:"match_re,omitempty" json:"match_re,omitempty"`
-	Matchers            Matchers     `yaml:"matchers,omitempty" json:"matchers,omitempty"`
-	MuteTimeIntervals   []string     `yaml:"mute_time_intervals,omitempty" json:"mute_time_intervals,omitempty"`
-	ActiveTimeIntervals []string     `yaml:"active_time_intervals,omitempty" json:"active_time_intervals,omitempty"`
-	Continue            bool         `yaml:"continue" json:"continue,omitempty"`
-	Routes              []*Route     `yaml:"routes,omitempty" json:"routes,omitempty"`
+	MatchRE             amcommoncfg.MatchRegexps `yaml:"match_re,omitempty" json:"match_re,omitempty"`
+	Matchers            amcommoncfg.Matchers     `yaml:"matchers,omitempty" json:"matchers,omitempty"`
+	MuteTimeIntervals   []string                 `yaml:"mute_time_intervals,omitempty" json:"mute_time_intervals,omitempty"`
+	ActiveTimeIntervals []string                 `yaml:"active_time_intervals,omitempty" json:"active_time_intervals,omitempty"`
+	Continue            bool                     `yaml:"continue" json:"continue,omitempty"`
+	Routes              []*Route                 `yaml:"routes,omitempty" json:"routes,omitempty"`
 
 	GroupWait      *model.Duration `yaml:"group_wait,omitempty" json:"group_wait,omitempty"`
 	GroupInterval  *model.Duration `yaml:"group_interval,omitempty" json:"group_interval,omitempty"`
@@ -935,17 +932,17 @@ type InhibitRule struct {
 	SourceMatch map[string]string `yaml:"source_match,omitempty" json:"source_match,omitempty"`
 	// SourceMatchRE defines pairs like SourceMatch but does regular expression
 	// matching. Deprecated. Remove before v1.0 release.
-	SourceMatchRE MatchRegexps `yaml:"source_match_re,omitempty" json:"source_match_re,omitempty"`
+	SourceMatchRE amcommoncfg.MatchRegexps `yaml:"source_match_re,omitempty" json:"source_match_re,omitempty"`
 	// SourceMatchers defines a set of label matchers that have to be fulfilled for source alerts.
-	SourceMatchers Matchers `yaml:"source_matchers,omitempty" json:"source_matchers,omitempty"`
+	SourceMatchers amcommoncfg.Matchers `yaml:"source_matchers,omitempty" json:"source_matchers,omitempty"`
 	// TargetMatch defines a set of labels that have to equal the given
 	// value for target alerts. Deprecated. Remove before v1.0 release.
 	TargetMatch map[string]string `yaml:"target_match,omitempty" json:"target_match,omitempty"`
 	// TargetMatchRE defines pairs like TargetMatch but does regular expression
 	// matching. Deprecated. Remove before v1.0 release.
-	TargetMatchRE MatchRegexps `yaml:"target_match_re,omitempty" json:"target_match_re,omitempty"`
+	TargetMatchRE amcommoncfg.MatchRegexps `yaml:"target_match_re,omitempty" json:"target_match_re,omitempty"`
 	// TargetMatchers defines a set of label matchers that have to be fulfilled for target alerts.
-	TargetMatchers Matchers `yaml:"target_matchers,omitempty" json:"target_matchers,omitempty"`
+	TargetMatchers amcommoncfg.Matchers `yaml:"target_matchers,omitempty" json:"target_matchers,omitempty"`
 	// A set of labels that must be equal between the source and target alert
 	// for them to be a match.
 	Equal []string `yaml:"equal,omitempty" json:"equal,omitempty"`
@@ -1015,135 +1012,4 @@ func (c *Receiver) UnmarshalYAML(unmarshal func(any) error) error {
 		return errors.New("missing name in receiver")
 	}
 	return nil
-}
-
-// MatchRegexps represents a map of Regexp.
-type MatchRegexps map[string]Regexp
-
-// UnmarshalYAML implements the yaml.Unmarshaler interface for MatchRegexps.
-func (m *MatchRegexps) UnmarshalYAML(unmarshal func(any) error) error {
-	type plain MatchRegexps
-	if err := unmarshal((*plain)(m)); err != nil {
-		return err
-	}
-	for k, v := range *m {
-		if !model.LabelNameRE.MatchString(k) {
-			return fmt.Errorf("invalid label name %q", k)
-		}
-		if v.Regexp == nil {
-			return fmt.Errorf("invalid regexp value for %q", k)
-		}
-	}
-	return nil
-}
-
-// Regexp encapsulates a regexp.Regexp and makes it YAML marshalable.
-type Regexp struct {
-	*regexp.Regexp
-	original string
-}
-
-// UnmarshalYAML implements the yaml.Unmarshaler interface for Regexp.
-func (re *Regexp) UnmarshalYAML(unmarshal func(any) error) error {
-	var s string
-	if err := unmarshal(&s); err != nil {
-		return err
-	}
-	regex, err := regexp.Compile("^(?:" + s + ")$")
-	if err != nil {
-		return err
-	}
-	re.Regexp = regex
-	re.original = s
-	return nil
-}
-
-// MarshalYAML implements the yaml.Marshaler interface for Regexp.
-func (re Regexp) MarshalYAML() (any, error) {
-	if re.original != "" {
-		return re.original, nil
-	}
-	return nil, nil
-}
-
-// UnmarshalJSON implements the json.Unmarshaler interface for Regexp.
-func (re *Regexp) UnmarshalJSON(data []byte) error {
-	var s string
-	if err := json.Unmarshal(data, &s); err != nil {
-		return err
-	}
-	regex, err := regexp.Compile("^(?:" + s + ")$")
-	if err != nil {
-		return err
-	}
-	re.Regexp = regex
-	re.original = s
-	return nil
-}
-
-// MarshalJSON implements the json.Marshaler interface for Regexp.
-func (re Regexp) MarshalJSON() ([]byte, error) {
-	if re.original != "" {
-		return json.Marshal(re.original)
-	}
-	return []byte("null"), nil
-}
-
-// Matchers is label.Matchers with an added UnmarshalYAML method to implement the yaml.Unmarshaler interface
-// and MarshalYAML to implement the yaml.Marshaler interface.
-type Matchers labels.Matchers
-
-// UnmarshalYAML implements the yaml.Unmarshaler interface for Matchers.
-func (m *Matchers) UnmarshalYAML(unmarshal func(any) error) error {
-	var lines []string
-	if err := unmarshal(&lines); err != nil {
-		return err
-	}
-	for _, line := range lines {
-		pm, err := compat.Matchers(line, "config")
-		if err != nil {
-			return err
-		}
-		*m = append(*m, pm...)
-	}
-	sort.Sort(labels.Matchers(*m))
-	return nil
-}
-
-// MarshalYAML implements the yaml.Marshaler interface for Matchers.
-func (m Matchers) MarshalYAML() (any, error) {
-	result := make([]string, len(m))
-	for i, matcher := range m {
-		result[i] = matcher.String()
-	}
-	return result, nil
-}
-
-// UnmarshalJSON implements the json.Unmarshaler interface for Matchers.
-func (m *Matchers) UnmarshalJSON(data []byte) error {
-	var lines []string
-	if err := json.Unmarshal(data, &lines); err != nil {
-		return err
-	}
-	for _, line := range lines {
-		pm, err := compat.Matchers(line, "config")
-		if err != nil {
-			return err
-		}
-		*m = append(*m, pm...)
-	}
-	sort.Sort(labels.Matchers(*m))
-	return nil
-}
-
-// MarshalJSON implements the json.Marshaler interface for Matchers.
-func (m Matchers) MarshalJSON() ([]byte, error) {
-	if len(m) == 0 {
-		return []byte("[]"), nil
-	}
-	result := make([]string, len(m))
-	for i, matcher := range m {
-		result[i] = matcher.String()
-	}
-	return json.Marshal(result)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -538,69 +538,6 @@ func TestJSONMarshal(t *testing.T) {
 	}
 }
 
-func TestMarshalRegexpWithNilValue(t *testing.T) {
-	r := &Regexp{}
-
-	out, err := json.Marshal(r)
-	require.NoError(t, err)
-	require.Equal(t, "null", string(out))
-
-	out, err = yaml.Marshal(r)
-	require.NoError(t, err)
-	require.Equal(t, "null\n", string(out))
-}
-
-func TestUnmarshalEmptyRegexp(t *testing.T) {
-	b := []byte(`""`)
-
-	{
-		var re Regexp
-		err := json.Unmarshal(b, &re)
-		require.NoError(t, err)
-		require.Equal(t, regexp.MustCompile("^(?:)$"), re.Regexp)
-		require.Empty(t, re.original)
-	}
-
-	{
-		var re Regexp
-		err := yaml.Unmarshal(b, &re)
-		require.NoError(t, err)
-		require.Equal(t, regexp.MustCompile("^(?:)$"), re.Regexp)
-		require.Empty(t, re.original)
-	}
-}
-
-func TestUnmarshalNullRegexp(t *testing.T) {
-	input := []byte(`null`)
-
-	{
-		var re Regexp
-		err := json.Unmarshal(input, &re)
-		require.NoError(t, err)
-		require.Empty(t, re.original)
-	}
-
-	{
-		var re Regexp
-		err := yaml.Unmarshal(input, &re) // Interestingly enough, unmarshalling `null` in YAML doesn't even call UnmarshalYAML.
-		require.NoError(t, err)
-		require.Nil(t, re.Regexp)
-		require.Empty(t, re.original)
-	}
-}
-
-func TestMarshalEmptyMatchers(t *testing.T) {
-	r := Matchers{}
-
-	out, err := json.Marshal(r)
-	require.NoError(t, err)
-	require.Equal(t, "[]", string(out))
-
-	out, err = yaml.Marshal(r)
-	require.NoError(t, err)
-	require.Equal(t, "[]\n", string(out))
-}
-
 func TestJSONUnmarshal(t *testing.T) {
 	c, err := LoadFile("testdata/conf.good.yml")
 	if err != nil {
@@ -656,9 +593,9 @@ receivers:
 
 func TestEmptyFieldsAndRegex(t *testing.T) {
 	boolFoo := true
-	regexpFoo := Regexp{
+	regexpFoo := amcommoncfg.Regexp{
 		Regexp:   regexp.MustCompile("^(?:^(foo1|foo2|baz)$)$"),
-		original: "^(foo1|foo2|baz)$",
+		Original: "^(foo1|foo2|baz)$",
 	}
 
 	expectedConf := Config{
@@ -704,7 +641,7 @@ func TestEmptyFieldsAndRegex(t *testing.T) {
 			Routes: []*Route{
 				{
 					Receiver: "team-X-mails",
-					MatchRE: map[string]Regexp{
+					MatchRE: map[string]amcommoncfg.Regexp{
 						"service": regexpFoo,
 					},
 				},

--- a/inhibit/inhibit_bench_test.go
+++ b/inhibit/inhibit_bench_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/alertmanager/config"
+	amcommoncfg "github.com/prometheus/alertmanager/config/common"
 	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/prometheus/alertmanager/provider/mem"
 	"github.com/prometheus/alertmanager/types"
@@ -109,10 +110,10 @@ func allRulesMatchBenchmark(b *testing.B, numInhibitionRules, numInhibitingAlert
 		n: numInhibitionRules,
 		newRuleFunc: func(idx int) config.InhibitRule {
 			return config.InhibitRule{
-				SourceMatchers: config.Matchers{
+				SourceMatchers: amcommoncfg.Matchers{
 					mustNewMatcher(b, labels.MatchEqual, "src", strconv.Itoa(idx)),
 				},
-				TargetMatchers: config.Matchers{
+				TargetMatchers: amcommoncfg.Matchers{
 					mustNewMatcher(b, labels.MatchEqual, "dst", "0"),
 				},
 			}
@@ -152,10 +153,10 @@ func lastRuleMatchesBenchmark(b *testing.B, n int) benchmarkOptions {
 		n: n,
 		newRuleFunc: func(idx int) config.InhibitRule {
 			return config.InhibitRule{
-				SourceMatchers: config.Matchers{
+				SourceMatchers: amcommoncfg.Matchers{
 					mustNewMatcher(b, labels.MatchEqual, "src", strconv.Itoa(idx)),
 				},
-				TargetMatchers: config.Matchers{
+				TargetMatchers: amcommoncfg.Matchers{
 					mustNewMatcher(b, labels.MatchEqual, "dst", "0"),
 				},
 			}

--- a/inhibit/inhibit_test.go
+++ b/inhibit/inhibit_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/alertmanager/config"
+	amcommoncfg "github.com/prometheus/alertmanager/config/common"
 	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/prometheus/alertmanager/provider"
 	"github.com/prometheus/alertmanager/store"
@@ -251,13 +252,13 @@ func TestInhibitRuleMatchers(t *testing.T) {
 	t.Parallel()
 
 	rule1 := config.InhibitRule{
-		SourceMatchers: config.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "s1", Value: "1"}},
-		TargetMatchers: config.Matchers{&labels.Matcher{Type: labels.MatchNotEqual, Name: "t1", Value: "1"}},
+		SourceMatchers: amcommoncfg.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "s1", Value: "1"}},
+		TargetMatchers: amcommoncfg.Matchers{&labels.Matcher{Type: labels.MatchNotEqual, Name: "t1", Value: "1"}},
 		Equal:          []string{"e"},
 	}
 	rule2 := config.InhibitRule{
-		SourceMatchers: config.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "s2", Value: "1"}},
-		TargetMatchers: config.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "t2", Value: "1"}},
+		SourceMatchers: amcommoncfg.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "s2", Value: "1"}},
+		TargetMatchers: amcommoncfg.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "t2", Value: "1"}},
 		Equal:          []string{"e"},
 	}
 


### PR DESCRIPTION
This moves MatchRegexps,Regexp and Matcher types to config/common. It allows to reuse theses types in the notify package without creating circular dependencies between the notify and config packages. This is a preparation to further separate notifier specific code from the config package and move it to the notify sub packages.

<!--
    - Please give your PR a title in the form "area: short description".  For example "dispatcher: improve performance"

    - Please sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Pull Request Checklist
Please check all the applicable boxes.

- Please list all open issue(s) discussed with maintainers related to this change
    - Fixes #<issue number>
    <!--
    If it applies.
    Automatically closes linked issue when PR is merged.
    Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
    More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
    -->
- Is this a new Receiver integration?
    - [ ] I have already tried to use the [Webhook Receiver Integration](https://prometheus.io/docs/alerting/latest/configuration/#webhook_config) and [3rd party integrations](https://prometheus.io/docs/operating/integrations/#alertmanager-webhook-receiver) before adding this new Receiver Integration
- Is this a bugfix?
    - [ ] I have added tests that can reproduce the bug which pass with this bugfix applied
- Is this a new feature?
    - [ ] I have added tests that test the new feature's functionality
- Does this change affect performance?
    - [ ] I have provided benchmarks comparison that shows performance is improved or is not degraded
        - You can use [`benchstat`](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat) to compare benchmarks
    - [ ] I have added new benchmarks if required or requested by maintainers
- Is this a breaking change?
    - [ ] My changes do not break the existing cluster messages
    - [ ] My changes do not break the existing api
- [ ] I have added/updated the required documentation
- [x] I have signed-off my commits
- [x] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/alertmanager/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
