### PR TITLE
feat(notify): optional abandon of long-undelivered notifications

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -414,8 +414,9 @@ func run() int {
 	tracingManager := tracing.NewManager(logger.With("component", "tracing"))
 
 	var (
-		inhibitor atomic.Pointer[inhibit.Inhibitor]
-		tmpl      *template.Template
+		inhibitor          atomic.Pointer[inhibit.Inhibitor]
+		tmpl               *template.Template
+		undeliveredTracker *notify.UndeliveredTracker
 	)
 
 	dispMetrics := dispatch.NewDispatcherMetrics(false, prometheus.DefaultRegisterer)
@@ -484,12 +485,15 @@ func run() int {
 			pipelinePeer = peer
 		}
 
-		var undeliveredTracker *notify.UndeliveredTracker
 		abandonUndeliveredAfter := time.Duration(0)
 		if conf.Global.AbandonUndeliveredNotifications {
 			abandonUndeliveredAfter = time.Duration(conf.Global.AbandonUndeliveredAfter)
 			gcTTL := max(2*abandonUndeliveredAfter, time.Hour)
-			undeliveredTracker = notify.NewUndeliveredTracker(gcTTL)
+			if undeliveredTracker == nil {
+				undeliveredTracker = notify.NewUndeliveredTracker(gcTTL)
+			}
+		} else {
+			undeliveredTracker = nil
 		}
 
 		pipeline := pipelineBuilder.New(

--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -484,6 +484,14 @@ func run() int {
 			pipelinePeer = peer
 		}
 
+		var undeliveredTracker *notify.UndeliveredTracker
+		abandonUndeliveredAfter := time.Duration(0)
+		if conf.Global.AbandonUndeliveredNotifications {
+			abandonUndeliveredAfter = time.Duration(conf.Global.AbandonUndeliveredAfter)
+			gcTTL := max(2*abandonUndeliveredAfter, time.Hour)
+			undeliveredTracker = notify.NewUndeliveredTracker(gcTTL)
+		}
+
 		pipeline := pipelineBuilder.New(
 			receivers,
 			waitFunc,
@@ -493,6 +501,8 @@ func run() int {
 			marker,
 			notificationLog,
 			pipelinePeer,
+			undeliveredTracker,
+			abandonUndeliveredAfter,
 		)
 
 		configuredReceivers.Set(float64(len(activeReceivers)))

--- a/config/config.go
+++ b/config/config.go
@@ -350,6 +350,10 @@ func (c *Config) UnmarshalYAML(unmarshal func(any) error) error {
 		return errors.New("at most one of mattermost_webhook_url & mattermost_webhook_url_file must be configured")
 	}
 
+	if c.Global.AbandonUndeliveredNotifications && time.Duration(c.Global.AbandonUndeliveredAfter) <= 0 {
+		return errors.New("abandon_undelivered_after must be greater than zero when abandon_undelivered_notifications is enabled")
+	}
+
 	names := map[string]struct{}{}
 
 	for _, rcv := range c.Receivers {
@@ -838,6 +842,13 @@ type GlobalConfig struct {
 	RocketchatTokenIDFile    string                 `yaml:"rocketchat_token_id_file,omitempty" json:"rocketchat_token_id_file,omitempty"`
 	MattermostWebhookURL     *amcommoncfg.SecretURL `yaml:"mattermost_webhook_url,omitempty" json:"mattermost_webhook_url,omitempty"`
 	MattermostWebhookURLFile string                 `yaml:"mattermost_webhook_url_file,omitempty" json:"mattermost_webhook_url_file,omitempty"`
+	// AbandonUndeliveredNotifications, when true, stops calling an integration after
+	// AbandonUndeliveredAfter from the first failed delivery attempt for a notification
+	// key, and suppresses further attempts for the same firing alert set without calling
+	// the integration.
+	AbandonUndeliveredNotifications bool `yaml:"abandon_undelivered_notifications" json:"abandon_undelivered_notifications"`
+	// AbandonUndeliveredAfter must be positive when AbandonUndeliveredNotifications is true.
+	AbandonUndeliveredAfter model.Duration `yaml:"abandon_undelivered_after" json:"abandon_undelivered_after"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for GlobalConfig.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -62,6 +62,23 @@ route:
 	}
 }
 
+func TestAbandonUndeliveredInvalid(t *testing.T) {
+	in := `
+global:
+  abandon_undelivered_notifications: true
+  abandon_undelivered_after: 0s
+route:
+  receiver: x
+receivers:
+- name: x
+  webhook_configs:
+  - url: http://example.com
+`
+	_, err := Load(in)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "abandon_undelivered_after")
+}
+
 func TestReceiverNameIsUnique(t *testing.T) {
 	in := `
 route:

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -302,12 +302,14 @@ type NotificationLog interface {
 }
 
 type Metrics struct {
-	numNotifications                   *prometheus.CounterVec
-	numTotalFailedNotifications        *prometheus.CounterVec
-	numNotificationRequestsTotal       *prometheus.CounterVec
-	numNotificationRequestsFailedTotal *prometheus.CounterVec
-	numNotificationSuppressedTotal     *prometheus.CounterVec
-	notificationLatencySeconds         *prometheus.HistogramVec
+	numNotifications                         *prometheus.CounterVec
+	numTotalFailedNotifications              *prometheus.CounterVec
+	numNotificationRequestsTotal             *prometheus.CounterVec
+	numNotificationRequestsFailedTotal       *prometheus.CounterVec
+	numNotificationsAbandonedTotal           *prometheus.CounterVec
+	numNotificationsAbandonedSuppressedTotal *prometheus.CounterVec
+	numNotificationSuppressedTotal           *prometheus.CounterVec
+	notificationLatencySeconds               *prometheus.HistogramVec
 
 	ff featurecontrol.Flagger
 }
@@ -340,6 +342,16 @@ func NewMetrics(r prometheus.Registerer, ff featurecontrol.Flagger) *Metrics {
 			Name:      "notification_requests_failed_total",
 			Help:      "The total number of failed notification requests.",
 		}, labels),
+		numNotificationsAbandonedTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Namespace: "alertmanager",
+			Name:      "notifications_abandoned_total",
+			Help:      "The total number of notifications abandoned after undelivered threshold without calling the integration.",
+		}, labels),
+		numNotificationsAbandonedSuppressedTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Namespace: "alertmanager",
+			Name:      "notifications_abandoned_suppressed_total",
+			Help:      "The total number of notification attempts suppressed after abandon for the same firing alert set.",
+		}, labels),
 		numNotificationSuppressedTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "alertmanager",
 			Name:      "notifications_suppressed_total",
