### PR TITLE
Add timeout option for telegram notifier

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1896,6 +1896,12 @@ attributes:
 
 # The HTTP client's configuration.
 [ http_config: <http_config> | default = global.http_config ]
+
+# The maximum time to wait for a telegram request to complete, before failing the
+# request and allowing it to be retried. The default value of 0s indicates that
+# no timeout should be applied.
+# NOTE: This will have no effect if set higher than the group_interval.
+[ timeout: <duration> | default = 0s ]
 ```
 
 ### `<victorops_config>`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1900,6 +1900,12 @@ attributes:
 
 # The HTTP client's configuration.
 [ http_config: <http_config> | default = global.http_config ]
+
+# The maximum time to wait for a telegram request to complete, before failing the
+# request and allowing it to be retried. The default value of 0s indicates that
+# no timeout should be applied.
+# NOTE: This will have no effect if set higher than the group_interval.
+[ timeout: <duration> | default = 0s ]
 ```
 
 ### `<victorops_config>`

--- a/notify/telegram/config.go
+++ b/notify/telegram/config.go
@@ -15,6 +15,7 @@ package telegram
 
 import (
 	"errors"
+	"time"
 
 	commoncfg "github.com/prometheus/common/config"
 
@@ -45,6 +46,10 @@ type TelegramConfig struct {
 	Message              string           `yaml:"message,omitempty" json:"message,omitempty"`
 	DisableNotifications bool             `yaml:"disable_notifications,omitempty" json:"disable_notifications,omitempty"`
 	ParseMode            string           `yaml:"parse_mode,omitempty" json:"parse_mode,omitempty"`
+
+	// Timeout is the maximum time allowed to invoke the telegram. Setting this to 0
+	// does not impose a timeout.
+	Timeout time.Duration `yaml:"timeout" json:"timeout"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/notify/telegram/telegram.go
+++ b/notify/telegram/telegram.go
@@ -50,6 +50,10 @@ func New(conf *TelegramConfig, t *template.Template, l *slog.Logger, httpOpts ..
 		return nil, err
 	}
 
+	if conf.Timeout > 0 {
+		httpclient.Timeout = conf.Timeout
+	}
+
 	client, err := createTelegramClient(conf.APIUrl.String(), conf.ParseMode, httpclient)
 	if err != nil {
 		return nil, err

--- a/notify/telegram/telegram.go
+++ b/notify/telegram/telegram.go
@@ -123,6 +123,9 @@ func (n *Notifier) Notify(ctx context.Context, alert ...*types.Alert) (bool, err
 		ParseMode:             n.conf.ParseMode,
 	})
 	if err != nil {
+		if n.conf.Timeout > 0 && errors.Is(err, context.DeadlineExceeded) {
+			err = fmt.Errorf("configured telegram timeout reached (%s)", n.conf.Timeout)
+		}
 		return true, wrapWithFailureReason(notify.RedactURL(err))
 	}
 	logger.Debug("Telegram message successfully published", "message_id", message.ID, "chat_id", message.Chat.ID)

--- a/notify/telegram/telegram.go
+++ b/notify/telegram/telegram.go
@@ -49,6 +49,10 @@ func New(conf *TelegramConfig, t *template.Template, l *slog.Logger, httpOpts ..
 		return nil, err
 	}
 
+	if conf.Timeout > 0 {
+		httpclient.Timeout = conf.Timeout
+	}
+
 	client, err := createTelegramClient(conf.APIUrl.String(), conf.ParseMode, httpclient)
 	if err != nil {
 		return nil, err

--- a/notify/telegram/telegram_test.go
+++ b/notify/telegram/telegram_test.go
@@ -16,6 +16,7 @@ package telegram
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -307,7 +308,7 @@ func TestTelegramNotifyRedactURL(t *testing.T) {
 		defer cancel()
 		ctx = notify.WithGroupKey(ctx, "1")
 
-		retry, err := notifier.Notify(ctx, &types.Alert{
+		retry, err := notifier.Notify(ctx, &alert.Alert{
 			Alert: model.Alert{Labels: model.LabelSet{"alertname": "test"}},
 		})
 		require.True(t, retry)
@@ -344,7 +345,7 @@ func TestTelegramNotifyRedactURL(t *testing.T) {
 		defer cancel()
 		ctx = notify.WithGroupKey(ctx, "1")
 
-		retry, err := notifier.Notify(ctx, &types.Alert{
+		retry, err := notifier.Notify(ctx, &alert.Alert{
 			Alert: model.Alert{Labels: model.LabelSet{"alertname": "test"}},
 		})
 		require.True(t, retry)
@@ -411,6 +412,9 @@ func TestTelegramTimeout(t *testing.T) {
 
 			_, err = notifier.Notify(ctx, testAlert)
 			require.Equal(t, tc.wantErr, err != nil)
+			if tc.wantErr {
+				require.EqualError(t, err, fmt.Sprintf("configured telegram timeout reached (%s)", tc.timeout))
+			}
 		})
 	}
 }

--- a/notify/telegram/telegram_test.go
+++ b/notify/telegram/telegram_test.go
@@ -205,3 +205,65 @@ func TestTelegramNotify(t *testing.T) {
 		})
 	}
 }
+
+func TestTelegramTimeout(t *testing.T) {
+	token := "secret"
+
+	tests := []struct {
+		name    string
+		latency time.Duration
+		timeout time.Duration
+		wantErr bool
+	}{
+		{
+			name:    "success",
+			latency: 100 * time.Millisecond,
+			timeout: 120 * time.Millisecond,
+			wantErr: false,
+		},
+		{
+			name:    "timeout",
+			latency: 100 * time.Millisecond,
+			timeout: 80 * time.Millisecond,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, "/bot"+token+"/sendMessage", r.URL.Path)
+				_, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+				time.Sleep(tc.latency)
+				w.Write([]byte(`{"ok":true,"result":{"chat":{}}}`))
+			}))
+			defer srv.Close()
+			u, _ := url.Parse(srv.URL)
+
+			cfg := &TelegramConfig{
+				Message:    "test",
+				HTTPConfig: &commoncfg.HTTPClientConfig{},
+				BotToken:   commoncfg.Secret(token),
+				Timeout:    tc.timeout,
+				APIUrl:     &amcommoncfg.URL{URL: u},
+			}
+
+			notifier, err := New(cfg, test.CreateTmpl(t), promslog.NewNopLogger())
+			require.NoError(t, err)
+
+			ctx := context.Background()
+			ctx = notify.WithGroupKey(ctx, "1")
+
+			alert := &types.Alert{
+				Alert: model.Alert{
+					StartsAt: time.Now(),
+					EndsAt:   time.Now().Add(time.Hour),
+				},
+			}
+
+			_, err = notifier.Notify(ctx, alert)
+			require.Equal(t, tc.wantErr, err != nil)
+		})
+	}
+}

--- a/notify/telegram/telegram_test.go
+++ b/notify/telegram/telegram_test.go
@@ -352,3 +352,65 @@ func TestTelegramNotifyRedactURL(t *testing.T) {
 		require.NotContains(t, err.Error(), token, "bot token leaked in API error")
 	})
 }
+
+func TestTelegramTimeout(t *testing.T) {
+	token := "secret"
+
+	tests := []struct {
+		name    string
+		latency time.Duration
+		timeout time.Duration
+		wantErr bool
+	}{
+		{
+			name:    "success",
+			latency: 100 * time.Millisecond,
+			timeout: 120 * time.Millisecond,
+			wantErr: false,
+		},
+		{
+			name:    "timeout",
+			latency: 100 * time.Millisecond,
+			timeout: 80 * time.Millisecond,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, "/bot"+token+"/sendMessage", r.URL.Path)
+				_, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+				time.Sleep(tc.latency)
+				w.Write([]byte(`{"ok":true,"result":{"chat":{}}}`))
+			}))
+			defer srv.Close()
+			u, _ := url.Parse(srv.URL)
+
+			cfg := &TelegramConfig{
+				Message:    "test",
+				HTTPConfig: &commoncfg.HTTPClientConfig{},
+				BotToken:   commoncfg.Secret(token),
+				Timeout:    tc.timeout,
+				APIUrl:     &amcommoncfg.URL{URL: u},
+			}
+
+			notifier, err := New(cfg, test.CreateTmpl(t), promslog.NewNopLogger())
+			require.NoError(t, err)
+
+			ctx := context.Background()
+			ctx = notify.WithGroupKey(ctx, "1")
+
+			testAlert := &alert.Alert{
+				Alert: model.Alert{
+					StartsAt: time.Now(),
+					EndsAt:   time.Now().Add(time.Hour),
+				},
+			}
+
+			_, err = notifier.Notify(ctx, testAlert)
+			require.Equal(t, tc.wantErr, err != nil)
+		})
+	}
+}

--- a/notify/telegram/telegram_test.go
+++ b/notify/telegram/telegram_test.go
@@ -33,9 +33,9 @@ import (
 
 	amcommoncfg "github.com/prometheus/alertmanager/config/common"
 
+	"github.com/prometheus/alertmanager/alert"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/notify/test"
-	"github.com/prometheus/alertmanager/types"
 )
 
 func TestTelegramUnmarshal(t *testing.T) {
@@ -182,7 +182,7 @@ func TestTelegramNotify(t *testing.T) {
 			defer cancel()
 			ctx = notify.WithGroupKey(ctx, "1")
 
-			retry, err := notifier.Notify(ctx, []*types.Alert{
+			retry, err := notifier.Notify(ctx, []*alert.Alert{
 				{
 					Alert: model.Alert{
 						Labels: model.LabelSet{
@@ -261,7 +261,7 @@ func TestTelegramNotifyFailureReason(t *testing.T) {
 			defer cancel()
 			ctx = notify.WithGroupKey(ctx, "1")
 
-			retry, err := notifier.Notify(ctx, []*types.Alert{
+			retry, err := notifier.Notify(ctx, []*alert.Alert{
 				{
 					Alert: model.Alert{
 						Labels:   model.LabelSet{"lbl1": "val1"},

--- a/notify/telegram/telegram_test.go
+++ b/notify/telegram/telegram_test.go
@@ -33,9 +33,9 @@ import (
 
 	amcommoncfg "github.com/prometheus/alertmanager/config/common"
 
+	"github.com/prometheus/alertmanager/alert"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/notify/test"
-	"github.com/prometheus/alertmanager/types"
 )
 
 func TestTelegramUnmarshal(t *testing.T) {
@@ -182,7 +182,7 @@ func TestTelegramNotify(t *testing.T) {
 			defer cancel()
 			ctx = notify.WithGroupKey(ctx, "1")
 
-			retry, err := notifier.Notify(ctx, []*types.Alert{
+			retry, err := notifier.Notify(ctx, []*alert.Alert{
 				{
 					Alert: model.Alert{
 						Labels: model.LabelSet{
@@ -255,14 +255,14 @@ func TestTelegramTimeout(t *testing.T) {
 			ctx := context.Background()
 			ctx = notify.WithGroupKey(ctx, "1")
 
-			alert := &types.Alert{
+			testAlert := &alert.Alert{
 				Alert: model.Alert{
 					StartsAt: time.Now(),
 					EndsAt:   time.Now().Add(time.Hour),
 				},
 			}
 
-			_, err = notifier.Notify(ctx, alert)
+			_, err = notifier.Notify(ctx, testAlert)
 			require.Equal(t, tc.wantErr, err != nil)
 		})
 	}


### PR DESCRIPTION
This change introduces a `Timeout` option for the Telegram notifier. When set, the HTTP client used by the notifier will time out if a request to the Telegram API takes longer than the configured duration.

#### Pull Request Checklist
Please check all the applicable boxes.

- Please list all open issue(s) discussed with maintainers related to this change
    - Fixes #<issue number>
- Is this a new Receiver integration?
    - [ ] I have already tried to use the [Webhook Receiver Integration](https://prometheus.io/docs/alerting/latest/configuration/#webhook_config) and [3rd party integrations](https://prometheus.io/docs/operating/integrations/#alertmanager-webhook-receiver) before adding this new Receiver Integration
- Is this a bugfix?
    - [ ] I have added tests that can reproduce the bug which pass with this bugfix applied
- Is this a new feature?
    - [x] I have added tests that test the new feature's functionality
- Does this change affect performance?
    - [ ] I have provided benchmarks comparison that shows performance is improved or is not degraded
        - You can use [`benchstat`](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat) to compare benchmarks
    - [ ] I have added new benchmarks if required or requested by maintainers
- Is this a breaking change?
    - [ ] My changes do not break the existing cluster messages
    - [ ] My changes do not break the existing api
- [x] I have added/updated the required documentation
- [x] I have signed-off my commits
- [x] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?
```release-notes
NONE
```