### PR TITLE
ui: Move useful parts to `httpserver`

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -51,6 +51,7 @@ import (
 	"github.com/prometheus/alertmanager/config/receiver"
 	"github.com/prometheus/alertmanager/dispatch"
 	"github.com/prometheus/alertmanager/featurecontrol"
+	"github.com/prometheus/alertmanager/httpserver"
 	"github.com/prometheus/alertmanager/inhibit"
 	"github.com/prometheus/alertmanager/matcher/compat"
 	"github.com/prometheus/alertmanager/nflog"
@@ -582,7 +583,8 @@ func run() int {
 
 	webReload := make(chan chan error)
 
-	ui.Register(router, webReload, logger)
+	ui.Register(router)
+	httpserver.Register(router, webReload)
 
 	mux := api.Register(router, *routePrefix)
 

--- a/httpserver/httpserver.go
+++ b/httpserver/httpserver.go
@@ -1,0 +1,67 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"fmt"
+	"net/http"
+	_ "net/http/pprof" // Comment this line to disable pprof endpoint.
+	"path"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/common/route"
+)
+
+// Register registers handlers to serve files for automations.
+func Register(r *route.Router, reloadCh chan<- chan error) {
+	r.Get("/metrics", promhttp.Handler().ServeHTTP)
+
+	r.Post("/-/reload", func(w http.ResponseWriter, req *http.Request) {
+		errc := make(chan error)
+		defer close(errc)
+
+		reloadCh <- errc
+		if err := <-errc; err != nil {
+			http.Error(w, fmt.Sprintf("failed to reload config: %s", err), http.StatusInternalServerError)
+		}
+	})
+
+	r.Get("/-/healthy", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, "OK")
+	})
+	r.Head("/-/healthy", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	r.Get("/-/ready", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, "OK")
+	})
+	r.Head("/-/ready", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	debugHandlerFunc := func(w http.ResponseWriter, req *http.Request) {
+		subpath := route.Param(req.Context(), "subpath")
+		req.URL.Path = path.Join("/debug", subpath)
+		// path.Join removes trailing slashes, but some pprof handlers expect them.
+		if strings.HasSuffix(subpath, "/") && !strings.HasSuffix(req.URL.Path, "/") {
+			req.URL.Path += "/"
+		}
+		http.DefaultServeMux.ServeHTTP(w, req)
+	}
+	r.Get("/debug/*subpath", debugHandlerFunc)
+	r.Post("/debug/*subpath", debugHandlerFunc)
+}

--- a/httpserver/httpserver_test.go
+++ b/httpserver/httpserver_test.go
@@ -1,0 +1,58 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/prometheus/common/route"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDebugHandlersWithRoutePrefix(t *testing.T) {
+	reloadCh := make(chan chan error)
+
+	// Test with route prefix
+	routePrefix := "/prometheus/alertmanager"
+	router := route.New().WithPrefix(routePrefix)
+	Register(router, reloadCh)
+
+	// Test GET request to pprof index (note: pprof index returns text/html)
+	req := httptest.NewRequest("GET", routePrefix+"/debug/pprof/", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Body.String(), "/debug/pprof/", "pprof page did not load with expected content when using a route prefix")
+
+	// Test GET request to pprof heap endpoint
+	req = httptest.NewRequest("GET", routePrefix+"/debug/pprof/heap", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// Test without route prefix (should also work)
+	router2 := route.New()
+	Register(router2, reloadCh)
+
+	req = httptest.NewRequest("GET", "/debug/pprof/", nil)
+	w = httptest.NewRecorder()
+	router2.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Body.String(), "/debug/pprof/", "pprof page did not load with expected content")
+}

--- a/ui/web.go
+++ b/ui/web.go
@@ -15,15 +15,9 @@ package ui
 
 import (
 	"embed"
-	"fmt"
 	"io/fs"
-	"log/slog"
 	"net/http"
-	_ "net/http/pprof" // Comment this line to disable pprof endpoint.
-	"path"
-	"strings"
 
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/route"
 )
 
