### PR TITLE
sns: fix client when AWS_CA_BUNDLE is set

### DIFF
--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -908,6 +908,10 @@ type SNSConfig struct {
 	Subject     string            `yaml:"subject,omitempty" json:"subject,omitempty"`
 	Message     string            `yaml:"message,omitempty" json:"message,omitempty"`
 	Attributes  map[string]string `yaml:"attributes,omitempty" json:"attributes,omitempty"`
+	// UseAWSHTTPClient forces the AWS SDK's BuildableClient instead of
+	// alertmanager's tracing-wrapped HTTP client. Auto-enabled when AWS_CA_BUNDLE
+	// is set; set explicitly when configuring ca_bundle via shared AWS config.
+	UseAWSHTTPClient bool `yaml:"use_aws_http_client,omitempty" json:"use_aws_http_client,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1746,6 +1746,13 @@ attributes:
 
 # The HTTP client's configuration.
 [ http_config: <http_config> | default = global.http_config ]
+
+# Force the AWS SDK's HTTP client (BuildableClient) instead of the default
+# tracing-wrapped client. Required when the AWS SDK needs to inject a custom
+# CA bundle (e.g. via `ca_bundle` in the AWS shared config). Auto-enabled
+# when the AWS_CA_BUNDLE environment variable is set; tracing is disabled
+# for SNS requests when this path is taken.
+[ use_aws_http_client: <boolean> | default = false ]
 ```
 
 #### `<sigv4_config>` (SNS)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1750,8 +1750,14 @@ attributes:
 # Force the AWS SDK's HTTP client (BuildableClient) instead of the default
 # tracing-wrapped client. Required when the AWS SDK needs to inject a custom
 # CA bundle (e.g. via `ca_bundle` in the AWS shared config). Auto-enabled
-# when the AWS_CA_BUNDLE environment variable is set; tracing is disabled
-# for SNS requests when this path is taken.
+# when the AWS_CA_BUNDLE environment variable is set.
+#
+# When this flag is set tracing is disabled for SNS requests, and only the
+# `tls_config` and proxy fields of `http_config` are honored. Other
+# `http_config` knobs (basic_auth, oauth2, authorization, follow_redirects,
+# enable_http2, http_headers) are silently ignored — most are irrelevant for
+# AWS calls (which use SigV4) but if you depend on them for SNS, do not enable
+# this.
 [ use_aws_http_client: <boolean> | default = false ]
 ```
 

--- a/notify/sns/sns.go
+++ b/notify/sns/sns.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"os"
 	"strings"
 	"unicode/utf8"
 
@@ -32,6 +33,7 @@ import (
 	"github.com/aws/smithy-go"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	commoncfg "github.com/prometheus/common/config"
 
 	"github.com/prometheus/alertmanager/config"
@@ -45,13 +47,13 @@ type Notifier struct {
 	conf    *config.SNSConfig
 	tmpl    *template.Template
 	logger  *slog.Logger
-	client  *http.Client
+	client  aws.HTTPClient
 	retrier *notify.Retrier
 }
 
 // New returns a new SNS notification handler.
 func New(c *config.SNSConfig, t *template.Template, l *slog.Logger, httpOpts ...commoncfg.HTTPClientOption) (*Notifier, error) {
-	client, err := notify.NewClientWithTracing(*c.HTTPConfig, "sns", httpOpts...)
+	client, err := newSNSHTTPClient(c, httpOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -62,6 +64,31 @@ func New(c *config.SNSConfig, t *template.Template, l *slog.Logger, httpOpts ...
 		client:  client,
 		retrier: &notify.Retrier{},
 	}, nil
+}
+
+// newSNSHTTPClient picks the right HTTP client for the AWS SDK. The SDK's
+// custom-CA-bundle path requires a *awshttp.BuildableClient (concrete type
+// assertion in resolveCustomCABundle), so we use one when AWS_CA_BUNDLE is set
+// or the user opts in. Otherwise we use the standard tracing-wrapped client.
+func newSNSHTTPClient(c *config.SNSConfig, httpOpts ...commoncfg.HTTPClientOption) (aws.HTTPClient, error) {
+	if c.UseAWSHTTPClient || os.Getenv("AWS_CA_BUNDLE") != "" {
+		return newAWSBuildableClient(c)
+	}
+	return notify.NewClientWithTracing(*c.HTTPConfig, "sns", httpOpts...)
+}
+
+func newAWSBuildableClient(c *config.SNSConfig) (*awshttp.BuildableClient, error) {
+	client := awshttp.NewBuildableClient()
+	if c.HTTPConfig == nil {
+		return client, nil
+	}
+	tlsConfig, err := commoncfg.NewTLSConfig(&c.HTTPConfig.TLSConfig)
+	if err != nil {
+		return nil, fmt.Errorf("build SNS TLS config: %w", err)
+	}
+	return client.WithTransportOptions(func(tr *http.Transport) {
+		tr.TLSClientConfig = tlsConfig
+	}), nil
 }
 
 func (n *Notifier) Notify(ctx context.Context, alert ...*types.Alert) (bool, error) {

--- a/notify/sns/sns.go
+++ b/notify/sns/sns.go
@@ -70,6 +70,9 @@ func New(c *config.SNSConfig, t *template.Template, l *slog.Logger, httpOpts ...
 // custom-CA-bundle path requires a *awshttp.BuildableClient (concrete type
 // assertion in resolveCustomCABundle), so we use one when AWS_CA_BUNDLE is set
 // or the user opts in. Otherwise we use the standard tracing-wrapped client.
+//
+// AWS_CA_BUNDLE is handled by the aws sdk's resolveCustomCABundle function,
+// so we don't need to handle it manually when building the client.
 func newSNSHTTPClient(c *config.SNSConfig, httpOpts ...commoncfg.HTTPClientOption) (aws.HTTPClient, error) {
 	if c.UseAWSHTTPClient || os.Getenv("AWS_CA_BUNDLE") != "" {
 		return newAWSBuildableClient(c)
@@ -77,17 +80,23 @@ func newSNSHTTPClient(c *config.SNSConfig, httpOpts ...commoncfg.HTTPClientOptio
 	return notify.NewClientWithTracing(*c.HTTPConfig, "sns", httpOpts...)
 }
 
+// newAWSBuildableClient builds a BuildableClient pre-configured with the
+// user's TLSConfig and proxy settings from HTTPClientConfig. Other
+// HTTPClientConfig knobs (BasicAuth, OAuth2, FollowRedirects, EnableHTTP2,
+// HTTPHeaders, etc.) are intentionally not propagated: AWS uses sigv4 so
+// auth knobs are irrelevant, and the rest are managed by the SDK itself.
 func newAWSBuildableClient(c *config.SNSConfig) (*awshttp.BuildableClient, error) {
-	client := awshttp.NewBuildableClient()
-	if c.HTTPConfig == nil {
-		return client, nil
-	}
 	tlsConfig, err := commoncfg.NewTLSConfig(&c.HTTPConfig.TLSConfig)
 	if err != nil {
 		return nil, fmt.Errorf("build SNS TLS config: %w", err)
 	}
-	return client.WithTransportOptions(func(tr *http.Transport) {
+	proxyFn := c.HTTPConfig.Proxy()
+	return awshttp.NewBuildableClient().WithTransportOptions(func(tr *http.Transport) {
 		tr.TLSClientConfig = tlsConfig
+		if proxyFn != nil {
+			tr.Proxy = proxyFn
+			tr.ProxyConnectHeader = c.HTTPConfig.GetProxyConnectHeader()
+		}
 	}), nil
 }
 


### PR DESCRIPTION
The aws sdk forces a cast to its own http client to inkect a custom CA bundle here:
https://github.com/aws/aws-sdk-go-v2/blob/v1.41.5/config/resolve.go#L57-L61

So alertmanager and the tests break, if that variable is set. The fix is that if the CA bundle is set we need for now to use aws's own http client. This can also be configured by the user in case their ca bundle is set via the config file instead of an env variable.

<!--
    - Please give your PR a title in the form "area: short description".  For example "dispatcher: improve performance"

    - Please sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Pull Request Checklist
Please check all the applicable boxes.

- Please list all open issue(s) discussed with maintainers related to this change
    - Fixes a test failure if AWS_CA_BUNDLE is set.
    <!--
    If it applies.
    Automatically closes linked issue when PR is merged.
    Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
    More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
    -->
- Is this a bugfix?
    - [X] Tests already reproduce the bug, with that environment variable set.
- [X] I have added/updated the required documentation
- [X] I have signed-off my commits
- [X] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?
New use_aws_http_client config option for the sns notifier.

<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/alertmanager/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[BUGFIX] Support the AWS_CA_BUNDLE env variable for the sns notifier
[ENHANCEMENT] Add the use_aws_http_client config option to the sns notifier
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `use_aws_http_client` option for SNS receivers; defaults to false and auto-enables when AWS_CA_BUNDLE is set.
* **Behavior Changes**
  * When enabled, SNS requests use the alternative AWS HTTP client and tracing for SNS is disabled.
  * Only TLS config and proxy settings from HTTP config are honored for SNS; other HTTP config options are ignored.
* **Documentation**
  * Configuration docs updated with the new option and its semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->