### PR TITLE
config: honor global slack_api_url for update_message validation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -428,6 +428,9 @@ func (c *Config) UnmarshalYAML(unmarshal func(any) error) error {
 				}
 				sc.APIURL = (*amcommoncfg.SecretURL)(sc.AppURL)
 			}
+			if err := validateSlackUpdateMessageAPIURL(sc.UpdateMessage, sc.APIURL); err != nil {
+				return err
+			}
 		}
 		for _, poc := range rcv.PushoverConfigs {
 			if poc == nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1082,6 +1082,17 @@ func TestSlackUpdateMessageWebhookURL(t *testing.T) {
 	}
 }
 
+func TestSlackUpdateMessageGlobalAPIURL(t *testing.T) {
+	conf, err := LoadFile("testdata/conf.slack-update-message-global-api-url.yml")
+	if err != nil {
+		t.Fatalf("Error parsing %s: %s", "testdata/conf.slack-update-message-global-api-url.yml", err)
+	}
+
+	if got := conf.Receivers[0].SlackConfigs[0].APIURL.String(); got != slackUpdateMessageAPIURL {
+		t.Fatalf("Invalid Slack URL: %s\nExpected: %s", got, slackUpdateMessageAPIURL)
+	}
+}
+
 func TestSlackGlobalAppToken(t *testing.T) {
 	conf, err := LoadFile("testdata/conf.slack-default-app-token.yml")
 	if err != nil {

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -520,6 +520,16 @@ func (c *SlackField) UnmarshalYAML(unmarshal func(any) error) error {
 	return nil
 }
 
+const slackUpdateMessageAPIURL = "https://slack.com/api/chat.postMessage"
+
+func validateSlackUpdateMessageAPIURL(updateMessage bool, apiURL *amcommoncfg.SecretURL) error {
+	if updateMessage && apiURL != nil && apiURL.String() != slackUpdateMessageAPIURL {
+		return errors.New("update_message can only be used with bot tokens. api_url must be set to https://slack.com/api/chat.postMessage")
+	}
+
+	return nil
+}
+
 // SlackConfig configures notifications via Slack.
 type SlackConfig struct {
 	amcommoncfg.NotifierConfig `yaml:",inline" json:",inline"`
@@ -582,8 +592,8 @@ func (c *SlackConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		return errors.New("at most one of api_url/api_url_file & app_token/app_token_file must be configured")
 	}
 
-	if c.UpdateMessage && c.APIURL.String() != "https://slack.com/api/chat.postMessage" {
-		return errors.New("update_message can only be used with bot tokens. api_url must be set to https://slack.com/api/chat.postMessage")
+	if err := validateSlackUpdateMessageAPIURL(c.UpdateMessage, c.APIURL); err != nil {
+		return err
 	}
 
 	return nil

--- a/config/testdata/conf.slack-update-message-global-api-url.yml
+++ b/config/testdata/conf.slack-update-message-global-api-url.yml
@@ -1,0 +1,12 @@
+global:
+  slack_api_url: "https://slack.com/api/chat.postMessage"
+
+route:
+  receiver: foo
+
+receivers:
+  - name: foo
+    slack_configs:
+      - channel: bar-channel
+        send_resolved: true
+        update_message: true


### PR DESCRIPTION
#### Pull Request Checklist
Please check all the applicable boxes.

- Please list all open issue(s) discussed with maintainers related to this change
    - Fixes #5164
- Is this a new Receiver integration?
    - [ ] I have already tried to use the [Webhook Receiver Integration](https://prometheus.io/docs/alerting/latest/configuration/#webhook_config) and [3rd party integrations](https://prometheus.io/docs/operating/integrations/#alertmanager-webhook-receiver) before adding this new Receiver Integration
- Is this a bugfix?
    - [x] I have added tests that can reproduce the bug which pass with this bugfix applied
- Is this a new feature?
    - [ ] I have added tests that test the new feature's functionality
- Does this change affect performance?
    - [ ] I have provided benchmarks comparison that shows performance is improved or is not degraded
    - [ ] I have added new benchmarks if required or requested by maintainers
- Is this a breaking change?
    - [x] My changes do not break the existing cluster messages
    - [x] My changes do not break the existing api
- [ ] I have added/updated the required documentation
- [x] I have signed-off my commits
- [x] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?
```release-notes
[BUGFIX] config: Avoid a panic when `slack_configs[].update_message` relies on `global.slack_api_url`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Slack configuration validation to prevent invalid API URL and message update setting combinations from being accepted during configuration parsing.

* **Tests**
  * Expanded test coverage for Slack configuration with global API URL settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->