@@ -367,6 +379,8 @@ func (m *Metrics) InitializeFor(receiver map[string][]Integration) {
 		m.numNotifications.Reset()
 		m.numNotificationRequestsTotal.Reset()
 		m.numNotificationRequestsFailedTotal.Reset()
+		m.numNotificationsAbandonedTotal.Reset()
+		m.numNotificationsAbandonedSuppressedTotal.Reset()
 		m.notificationLatencySeconds.Reset()
 		m.numTotalFailedNotifications.Reset()
 
@@ -376,6 +390,8 @@ func (m *Metrics) InitializeFor(receiver map[string][]Integration) {
 				m.numNotifications.WithLabelValues(integration.Name(), name)
 				m.numNotificationRequestsTotal.WithLabelValues(integration.Name(), name)
 				m.numNotificationRequestsFailedTotal.WithLabelValues(integration.Name(), name)
+				m.numNotificationsAbandonedTotal.WithLabelValues(integration.Name(), name)
+				m.numNotificationsAbandonedSuppressedTotal.WithLabelValues(integration.Name(), name)
 				m.notificationLatencySeconds.WithLabelValues(integration.Name(), name)
 
 				for _, reason := range possibleFailureReasonCategory {
@@ -411,6 +427,8 @@ func (m *Metrics) InitializeFor(receiver map[string][]Integration) {
 		m.numNotifications.WithLabelValues(integration)
 		m.numNotificationRequestsTotal.WithLabelValues(integration)
 		m.numNotificationRequestsFailedTotal.WithLabelValues(integration)
+		m.numNotificationsAbandonedTotal.WithLabelValues(integration)
+		m.numNotificationsAbandonedSuppressedTotal.WithLabelValues(integration)
 		m.notificationLatencySeconds.WithLabelValues(integration)
 
 		for _, reason := range possibleFailureReasonCategory {
@@ -441,6 +459,8 @@ func (pb *PipelineBuilder) New(
 	marker types.GroupMarker,
 	notificationLog NotificationLog,
 	peer Peer,
+	undeliveredTracker *UndeliveredTracker,
+	abandonUndeliveredAfter time.Duration,
 ) RoutingStage {
 	rs := make(RoutingStage, len(receivers))
 
@@ -451,7 +471,7 @@ func (pb *PipelineBuilder) New(
 	ss := NewMuteStage(silencer, pb.metrics)
 
 	for name := range receivers {
-		st := createReceiverStage(name, receivers[name], wait, notificationLog, pb.metrics)
+		st := createReceiverStage(name, receivers[name], wait, notificationLog, pb.metrics, undeliveredTracker, abandonUndeliveredAfter)
 		rs[name] = MultiStage{ms, is, tas, tms, ss, st}
 	}
 
@@ -467,6 +487,8 @@ func createReceiverStage(
 	wait func() time.Duration,
 	notificationLog NotificationLog,
 	metrics *Metrics,
+	undeliveredTracker *UndeliveredTracker,
+	abandonUndeliveredAfter time.Duration,
 ) Stage {
 	var fs FanoutStage
 	for i := range integrations {
@@ -478,7 +500,7 @@ func createReceiverStage(
 		var s MultiStage
 		s = append(s, NewWaitStage(wait))
 		s = append(s, NewDedupStage(&integrations[i], notificationLog, recv))
-		s = append(s, NewRetryStage(integrations[i], name, metrics))
+		s = append(s, NewRetryStage(integrations[i], name, metrics, undeliveredTracker, abandonUndeliveredAfter))
 		s = append(s, NewSetNotifiesStage(notificationLog, recv))
 
 		fs = append(fs, s)
@@ -830,17 +852,27 @@ func (n *DedupStage) Exec(ctx context.Context, _ *slog.Logger, alerts ...*types.
 	return ctx, nil, nil
 }
 
+func retryDeliveryKey(ctx context.Context, receiver string, integration Integration) (string, bool) {
+	gkey, ok := GroupKey(ctx)
+	if !ok {
+		return "", false
+	}
+	return fmt.Sprintf("%s\x00%s\x00%s\x00%d", gkey, receiver, integration.Name(), integration.Index()), true
+}
+
 // RetryStage notifies via passed integration with exponential backoff until it
 // succeeds. It aborts if the context is canceled or timed out.
 type RetryStage struct {
-	integration Integration
-	groupName   string
-	metrics     *Metrics
-	labelValues []string
+	integration             Integration
+	groupName               string
+	metrics                 *Metrics
+	labelValues             []string
+	undeliveredTracker      *UndeliveredTracker
+	abandonUndeliveredAfter time.Duration
 }
 
 // NewRetryStage returns a new instance of a RetryStage.
-func NewRetryStage(i Integration, groupName string, metrics *Metrics) *RetryStage {
+func NewRetryStage(i Integration, groupName string, metrics *Metrics, undeliveredTracker *UndeliveredTracker, abandonUndeliveredAfter time.Duration) *RetryStage {
 	labelValues := []string{i.Name()}
 
 	if metrics.ff.EnableReceiverNamesInMetrics() {
@@ -848,11 +880,17 @@ func NewRetryStage(i Integration, groupName string, metrics *Metrics) *RetryStag
 	}
 
 	return &RetryStage{
-		integration: i,
-		groupName:   groupName,
-		metrics:     metrics,
-		labelValues: labelValues,
+		integration:             i,
+		groupName:               groupName,
+		metrics:                 metrics,
+		labelValues:             labelValues,
+		undeliveredTracker:      undeliveredTracker,
+		abandonUndeliveredAfter: abandonUndeliveredAfter,
 	}
+}
+
+func (r RetryStage) retrySuppressEnabled() bool {
+	return r.undeliveredTracker != nil && r.abandonUndeliveredAfter > 0
 }
 
 func (r RetryStage) Exec(ctx context.Context, l *slog.Logger, alerts ...*types.Alert) (context.Context, []*types.Alert, error) {
@@ -895,6 +933,11 @@ func (r RetryStage) exec(ctx context.Context, l *slog.Logger, alerts ...*types.A
 			return ctx, nil, errors.New("firing alerts missing")
 		}
 		if len(firing) == 0 {
+			if r.retrySuppressEnabled() {
+				if key, keyOK := retryDeliveryKey(ctx, r.groupName, r.integration); keyOK {
+					r.undeliveredTracker.Clear(key)
+				}
+			}
 			return ctx, alerts, nil
 		}
 		for _, a := range alerts {
@@ -920,6 +963,27 @@ func (r RetryStage) exec(ctx context.Context, l *slog.Logger, alerts ...*types.A
 	l = l.With("receiver", r.groupName, "integration", r.integration.String())
 	if groupKey, ok := GroupKey(ctx); ok {
 		l = l.With("aggrGroup", groupKey)
+	}
+
+	if r.retrySuppressEnabled() {
+		firing, firingOK := FiringAlerts(ctx)
+		if firingOK {
+			if key, keyOK := retryDeliveryKey(ctx, r.groupName, r.integration); keyOK {
+				now := time.Now()
+				r.undeliveredTracker.ResetIfFiringChanged(key, firing, now)
+				if r.undeliveredTracker.ShouldSuppressAbandoned(key, firing, now) {
+					l.Debug("Suppressing notification after prior abandon for same firing set without calling integration")
+					r.metrics.numNotificationsAbandonedSuppressedTotal.WithLabelValues(r.labelValues...).Inc()
+					return ctx, alerts, nil
+				}
+				if r.undeliveredTracker.ShouldAbandon(key, r.abandonUndeliveredAfter, now) {
+					l.Info("Abandoning notification after undelivered threshold without calling integration", "abandon_after", r.abandonUndeliveredAfter)
+					r.metrics.numNotificationsAbandonedTotal.WithLabelValues(r.labelValues...).Inc()
+					r.undeliveredTracker.MarkAbandoned(key, firing, now)
+					return ctx, alerts, nil
+				}
+			}
+		}
 	}
 
 	for {
@@ -957,6 +1021,11 @@ func (r RetryStage) exec(ctx context.Context, l *slog.Logger, alerts ...*types.A
 					return ctx, alerts, fmt.Errorf("%s/%s: notify retry canceled due to unrecoverable error after %d attempts: %w", r.groupName, r.integration.String(), i, err)
 				}
 				if ctx.Err() == nil {
+					if r.retrySuppressEnabled() {
+						if key, ok := retryDeliveryKey(ctx, r.groupName, r.integration); ok {
+							r.undeliveredTracker.NoteFailure(key, time.Now())
+						}
+					}
 					if iErr == nil || err.Error() != iErr.Error() {
 						// Log the error if the context isn't done and the error isn't the same as before.
 						l.Warn("Notify attempt failed, will retry later", "attempts", i, "err", err)
@@ -966,6 +1035,11 @@ func (r RetryStage) exec(ctx context.Context, l *slog.Logger, alerts ...*types.A
 					iErr = err
 				}
 			} else {
+				if r.retrySuppressEnabled() {
+					if key, ok := retryDeliveryKey(ctx, r.groupName, r.integration); ok {
+						r.undeliveredTracker.Clear(key)
+					}
+				}
 				l := l.With(
 					"attempts", i,
 					"duration", dur,

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -968,7 +968,11 @@ func (r RetryStage) exec(ctx context.Context, l *slog.Logger, alerts ...*types.A
 	if r.retrySuppressEnabled() {
 		firing, firingOK := FiringAlerts(ctx)
 		if firingOK {
-			if key, keyOK := retryDeliveryKey(ctx, r.groupName, r.integration); keyOK {
+			if len(firing) == 0 {
+				if key, keyOK := retryDeliveryKey(ctx, r.groupName, r.integration); keyOK {
+					r.undeliveredTracker.Clear(key)
+				}
+			} else if key, keyOK := retryDeliveryKey(ctx, r.groupName, r.integration); keyOK {
 				now := time.Now()
 				r.undeliveredTracker.ResetIfFiringChanged(key, firing, now)
 				if r.undeliveredTracker.ShouldSuppressAbandoned(key, firing, now) {
@@ -976,7 +980,7 @@ func (r RetryStage) exec(ctx context.Context, l *slog.Logger, alerts ...*types.A
 					r.metrics.numNotificationsAbandonedSuppressedTotal.WithLabelValues(r.labelValues...).Inc()
 					return ctx, alerts, nil
 				}
-				if r.undeliveredTracker.ShouldAbandon(key, r.abandonUndeliveredAfter, now) {
+				if r.undeliveredTracker.ShouldAbandon(key, firing, r.abandonUndeliveredAfter, now) {
 					l.Info("Abandoning notification after undelivered threshold without calling integration", "abandon_after", r.abandonUndeliveredAfter)
 					r.metrics.numNotificationsAbandonedTotal.WithLabelValues(r.labelValues...).Inc()
 					r.undeliveredTracker.MarkAbandoned(key, firing, now)
@@ -1020,12 +1024,17 @@ func (r RetryStage) exec(ctx context.Context, l *slog.Logger, alerts ...*types.A
 				if !retry {
 					return ctx, alerts, fmt.Errorf("%s/%s: notify retry canceled due to unrecoverable error after %d attempts: %w", r.groupName, r.integration.String(), i, err)
 				}
-				if ctx.Err() == nil {
-					if r.retrySuppressEnabled() {
-						if key, ok := retryDeliveryKey(ctx, r.groupName, r.integration); ok {
-							r.undeliveredTracker.NoteFailure(key, time.Now())
+				// Count failures toward abandon even when Notify returns after the per-attempt
+				// context deadline; otherwise hanging receivers never advance firstFail.
+				shouldNoteFailure := ctx.Err() == nil || errors.Is(ctx.Err(), context.DeadlineExceeded)
+				if shouldNoteFailure && r.retrySuppressEnabled() {
+					if key, ok := retryDeliveryKey(ctx, r.groupName, r.integration); ok {
+						if firing, firingOK := FiringAlerts(ctx); firingOK {
+							r.undeliveredTracker.NoteFailure(key, firing, time.Now())
 						}
 					}
+				}
+				if ctx.Err() == nil {
 					if iErr == nil || err.Error() != iErr.Error() {
 						// Log the error if the context isn't done and the error isn't the same as before.
 						l.Warn("Notify attempt failed, will retry later", "attempts", i, "err", err)

--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"log/slog"
 	"reflect"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -428,7 +429,7 @@ func TestRetryStageWithError(t *testing.T) {
 		}),
 		rs: sendResolved(false),
 	}
-	r := NewRetryStage(i, "", NewMetrics(prometheus.NewRegistry(), featurecontrol.NoopFlags{}))
+	r := NewRetryStage(i, "", NewMetrics(prometheus.NewRegistry(), featurecontrol.NoopFlags{}), nil, 0)
 
 	alerts := []*types.Alert{
 		{
@@ -481,7 +482,7 @@ func TestRetryStageWithErrorCode(t *testing.T) {
 			}),
 			rs: sendResolved(false),
 		}
-		r := NewRetryStage(i, "", NewMetrics(prometheus.NewRegistry(), featurecontrol.NoopFlags{}))
+		r := NewRetryStage(i, "", NewMetrics(prometheus.NewRegistry(), featurecontrol.NoopFlags{}), nil, 0)
 
 		alerts := []*types.Alert{
 			{
@@ -516,7 +517,7 @@ func TestRetryStageWithContextCanceled(t *testing.T) {
 		}),
 		rs: sendResolved(false),
 	}
-	r := NewRetryStage(i, "", NewMetrics(prometheus.NewRegistry(), featurecontrol.NoopFlags{}))
+	r := NewRetryStage(i, "", NewMetrics(prometheus.NewRegistry(), featurecontrol.NoopFlags{}), nil, 0)
 
 	alerts := []*types.Alert{
 		{
@@ -548,7 +549,7 @@ func TestRetryStageNoResolved(t *testing.T) {
 		}),
 		rs: sendResolved(false),
 	}
-	r := NewRetryStage(i, "", NewMetrics(prometheus.NewRegistry(), featurecontrol.NoopFlags{}))
+	r := NewRetryStage(i, "", NewMetrics(prometheus.NewRegistry(), featurecontrol.NoopFlags{}), nil, 0)
 
 	alerts := []*types.Alert{
 		{
@@ -599,7 +600,7 @@ func TestRetryStageSendResolved(t *testing.T) {
 		}),
 		rs: sendResolved(true),
 	}
-	r := NewRetryStage(i, "", NewMetrics(prometheus.NewRegistry(), featurecontrol.NoopFlags{}))
+	r := NewRetryStage(i, "", NewMetrics(prometheus.NewRegistry(), featurecontrol.NoopFlags{}), nil, 0)
 
 	alerts := []*types.Alert{
 		{
@@ -633,6 +634,103 @@ func TestRetryStageSendResolved(t *testing.T) {
 	require.Equal(t, alerts, res)
 	require.Equal(t, alerts, sent)
 	require.NotNil(t, resctx)
+}
+
+func TestRetryStageAbandonUndelivered(t *testing.T) {
+	var notifyCalls atomic.Int32
+	tracker := NewUndeliveredTracker(time.Hour)
+	reg := prometheus.NewRegistry()
+	metrics := NewMetrics(reg, featurecontrol.NoopFlags{})
+	i := Integration{
+		name: "webhook",
+		idx:  0,
+		notifier: notifierFunc(func(ctx context.Context, alerts ...*types.Alert) (bool, error) {
+			notifyCalls.Add(1)
+			return true, errors.New("fail")
+		}),
+		rs: sendResolved(false),
+	}
+	r := NewRetryStage(i, "team", metrics, tracker, 30*time.Millisecond)
+
+	alerts := []*types.Alert{{Alert: model.Alert{EndsAt: time.Now().Add(time.Hour)}}}
+	ctx := context.Background()
+	ctx = WithGroupKey(ctx, "routekey:labels")
+	ctx = WithFiringAlerts(ctx, []uint64{0})
+
+	ctx1, cancel := context.WithTimeout(ctx, 80*time.Millisecond)
+	defer cancel()
+	_, _, err := r.Exec(ctx1, promslog.NewNopLogger(), alerts...)
+	require.Error(t, err)
+	firstRound := notifyCalls.Load()
+	require.Positive(t, firstRound)
+
+	time.Sleep(50 * time.Millisecond)
+
+	_, _, err = r.Exec(ctx, promslog.NewNopLogger(), alerts...)
+	require.NoError(t, err)
+	require.Equal(t, firstRound, notifyCalls.Load(), "abandon should skip calling the integration")
+
+	ab := prom_testutil.ToFloat64(metrics.numNotificationsAbandonedTotal.WithLabelValues("webhook"))
+	require.Equal(t, 1.0, ab)
+
+	_, _, err = r.Exec(ctx, promslog.NewNopLogger(), alerts...)
+	require.NoError(t, err)
+	require.Equal(t, firstRound, notifyCalls.Load(), "same firing set: suppress without calling integration")
+	sup := prom_testutil.ToFloat64(metrics.numNotificationsAbandonedSuppressedTotal.WithLabelValues("webhook"))
+	require.Equal(t, 1.0, sup)
+
+	ctxOtherFiring := WithFiringAlerts(ctx, []uint64{99})
+	ctx1, cancel1 := context.WithTimeout(ctxOtherFiring, 80*time.Millisecond)
+	defer cancel1()
+	_, _, err = r.Exec(ctx1, promslog.NewNopLogger(), alerts...)
+	require.Error(t, err)
+	require.Greater(t, notifyCalls.Load(), firstRound, "different firing set should call integration again")
+}
+
+func TestRetryStageAbandonClearsWhenNoFiringAlerts(t *testing.T) {
+	var notifyCalls atomic.Int32
+	var failPings atomic.Bool
+	failPings.Store(true)
+	tracker := NewUndeliveredTracker(time.Hour)
+	metrics := NewMetrics(prometheus.NewRegistry(), featurecontrol.NoopFlags{})
+	i := Integration{
+		name: "webhook",
+		idx:  0,
+		notifier: notifierFunc(func(ctx context.Context, alerts ...*types.Alert) (bool, error) {
+			notifyCalls.Add(1)
+			if failPings.Load() {
+				return true, errors.New("fail")
+			}
+			return false, nil
+		}),
+		rs: sendResolved(false),
+	}
+	r := NewRetryStage(i, "team", metrics, tracker, 30*time.Millisecond)
+
+	alerts := []*types.Alert{{Alert: model.Alert{EndsAt: time.Now().Add(time.Hour)}}}
+	ctx := context.Background()
+	ctx = WithGroupKey(ctx, "routekey:labels")
+	ctx = WithFiringAlerts(ctx, []uint64{0})
+
+	ctx1, cancel := context.WithTimeout(ctx, 80*time.Millisecond)
+	defer cancel()
+	_, _, err := r.Exec(ctx1, promslog.NewNopLogger(), alerts...)
+	require.Error(t, err)
+
+	time.Sleep(50 * time.Millisecond)
+	_, _, err = r.Exec(ctx, promslog.NewNopLogger(), alerts...)
+	require.NoError(t, err)
+
+	// All resolved: empty firing — should clear tracker so same fingerprint can notify again.
+	ctxResolved := WithFiringAlerts(ctx, []uint64{})
+	_, _, err = r.Exec(ctxResolved, promslog.NewNopLogger(), alerts...)
+	require.NoError(t, err)
+
+	failPings.Store(false)
+	ctxReopen := WithFiringAlerts(ctx, []uint64{0})
+	_, _, err = r.Exec(ctxReopen, promslog.NewNopLogger(), alerts...)
+	require.NoError(t, err)
+	require.Positive(t, notifyCalls.Load(), "after clear on empty firing, integration should be called again")
 }
 
 func TestSetNotifiesStage(t *testing.T) {
@@ -728,7 +826,7 @@ func TestReceiverData_PreservationWhenNotifierDoesNotUpdate(t *testing.T) {
 	})
 
 	integration := NewIntegration(notifier, sendResolved(true), "test", 0, "test-receiver")
-	retryStage := NewRetryStage(integration, "test", NewMetrics(prometheus.NewRegistry(), featurecontrol.NoopFlags{}))
+	retryStage := NewRetryStage(integration, "test", NewMetrics(prometheus.NewRegistry(), featurecontrol.NoopFlags{}), nil, 0)
 	setNotifiesStage := NewSetNotifiesStage(tnflog, recv)
 
 	ctx := context.Background()
@@ -943,7 +1041,7 @@ func TestNflogStore_NoLeakBetweenNotificationSequences(t *testing.T) {
 	})
 
 	integration := NewIntegration(notifier, sendResolved(true), "test", 0, "test-receiver")
-	retryStage := NewRetryStage(integration, "test", NewMetrics(prometheus.NewRegistry(), featurecontrol.NoopFlags{}))
+	retryStage := NewRetryStage(integration, "test", NewMetrics(prometheus.NewRegistry(), featurecontrol.NoopFlags{}), nil, 0)
 	setNotifiesStage := NewSetNotifiesStage(tnflog, recv)
 
 	alerts := []*types.Alert{

--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -728,9 +728,84 @@ func TestRetryStageAbandonClearsWhenNoFiringAlerts(t *testing.T) {
 
 	failPings.Store(false)
 	ctxReopen := WithFiringAlerts(ctx, []uint64{0})
+	beforeReopen := notifyCalls.Load()
 	_, _, err = r.Exec(ctxReopen, promslog.NewNopLogger(), alerts...)
 	require.NoError(t, err)
-	require.Positive(t, notifyCalls.Load(), "after clear on empty firing, integration should be called again")
+	require.Greater(t, notifyCalls.Load(), beforeReopen, "after clear on empty firing, integration should be called again")
+}
+
+func TestRetryStageAbandonSendResolvedClearsTrackerOnEmptyFiring(t *testing.T) {
+	var notifyCalls atomic.Int32
+	tracker := NewUndeliveredTracker(time.Hour)
+	metrics := NewMetrics(prometheus.NewRegistry(), featurecontrol.NoopFlags{})
+	i := Integration{
+		name: "webhook",
+		idx:  0,
+		notifier: notifierFunc(func(ctx context.Context, alerts ...*types.Alert) (bool, error) {
+			notifyCalls.Add(1)
+			firing, ok := FiringAlerts(ctx)
+			if ok && len(firing) > 0 {
+				return true, errors.New("fail")
+			}
+			return false, nil
+		}),
+		rs: sendResolved(true),
+	}
+	r := NewRetryStage(i, "team", metrics, tracker, 30*time.Millisecond)
+
+	alerts := []*types.Alert{{Alert: model.Alert{EndsAt: time.Now().Add(time.Hour)}}}
+	ctx := context.Background()
+	ctx = WithGroupKey(ctx, "routekey:labels")
+	ctx = WithFiringAlerts(ctx, []uint64{0})
+
+	ctx1, cancel := context.WithTimeout(ctx, 80*time.Millisecond)
+	defer cancel()
+	_, _, err := r.Exec(ctx1, promslog.NewNopLogger(), alerts...)
+	require.Error(t, err)
+
+	time.Sleep(40 * time.Millisecond)
+
+	ctxResolved := WithFiringAlerts(ctx, []uint64{})
+	before := notifyCalls.Load()
+	_, _, err = r.Exec(ctxResolved, promslog.NewNopLogger(), alerts...)
+	require.NoError(t, err)
+	require.Greater(t, notifyCalls.Load(), before, "resolved notification must call integration; empty firing must clear undelivered state first")
+}
+
+func TestRetryStageAbandonNotesFailureWhenNotifyReturnsAfterDeadline(t *testing.T) {
+	var notifyCalls atomic.Int32
+	tracker := NewUndeliveredTracker(time.Hour)
+	reg := prometheus.NewRegistry()
+	metrics := NewMetrics(reg, featurecontrol.NoopFlags{})
+	i := Integration{
+		name: "webhook",
+		idx:  0,
+		notifier: notifierFunc(func(ctx context.Context, alerts ...*types.Alert) (bool, error) {
+			notifyCalls.Add(1)
+			<-ctx.Done()
+			return true, errors.New("fail after deadline")
+		}),
+		rs: sendResolved(false),
+	}
+	r := NewRetryStage(i, "team", metrics, tracker, 30*time.Millisecond)
+
+	alerts := []*types.Alert{{Alert: model.Alert{EndsAt: time.Now().Add(time.Hour)}}}
+	ctx := context.Background()
+	ctx = WithGroupKey(ctx, "routekey:labels")
+	ctx = WithFiringAlerts(ctx, []uint64{0})
+
+	ctx1, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
+	defer cancel()
+	_, _, err := r.Exec(ctx1, promslog.NewNopLogger(), alerts...)
+	require.Error(t, err)
+
+	time.Sleep(40 * time.Millisecond)
+	_, _, err = r.Exec(ctx, promslog.NewNopLogger(), alerts...)
+	require.NoError(t, err)
+
+	require.Equal(t, int32(1), notifyCalls.Load(), "deadline-driven attempt should still count as one notify try")
+	ab := prom_testutil.ToFloat64(metrics.numNotificationsAbandonedTotal.WithLabelValues("webhook"))
+	require.Equal(t, 1.0, ab, "firstFail must be recorded when Notify returns after context deadline")
 }
 
 func TestSetNotifiesStage(t *testing.T) {

--- a/notify/undelivered_tracker.go
+++ b/notify/undelivered_tracker.go
@@ -1,0 +1,159 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package notify
+
+import (
+	"slices"
+	"sync"
+	"time"
+)
+
+type undeliveredEntry struct {
+	firstFail       time.Time
+	lastSeen        time.Time
+	abandoned       bool
+	abandonedFiring []uint64 // sorted; set when abandoned
+}
+
+// UndeliveredTracker records the first failure time for notification delivery
+// retries so delivery can be abandoned after a wall-clock threshold. Entries
+// that are inactive longer than gcTTL are removed periodically.
+type UndeliveredTracker struct {
+	mu      sync.Mutex
+	entries map[string]undeliveredEntry
+	gcTTL   time.Duration
+}
+
+// NewUndeliveredTracker returns a tracker that garbage-collects keys whose
+// lastSeen is older than gcTTL. If gcTTL <= 0, a default of 1h is used.
+func NewUndeliveredTracker(gcTTL time.Duration) *UndeliveredTracker {
+	if gcTTL <= 0 {
+		gcTTL = time.Hour
+	}
+	return &UndeliveredTracker{
+		entries: make(map[string]undeliveredEntry),
+		gcTTL:   gcTTL,
+	}
+}
+
+func sortedFiringCopy(firing []uint64) []uint64 {
+	out := slices.Clone(firing)
+	slices.Sort(out)
+	return out
+}
+
+func firingSlicesEqual(a, b []uint64) bool {
+	return slices.Equal(a, b)
+}
+
+func (t *UndeliveredTracker) gc(now time.Time) {
+	cutoff := now.Add(-t.gcTTL)
+	for k, e := range t.entries {
+		if e.lastSeen.Before(cutoff) {
+			delete(t.entries, k)
+		}
+	}
+}
+
+// NoteFailure records the first wall-clock time we saw a failed delivery for key,
+// or refreshes lastSeen if the series already started.
+func (t *UndeliveredTracker) NoteFailure(key string, now time.Time) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.gc(now)
+	if e, ok := t.entries[key]; ok {
+		e.lastSeen = now
+		t.entries[key] = e
+		return
+	}
+	t.entries[key] = undeliveredEntry{firstFail: now, lastSeen: now}
+}
+
+// Clear removes state for key after successful delivery.
+func (t *UndeliveredTracker) Clear(key string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.entries, key)
+}
+
+// ResetIfFiringChanged deletes the key if it was abandoned for a different firing set.
+func (t *UndeliveredTracker) ResetIfFiringChanged(key string, firing []uint64, now time.Time) {
+	sorted := sortedFiringCopy(firing)
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.gc(now)
+	e, ok := t.entries[key]
+	if !ok || !e.abandoned {
+		return
+	}
+	if firingSlicesEqual(sorted, e.abandonedFiring) {
+		return
+	}
+	delete(t.entries, key)
+}
+
+// ShouldSuppressAbandoned returns true if the key was abandoned and the current
+// firing set matches the set at abandon time. It refreshes lastSeen for GC.
+func (t *UndeliveredTracker) ShouldSuppressAbandoned(key string, firing []uint64, now time.Time) bool {
+	sorted := sortedFiringCopy(firing)
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.gc(now)
+	e, ok := t.entries[key]
+	if !ok || !e.abandoned {
+		return false
+	}
+	if !firingSlicesEqual(sorted, e.abandonedFiring) {
+		return false
+	}
+	e.lastSeen = now
+	t.entries[key] = e
+	return true
+}
+
+// MarkAbandoned records that delivery was abandoned for the given firing set.
+func (t *UndeliveredTracker) MarkAbandoned(key string, firing []uint64, now time.Time) {
+	sorted := sortedFiringCopy(firing)
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.gc(now)
+	e, ok := t.entries[key]
+	if !ok {
+		e.firstFail = now
+	}
+	e.lastSeen = now
+	e.abandoned = true
+	e.abandonedFiring = sorted
+	t.entries[key] = e
+}
+
+// ShouldAbandon returns true if key has been failing since at least firstFail+abandonAfter.
+// It refreshes lastSeen for GC when the key exists. Always false if already abandoned.
+func (t *UndeliveredTracker) ShouldAbandon(key string, abandonAfter time.Duration, now time.Time) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.gc(now)
+	e, ok := t.entries[key]
+	if !ok {
+		return false
+	}
+	if e.abandoned {
+		e.lastSeen = now
+		t.entries[key] = e
+		return false
+	}
+	e.lastSeen = now
+	t.entries[key] = e
+	return now.Sub(e.firstFail) >= abandonAfter
+}

--- a/notify/undelivered_tracker.go
+++ b/notify/undelivered_tracker.go
@@ -23,6 +23,7 @@ type undeliveredEntry struct {
 	firstFail       time.Time
 	lastSeen        time.Time
 	abandoned       bool
+	failingFiring   []uint64 // sorted; firing set for the active failure streak when !abandoned
 	abandonedFiring []uint64 // sorted; set when abandoned
 }
 
@@ -66,18 +67,38 @@ func (t *UndeliveredTracker) gc(now time.Time) {
 	}
 }
 
-// NoteFailure records the first wall-clock time we saw a failed delivery for key,
-// or refreshes lastSeen if the series already started.
-func (t *UndeliveredTracker) NoteFailure(key string, now time.Time) {
+// NoteFailure records the first wall-clock time we saw a failed delivery for key
+// and the firing set that attempt belonged to. If the firing set changes before
+// abandonment, firstFail is restarted so a new set does not inherit the old timer.
+func (t *UndeliveredTracker) NoteFailure(key string, firing []uint64, now time.Time) {
+	sorted := sortedFiringCopy(firing)
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.gc(now)
-	if e, ok := t.entries[key]; ok {
-		e.lastSeen = now
-		t.entries[key] = e
+	e, ok := t.entries[key]
+	if !ok {
+		t.entries[key] = undeliveredEntry{
+			firstFail:     now,
+			lastSeen:      now,
+			failingFiring: sorted,
+		}
 		return
 	}
-	t.entries[key] = undeliveredEntry{firstFail: now, lastSeen: now}
+	if e.abandoned {
+		// Defensive: start a fresh streak if a failure is recorded after abandon.
+		t.entries[key] = undeliveredEntry{
+			firstFail:     now,
+			lastSeen:      now,
+			failingFiring: sorted,
+		}
+		return
+	}
+	if !firingSlicesEqual(sorted, e.failingFiring) {
+		e.firstFail = now
+		e.failingFiring = sorted
+	}
+	e.lastSeen = now
+	t.entries[key] = e
 }
 
 // Clear removes state for key after successful delivery.
@@ -135,12 +156,15 @@ func (t *UndeliveredTracker) MarkAbandoned(key string, firing []uint64, now time
 	e.lastSeen = now
 	e.abandoned = true
 	e.abandonedFiring = sorted
+	e.failingFiring = nil
 	t.entries[key] = e
 }
 
-// ShouldAbandon returns true if key has been failing since at least firstFail+abandonAfter.
-// It refreshes lastSeen for GC when the key exists. Always false if already abandoned.
-func (t *UndeliveredTracker) ShouldAbandon(key string, abandonAfter time.Duration, now time.Time) bool {
+// ShouldAbandon returns true if key has been failing since at least firstFail+abandonAfter
+// for the same firing set as recorded on failures. It refreshes lastSeen for GC when the
+// key exists. Always false if already abandoned or if firing does not match the failure streak.
+func (t *UndeliveredTracker) ShouldAbandon(key string, firing []uint64, abandonAfter time.Duration, now time.Time) bool {
+	sorted := sortedFiringCopy(firing)
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.gc(now)
@@ -151,6 +175,9 @@ func (t *UndeliveredTracker) ShouldAbandon(key string, abandonAfter time.Duratio
 	if e.abandoned {
 		e.lastSeen = now
 		t.entries[key] = e
+		return false
+	}
+	if !firingSlicesEqual(sorted, e.failingFiring) {
 		return false
 	}
 	e.lastSeen = now

--- a/notify/undelivered_tracker_test.go
+++ b/notify/undelivered_tracker_test.go
@@ -1,0 +1,200 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package notify
+
+import (
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUndeliveredTracker_NewDefaultGCTTL(t *testing.T) {
+	cases := []struct {
+		name string
+		in   time.Duration
+		want time.Duration
+	}{
+		{"zero uses one hour", 0, time.Hour},
+		{"negative uses one hour", -time.Minute, time.Hour},
+		{"positive unchanged", 30 * time.Minute, 30 * time.Minute},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := NewUndeliveredTracker(tc.in)
+			require.Equal(t, tc.want, tr.gcTTL)
+		})
+	}
+}
+
+func TestUndeliveredTracker_NoteFailureKeepsFirstFailTime(t *testing.T) {
+	t0 := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	t1 := t0.Add(7 * time.Minute)
+	tr := NewUndeliveredTracker(time.Hour)
+
+	tr.NoteFailure("k", t0)
+	require.False(t, tr.ShouldAbandon("k", 10*time.Minute, t1))
+
+	tr.NoteFailure("k", t1)
+	require.True(t, tr.ShouldAbandon("k", 5*time.Minute, t1), "first failure time should stay at t0")
+}
+
+func TestUndeliveredTracker_ShouldAbandon(t *testing.T) {
+	t0 := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name         string
+		now          time.Time
+		abandonAfter time.Duration
+		want         bool
+	}{
+		{
+			name:         "unknown key",
+			now:          t0,
+			abandonAfter: time.Nanosecond,
+			want:         false,
+		},
+		{
+			name:         "below threshold",
+			now:          t0.Add(4 * time.Minute),
+			abandonAfter: 5 * time.Minute,
+			want:         false,
+		},
+		{
+			name:         "at threshold",
+			now:          t0.Add(5 * time.Minute),
+			abandonAfter: 5 * time.Minute,
+			want:         true,
+		},
+		{
+			name:         "above threshold",
+			now:          t0.Add(6 * time.Minute),
+			abandonAfter: 5 * time.Minute,
+			want:         true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			trFresh := NewUndeliveredTracker(time.Hour)
+			key := "k"
+			if tc.name == "unknown key" {
+				key = "missing"
+			} else {
+				trFresh.NoteFailure("k", t0)
+			}
+			got := trFresh.ShouldAbandon(key, tc.abandonAfter, tc.now)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestUndeliveredTracker_Clear(t *testing.T) {
+	t0 := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	tr := NewUndeliveredTracker(time.Hour)
+	tr.NoteFailure("k", t0)
+	require.True(t, tr.ShouldAbandon("k", time.Minute, t0.Add(2*time.Minute)))
+
+	tr.Clear("k")
+	require.False(t, tr.ShouldAbandon("k", time.Nanosecond, t0.Add(time.Hour)))
+
+	tr.Clear("nonexistent")
+}
+
+func TestUndeliveredTracker_GCRemovesStaleEntries(t *testing.T) {
+	t0 := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	gcTTL := 10 * time.Minute
+	tr := NewUndeliveredTracker(gcTTL)
+
+	tr.NoteFailure("stale", t0)
+	// lastSeen for "stale" is t0; at t0+15m cutoff is t0+5m, so entry is removed on next op.
+	tr.NoteFailure("fresh", t0.Add(15*time.Minute))
+
+	require.False(t, tr.ShouldAbandon("stale", time.Nanosecond, t0.Add(15*time.Minute)))
+	require.False(t, tr.ShouldAbandon("fresh", time.Hour, t0.Add(15*time.Minute)))
+}
+
+func TestUndeliveredTracker_ShouldAbandonRefreshesLastSeen(t *testing.T) {
+	t0 := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	// Long gcTTL so the initial entry is not removed by gc inside ShouldAbandon before lastSeen is refreshed.
+	tr := NewUndeliveredTracker(time.Hour)
+
+	tr.NoteFailure("k", t0)
+	require.False(t, tr.ShouldAbandon("k", time.Hour, t0.Add(15*time.Minute)))
+
+	tr.NoteFailure("other", t0.Add(20*time.Minute))
+	require.True(t, tr.ShouldAbandon("k", time.Minute, t0.Add(21*time.Minute)),
+		"firstFail should stay at t0 after ShouldAbandon refreshed lastSeen")
+}
+
+func TestUndeliveredTracker_Concurrent(t *testing.T) {
+	tr := NewUndeliveredTracker(time.Hour)
+	t0 := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	var wg sync.WaitGroup
+	for i := range 32 {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			key := string(rune('a' + id%8))
+			tr.NoteFailure(key, t0)
+			tr.ShouldAbandon(key, 30*time.Minute, t0.Add(31*time.Minute))
+			tr.Clear(key)
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestUndeliveredTracker_MarkAbandonedAndSuppress(t *testing.T) {
+	t0 := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	tr := NewUndeliveredTracker(time.Hour)
+	firing := []uint64{3, 1, 2}
+
+	tr.MarkAbandoned("k", firing, t0)
+	require.False(t, tr.ShouldAbandon("k", time.Nanosecond, t0.Add(time.Hour)))
+
+	require.True(t, tr.ShouldSuppressAbandoned("k", []uint64{2, 3, 1}, t0.Add(time.Minute)))
+	require.False(t, tr.ShouldSuppressAbandoned("k", []uint64{1, 2}, t0.Add(2*time.Minute)))
+}
+
+func TestUndeliveredTracker_ResetIfFiringChanged(t *testing.T) {
+	t0 := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	tr := NewUndeliveredTracker(time.Hour)
+	tr.MarkAbandoned("k", []uint64{1, 2}, t0)
+
+	tr.ResetIfFiringChanged("k", []uint64{1, 2}, t0.Add(time.Minute))
+	require.True(t, tr.ShouldSuppressAbandoned("k", []uint64{2, 1}, t0.Add(2*time.Minute)))
+
+	tr.ResetIfFiringChanged("k", []uint64{1, 2, 3}, t0.Add(3*time.Minute))
+	require.False(t, tr.ShouldSuppressAbandoned("k", []uint64{1, 2, 3}, t0.Add(4*time.Minute)))
+	require.False(t, tr.ShouldAbandon("k", time.Nanosecond, t0.Add(4*time.Minute)))
+}
+
+func TestUndeliveredTracker_GCRemovesAbandonedEntry(t *testing.T) {
+	t0 := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	gcTTL := 5 * time.Minute
+	tr := NewUndeliveredTracker(gcTTL)
+	tr.MarkAbandoned("k", []uint64{1}, t0)
+
+	tr.NoteFailure("other", t0.Add(6*time.Minute))
+	require.False(t, tr.ShouldSuppressAbandoned("k", []uint64{1}, t0.Add(6*time.Minute)))
+}
+
+func TestUndeliveredTracker_SortedFiringCopy(t *testing.T) {
+	got := sortedFiringCopy([]uint64{9, 1, 5})
+	require.True(t, slices.IsSorted(got))
+	require.Equal(t, []uint64{1, 5, 9}, got)
+}

--- a/notify/undelivered_tracker_test.go
+++ b/notify/undelivered_tracker_test.go
@@ -44,12 +44,13 @@ func TestUndeliveredTracker_NoteFailureKeepsFirstFailTime(t *testing.T) {
 	t0 := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
 	t1 := t0.Add(7 * time.Minute)
 	tr := NewUndeliveredTracker(time.Hour)
+	firing := []uint64{1}
 
-	tr.NoteFailure("k", t0)
-	require.False(t, tr.ShouldAbandon("k", 10*time.Minute, t1))
+	tr.NoteFailure("k", firing, t0)
+	require.False(t, tr.ShouldAbandon("k", firing, 10*time.Minute, t1))
 
-	tr.NoteFailure("k", t1)
-	require.True(t, tr.ShouldAbandon("k", 5*time.Minute, t1), "first failure time should stay at t0")
+	tr.NoteFailure("k", firing, t1)
+	require.True(t, tr.ShouldAbandon("k", firing, 5*time.Minute, t1), "first failure time should stay at t0")
 }
 
 func TestUndeliveredTracker_ShouldAbandon(t *testing.T) {
@@ -87,6 +88,7 @@ func TestUndeliveredTracker_ShouldAbandon(t *testing.T) {
 		},
 	}
 
+	firing := []uint64{1}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			trFresh := NewUndeliveredTracker(time.Hour)
@@ -94,9 +96,9 @@ func TestUndeliveredTracker_ShouldAbandon(t *testing.T) {
 			if tc.name == "unknown key" {
 				key = "missing"
 			} else {
-				trFresh.NoteFailure("k", t0)
+				trFresh.NoteFailure("k", firing, t0)
 			}
-			got := trFresh.ShouldAbandon(key, tc.abandonAfter, tc.now)
+			got := trFresh.ShouldAbandon(key, firing, tc.abandonAfter, tc.now)
 			require.Equal(t, tc.want, got)
 		})
 	}
@@ -105,11 +107,12 @@ func TestUndeliveredTracker_ShouldAbandon(t *testing.T) {
 func TestUndeliveredTracker_Clear(t *testing.T) {
 	t0 := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
 	tr := NewUndeliveredTracker(time.Hour)
-	tr.NoteFailure("k", t0)
-	require.True(t, tr.ShouldAbandon("k", time.Minute, t0.Add(2*time.Minute)))
+	firing := []uint64{1}
+	tr.NoteFailure("k", firing, t0)
+	require.True(t, tr.ShouldAbandon("k", firing, time.Minute, t0.Add(2*time.Minute)))
 
 	tr.Clear("k")
-	require.False(t, tr.ShouldAbandon("k", time.Nanosecond, t0.Add(time.Hour)))
+	require.False(t, tr.ShouldAbandon("k", firing, time.Nanosecond, t0.Add(time.Hour)))
 
 	tr.Clear("nonexistent")
 }
@@ -118,25 +121,27 @@ func TestUndeliveredTracker_GCRemovesStaleEntries(t *testing.T) {
 	t0 := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
 	gcTTL := 10 * time.Minute
 	tr := NewUndeliveredTracker(gcTTL)
+	f := []uint64{1}
 
-	tr.NoteFailure("stale", t0)
+	tr.NoteFailure("stale", f, t0)
 	// lastSeen for "stale" is t0; at t0+15m cutoff is t0+5m, so entry is removed on next op.
-	tr.NoteFailure("fresh", t0.Add(15*time.Minute))
+	tr.NoteFailure("fresh", f, t0.Add(15*time.Minute))
 
-	require.False(t, tr.ShouldAbandon("stale", time.Nanosecond, t0.Add(15*time.Minute)))
-	require.False(t, tr.ShouldAbandon("fresh", time.Hour, t0.Add(15*time.Minute)))
+	require.False(t, tr.ShouldAbandon("stale", f, time.Nanosecond, t0.Add(15*time.Minute)))
+	require.False(t, tr.ShouldAbandon("fresh", f, time.Hour, t0.Add(15*time.Minute)))
 }
 
 func TestUndeliveredTracker_ShouldAbandonRefreshesLastSeen(t *testing.T) {
 	t0 := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
 	// Long gcTTL so the initial entry is not removed by gc inside ShouldAbandon before lastSeen is refreshed.
 	tr := NewUndeliveredTracker(time.Hour)
+	fk := []uint64{9}
 
-	tr.NoteFailure("k", t0)
-	require.False(t, tr.ShouldAbandon("k", time.Hour, t0.Add(15*time.Minute)))
+	tr.NoteFailure("k", fk, t0)
+	require.False(t, tr.ShouldAbandon("k", fk, time.Hour, t0.Add(15*time.Minute)))
 
-	tr.NoteFailure("other", t0.Add(20*time.Minute))
-	require.True(t, tr.ShouldAbandon("k", time.Minute, t0.Add(21*time.Minute)),
+	tr.NoteFailure("other", []uint64{2}, t0.Add(20*time.Minute))
+	require.True(t, tr.ShouldAbandon("k", fk, time.Minute, t0.Add(21*time.Minute)),
 		"firstFail should stay at t0 after ShouldAbandon refreshed lastSeen")
 }
 
@@ -150,8 +155,9 @@ func TestUndeliveredTracker_Concurrent(t *testing.T) {
 		go func(id int) {
 			defer wg.Done()
 			key := string(rune('a' + id%8))
-			tr.NoteFailure(key, t0)
-			tr.ShouldAbandon(key, 30*time.Minute, t0.Add(31*time.Minute))
+			f := []uint64{0}
+			tr.NoteFailure(key, f, t0)
+			tr.ShouldAbandon(key, f, 30*time.Minute, t0.Add(31*time.Minute))
 			tr.Clear(key)
 		}(i)
 	}
@@ -164,7 +170,7 @@ func TestUndeliveredTracker_MarkAbandonedAndSuppress(t *testing.T) {
 	firing := []uint64{3, 1, 2}
 
 	tr.MarkAbandoned("k", firing, t0)
-	require.False(t, tr.ShouldAbandon("k", time.Nanosecond, t0.Add(time.Hour)))
+	require.False(t, tr.ShouldAbandon("k", firing, time.Nanosecond, t0.Add(time.Hour)))
 
 	require.True(t, tr.ShouldSuppressAbandoned("k", []uint64{2, 3, 1}, t0.Add(time.Minute)))
 	require.False(t, tr.ShouldSuppressAbandoned("k", []uint64{1, 2}, t0.Add(2*time.Minute)))
@@ -180,7 +186,7 @@ func TestUndeliveredTracker_ResetIfFiringChanged(t *testing.T) {
 
 	tr.ResetIfFiringChanged("k", []uint64{1, 2, 3}, t0.Add(3*time.Minute))
 	require.False(t, tr.ShouldSuppressAbandoned("k", []uint64{1, 2, 3}, t0.Add(4*time.Minute)))
-	require.False(t, tr.ShouldAbandon("k", time.Nanosecond, t0.Add(4*time.Minute)))
+	require.False(t, tr.ShouldAbandon("k", []uint64{1, 2, 3}, time.Nanosecond, t0.Add(4*time.Minute)))
 }
 
 func TestUndeliveredTracker_GCRemovesAbandonedEntry(t *testing.T) {
@@ -189,8 +195,28 @@ func TestUndeliveredTracker_GCRemovesAbandonedEntry(t *testing.T) {
 	tr := NewUndeliveredTracker(gcTTL)
 	tr.MarkAbandoned("k", []uint64{1}, t0)
 
-	tr.NoteFailure("other", t0.Add(6*time.Minute))
+	tr.NoteFailure("other", []uint64{0}, t0.Add(6*time.Minute))
 	require.False(t, tr.ShouldSuppressAbandoned("k", []uint64{1}, t0.Add(6*time.Minute)))
+}
+
+func TestUndeliveredTracker_FiringChangeResetsFirstFail(t *testing.T) {
+	t0 := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	tr := NewUndeliveredTracker(time.Hour)
+	fa := []uint64{1, 2}
+	fb := []uint64{3}
+
+	tr.NoteFailure("k", fa, t0)
+	tr.NoteFailure("k", fa, t0.Add(50*time.Minute))
+	require.True(t, tr.ShouldAbandon("k", fa, 45*time.Minute, t0.Add(50*time.Minute)),
+		"long failure streak for set A should cross abandon threshold")
+
+	require.False(t, tr.ShouldAbandon("k", fb, time.Nanosecond, t0.Add(50*time.Minute)),
+		"switched firing set must not inherit A's firstFail before any failure for B")
+
+	tr.NoteFailure("k", fb, t0.Add(50*time.Minute))
+	require.False(t, tr.ShouldAbandon("k", fb, 40*time.Minute, t0.Add(50*time.Minute)),
+		"B's abandon timer starts at B's first recorded failure")
+	require.True(t, tr.ShouldAbandon("k", fb, 40*time.Minute, t0.Add(91*time.Minute)))
 }
 
 func TestUndeliveredTracker_SortedFiringCopy(t *testing.T) {


### PR DESCRIPTION
Implements the proposal in #5134: after a long period of failed delivery for a notification key, optionally stop calling the integration and suppress further attempts while the same firing alert set is still active, so receivers are not hit with a large backlog when connectivity returns. Default behaviour is unchanged when the feature is off.

What this PR does

- Adds global settings abandon_undelivered_notifications and abandon_undelivered_after (positive duration required when enabled); validated in config.
- Introduces UndeliveredTracker to record first failure time per key, decide when to abandon, track the firing set at abandon time, suppress retries for that set, and reset when the firing set changes (with GC for stale entries).
- Wires the tracker into the notify pipeline (RetryStage) and main when the feature is enabled.
- Adds metrics notifications_abandoned_total and notifications_abandoned_suppressed_total.
- Adds unit tests for the tracker, retry/abandon behaviour in notify, and invalid global config.

#### Pull Request Checklist
Please check all the applicable boxes.

- Please list all open issue(s) discussed with maintainers related to this change
    - Fixes #5134
    <!--
    If it applies.
    Automatically closes linked issue when PR is merged.
    Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
    More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
    -->
- Is this a new Receiver integration?
    - [ ] I have already tried to use the [Webhook Receiver Integration](https://prometheus.io/docs/alerting/latest/configuration/#webhook_config) and [3rd party integrations](https://prometheus.io/docs/operating/integrations/#alertmanager-webhook-receiver) before adding this new Receiver Integration
- Is this a bugfix?
    - [ ] I have added tests that can reproduce the bug which pass with this bugfix applied
- Is this a new feature?
    - [x] I have added tests that test the new feature's functionality
- Does this change affect performance?
    - [ ] I have provided benchmarks comparison that shows performance is improved or is not degraded
        - You can use [`benchstat`](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat) to compare benchmarks
    - [ ] I have added new benchmarks if required or requested by maintainers
- Is this a breaking change?
    - [x] My changes do not break the existing cluster messages
    - [x] My changes do not break the existing api
- [ ] I have added/updated the required documentation
- [X] I have signed-off my commits
- [X] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/alertmanager/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[FEATURE] Config: Optional global abandon_undelivered_notifications and abandon_undelivered_after to abandon prolonged undelivered notifications and suppress retries for the same firing alert set; adds notifications_abandoned_total and notifications_abandoned_suppressed_total metrics.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notification abandonment: stop retrying undelivered notifications after a configurable threshold and suppress duplicate abandoned deliveries until the firing set changes.

* **Configuration**
  * New global settings to enable abandonment and set abandonment duration; validation prevents non-positive durations.

* **Monitoring**
  * New metrics tracking abandoned and suppressed notifications.

* **Tests**
  * Extensive unit tests for abandonment, suppression, clearing, GC behavior, and concurrency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->