### PR TITLE
chore(ui): Allow creating UI artefacts inside container

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -1,6 +1,6 @@
 go:
     # Whenever the Go version is updated here,
-    # .circle/config.yml should also be updated.
+    # .github/workflows/ci.yml and ui/app/Makefile should also be updated.
     version: 1.26
 repository:
     path: github.com/prometheus/alertmanager

--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ Building from source requires [Go](https://golang.org/) and [Node.js](https://no
 Clone the repository and build manually:
 
 ```
-$ mkdir -p $GOPATH/src/github.com/prometheus
-$ cd $GOPATH/src/github.com/prometheus
 $ git clone https://github.com/prometheus/alertmanager.git
 $ cd alertmanager
 $ make build

--- a/ui/app/Makefile
+++ b/ui/app/Makefile
@@ -2,60 +2,102 @@
 # elm files change during execution.
 ELM_FILES = $(shell find src -iname *.elm)
 # If JUNIT_DIR is set, the tests are executed with the JUnit reporter and the result is stored in the given directory.
-JUNIT_DIR ?=
-DOCKER              ?= docker
-OPENAPI_GEN_IMAGE   ?= openapitools/openapi-generator-cli:v3.3.4
+JUNIT_DIR           ?=
+DOCKER              ?=
+OPENAPI_GEN_IMAGE   ?= docker.io/openapitools/openapi-generator-cli:v3.3.4
+UI_BUILD_IMAGE      ?= quay.io/prometheus/golang-builder:1.26-base #  Derived from ../../.promu.yml.
+CA_BUNDLE           ?=
+
+ifeq ($(DOCKER),)
+  # Run locally.
+  NPM = npm
+  NPX = npx
+  CONTAINER_RUNTIME = docker # Runtime is needed, since src/Data requires the OPENAPI_GEN_IMAGE.
+  USER_ARGS = --user $(shell id -u):$(shell id -g)
+else
+  # Run npm and npx inside container runtime.
+	# `USER_ARGS` prevents creation of root-owned files.
+  ifeq ($(DOCKER),podman)
+    USER_ARGS = --userns=keep-id --user $(shell id -u):$(shell id -g)
+  else
+    USER_ARGS = --user $(shell id -u):$(shell id -g)
+  endif
+  CA_BUNDLE_ARGS = $(if $(CA_BUNDLE),--volume $(CA_BUNDLE):/etc/ssl/certs/ca-certificates.crt:ro \
+    --env NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt)
+  DOCKER_RUN = $(DOCKER) run --rm -i \
+    --entrypoint "" \
+    -v "$(CURDIR):/app" \
+    -w /app \
+    $(USER_ARGS) \
+    --env HOME=/tmp \
+    $(CA_BUNDLE_ARGS) \
+    $(UI_BUILD_IMAGE)
+  NPM = $(DOCKER_RUN) npm
+  NPX = $(DOCKER_RUN) npx
+  CONTAINER_RUNTIME = $(DOCKER)
+endif
 
 .PHONY: all
 all: src/Data build test
 
 node_modules: package-lock.json
-	npm ci
+	@echo ">> installing dependencies"
+	$(NPM) ci
 
 .PHONY: format
 format: node_modules $(ELM_FILES)
 	@echo ">> format front-end code"
-	@npx elm-format --yes $(ELM_FILES)
+	@$(NPX) elm-format --yes $(ELM_FILES)
 
 .PHONY: review
 review: node_modules
-	@npx elm-review --fix
+	@$(NPX) elm-review --fix
 
 .PHONY: test
 test: node_modules
 	rm -rf elm-stuff/generated-code
-	@npx elm-format $(ELM_FILES) --validate
-	@npx elm-review
+	@$(NPX) elm-format $(ELM_FILES) --validate
+	@$(NPX) elm-review
 ifneq ($(JUNIT_DIR),)
 	mkdir -p $(JUNIT_DIR)
-	@npx elm-test --report=junit | tee $(JUNIT_DIR)/junit.xml
+	@$(NPX) elm-test --report=junit | tee $(JUNIT_DIR)/junit.xml
 else
-	@npx elm-test
+	@$(NPX) elm-test
 endif
 
 .PHONY: dev-server
-dev-server:
+dev-server: node_modules
+ifeq ($(DOCKER),)
 	npx elm reactor
+else
+	$(DOCKER) run --rm -it \
+	  --entrypoint "" \
+	  -v "$(CURDIR):/app" \
+	  -w /app \
+	  -p 8000:8000 \
+	  $(USER_ARGS) \
+	  $(CA_BUNDLE_ARGS) \
+	  $(UI_BUILD_IMAGE) \
+	  npx elm reactor
+endif
 
 .PHONY: build
 build: .build_stamp
 
 .build_stamp: $(ELM_FILES) index.html vite.config.mjs node_modules
 	@echo ">> building frontend"
-	npm run build
+	$(NPM) run build
 	@touch .build_stamp
 
 src/Data: ../../api/v2/openapi.yaml
-	-rm -r src/Data
-	set -e; \
-	$(DOCKER) run \
-	  --name openapi-gen \
+	-rm -rf src/Data src/DateTime.elm
+	$(CONTAINER_RUNTIME) run --rm \
+	  $(USER_ARGS) \
+	  --entrypoint sh \
 	  -v ${PWD}/../..:/local \
+	  -v ${PWD}/src:/output/src \
 	  $(OPENAPI_GEN_IMAGE) \
-	  generate -i /local/api/v2/openapi.yaml -g elm -o /tmp/openapi-gen; \
-	trap "$(DOCKER) rm openapi-gen" EXIT; \
-	$(DOCKER) cp openapi-gen:/tmp/openapi-gen/src/Data src/Data; \
-	$(DOCKER) cp openapi-gen:/tmp/openapi-gen/src/DateTime.elm src/DateTime.elm
+	  -c 'java -jar /opt/openapi-generator/modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -i /local/api/v2/openapi.yaml -g elm -o /tmp/openapi-gen && cp -r /tmp/openapi-gen/src/Data /output/src/Data && cp /tmp/openapi-gen/src/DateTime.elm /output/src/DateTime.elm'
 	make format
 
 .PHONY: clean

--- a/ui/app/Makefile
+++ b/ui/app/Makefile
@@ -6,18 +6,22 @@ JUNIT_DIR ?=
 DOCKER              ?= docker
 OPENAPI_GEN_IMAGE   ?= openapitools/openapi-generator-cli:v3.3.4
 
+.PHONY: all
 all: src/Data build test
 
 node_modules: package-lock.json
 	npm ci
 
+.PHONY: format
 format: node_modules $(ELM_FILES)
 	@echo ">> format front-end code"
 	@npx elm-format --yes $(ELM_FILES)
 
+.PHONY: review
 review: node_modules
 	@npx elm-review --fix
 
+.PHONY: test
 test: node_modules
 	rm -rf elm-stuff/generated-code
 	@npx elm-format $(ELM_FILES) --validate
@@ -29,6 +33,7 @@ else
 	@npx elm-test
 endif
 
+.PHONY: dev-server
 dev-server:
 	npx elm reactor
 


### PR DESCRIPTION
In previous commit, I replaced the dockerized `npm` builds with one that runs locally. This was necessary to build our our `UI` via `promu`.
    
* `podman` can be used to build `elm`.
* `CA_BUNDLE` can be used to to pass a certificate bundle into the container.
    
Fixes: #2848