### PR TITLE
dispatcher: Fix issue with dispatching to a contended route

### DIFF
--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -56,9 +56,11 @@ var tracer = tracing.NewTracer("github.com/prometheus/alertmanager/dispatch")
 
 // DispatcherMetrics represents metrics associated to a dispatcher.
 type DispatcherMetrics struct {
-	aggrGroups            prometheus.Gauge
-	processingDuration    prometheus.Summary
-	aggrGroupLimitReached prometheus.Counter
+	aggrGroups               prometheus.Gauge
+	processingDuration       prometheus.Summary
+	aggrGroupLimitReached    prometheus.Counter
+	aggrGroupCreationRetries prometheus.Counter
+	aggrGroupCreationGivenUp prometheus.Counter
 }
 
 // NewDispatcherMetrics returns a new registered DispatchMetrics.
@@ -83,6 +85,18 @@ func NewDispatcherMetrics(registerLimitMetrics bool, r prometheus.Registerer) *D
 			prometheus.CounterOpts{
 				Name: "alertmanager_dispatcher_aggregation_group_limit_reached_total",
 				Help: "Number of times when dispatcher failed to create new aggregation group due to limit.",
+			},
+		),
+		aggrGroupCreationRetries: promauto.With(r).NewCounter(
+			prometheus.CounterOpts{
+				Name: "alertmanager_dispatcher_aggregation_group_creation_retries_total",
+				Help: "Number of CAS retries while creating aggregation groups under contention.",
+			},
+		),
+		aggrGroupCreationGivenUp: promauto.With(r).NewCounter(
+			prometheus.CounterOpts{
+				Name: "alertmanager_dispatcher_aggregation_group_creation_given_up_total",
+				Help: "Number of alerts dropped because aggregation group creation exceeded the retry limit.",
 			},
 		),
 	}