@@ -31,9 +25,7 @@ import (
 var asset embed.FS
 
 // Register registers handlers to serve files for the web interface.
-func Register(r *route.Router, reloadCh chan<- chan error, logger *slog.Logger) {
-	r.Get("/metrics", promhttp.Handler().ServeHTTP)
-
+func Register(r *route.Router) {
 	appFS, err := fs.Sub(asset, "app")
 	if err != nil {
 		panic(err) // During build step, we did not embed a directory named `app`.
@@ -58,43 +50,6 @@ func Register(r *route.Router, reloadCh chan<- chan error, logger *slog.Logger) 
 		disableCaching(w)
 		fs.ServeHTTP(w, req)
 	})
-
-	r.Post("/-/reload", func(w http.ResponseWriter, req *http.Request) {
-		errc := make(chan error)
-		defer close(errc)
-
-		reloadCh <- errc
-		if err := <-errc; err != nil {
-			http.Error(w, fmt.Sprintf("failed to reload config: %s", err), http.StatusInternalServerError)
-		}
-	})
-
-	r.Get("/-/healthy", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, "OK")
-	})
-	r.Head("/-/healthy", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-	r.Get("/-/ready", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, "OK")
-	})
-	r.Head("/-/ready", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-
-	debugHandlerFunc := func(w http.ResponseWriter, req *http.Request) {
-		subpath := route.Param(req.Context(), "subpath")
-		req.URL.Path = path.Join("/debug", subpath)
-		// path.Join removes trailing slashes, but some pprof handlers expect them.
-		if strings.HasSuffix(subpath, "/") && !strings.HasSuffix(req.URL.Path, "/") {
-			req.URL.Path += "/"
-		}
-		http.DefaultServeMux.ServeHTTP(w, req)
-	}
-	r.Get("/debug/*subpath", debugHandlerFunc)
-	r.Post("/debug/*subpath", debugHandlerFunc)
 }
 
 func disableCaching(w http.ResponseWriter) {

--- a/ui/web_test.go
+++ b/ui/web_test.go
@@ -14,56 +14,17 @@
 package ui
 
 import (
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/prometheus/common/route"
 	"github.com/stretchr/testify/require"
 )
 
-func TestDebugHandlersWithRoutePrefix(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
-	reloadCh := make(chan chan error)
-
-	// Test with route prefix
-	routePrefix := "/prometheus/alertmanager"
-	router := route.New().WithPrefix(routePrefix)
-	Register(router, reloadCh, logger)
-
-	// Test GET request to pprof index (note: pprof index returns text/html)
-	req := httptest.NewRequest("GET", routePrefix+"/debug/pprof/", nil)
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	require.Equal(t, http.StatusOK, w.Code)
-	require.Contains(t, w.Body.String(), "/debug/pprof/", "pprof page did not load with expected content when using a route prefix")
-
-	// Test GET request to pprof heap endpoint
-	req = httptest.NewRequest("GET", routePrefix+"/debug/pprof/heap", nil)
-	w = httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	require.Equal(t, http.StatusOK, w.Code)
-
-	// Test without route prefix (should also work)
-	router2 := route.New()
-	Register(router2, reloadCh, logger)
-
-	req = httptest.NewRequest("GET", "/debug/pprof/", nil)
-	w = httptest.NewRecorder()
-	router2.ServeHTTP(w, req)
-
-	require.Equal(t, http.StatusOK, w.Code)
-	require.Contains(t, w.Body.String(), "/debug/pprof/", "pprof page did not load with expected content")
-}
-
 func TestWebRoutes(t *testing.T) {
 	router := route.New()
-	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
-	Register(router, make(chan chan error), logger)
+	Register(router)
 
 	tests := []struct {
 		name         string


### PR DESCRIPTION
Stacks on top of https://github.com/prometheus/alertmanager/pull/5092

We want to allow users to still be able to import parts of the `ui`, just not the ones depending on `js`. Ideas for naming welcome. I also considered changing the name of `Register` to make it a bit more obvious that this function now does something different, but decided to only change the signature in the end, since we don't plan to expose it.

#### Pull Request Checklist
- [x] I have signed-off my commits
- [x] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/alertmanager/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
CHANGE: `ui.Register` no longer exposes all endpoints, one must use `weboperations.Register` as well.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Operational HTTP endpoints (metrics, reload, health/readiness and debug/pprof) are now registered via a dedicated HTTP handler instead of the UI registration.

* **Tests**
  * Added/updated tests to verify debug/pprof routing with and without a route prefix and to reflect the new handler registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->