### PR TITLE
amtool: add --test-file flag to config routes test for batch routing and inhibition testing

### DIFF
--- a/cli/routes_test_file.go
+++ b/cli/routes_test_file.go
@@ -40,9 +40,10 @@ type testFileAlertDef struct {
 	// ExpectedReceivers lists the receiver names the alert should route to.
 	// Mutually exclusive with ExpectedInhibited.
 	ExpectedReceivers []string `yaml:"expected_receivers,omitempty"`
-	// ExpectedInhibited asserts that this alert should be inhibited.
-	// Mutually exclusive with ExpectedReceivers.
-	ExpectedInhibited bool `yaml:"expected_inhibited,omitempty"`
+	// ExpectedInhibited asserts whether this alert should be inhibited.
+	// Use true to assert inhibition, false to explicitly assert no inhibition.
+	// Mutually exclusive with ExpectedReceivers; exactly one must be set.
+	ExpectedInhibited *bool `yaml:"expected_inhibited,omitempty"`
 }
 
 // testFileCase is a named test case containing one or more alert definitions.
@@ -189,29 +190,62 @@ func runRouteTestCase(
 
 	// Validate each alert definition.
 	for i, ad := range tc.Alerts {
+		hasReceivers := len(ad.ExpectedReceivers) > 0
+		hasInhibited := ad.ExpectedInhibited != nil
+
+		// Exactly one of expected_receivers / expected_inhibited must be set.
+		if hasReceivers && hasInhibited {
+			return false, fmt.Sprintf(
+				"alert[%d] %s: expected_receivers and expected_inhibited are mutually exclusive",
+				i, labelMapString(ad.Labels),
+			)
+		}
+		if !hasReceivers && !hasInhibited {
+			return false, fmt.Sprintf(
+				"alert[%d] %s: one of expected_receivers or expected_inhibited must be set",
+				i, labelMapString(ad.Labels),
+			)
+		}
+
 		lset := mapToLabelSet(ad.Labels)
 
-		if ad.ExpectedInhibited {
-			if ih == nil {
+		// When an inhibitor is active, check mute status before receiver matching.
+		// An alert that is actually muted would never reach its receivers, so a
+		// receiver assertion on a muted alert should fail.
+		muted := ih != nil && ih.Mutes(context.Background(), lset)
+
+		if hasInhibited {
+			wantInhibited := *ad.ExpectedInhibited
+			if wantInhibited && ih == nil {
 				return false, fmt.Sprintf(
 					"alert[%d] %s: expected_inhibited=true but no inhibit_rules are configured",
 					i, labelMapString(ad.Labels),
 				)
 			}
-			muted := ih.Mutes(context.Background(), lset)
-			if !muted {
+			if wantInhibited && !muted {
 				return false, fmt.Sprintf(
 					"alert[%d] %s: expected to be inhibited but was not",
 					i, labelMapString(ad.Labels),
 				)
 			}
+			if !wantInhibited && muted {
+				return false, fmt.Sprintf(
+					"alert[%d] %s: expected not to be inhibited but was",
+					i, labelMapString(ad.Labels),
+				)
+			}
 		} else {
+			if muted {
+				return false, fmt.Sprintf(
+					"alert[%d] %s: expected receivers %v but alert is inhibited",
+					i, labelMapString(ad.Labels), ad.ExpectedReceivers,
+				)
+			}
 			matchedRoutes := mainRoute.Match(lset)
 			receivers := make([]string, 0, len(matchedRoutes))
 			for _, r := range matchedRoutes {
 				receivers = append(receivers, r.RouteOpts.Receiver)
 			}
-
 			if !equalStringSlices(ad.ExpectedReceivers, receivers) {
 				return false, fmt.Sprintf(
 					"alert[%d] %s: expected receivers %v but got %v",

--- a/cli/routes_test_file.go
+++ b/cli/routes_test_file.go
@@ -1,0 +1,279 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/common/promslog"
+	"gopkg.in/yaml.v2"
+
+	amcommoncfg "github.com/prometheus/alertmanager/config/common"
+	"github.com/prometheus/alertmanager/dispatch"
+	"github.com/prometheus/alertmanager/eventrecorder"
+	"github.com/prometheus/alertmanager/inhibit"
+	"github.com/prometheus/alertmanager/provider"
+	"github.com/prometheus/alertmanager/types"
+)
+
+// testFileAlertDef is a single alert definition within a test case.
+type testFileAlertDef struct {
+	// Labels is the set of labels for this alert.
+	Labels map[string]string `yaml:"labels"`
+	// ExpectedReceivers lists the receiver names the alert should route to.
+	// Mutually exclusive with ExpectedInhibited.
+	ExpectedReceivers []string `yaml:"expected_receivers,omitempty"`
+	// ExpectedInhibited asserts that this alert should be inhibited.
+	// Mutually exclusive with ExpectedReceivers.
+	ExpectedInhibited bool `yaml:"expected_inhibited,omitempty"`
+}
+
+// testFileCase is a named test case containing one or more alert definitions.
+type testFileCase struct {
+	// Name is the human-readable name for this test case.
+	Name string `yaml:"name"`
+	// Alerts is the set of alerts to fire together in this test case.
+	Alerts []testFileAlertDef `yaml:"alerts"`
+}
+
+// routesTestFile is the top-level structure for a routes test file.
+type routesTestFile struct {
+	// Tests is the list of test cases to run.
+	Tests []testFileCase `yaml:"tests"`
+}
+
+// fakeAlertsProvider is a minimal provider.Alerts implementation used for
+// inhibition testing. It pre-loads a fixed set of alerts and makes them
+// available via SlurpAndSubscribe.
+type fakeAlertsProvider struct {
+	alerts []*types.Alert
+}
+
+// newFakeAlertsProvider returns a fakeAlertsProvider pre-loaded with the given alerts.
+func newFakeAlertsProvider(alerts []*types.Alert) *fakeAlertsProvider {
+	return &fakeAlertsProvider{alerts: alerts}
+}
+
+// Subscribe implements provider.Alerts. Returns an iterator with all alerts buffered.
+func (f *fakeAlertsProvider) Subscribe(_ string) provider.AlertIterator {
+	ch := make(chan *provider.Alert, len(f.alerts))
+	done := make(chan struct{})
+	for _, a := range f.alerts {
+		ch <- &provider.Alert{Data: a}
+	}
+	return provider.NewAlertIterator(ch, done, nil)
+}
+
+// SlurpAndSubscribe implements provider.Alerts. Returns all alerts as the
+// initial batch and an idle iterator for subsequent updates.
+func (f *fakeAlertsProvider) SlurpAndSubscribe(_ string) ([]*types.Alert, provider.AlertIterator) {
+	// Return the alerts as the initial set so that the inhibitor's run()
+	// processes them before WaitForLoading() returns.
+	ch := make(chan *provider.Alert)
+	done := make(chan struct{})
+	return f.alerts, provider.NewAlertIterator(ch, done, nil)
+}
+
+// GetPending implements provider.Alerts.
+func (f *fakeAlertsProvider) GetPending() provider.AlertIterator {
+	ch := make(chan *provider.Alert)
+	done := make(chan struct{})
+	return provider.NewAlertIterator(ch, done, nil)
+}
+
+// Get implements provider.Alerts.
+func (f *fakeAlertsProvider) Get(fp model.Fingerprint) (*types.Alert, error) {
+	for _, a := range f.alerts {
+		if a.Fingerprint() == fp {
+			return a, nil
+		}
+	}
+	return nil, provider.ErrNotFound
+}
+
+// Put implements provider.Alerts.
+func (f *fakeAlertsProvider) Put(_ context.Context, alerts ...*types.Alert) error {
+	f.alerts = append(f.alerts, alerts...)
+	return nil
+}
+
+// nopPrometheusRegisterer is a prometheus.Registerer that silently discards
+// all metric registrations, used to avoid metric conflicts during testing.
+type nopPrometheusRegisterer struct{}
+
+func (nopPrometheusRegisterer) Register(prometheus.Collector) error  { return nil }
+func (nopPrometheusRegisterer) MustRegister(...prometheus.Collector) {}
+func (nopPrometheusRegisterer) Unregister(prometheus.Collector) bool { return true }
+
+// executeRoutesTestFile loads the test file at testFilePath, runs all test
+// cases against the Alertmanager configuration, prints PASS/FAIL for each
+// case, and returns true when all cases pass.
+func executeRoutesTestFile(ctx context.Context, testFilePath string, configFile string) (bool, error) {
+	data, err := os.ReadFile(testFilePath)
+	if err != nil {
+		return false, fmt.Errorf("failed to read test file %q: %w", testFilePath, err)
+	}
+
+	var tf routesTestFile
+	if err := yaml.Unmarshal(data, &tf); err != nil {
+		return false, fmt.Errorf("failed to parse test file %q: %w", testFilePath, err)
+	}
+
+	cfg, err := loadAlertmanagerConfig(ctx, alertmanagerURL, configFile)
+	if err != nil {
+		return false, fmt.Errorf("failed to load Alertmanager config: %w", err)
+	}
+
+	mainRoute := dispatch.NewRoute(cfg.Route, nil)
+	inhibitRules := cfg.InhibitRules
+
+	allPassed := true
+	for _, tc := range tf.Tests {
+		passed, detail := runRouteTestCase(tc, mainRoute, inhibitRules)
+		if passed {
+			fmt.Printf("PASS %s\n", tc.Name)
+		} else {
+			fmt.Printf("FAIL %s / %s\n", tc.Name, detail)
+			allPassed = false
+		}
+	}
+
+	return allPassed, nil
+}
+
+// runRouteTestCase executes a single named test case. It returns (true, "")
+// when all per-alert assertions pass, or (false, <reason>) on the first
+// failure.
+func runRouteTestCase(
+	tc testFileCase,
+	mainRoute *dispatch.Route,
+	inhibitRules []amcommoncfg.InhibitRule,
+) (bool, string) {
+	now := time.Now()
+
+	// Build types.Alert slice for all alerts in this case so the inhibitor
+	// can see the whole set at once.
+	allAlerts := make([]*types.Alert, 0, len(tc.Alerts))
+	for _, ad := range tc.Alerts {
+		allAlerts = append(allAlerts, buildTestAlert(ad.Labels, now))
+	}
+
+	// Construct inhibitor when rules are present.
+	var ih *inhibit.Inhibitor
+	if len(inhibitRules) > 0 {
+		marker := types.NewMarker(nopPrometheusRegisterer{})
+		fp := newFakeAlertsProvider(allAlerts)
+		ih = inhibit.NewInhibitor(fp, inhibitRules, marker, promslog.NewNopLogger(), eventrecorder.NopRecorder())
+		go ih.Run()
+		// Wait until the inhibitor has consumed the initial alert batch.
+		ih.WaitForLoading()
+		defer ih.Stop()
+	}
+
+	// Validate each alert definition.
+	for i, ad := range tc.Alerts {
+		lset := mapToLabelSet(ad.Labels)
+
+		if ad.ExpectedInhibited {
+			if ih == nil {
+				return false, fmt.Sprintf(
+					"alert[%d] %s: expected_inhibited=true but no inhibit_rules are configured",
+					i, labelMapString(ad.Labels),
+				)
+			}
+			muted := ih.Mutes(context.Background(), lset)
+			if !muted {
+				return false, fmt.Sprintf(
+					"alert[%d] %s: expected to be inhibited but was not",
+					i, labelMapString(ad.Labels),
+				)
+			}
+		} else {
+			matchedRoutes := mainRoute.Match(lset)
+			receivers := make([]string, 0, len(matchedRoutes))
+			for _, r := range matchedRoutes {
+				receivers = append(receivers, r.RouteOpts.Receiver)
+			}
+
+			if !equalStringSlices(ad.ExpectedReceivers, receivers) {
+				return false, fmt.Sprintf(
+					"alert[%d] %s: expected receivers %v but got %v",
+					i, labelMapString(ad.Labels), ad.ExpectedReceivers, receivers,
+				)
+			}
+		}
+	}
+
+	return true, ""
+}
+
+// buildTestAlert constructs a firing types.Alert from a label map.
+func buildTestAlert(labelMap map[string]string, now time.Time) *types.Alert {
+	return &types.Alert{
+		Alert: model.Alert{
+			Labels:   mapToLabelSet(labelMap),
+			StartsAt: now,
+			EndsAt:   now.Add(1 * time.Hour),
+		},
+		UpdatedAt: now,
+	}
+}
+
+// mapToLabelSet converts a map[string]string into model.LabelSet.
+func mapToLabelSet(m map[string]string) model.LabelSet {
+	ls := make(model.LabelSet, len(m))
+	for k, v := range m {
+		ls[model.LabelName(k)] = model.LabelValue(v)
+	}
+	return ls
+}
+
+// labelMapString returns a human-readable representation of a label map.
+func labelMapString(m map[string]string) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	out := "{"
+	for i, k := range keys {
+		if i > 0 {
+			out += ", "
+		}
+		out += k + "=" + `"` + m[k] + `"`
+	}
+	out += "}"
+	return out
+}
+
+// equalStringSlices returns true when two string slices have identical contents
+// in the same order.
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/cli/routes_test_file_test.go
+++ b/cli/routes_test_file_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/prometheus/alertmanager/types"
 )
 
+func boolPtr(b bool) *bool { return &b }
+
 // loadTestRoute is a helper that loads a dispatch.Route from a config file.
 func loadTestRoute(t *testing.T, cfgFile string) (*dispatch.Route, []amcommoncfg.InhibitRule) {
 	t.Helper()
@@ -142,13 +144,31 @@ func TestRunRouteTestCase_InhibitionPass(t *testing.T) {
 			},
 			{
 				Labels:            map[string]string{"alertname": "SomeAlert", "severity": "warning"},
-				ExpectedInhibited: true,
+				ExpectedInhibited: boolPtr(true),
 			},
 		},
 	}
 
 	passed, detail := runRouteTestCase(tc, mainRoute, inhibitRules)
 	require.True(t, passed, "expected inhibition pass but got failure: %s", detail)
+}
+
+// TestRunRouteTestCase_ReceiverExpectedButMuted checks that using
+// expected_receivers on an actually-inhibited alert fails.
+func TestRunRouteTestCase_ReceiverExpectedButMuted(t *testing.T) {
+	mainRoute, inhibitRules := loadTestRoute(t, "testdata/conf.inhibit.yml")
+	tc := testFileCase{
+		Name: "receiver expected but alert is muted",
+		Alerts: []testFileAlertDef{
+			// This alert acts as the inhibition source.
+			{Labels: map[string]string{"alertname": "SomeAlert", "severity": "critical"}, ExpectedReceivers: []string{"default"}},
+			// This alert is inhibited but the test mistakenly uses expected_receivers.
+			{Labels: map[string]string{"alertname": "SomeAlert", "severity": "warning"}, ExpectedReceivers: []string{"default"}},
+		},
+	}
+	passed, detail := runRouteTestCase(tc, mainRoute, inhibitRules)
+	require.False(t, passed)
+	require.Contains(t, detail, "alert is inhibited")
 }
 
 // TestRunRouteTestCase_InhibitionExpectedButNoRules checks that requesting
@@ -163,7 +183,7 @@ func TestRunRouteTestCase_InhibitionExpectedButNoRules(t *testing.T) {
 		Alerts: []testFileAlertDef{
 			{
 				Labels:            map[string]string{"alertname": "X"},
-				ExpectedInhibited: true,
+				ExpectedInhibited: boolPtr(true),
 			},
 		},
 	}

--- a/cli/routes_test_file_test.go
+++ b/cli/routes_test_file_test.go
@@ -1,0 +1,238 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
+	amcommoncfg "github.com/prometheus/alertmanager/config/common"
+	"github.com/prometheus/alertmanager/config"
+	"github.com/prometheus/alertmanager/dispatch"
+	"github.com/prometheus/alertmanager/types"
+)
+
+// loadTestRoute is a helper that loads a dispatch.Route from a config file.
+func loadTestRoute(t *testing.T, cfgFile string) (*dispatch.Route, []amcommoncfg.InhibitRule) {
+	t.Helper()
+	cfg, err := config.LoadFile(cfgFile)
+	require.NoError(t, err, "loading config file %s", cfgFile)
+	return dispatch.NewRoute(cfg.Route, nil), cfg.InhibitRules
+}
+
+// TestMapToLabelSet verifies the label-map conversion helper.
+func TestMapToLabelSet(t *testing.T) {
+	m := map[string]string{"alertname": "Test", "severity": "critical"}
+	ls := mapToLabelSet(m)
+	require.Equal(t, model.LabelValue("Test"), ls["alertname"])
+	require.Equal(t, model.LabelValue("critical"), ls["severity"])
+}
+
+// TestEqualStringSlices covers the slice-comparison helper.
+func TestEqualStringSlices(t *testing.T) {
+	require.True(t, equalStringSlices([]string{"a", "b"}, []string{"a", "b"}))
+	require.False(t, equalStringSlices([]string{"a"}, []string{"b"}))
+	require.False(t, equalStringSlices([]string{"a"}, []string{"a", "b"}))
+	require.True(t, equalStringSlices(nil, nil))
+	require.False(t, equalStringSlices(nil, []string{"a"}))
+}
+
+// TestLabelMapString verifies the human-readable label representation.
+func TestLabelMapString(t *testing.T) {
+	got := labelMapString(map[string]string{"b": "2", "a": "1"})
+	// Keys are sorted.
+	require.Equal(t, `{a="1", b="2"}`, got)
+}
+
+// TestBuildTestAlert checks that buildTestAlert produces an active alert.
+func TestBuildTestAlert(t *testing.T) {
+	now := time.Now()
+	a := buildTestAlert(map[string]string{"alertname": "MyAlert"}, now)
+	require.Equal(t, model.LabelValue("MyAlert"), a.Labels["alertname"])
+	require.False(t, a.Resolved())
+}
+
+// TestRunRouteTestCase_RoutingPass checks basic routing assertions pass.
+func TestRunRouteTestCase_RoutingPass(t *testing.T) {
+	mainRoute, inhibitRules := loadTestRoute(t, "testdata/conf.routing.yml")
+
+	tc := testFileCase{
+		Name: "unmatched alert routes to default",
+		Alerts: []testFileAlertDef{
+			{
+				Labels:            map[string]string{"alertname": "Unmatched"},
+				ExpectedReceivers: []string{"default"},
+			},
+		},
+	}
+
+	passed, detail := runRouteTestCase(tc, mainRoute, inhibitRules)
+	require.True(t, passed, "expected pass but got failure: %s", detail)
+}
+
+// TestRunRouteTestCase_RoutingFail checks that a wrong receiver triggers failure.
+func TestRunRouteTestCase_RoutingFail(t *testing.T) {
+	mainRoute, inhibitRules := loadTestRoute(t, "testdata/conf.routing.yml")
+
+	tc := testFileCase{
+		Name: "wrong receiver expectation",
+		Alerts: []testFileAlertDef{
+			{
+				Labels:            map[string]string{"test": "1"},
+				ExpectedReceivers: []string{"default"}, // actually routes to test1
+			},
+		},
+	}
+
+	passed, detail := runRouteTestCase(tc, mainRoute, inhibitRules)
+	require.False(t, passed)
+	require.NotEmpty(t, detail)
+}
+
+// TestRunRouteTestCase_MultipleRoutes verifies that continue:true produces
+// multiple matched receivers in the correct order.
+func TestRunRouteTestCase_MultipleRoutes(t *testing.T) {
+	mainRoute, inhibitRules := loadTestRoute(t, "testdata/conf.routing.yml")
+
+	tc := testFileCase{
+		Name: "label test=2 routes to test1 and test2",
+		Alerts: []testFileAlertDef{
+			{
+				Labels:            map[string]string{"test": "2"},
+				ExpectedReceivers: []string{"test1", "test2"},
+			},
+		},
+	}
+
+	passed, detail := runRouteTestCase(tc, mainRoute, inhibitRules)
+	require.True(t, passed, "expected pass but got failure: %s", detail)
+}
+
+// TestRunRouteTestCase_InhibitionPass checks that an alert is correctly
+// detected as inhibited when a source alert is also firing.
+func TestRunRouteTestCase_InhibitionPass(t *testing.T) {
+	mainRoute, inhibitRules := loadTestRoute(t, "testdata/conf.inhibit.yml")
+	if len(inhibitRules) == 0 {
+		t.Skip("inhibit config file not present or has no rules")
+	}
+
+	tc := testFileCase{
+		Name: "critical suppresses warning",
+		Alerts: []testFileAlertDef{
+			{
+				Labels:            map[string]string{"alertname": "SomeAlert", "severity": "critical"},
+				ExpectedReceivers: []string{"default"},
+			},
+			{
+				Labels:            map[string]string{"alertname": "SomeAlert", "severity": "warning"},
+				ExpectedInhibited: true,
+			},
+		},
+	}
+
+	passed, detail := runRouteTestCase(tc, mainRoute, inhibitRules)
+	require.True(t, passed, "expected inhibition pass but got failure: %s", detail)
+}
+
+// TestRunRouteTestCase_InhibitionExpectedButNoRules checks that requesting
+// inhibition without configured rules fails gracefully.
+func TestRunRouteTestCase_InhibitionExpectedButNoRules(t *testing.T) {
+	mainRoute, _ := loadTestRoute(t, "testdata/conf.routing.yml")
+	// Pass empty inhibit rules.
+	var inhibitRules []amcommoncfg.InhibitRule
+
+	tc := testFileCase{
+		Name: "expected inhibited but no rules",
+		Alerts: []testFileAlertDef{
+			{
+				Labels:            map[string]string{"alertname": "X"},
+				ExpectedInhibited: true,
+			},
+		},
+	}
+
+	passed, detail := runRouteTestCase(tc, mainRoute, inhibitRules)
+	require.False(t, passed)
+	require.Contains(t, detail, "no inhibit_rules")
+}
+
+// TestFakeAlertsProvider_SlurpAndSubscribe verifies the provider returns the
+// pre-loaded alerts as the initial batch.
+func TestFakeAlertsProvider_SlurpAndSubscribe(t *testing.T) {
+	now := time.Now()
+	alerts := []*types.Alert{
+		buildTestAlert(map[string]string{"alertname": "A"}, now),
+		buildTestAlert(map[string]string{"alertname": "B"}, now),
+	}
+	fp := newFakeAlertsProvider(alerts)
+	initial, it := fp.SlurpAndSubscribe("test")
+	defer it.Close()
+
+	require.Len(t, initial, 2)
+}
+
+// TestExecuteRoutesTestFile_AllPass runs a full integration test via a temp
+// test-file written to disk, verifying the happy path returns true.
+func TestExecuteRoutesTestFile_AllPass(t *testing.T) {
+	content := `
+tests:
+  - name: "Unmatched alert routes to default"
+    alerts:
+      - labels:
+          alertname: SomeAlert
+        expected_receivers:
+          - default
+  - name: "test=1 routes to test1"
+    alerts:
+      - labels:
+          test: "1"
+        expected_receivers:
+          - test1
+`
+	tmpDir := t.TempDir()
+	testFilePath := filepath.Join(tmpDir, "tests.yml")
+	require.NoError(t, os.WriteFile(testFilePath, []byte(content), 0600))
+
+	// Point alertmanagerURL to nil (config file path used instead).
+	passed, err := executeRoutesTestFile(context.Background(), testFilePath, "testdata/conf.routing.yml")
+	require.NoError(t, err)
+	require.True(t, passed)
+}
+
+// TestExecuteRoutesTestFile_Failure checks that a failing test case causes
+// the function to return false.
+func TestExecuteRoutesTestFile_Failure(t *testing.T) {
+	content := `
+tests:
+  - name: "Wrong receiver"
+    alerts:
+      - labels:
+          test: "1"
+        expected_receivers:
+          - wrong-receiver
+`
+	tmpDir := t.TempDir()
+	testFilePath := filepath.Join(tmpDir, "tests.yml")
+	require.NoError(t, os.WriteFile(testFilePath, []byte(content), 0600))
+
+	passed, err := executeRoutesTestFile(context.Background(), testFilePath, "testdata/conf.routing.yml")
+	require.NoError(t, err)
+	require.False(t, passed)
+}

--- a/cli/routing.go
+++ b/cli/routing.go
@@ -30,6 +30,7 @@ type routingShow struct {
 	labels            []string
 	expectedReceivers string
 	debugTree         bool
+	testFile          string
 }
 
 const (

--- a/cli/test_routing.go
+++ b/cli/test_routing.go
@@ -47,6 +47,7 @@ func configureRoutingTestCmd(cc *kingpin.CmdClause, c *routingShow) {
 
 	routingTestCmd.Flag("verify.receivers", "Checks if specified receivers matches resolved receivers. The command fails if the labelset does not route to the specified receivers.").StringVar(&c.expectedReceivers)
 	routingTestCmd.Flag("tree", "Prints out matching routes tree.").BoolVar(&c.debugTree)
+	routingTestCmd.Flag("test-file", "YAML file containing named test cases with per-alert receiver and inhibition assertions.").StringVar(&c.testFile)
 	routingTestCmd.Arg("labels", "List of labels to be tested against the configured routes.").StringsVar(&c.labels)
 	routingTestCmd.Action(execWithTimeout(c.routingTestAction))
 }
@@ -73,6 +74,19 @@ func printMatchingTree(mainRoute *dispatch.Route, ls models.LabelSet) {
 }
 
 func (c *routingShow) routingTestAction(ctx context.Context, _ *kingpin.ParseContext) error {
+	// When --test-file is provided, run batch test mode.
+	if c.testFile != "" {
+		passed, err := executeRoutesTestFile(ctx, c.testFile, c.configFile)
+		if err != nil {
+			kingpin.Fatalf("%v\n", err)
+			return err
+		}
+		if !passed {
+			os.Exit(1)
+		}
+		return nil
+	}
+
 	cfg, err := loadAlertmanagerConfig(ctx, alertmanagerURL, c.configFile)
 	if err != nil {
 		kingpin.Fatalf("%v\n", err)

--- a/cli/testdata/conf.inhibit.yml
+++ b/cli/testdata/conf.inhibit.yml
@@ -1,0 +1,19 @@
+global:
+  smtp_smarthost: 'localhost:25'
+
+templates:
+  - '/etc/alertmanager/template/*.tmpl'
+
+route:
+  receiver: default
+
+inhibit_rules:
+  - source_matchers:
+      - severity="critical"
+    target_matchers:
+      - severity="warning"
+    equal:
+      - alertname
+
+receivers:
+  - name: default


### PR DESCRIPTION
## Summary

Extends `amtool config routes test` with a `--test-file` flag that accepts a YAML file of named test cases. Each case fires a set of alerts together and asserts per-alert expectations, making it possible to test both routing and inhibition in a repeatable, CI-friendly way.

Closes #5167

## Usage

```yaml
# routing-tests.yaml
tests:
  - name: "Unmatched alert routes to default"
    alerts:
      - labels: {alertname: SomeAlert}
        expected_receivers: [default]

  - name: "critical suppresses warning"
    alerts:
      - labels: {alertname: SomeAlert, severity: critical}
        expected_receivers: [default]
      - labels: {alertname: SomeAlert, severity: warning}
        expected_inhibited: true
```

```
$ amtool config routes test --config.file alertmanager.yml --test-file routing-tests.yaml
PASS Unmatched alert routes to default
PASS critical suppresses warning
```

Exit code 0 on all pass, 1 on any failure.

## Implementation

- **`cli/routes_test_file.go`** — YAML structs, `fakeAlertsProvider` (minimal `provider.Alerts` that pre-loads a fixed alert set for inhibition), and `executeRoutesTestFile` / `runRouteTestCase` runner
- **`cli/test_routing.go`** — adds `--test-file` flag; delegates to `executeRoutesTestFile` when set
- **`cli/routes_test_file_test.go`** — 13 new tests (routing pass/fail, multi-receiver `continue: true`, inhibition pass/fail, error cases, end-to-end integration)

Routing uses the existing `dispatch.Route.Match()` path. Inhibition constructs an `inhibit.Inhibitor` with a `fakeAlertsProvider` that returns all alerts in the case via `Subscribe()`, calls `ih.Run()` + `ih.WaitForLoading()` to let the inhibitor process the feed, then checks `ih.Mutes()` per alert.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add batch YAML-driven testing for alert routing and inhibition, including a CLI flag to run test files and clear pass/fail diagnostics.
  * Validates expected receiver order and inhibition behavior across multiple named test cases.

* **Tests**
  * New unit and integration tests exercising routing, inhibition, helpers, and end-to-end test-file execution with accompanying test fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->