### PR TITLE
feat(template): add dict, map and append functions

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -85,9 +85,12 @@ templating.
 
 | Name             | Arguments                  | Description |
 | ---------------- | -------------------------- | ----------- |
+| append           | slice []any, args ...any   | Returns a new slice with the provided arguments appended to the provided slice. |
 | date             | string, time.Time          | Returns the text representation of the time in the specified format. For documentation on formats refer to [pkg.go.dev/time](https://pkg.go.dev/time#pkg-constants). |
+| dict             | values ...any              | Returns a map of string to any, constructed from the variadic list of key-value pairs. The number of arguments must be even, and the keys must be strings. |
 | humanizeDuration | number or string           | Returns a human-readable string representing the duration, and the error if it happened. |
 | join             | sep string, s []string     | [strings.Join](http://golang.org/pkg/strings/#Join), concatenates the elements of s to create a single string. The separator string sep is placed between elements in the resulting string. (note: argument order inverted for easier pipelining in templates.) |
+| list             | ...any                     | Returns the passed arguments as a slice of interfaces. |
 | match            | pattern, string            | [Regexp.MatchString](https://golang.org/pkg/regexp/#MatchString). Match a string using Regexp. |
 | reReplaceAll     | pattern, replacement, text | [Regexp.ReplaceAllString](http://golang.org/pkg/regexp/#Regexp.ReplaceAllString) Regexp substitution, unanchored. |
 | safeHtml         | text string                | [html/template.HTML](https://golang.org/pkg/html/template/#HTML), Marks string as HTML not requiring auto-escaping. |

--- a/template/template.go
+++ b/template/template.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"embed"
 	"encoding/json"
+	"fmt"
 	tmplhtml "html/template"
 	"io"
 	"net/url"
@@ -222,6 +223,31 @@ var DefaultFuncs = FuncMap{
 			return "", err
 		}
 		return string(bytes), nil
+	},
+	"list": func(args ...any) ([]any, error) {
+		if args == nil {
+			return []any{}, nil
+		}
+		return args, nil
+	},
+	"append": func(slice []any, args ...any) []any {
+		return append(slice, args...)
+	},
+	"dict": func(values ...any) (map[string]any, error) {
+		if len(values)%2 != 0 {
+			return nil, fmt.Errorf("dict requires an even number of arguments")
+		}
+
+		res := make(map[string]any, len(values)/2)
+		for i := 0; i < len(values); i += 2 {
+			key, ok := values[i].(string)
+			if !ok {
+				return nil, fmt.Errorf("dict keys must be strings")
+			}
+			res[key] = values[i+1]
+		}
+
+		return res, nil
 	},
 }
 

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -463,6 +463,52 @@ func TestTemplateExpansion(t *testing.T) {
 			},
 			exp: `[{"status":"firing","labels":null,"annotations":null,"startsAt":"0001-01-01T00:00:00Z","endsAt":"0001-01-01T00:00:00Z","generatorURL":"","fingerprint":""}]`,
 		},
+		{
+			title: "Template creates empty dict when using dict on nil",
+			in:    `{{- $test := dict -}}{{ $test }}`,
+			exp:   "map[]",
+		},
+		{
+			title: "Template creates dict with args",
+			in:    `{{- $test := dict "a" 1 "b" 2 "c" 3 -}}{{ $test }}`,
+			exp:   "map[a:1 b:2 c:3]",
+		},
+		{
+			title: "Template using dict with odd number of arguments",
+			in:    `{{ dict "a" }}`,
+			fail:  true,
+		},
+		{
+			title: "Template using dict with non-string key",
+			in:    `{{ dict 1 "value" }}`,
+			fail:  true,
+		},
+		{
+			title: "Template creates empty list when using list on nil",
+			in:    `{{- $test := list -}}{{ $test }}`,
+			exp:   "[]",
+		},
+		{
+			title: "Template creates list with args",
+			in:    `{{- $test := list "a" "b" "c" -}}{{ $test }}`,
+			exp:   "[a b c]",
+		},
+		{
+			title: "Template appends to list",
+			in:    `{{- $test := list "a" "b" -}}{{ $test = append $test "c" "d" -}}{{ $test }}`,
+			exp:   "[a b c d]",
+		},
+		{
+			title: "Compose json array using list and append",
+			data: Data{
+				Alerts: Alerts{
+					{Status: "firing"},
+					{Status: "resolved"},
+				},
+			},
+			in:  `{{- $newList := list -}}{{ range .Alerts }}{{ $m := dict "status" .Status "labels" .Labels }}{{ $newList = append $newList $m }}{{ end }}{{ toJson $newList }}`,
+			exp: `[{"labels":null,"status":"firing"},{"labels":null,"status":"resolved"}]`,
+		},
 	} {
 		t.Run(tc.title, func(t *testing.T) {
 			f := tmpl.ExecuteTextString


### PR DESCRIPTION
These functions are useful for constructing complex data structures in templates. For example to compose  K/V arrays to use with the existing `toJSON` function. The dict function allows for creating maps from a list of key-value pairs, the list function creates slices from a list of values, and the append function allows for adding elements to a slice.

The names dict and list where chosen instead of map and slice because there is very widspread use of the sprig library in templates, (eg helm) and these names are used in that library.

<!--
    - Please give your PR a title in the form "area: short description".  For example "dispatcher: improve performance"

    - Please sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Pull Request Checklist
Please check all the applicable boxes.

- Please list all open issue(s) discussed with maintainers related to this change
    - Fixes #<issue number>
    <!--
    If it applies.
    Automatically closes linked issue when PR is merged.
    Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
    More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
    -->
- Is this a new Receiver integration?
    - [ ] I have already tried to use the [Webhook Receiver Integration](https://prometheus.io/docs/alerting/latest/configuration/#webhook_config) and [3rd party integrations](https://prometheus.io/docs/operating/integrations/#alertmanager-webhook-receiver) before adding this new Receiver Integration
- Is this a bugfix?
    - [ ] I have added tests that can reproduce the bug which pass with this bugfix applied
- Is this a new feature?
    - [x] I have added tests that test the new feature's functionality
- Does this change affect performance?
    - [ ] I have provided benchmarks comparison that shows performance is improved or is not degraded
        - You can use [`benchstat`](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat) to compare benchmarks
    - [ ] I have added new benchmarks if required or requested by maintainers
- Is this a breaking change?
    - [ ] My changes do not break the existing cluster messages
    - [ ] My changes do not break the existing api
- [x] I have added/updated the required documentation
- [x] I have signed-off my commits
- [x] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/alertmanager/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three template helpers to build lists, append items, and construct key/value maps directly in templates.

* **Documentation**
  * Documented the new helpers with usage examples and expected error conditions.

* **Tests**
  * Added tests covering list/dict behaviors, nil handling, invalid-argument and non-string-key error cases, list mutation, and composed template scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->