### PR TITLE
refactor: move webhook config into webhhook package

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -32,6 +32,7 @@ import (
 	amcommoncfg "github.com/prometheus/alertmanager/config/common"
 	"github.com/prometheus/alertmanager/eventrecorder"
 	"github.com/prometheus/alertmanager/matcher/compat"
+	"github.com/prometheus/alertmanager/notify/webhook"
 	"github.com/prometheus/alertmanager/timeinterval"
 	"github.com/prometheus/alertmanager/tracing"
 )
@@ -938,24 +939,24 @@ type Receiver struct {
 	// A unique identifier for this receiver.
 	Name string `yaml:"name" json:"name"`
 
-	DiscordConfigs    []*DiscordConfig    `yaml:"discord_configs,omitempty" json:"discord_configs,omitempty"`
-	EmailConfigs      []*EmailConfig      `yaml:"email_configs,omitempty" json:"email_configs,omitempty"`
-	IncidentioConfigs []*IncidentioConfig `yaml:"incidentio_configs,omitempty" json:"incidentio_configs,omitempty"`
-	PagerdutyConfigs  []*PagerdutyConfig  `yaml:"pagerduty_configs,omitempty" json:"pagerduty_configs,omitempty"`
-	SlackConfigs      []*SlackConfig      `yaml:"slack_configs,omitempty" json:"slack_configs,omitempty"`
-	WebhookConfigs    []*WebhookConfig    `yaml:"webhook_configs,omitempty" json:"webhook_configs,omitempty"`
-	OpsGenieConfigs   []*OpsGenieConfig   `yaml:"opsgenie_configs,omitempty" json:"opsgenie_configs,omitempty"`
-	WechatConfigs     []*WechatConfig     `yaml:"wechat_configs,omitempty" json:"wechat_configs,omitempty"`
-	PushoverConfigs   []*PushoverConfig   `yaml:"pushover_configs,omitempty" json:"pushover_configs,omitempty"`
-	VictorOpsConfigs  []*VictorOpsConfig  `yaml:"victorops_configs,omitempty" json:"victorops_configs,omitempty"`
-	SNSConfigs        []*SNSConfig        `yaml:"sns_configs,omitempty" json:"sns_configs,omitempty"`
-	TelegramConfigs   []*TelegramConfig   `yaml:"telegram_configs,omitempty" json:"telegram_configs,omitempty"`
-	WebexConfigs      []*WebexConfig      `yaml:"webex_configs,omitempty" json:"webex_configs,omitempty"`
-	MSTeamsConfigs    []*MSTeamsConfig    `yaml:"msteams_configs,omitempty" json:"msteams_configs,omitempty"`
-	MSTeamsV2Configs  []*MSTeamsV2Config  `yaml:"msteamsv2_configs,omitempty" json:"msteamsv2_configs,omitempty"`
-	JiraConfigs       []*JiraConfig       `yaml:"jira_configs,omitempty" json:"jira_configs,omitempty"`
-	RocketchatConfigs []*RocketchatConfig `yaml:"rocketchat_configs,omitempty" json:"rocketchat_configs,omitempty"`
-	MattermostConfigs []*MattermostConfig `yaml:"mattermost_configs,omitempty" json:"mattermost_configs,omitempty"`
+	DiscordConfigs    []*DiscordConfig         `yaml:"discord_configs,omitempty" json:"discord_configs,omitempty"`
+	EmailConfigs      []*EmailConfig           `yaml:"email_configs,omitempty" json:"email_configs,omitempty"`
+	IncidentioConfigs []*IncidentioConfig      `yaml:"incidentio_configs,omitempty" json:"incidentio_configs,omitempty"`
+	PagerdutyConfigs  []*PagerdutyConfig       `yaml:"pagerduty_configs,omitempty" json:"pagerduty_configs,omitempty"`
+	SlackConfigs      []*SlackConfig           `yaml:"slack_configs,omitempty" json:"slack_configs,omitempty"`
+	WebhookConfigs    []*webhook.WebhookConfig `yaml:"webhook_configs,omitempty" json:"webhook_configs,omitempty"`
+	OpsGenieConfigs   []*OpsGenieConfig        `yaml:"opsgenie_configs,omitempty" json:"opsgenie_configs,omitempty"`
+	WechatConfigs     []*WechatConfig          `yaml:"wechat_configs,omitempty" json:"wechat_configs,omitempty"`
+	PushoverConfigs   []*PushoverConfig        `yaml:"pushover_configs,omitempty" json:"pushover_configs,omitempty"`
+	VictorOpsConfigs  []*VictorOpsConfig       `yaml:"victorops_configs,omitempty" json:"victorops_configs,omitempty"`
+	SNSConfigs        []*SNSConfig             `yaml:"sns_configs,omitempty" json:"sns_configs,omitempty"`
+	TelegramConfigs   []*TelegramConfig        `yaml:"telegram_configs,omitempty" json:"telegram_configs,omitempty"`
+	WebexConfigs      []*WebexConfig           `yaml:"webex_configs,omitempty" json:"webex_configs,omitempty"`
+	MSTeamsConfigs    []*MSTeamsConfig         `yaml:"msteams_configs,omitempty" json:"msteams_configs,omitempty"`
+	MSTeamsV2Configs  []*MSTeamsV2Config       `yaml:"msteamsv2_configs,omitempty" json:"msteamsv2_configs,omitempty"`
+	JiraConfigs       []*JiraConfig            `yaml:"jira_configs,omitempty" json:"jira_configs,omitempty"`
+	RocketchatConfigs []*RocketchatConfig      `yaml:"rocketchat_configs,omitempty" json:"rocketchat_configs,omitempty"`
+	MattermostConfigs []*MattermostConfig      `yaml:"mattermost_configs,omitempty" json:"mattermost_configs,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for Receiver.

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -38,13 +38,6 @@ var (
 		},
 	}
 
-	// DefaultWebhookConfig defines default values for Webhook configurations.
-	DefaultWebhookConfig = WebhookConfig{
-		NotifierConfig: amcommoncfg.NotifierConfig{
-			VSendResolved: true,
-		},
-	}
-
 	// DefaultWebexConfig defines default values for Webex configurations.
 	DefaultWebexConfig = WebexConfig{
 		NotifierConfig: amcommoncfg.NotifierConfig{
@@ -637,43 +630,6 @@ func (c *IncidentioConfig) UnmarshalYAML(unmarshal func(any) error) error {
 
 	if (c.HTTPConfig != nil && c.HTTPConfig.Authorization == nil) && c.AlertSourceToken == "" && c.AlertSourceTokenFile == "" {
 		return errors.New("at least one of alert_source_token, alert_source_token_file or http_config.authorization must be configured")
-	}
-	return nil
-}
-
-// WebhookConfig configures notifications via a generic webhook.
-type WebhookConfig struct {
-	amcommoncfg.NotifierConfig `yaml:",inline" json:",inline"`
-
-	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
-
-	// URL to send POST request to.
-	URL     SecretTemplateURL `yaml:"url,omitempty" json:"url,omitempty"`
-	URLFile string            `yaml:"url_file" json:"url_file"`
-
-	// MaxAlerts is the maximum number of alerts to be sent per webhook message.
-	// Alerts exceeding this threshold will be truncated. Setting this to 0
-	// allows an unlimited number of alerts.
-	MaxAlerts uint64 `yaml:"max_alerts" json:"max_alerts"`
-
-	// Timeout is the maximum time allowed to invoke the webhook. Setting this to 0
-	// does not impose a timeout.
-	Timeout time.Duration `yaml:"timeout" json:"timeout"`
-	Payload any           `yaml:"payload,omitempty" json:"payload,omitempty"`
-}
-
-// UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (c *WebhookConfig) UnmarshalYAML(unmarshal func(any) error) error {
-	*c = DefaultWebhookConfig
-	type plain WebhookConfig
-	if err := unmarshal((*plain)(c)); err != nil {
-		return err
-	}
-	if c.URL == "" && c.URLFile == "" {
-		return errors.New("one of url or url_file must be configured")
-	}
-	if c.URL != "" && c.URLFile != "" {
-		return errors.New("at most one of url & url_file must be configured")
 	}
 	return nil
 }

--- a/config/notifiers_test.go
+++ b/config/notifiers_test.go
@@ -17,7 +17,6 @@ import (
 	"errors"
 	"net/mail"
 	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -262,93 +261,6 @@ source: 'alert-manager-source'
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedSource, cfg.Source)
 		})
-	}
-}
-
-func TestWebhookURLIsPresent(t *testing.T) {
-	in := `{}`
-	var cfg WebhookConfig
-	err := yaml.UnmarshalStrict([]byte(in), &cfg)
-
-	expected := "one of url or url_file must be configured"
-
-	if err == nil {
-		t.Fatalf("no error returned, expected:\n%v", expected)
-	}
-	if err.Error() != expected {
-		t.Errorf("\nexpected:\n%v\ngot:\n%v", expected, err.Error())
-	}
-}
-
-func TestWebhookURLOrURLFile(t *testing.T) {
-	in := `
-url: 'http://example.com'
-url_file: 'http://example.com'
-`
-	var cfg WebhookConfig
-	err := yaml.UnmarshalStrict([]byte(in), &cfg)
-
-	expected := "at most one of url & url_file must be configured"
-
-	if err == nil {
-		t.Fatalf("no error returned, expected:\n%v", expected)
-	}
-	if err.Error() != expected {
-		t.Errorf("\nexpected:\n%v\ngot:\n%v", expected, err.Error())
-	}
-}
-
-func TestWebhookHttpConfigIsValid(t *testing.T) {
-	in := `
-url: 'http://example.com'
-http_config:
-  bearer_token: foo
-  bearer_token_file: /tmp/bar
-`
-	var cfg WebhookConfig
-	err := yaml.UnmarshalStrict([]byte(in), &cfg)
-
-	expected := "at most one of bearer_token & bearer_token_file must be configured"
-
-	if err == nil {
-		t.Fatalf("no error returned, expected:\n%v", expected)
-	}
-	if err.Error() != expected {
-		t.Errorf("\nexpected:\n%v\ngot:\n%v", expected, err.Error())
-	}
-}
-
-func TestWebhookHttpConfigIsOptional(t *testing.T) {
-	in := `
-url: 'http://example.com'
-`
-	var cfg WebhookConfig
-	err := yaml.UnmarshalStrict([]byte(in), &cfg)
-	if err != nil {
-		t.Fatalf("no error expected, returned:\n%v", err.Error())
-	}
-}
-
-func TestWebhookPasswordIsObfuscated(t *testing.T) {
-	in := `
-url: 'http://example.com'
-http_config:
-  basic_auth:
-    username: foo
-    password: supersecret
-`
-	var cfg WebhookConfig
-	err := yaml.UnmarshalStrict([]byte(in), &cfg)
-	if err != nil {
-		t.Fatalf("no error expected, returned:\n%v", err.Error())
-	}
-
-	ycfg, err := yaml.Marshal(cfg)
-	if err != nil {
-		t.Fatalf("no error expected, returned:\n%v", err.Error())
-	}
-	if strings.Contains(string(ycfg), "supersecret") {
-		t.Errorf("Found password in the YAML cfg: %s\n", ycfg)
 	}
 }
 

--- a/config/receiver/receiver_test.go
+++ b/config/receiver/receiver_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	amcommoncfg "github.com/prometheus/alertmanager/config/common"
+	"github.com/prometheus/alertmanager/notify/webhook"
 
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
@@ -38,7 +39,7 @@ func TestBuildReceiverIntegrations(t *testing.T) {
 		{
 			receiver: config.Receiver{
 				Name: "foo",
-				WebhookConfigs: []*config.WebhookConfig{
+				WebhookConfigs: []*webhook.WebhookConfig{
 					{
 						HTTPConfig: &commoncfg.HTTPClientConfig{},
 					},
@@ -58,7 +59,7 @@ func TestBuildReceiverIntegrations(t *testing.T) {
 		{
 			receiver: config.Receiver{
 				Name: "foo",
-				WebhookConfigs: []*config.WebhookConfig{
+				WebhookConfigs: []*webhook.WebhookConfig{
 					{
 						HTTPConfig: &commoncfg.HTTPClientConfig{
 							TLSConfig: commoncfg.TLSConfig{

--- a/notify/webhook/config.go
+++ b/notify/webhook/config.go
@@ -1,0 +1,67 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhook
+
+import (
+	"errors"
+	"time"
+
+	commoncfg "github.com/prometheus/common/config"
+
+	amcommoncfg "github.com/prometheus/alertmanager/config/common"
+)
+
+// defaultWebhookConfig defines default values for Webhook configurations.
+var defaultWebhookConfig = WebhookConfig{
+	NotifierConfig: amcommoncfg.NotifierConfig{
+		VSendResolved: true,
+	},
+}
+
+// WebhookConfig configures notifications via a generic webhook.
+type WebhookConfig struct {
+	amcommoncfg.NotifierConfig `yaml:",inline" json:",inline"`
+
+	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
+
+	// URL to send POST request to.
+	URL     amcommoncfg.SecretTemplateURL `yaml:"url,omitempty" json:"url,omitempty"`
+	URLFile string                        `yaml:"url_file" json:"url_file"`
+
+	// MaxAlerts is the maximum number of alerts to be sent per webhook message.
+	// Alerts exceeding this threshold will be truncated. Setting this to 0
+	// allows an unlimited number of alerts.
+	MaxAlerts uint64 `yaml:"max_alerts" json:"max_alerts"`
+
+	// Timeout is the maximum time allowed to invoke the webhook. Setting this to 0
+	// does not impose a timeout.
+	Timeout time.Duration `yaml:"timeout" json:"timeout"`
+	Payload any           `yaml:"payload,omitempty" json:"payload,omitempty"`
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (c *WebhookConfig) UnmarshalYAML(unmarshal func(any) error) error {
+	*c = defaultWebhookConfig
+	type plain WebhookConfig
+	if err := unmarshal((*plain)(c)); err != nil {
+		return err
+	}
+	if c.URL == "" && c.URLFile == "" {
+		return errors.New("one of url or url_file must be configured")
+	}
+	if c.URL != "" && c.URLFile != "" {
+		return errors.New("at most one of url & url_file must be configured")
+	}
+	return nil
+}

--- a/notify/webhook/config_test.go
+++ b/notify/webhook/config_test.go
@@ -1,0 +1,108 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhook
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+func TestWebhookURLIsPresent(t *testing.T) {
+	in := `{}`
+	var cfg WebhookConfig
+	err := yaml.UnmarshalStrict([]byte(in), &cfg)
+
+	expected := "one of url or url_file must be configured"
+
+	if err == nil {
+		t.Fatalf("no error returned, expected:\n%v", expected)
+	}
+	if err.Error() != expected {
+		t.Errorf("\nexpected:\n%v\ngot:\n%v", expected, err.Error())
+	}
+}
+
+func TestWebhookURLOrURLFile(t *testing.T) {
+	in := `
+url: 'http://example.com'
+url_file: 'http://example.com'
+`
+	var cfg WebhookConfig
+	err := yaml.UnmarshalStrict([]byte(in), &cfg)
+
+	expected := "at most one of url & url_file must be configured"
+
+	if err == nil {
+		t.Fatalf("no error returned, expected:\n%v", expected)
+	}
+	if err.Error() != expected {
+		t.Errorf("\nexpected:\n%v\ngot:\n%v", expected, err.Error())
+	}
+}
+
+func TestWebhookHttpConfigIsValid(t *testing.T) {
+	in := `
+url: 'http://example.com'
+http_config:
+  bearer_token: foo
+  bearer_token_file: /tmp/bar
+`
+	var cfg WebhookConfig
+	err := yaml.UnmarshalStrict([]byte(in), &cfg)
+
+	expected := "at most one of bearer_token & bearer_token_file must be configured"
+
+	if err == nil {
+		t.Fatalf("no error returned, expected:\n%v", expected)
+	}
+	if err.Error() != expected {
+		t.Errorf("\nexpected:\n%v\ngot:\n%v", expected, err.Error())
+	}
+}
+
+func TestWebhookHttpConfigIsOptional(t *testing.T) {
+	in := `
+url: 'http://example.com'
+`
+	var cfg WebhookConfig
+	err := yaml.UnmarshalStrict([]byte(in), &cfg)
+	if err != nil {
+		t.Fatalf("no error expected, returned:\n%v", err.Error())
+	}
+}
+
+func TestWebhookPasswordIsObfuscated(t *testing.T) {
+	in := `
+url: 'http://example.com'
+http_config:
+  basic_auth:
+    username: foo
+    password: supersecret
+`
+	var cfg WebhookConfig
+	err := yaml.UnmarshalStrict([]byte(in), &cfg)
+	if err != nil {
+		t.Fatalf("no error expected, returned:\n%v", err.Error())
+	}
+
+	ycfg, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("no error expected, returned:\n%v", err.Error())
+	}
+	if strings.Contains(string(ycfg), "supersecret") {
+		t.Errorf("Found password in the YAML cfg: %s\n", ycfg)
+	}
+}

--- a/notify/webhook/webhook.go
+++ b/notify/webhook/webhook.go
@@ -26,7 +26,6 @@ import (
 
 	commoncfg "github.com/prometheus/common/config"
 
-	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/alertmanager/types"
@@ -34,7 +33,7 @@ import (
 
 // Notifier implements a Notifier for generic webhooks.
 type Notifier struct {
-	conf    *config.WebhookConfig
+	conf    *WebhookConfig
 	tmpl    *template.Template
 	logger  *slog.Logger
 	client  *http.Client
@@ -42,7 +41,7 @@ type Notifier struct {
 }
 
 // New returns a new Webhook.
-func New(conf *config.WebhookConfig, t *template.Template, l *slog.Logger, httpOpts ...commoncfg.HTTPClientOption) (*Notifier, error) {
+func New(conf *WebhookConfig, t *template.Template, l *slog.Logger, httpOpts ...commoncfg.HTTPClientOption) (*Notifier, error) {
 	client, err := notify.NewClientWithTracing(*conf.HTTPConfig, "webhook", httpOpts...)
 	if err != nil {
 		return nil, err

--- a/notify/webhook/webhook_test.go
+++ b/notify/webhook/webhook_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 
-	"github.com/prometheus/alertmanager/config"
+	amcommoncfg "github.com/prometheus/alertmanager/config/common"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/notify/test"
 	"github.com/prometheus/alertmanager/types"
@@ -40,8 +40,8 @@ import (
 
 func TestWebhookRetry(t *testing.T) {
 	notifier, err := New(
-		&config.WebhookConfig{
-			URL:        config.SecretTemplateURL("http://example.com"),
+		&WebhookConfig{
+			URL:        amcommoncfg.SecretTemplateURL("http://example.com"),
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),
@@ -109,8 +109,8 @@ func TestWebhookRedactedURL(t *testing.T) {
 
 	secret := "secret"
 	notifier, err := New(
-		&config.WebhookConfig{
-			URL:        config.SecretTemplateURL(u.String()),
+		&WebhookConfig{
+			URL:        amcommoncfg.SecretTemplateURL(u.String()),
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 		},
 		test.CreateTmpl(t),
@@ -131,7 +131,7 @@ func TestWebhookReadingURLFromFile(t *testing.T) {
 	require.NoError(t, err, "writing to temp file failed")
 
 	notifier, err := New(
-		&config.WebhookConfig{
+		&WebhookConfig{
 			URLFile:    f.Name(),
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 		},
@@ -191,8 +191,8 @@ func TestWebhookURLTemplating(t *testing.T) {
 			calledURL = "" // Reset for each test
 
 			notifier, err := New(
-				&config.WebhookConfig{
-					URL:        config.SecretTemplateURL(tc.url),
+				&WebhookConfig{
+					URL:        amcommoncfg.SecretTemplateURL(tc.url),
 					HTTPConfig: &commoncfg.HTTPClientConfig{},
 				},
 				test.CreateTmpl(t),
@@ -255,8 +255,8 @@ func TestWebhookDefaultPayload(t *testing.T) {
 	u, err := url.Parse("http://localhost")
 	require.NoError(t, err)
 
-	conf := &config.WebhookConfig{
-		URL:        config.SecretTemplateURL(u.String()),
+	conf := &WebhookConfig{
+		URL:        amcommoncfg.SecretTemplateURL(u.String()),
 		HTTPConfig: &commoncfg.HTTPClientConfig{},
 	}
 
@@ -312,8 +312,8 @@ func TestWebhookCustomPayloadMap(t *testing.T) {
 	u, err := url.Parse("http://localhost")
 	require.NoError(t, err)
 
-	conf := &config.WebhookConfig{
-		URL:        config.SecretTemplateURL(u.String()),
+	conf := &WebhookConfig{
+		URL:        amcommoncfg.SecretTemplateURL(u.String()),
 		HTTPConfig: &commoncfg.HTTPClientConfig{},
 		Payload: map[string]any{
 			"custom":       `some custom content`,
@@ -380,8 +380,8 @@ func TestWebhookCustomPayloadList(t *testing.T) {
 `), &payload)
 	require.NoError(t, err)
 