@@ -534,8 +548,10 @@ func (d *Dispatcher) groupAlert(ctx context.Context, alert *types.Alert, route *
 
 		// If we failed to swap, it means another goroutine has created/modified the group
 		retries++
+		d.metrics.aggrGroupCreationRetries.Inc()
 		if retries > 100 {
 			// This shouldn't happen - indicates a bug or extreme contention
+			d.metrics.aggrGroupCreationGivenUp.Inc()
 			d.logger.Error("excessive retries creating aggregation group",
 				"fingerprint", fp,
 				"route", route.Key(),

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -512,6 +512,7 @@ func (d *Dispatcher) groupAlert(ctx context.Context, alert *types.Alert, route *
 				// We swapped the new group in, we can break and start it.
 				break
 			}
+			loaded = false
 		} else {
 			el, loaded = d.routeGroupsSlice[route.Idx].groups.LoadOrStore(fp, ag)
 			if !loaded {

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -840,10 +840,12 @@ func TestGroupAlert_RecoversWhenCASFails(t *testing.T) {
 	recorder := &recordStage{alerts: make(map[string]map[model.Fingerprint]*types.Alert)}
 	metrics := NewDispatcherMetrics(false, reg)
 	dispatcher := NewDispatcher(alerts, route, recorder, marker, timeout, testMaintenanceInterval, nil, logger, eventrecorder.NopRecorder(), metrics)
-	// Don't call Run — leave the dispatcher in WaitingToStart so groupAlert
-	// won't actually start the aggregation group's run goroutine.
+	// Don't call Run — the dispatcher stays in DispatcherStateUnknown so
+	// groupAlert's final switch falls through the default branch and the
+	// aggregation group's run goroutine is never started. (This does emit a
+	// benign "unknown state detected" warn per created group.)
 	dispatcher.routeGroupsSlice = []routeAggrGroups{{route: route}}
-
+	dispatcher.state.Store(DispatcherStateWaitingToStart) // silences the warn
 	rounds := 0
 	for rounds < maxRounds && testutil.ToFloat64(metrics.aggrGroupCreationRetries) == 0 {
 		groupLabels := model.LabelSet{"alertname": model.LabelValue(fmt.Sprintf("shared-%d", rounds))}

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -840,12 +840,11 @@ func TestGroupAlert_RecoversWhenCASFails(t *testing.T) {
 	recorder := &recordStage{alerts: make(map[string]map[model.Fingerprint]*types.Alert)}
 	metrics := NewDispatcherMetrics(false, reg)
 	dispatcher := NewDispatcher(alerts, route, recorder, marker, timeout, testMaintenanceInterval, nil, logger, eventrecorder.NopRecorder(), metrics)
-	// Don't call Run — the dispatcher stays in DispatcherStateUnknown so
-	// groupAlert's final switch falls through the default branch and the
-	// aggregation group's run goroutine is never started. (This does emit a
-	// benign "unknown state detected" warn per created group.)
+	// Don't call Run — put the dispatcher manually in  the DispatcherStateWaitingToStart
+	// state so groupAlert's final switch falls through the default branch and the
+	// aggregation group's run goroutine is never started.
 	dispatcher.routeGroupsSlice = []routeAggrGroups{{route: route}}
-	dispatcher.state.Store(DispatcherStateWaitingToStart) // silences the warn
+	dispatcher.state.Store(DispatcherStateWaitingToStart) // silences the warn that would happen in unknown mode.
 	rounds := 0
 	for rounds < maxRounds && testutil.ToFloat64(metrics.aggrGroupCreationRetries) == 0 {
 		groupLabels := model.LabelSet{"alertname": model.LabelValue(fmt.Sprintf("shared-%d", rounds))}

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"log/slog"
 	"reflect"
+	"runtime"
 	"sort"
 	"sync"
 	"testing"
@@ -884,12 +885,19 @@ func TestGroupAlert_RecoversWhenCASFails(t *testing.T) {
 		rounds++
 	}
 
-	// Retries > 0 proves the test actually exercised the contended CAS-recovery
-	// branch (rather than every goroutine taking the early Load+insert path).
 	// Give-ups must stay 0: losers must recover via LoadOrStore, not spin to
 	// the 100-retry limit.
-	require.Positive(t, testutil.ToFloat64(metrics.aggrGroupCreationRetries), "contended CAS path was not exercised in %d rounds — scheduler is unusually serial", rounds)
 	require.Zero(t, testutil.ToFloat64(metrics.aggrGroupCreationGivenUp), "no alert should be dropped to the give-up branch")
+
+	// With GOMAXPROCS=1 the contention can't be fully exercised.
+	// Skip the check that retries > 0.
+	if runtime.GOMAXPROCS(0) == 1 {
+		return
+	}
+
+	// Retries > 0 proves the test actually exercised the contended CAS-recovery
+	// branch (rather than every goroutine taking the early Load+insert path).
+	require.Positive(t, testutil.ToFloat64(metrics.aggrGroupCreationRetries), "contended CAS path was not exercised in %d rounds — scheduler is unusually serial", rounds)
 }
 
 func TestDispatcher_DeleteResolvedAlertsFromMarker(t *testing.T) {

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -801,6 +801,96 @@ func TestDispatcher_DoMaintenance(t *testing.T) {
 	require.Empty(t, mutedBy)
 }
 
+// TestGroupAlert_RecoversWhenCASFails reproduces a bug where groupAlert would
+// retry the same CompareAndSwap with a stale `el` reference after the slot at
+// fp had been mutated by a competing goroutine (or removed by maintenance).
+// Without the fix, CAS losers spin until the 100-retry give-up and lose their
+// alert. With the fix, they fall back to LoadOrStore and insert into whichever
+// live group now occupies the slot.
+//
+// Each round pre-stores a destroyed aggrGroup at fp and fires many concurrent
+// groupAlert calls. We keep running rounds until we observe the contended CAS
+// branch firing at least once (cap at maxRounds to avoid hangs on a pathologic
+// scheduler) — a single round can be unlucky and serialize, taking the early
+// Load+insert path on every goroutine.
+func TestGroupAlert_RecoversWhenCASFails(t *testing.T) {
+	const (
+		alertsPerRound = 200
+		maxRounds      = 50
+	)
+
+	logger := promslog.NewNopLogger()
+	reg := prometheus.NewRegistry()
+	marker := types.NewMarker(reg)
+	alerts, err := mem.NewAlerts(context.Background(), marker, time.Hour, 0, nil, logger, eventrecorder.NopRecorder(), reg, nil)
+	require.NoError(t, err)
+	defer alerts.Close()
+
+	route := &Route{
+		RouteOpts: RouteOpts{
+			Receiver:       "test",
+			GroupBy:        map[model.LabelName]struct{}{"alertname": {}},
+			GroupWait:      time.Hour, // never flush during this test
+			GroupInterval:  time.Hour,
+			RepeatInterval: time.Hour,
+		},
+		Idx: 0,
+	}
+	timeout := func(d time.Duration) time.Duration { return d }
+	recorder := &recordStage{alerts: make(map[string]map[model.Fingerprint]*types.Alert)}
+	metrics := NewDispatcherMetrics(false, reg)
+	dispatcher := NewDispatcher(alerts, route, recorder, marker, timeout, testMaintenanceInterval, nil, logger, eventrecorder.NopRecorder(), metrics)
+	// Don't call Run — leave the dispatcher in WaitingToStart so groupAlert
+	// won't actually start the aggregation group's run goroutine.
+	dispatcher.routeGroupsSlice = []routeAggrGroups{{route: route}}
+
+	rounds := 0
+	for rounds < maxRounds && testutil.ToFloat64(metrics.aggrGroupCreationRetries) == 0 {
+		groupLabels := model.LabelSet{"alertname": model.LabelValue(fmt.Sprintf("shared-%d", rounds))}
+		destroyedAg := newAggrGroup(context.Background(), groupLabels, route, timeout, marker, eventrecorder.NopRecorder(), logger)
+		// Mark the store destroyed: empty store + destroyIfEmpty=true.
+		require.NoError(t, destroyedAg.alerts.DeleteIfNotModified(types.AlertSlice{}, true))
+		require.True(t, destroyedAg.destroyed())
+		fp := destroyedAg.fingerprint()
+		dispatcher.routeGroupsSlice[0].groups.Store(fp, destroyedAg)
+
+		var ready, done sync.WaitGroup
+		ready.Add(alertsPerRound)
+		done.Add(alertsPerRound)
+		start := make(chan struct{})
+		for i := range alertsPerRound {
+			go func() {
+				defer done.Done()
+				alert := newAlert(model.LabelSet{
+					"alertname": groupLabels["alertname"],
+					"instance":  model.LabelValue(fmt.Sprintf("inst-%d", i)),
+				})
+				ready.Done()
+				<-start
+				dispatcher.groupAlert(context.Background(), alert, route)
+			}()
+		}
+		ready.Wait()
+		close(start)
+		done.Wait()
+
+		el, ok := dispatcher.routeGroupsSlice[0].groups.Load(fp)
+		require.True(t, ok, "round %d: a live group must occupy the fp after the race", rounds)
+		finalAg := el.(*aggrGroup)
+		require.False(t, finalAg.destroyed(), "round %d: the final group must not be destroyed", rounds)
+		require.NotSame(t, destroyedAg, finalAg, "round %d: destroyed group must have been replaced", rounds)
+		require.Len(t, finalAg.alerts.List(), alertsPerRound, "round %d: all alerts must land in the final group", rounds)
+		rounds++
+	}
+
+	// Retries > 0 proves the test actually exercised the contended CAS-recovery
+	// branch (rather than every goroutine taking the early Load+insert path).
+	// Give-ups must stay 0: losers must recover via LoadOrStore, not spin to
+	// the 100-retry limit.
+	require.Positive(t, testutil.ToFloat64(metrics.aggrGroupCreationRetries), "contended CAS path was not exercised in %d rounds — scheduler is unusually serial", rounds)
+	require.Zero(t, testutil.ToFloat64(metrics.aggrGroupCreationGivenUp), "no alert should be dropped to the give-up branch")
+}
+
 func TestDispatcher_DeleteResolvedAlertsFromMarker(t *testing.T) {
 	t.Run("successful flush deletes markers for resolved alerts", func(t *testing.T) {
 		ctx := context.Background()


### PR DESCRIPTION
When dispatching to a route by multiple goroutines, we hit an issue where if we can't swap the value in the map because another goroutine beat us to it, we should try to reload from the map, rather than swap again, and thus set loaded = false.

We also add metrics showing how many retries are happening, and whether the "giving up" situation is ever reached.

The test is a little convoluted, to make sure we are able to force that path, and that we never reach the "give up" state. If it becomes flaky we can remove it, or simplify it and also not call require.Positive(t, testutil.ToFloat64(metrics.aggrGroupCreationRetries), "contended CAS path was not exercised in %d rounds — scheduler is unusually serial", rounds), but as is it does show the issue, and the fix.

<!--
    - Please give your PR a title in the form "area: short description".  For example "dispatcher: improve performance"

    - Please sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Pull Request Checklist
Please check all the applicable boxes.

- Please list all open issue(s) discussed with maintainers related to this change
    - Fixes #5176
    <!--
    If it applies.
    Automatically closes linked issue when PR is merged.
    Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
    More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
    -->
- Is this a bugfix?
    - [X] I have added tests that can reproduce the bug which pass with this bugfix applied
- [X] I have signed-off my commits
- [X] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/alertmanager/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[BUGFIX] Fix the dispatcher in more contended cases
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics to track alert-group creation retries and when creation attempts are abandoned for improved observability.

* **Bug Fixes**
  * Improved concurrent alert-group creation handling so creation races recover reliably and avoid leaving groups in a destroyed state.

* **Tests**
  * Added a concurrency-focused regression test validating recovery from CAS-style failures and that retry/give-up metrics are recorded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->