### PR TITLE
inhibit: fix gcCallback removing live index entry for regex source matchers

### DIFF
--- a/inhibit/inhibit.go
+++ b/inhibit/inhibit.go
@@ -390,8 +390,27 @@ func (r *InhibitRule) findEqualSourceAlert(lset model.LabelSet, now time.Time) (
 
 func (r *InhibitRule) gcCallback(alerts []*types.Alert) {
 	for _, a := range alerts {
-		fp := r.fingerprintEquals(a.Labels)
-		r.sindex.Delete(fp)
+		eq := r.fingerprintEquals(a.Labels)
+
+		// Only act on the index entry if the GC'd alert is the one currently indexed.
+		// When multiple source alerts share the same equal-label fingerprint (e.g. via
+		// a regex source_matchers like alertname =~ "(a|b|c)"), the index holds only one
+		// of them. If a different alert is indexed, removing the entry would break
+		// inhibition for that other alert.
+		indexed, ok := r.sindex.Get(eq)
+		if !ok || indexed != a.Fingerprint() {
+			continue
+		}
+
+		// The GC'd alert was the indexed one. Remove it and promote another still-active
+		// source alert with the same equal labels, if any.
+		r.sindex.Delete(eq)
+		for _, candidate := range r.scache.List() {
+			if r.fingerprintEquals(candidate.Labels) == eq {
+				r.sindex.Set(eq, candidate.Fingerprint())
+				break
+			}
+		}
 	}
 }
 

--- a/inhibit/inhibit_test.go
+++ b/inhibit/inhibit_test.go
@@ -620,3 +620,59 @@ func BenchmarkFingerprintEquals(b *testing.B) {
 		})
 	}
 }
+
+// TestInhibitRule_gcCallback_preserves_regex_source_match is a regression test for
+// the case where multiple source alerts match via a regex matcher and share the same
+// equal-label fingerprint. When one of them is GC'd, inhibition for the remaining
+// active source alert must continue to work.
+func TestInhibitRule_gcCallback_preserves_regex_source_match(t *testing.T) {
+	// Build an InhibitRule with a regex source matcher (alertname =~ "src.*") and
+	// equal: [env] so that two source alerts with the same env share an index slot.
+	sourceMatcher, err := labels.NewMatcher(labels.MatchRegexp, "alertname", "src.*")
+	require.NoError(t, err)
+	targetMatcher, err := labels.NewMatcher(labels.MatchEqual, "alertname", "target")
+	require.NoError(t, err)
+
+	rule := &InhibitRule{
+		SourceMatchers: labels.Matchers{sourceMatcher},
+		TargetMatchers: labels.Matchers{targetMatcher},
+		Equal:          map[model.LabelName]struct{}{"env": {}},
+		scache:         store.NewAlerts(),
+		sindex:         newIndex(),
+	}
+
+	now := time.Now()
+	makeAlert := func(name, env string) *types.Alert {
+		return &types.Alert{
+			Alert: model.Alert{
+				Labels: model.LabelSet{
+					"alertname": model.LabelValue(name),
+					"env":       model.LabelValue(env),
+				},
+				StartsAt: now.Add(-1 * time.Minute),
+				EndsAt:   now.Add(10 * time.Minute),
+			},
+		}
+	}
+
+	src1 := makeAlert("src1", "prod")
+	src2 := makeAlert("src2", "prod")
+	target := makeAlert("target", "prod")
+
+	// Both source alerts arrive and are indexed.
+	require.NoError(t, rule.scache.Set(src1))
+	rule.updateIndex(src1)
+	require.NoError(t, rule.scache.Set(src2))
+	rule.updateIndex(src2)
+
+	// Target alert should be inhibited while both sources are active.
+	_, inhibited := rule.hasEqual(target.Labels, false, now)
+	require.True(t, inhibited, "target should be inhibited while both source alerts are active")
+
+	// src1 expires from the cache (GC).
+	rule.gcCallback([]*types.Alert{src1})
+
+	// src2 is still active; target must still be inhibited.
+	_, inhibited = rule.hasEqual(target.Labels, false, now)
+	require.True(t, inhibited, "target should still be inhibited after src1 is GC'd — src2 is still active")
+}


### PR DESCRIPTION
## Root cause

Since the `sindex` performance optimisation landed (v0.28.1 #4119), `gcCallback` unconditionally removes the `sindex` entry for an equal-label fingerprint whenever **any** source alert with that fingerprint is GC'd:

```go
// before
func (r *InhibitRule) gcCallback(alerts []*types.Alert) {
    for _, a := range alerts {
        fp := r.fingerprintEquals(a.Labels)
        r.sindex.Delete(fp)   // always removes, even if a different alert is indexed
    }
}
```

When a **regex** `source_matchers` (e.g. `alertname =~ "(alert_one|alert_two)"`) matches multiple source alerts that share the same equal-label fingerprint, the sindex holds only one of them. If that alert is **not** the indexed one, the delete removes the wrong entry. Worse, even if it is the indexed one, no replacement is promoted — so the remaining active source alert is orphaned in the scache and inhibition silently stops working.

This matches the exact symptom in #5162: splitting the regex into separate per-alertname rules (one alert per rule, no collision) worked around the problem.

## Fix

In `gcCallback`, only remove the index entry when the GC'd alert **is** the indexed one, then scan the source cache for another still-active alert with the same equal-label fingerprint to promote as its replacement:

```go
func (r *InhibitRule) gcCallback(alerts []*types.Alert) {
    for _, a := range alerts {
        eq := r.fingerprintEquals(a.Labels)
        indexed, ok := r.sindex.Get(eq)
        if !ok || indexed != a.Fingerprint() {
            continue
        }
        r.sindex.Delete(eq)
        for _, candidate := range r.scache.List() {
            if r.fingerprintEquals(candidate.Labels) == eq {
                r.sindex.Set(eq, candidate.Fingerprint())
                break
            }
        }
    }
}
```

The scan is O(n) in the source-alert cache size, but GC events are infrequent and the scache only holds alerts that matched the source matchers.

## Test

`TestInhibitRule_gcCallback_preserves_regex_source_match` — fires two regex-matching source alerts with the same `env` equal label, GC's the first, and asserts the target is still inhibited by the second.

Fixes #5162