-	conf := &config.WebhookConfig{
-		URL:        config.SecretTemplateURL(u.String()),
+	conf := &WebhookConfig{
+		URL:        amcommoncfg.SecretTemplateURL(u.String()),
 		HTTPConfig: &commoncfg.HTTPClientConfig{},
 		Payload:    payload,
 	}
@@ -437,8 +437,8 @@ func TestWebhookCustomPayloadStringList(t *testing.T) {
 - foo: bar
 `
 
-	conf := &config.WebhookConfig{
-		URL:        config.SecretTemplateURL(u.String()),
+	conf := &WebhookConfig{
+		URL:        amcommoncfg.SecretTemplateURL(u.String()),
 		HTTPConfig: &commoncfg.HTTPClientConfig{},
 		Payload:    payload,
 	}
@@ -499,8 +499,8 @@ func TestWebhookCustomPayloadString(t *testing.T) {
 `
 	require.NoError(t, err)
 
-	conf := &config.WebhookConfig{
-		URL:        config.SecretTemplateURL(u.String()),
+	conf := &WebhookConfig{
+		URL:        amcommoncfg.SecretTemplateURL(u.String()),
 		HTTPConfig: &commoncfg.HTTPClientConfig{},
 		Payload:    payload,
 	}


### PR DESCRIPTION
#### Pull Request Checklist
- [x] I have signed-off my commits
- [x] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/alertmanager/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Webhook notification configuration moved into a dedicated webhook module and integrated across notification receiver paths for clearer structure.

* **Tests**
  * Webhook configuration validation tests were consolidated, updated, and relocated to cover parsing, validation rules, and secret handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->