### PR TITLE
dispatch_test: fix race condition with timing

### DIFF
--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -97,16 +97,16 @@ func TestAggrGroup(t *testing.T) {
 		}
 	)
 
-	var (
-		last       = time.Now()
-		current    = time.Now()
-		lastCurMtx = &sync.Mutex{}
-		alertsCh   = make(chan types.AlertSlice)
-	)
+	type batch struct {
+		alerts types.AlertSlice
+		now    time.Time // timer fire time, propagated via notify.WithNow
+	}
+	batchCh := make(chan batch)
 
 	ntfy := func(ctx context.Context, alerts ...*types.Alert) bool {
 		// Validate that the context is properly populated.
-		if _, ok := notify.Now(ctx); !ok {
+		now, ok := notify.Now(ctx)
+		if !ok {
 			t.Errorf("now missing")
 		}
 		if _, ok := notify.GroupKey(ctx); !ok {
@@ -122,14 +122,7 @@ func TestAggrGroup(t *testing.T) {
 			t.Errorf("wrong repeat interval: %q", ri)
 		}
 
-		lastCurMtx.Lock()
-		last = current
-		// Subtract a millisecond to allow for races.
-		current = time.Now().Add(-time.Millisecond)
-		lastCurMtx.Unlock()
-
-		alertsCh <- types.AlertSlice(alerts)
-
+		batchCh <- batch{alerts: alerts, now: now}
 		return true
 	}
 
@@ -142,120 +135,70 @@ func TestAggrGroup(t *testing.T) {
 		return as
 	}
 
+	// receiveBatch waits for the next flush, asserts it didn't fire earlier than
+	// minWait after `since`, and returns the timer-reported fire time. We use
+	// the timer's own `now` (propagated via notify.WithNow) instead of a
+	// time.Now() snapshot inside ntfy — the latter accumulates scheduler jitter
+	// between the timer firing and ntfy actually running, which made the
+	// assertion flake under load.
+	receiveBatch := func(t *testing.T, since time.Time, minWait time.Duration, want types.AlertSlice) time.Time {
+		t.Helper()
+		select {
+		case <-time.After(2 * minWait):
+			t.Fatalf("expected new batch after %v but received none", minWait)
+		case b := <-batchCh:
+			if got := b.now.Sub(since); got < minWait {
+				t.Fatalf("received batch too early after %v (want >= %v)", got, minWait)
+			}
+			sort.Sort(b.alerts)
+			if !reflect.DeepEqual(b.alerts, want) {
+				t.Fatalf("expected alerts %v but got %v", want, b.alerts)
+			}
+			return b.now
+		}
+		return time.Time{}
+	}
+
 	// Test regular situation where we wait for group_wait to send out alerts.
+	createdAt := time.Now()
 	ag := newAggrGroup(context.Background(), lset, route, nil, types.NewMarker(prometheus.NewRegistry()), eventrecorder.NopRecorder(), promslog.NewNopLogger())
 	go ag.run(ntfy)
 
 	ctx := context.Background()
 	ag.insert(ctx, a1)
 
-	select {
-	case <-time.After(2 * opts.GroupWait):
-		t.Fatalf("expected initial batch after group_wait")
-
-	case batch := <-alertsCh:
-		lastCurMtx.Lock()
-		s := time.Since(last)
-		lastCurMtx.Unlock()
-		if s < opts.GroupWait {
-			t.Fatalf("received batch too early after %v", s)
-		}
-		exp := removeEndsAt(types.AlertSlice{a1})
-		sort.Sort(batch)
-
-		if !reflect.DeepEqual(batch, exp) {
-			t.Fatalf("expected alerts %v but got %v", exp, batch)
-		}
-	}
+	last := receiveBatch(t, createdAt, opts.GroupWait, removeEndsAt(types.AlertSlice{a1}))
 
 	for range 3 {
 		// New alert should come in after group interval.
 		ag.insert(ctx, a3)
-
-		select {
-		case <-time.After(2 * opts.GroupInterval):
-			t.Fatalf("expected new batch after group interval but received none")
-
-		case batch := <-alertsCh:
-			lastCurMtx.Lock()
-			s := time.Since(last)
-			lastCurMtx.Unlock()
-			if s < opts.GroupInterval {
-				t.Fatalf("received batch too early after %v", s)
-			}
-			exp := removeEndsAt(types.AlertSlice{a1, a3})
-			sort.Sort(batch)
-
-			if !reflect.DeepEqual(batch, exp) {
-				t.Fatalf("expected alerts %v but got %v", exp, batch)
-			}
-		}
+		last = receiveBatch(t, last, opts.GroupInterval, removeEndsAt(types.AlertSlice{a1, a3}))
 	}
 
 	ag.stop()
 
 	// Finally, set all alerts to be resolved. After successful notify the aggregation group
 	// should empty itself.
+	createdAt = time.Now()
 	ag = newAggrGroup(context.Background(), lset, route, nil, types.NewMarker(prometheus.NewRegistry()), eventrecorder.NopRecorder(), promslog.NewNopLogger())
 	go ag.run(ntfy)
 
 	ag.insert(ctx, a1)
 	ag.insert(ctx, a2)
 
-	batch := <-alertsCh
-	exp := removeEndsAt(types.AlertSlice{a1, a2})
-	sort.Sort(batch)
-
-	if !reflect.DeepEqual(batch, exp) {
-		t.Fatalf("expected alerts %v but got %v", exp, batch)
-	}
+	last = receiveBatch(t, createdAt, opts.GroupWait, removeEndsAt(types.AlertSlice{a1, a2}))
 
 	for range 3 {
 		// New alert should come in after group interval.
 		ag.insert(ctx, a3)
-
-		select {
-		case <-time.After(2 * opts.GroupInterval):
-			t.Fatalf("expected new batch after group interval but received none")
-
-		case batch := <-alertsCh:
-			lastCurMtx.Lock()
-			s := time.Since(last)
-			lastCurMtx.Unlock()
-			if s < opts.GroupInterval {
-				t.Fatalf("received batch too early after %v", s)
-			}
-			exp := removeEndsAt(types.AlertSlice{a1, a2, a3})
-			sort.Sort(batch)
-
-			if !reflect.DeepEqual(batch, exp) {
-				t.Fatalf("expected alerts %v but got %v", exp, batch)
-			}
-		}
+		last = receiveBatch(t, last, opts.GroupInterval, removeEndsAt(types.AlertSlice{a1, a2, a3}))
 	}
 
 	// Resolve an alert, and it should be removed after the next batch was sent.
 	a1r := *a1
 	a1r.EndsAt = time.Now()
 	ag.insert(ctx, &a1r)
-	exp = append(types.AlertSlice{&a1r}, removeEndsAt(types.AlertSlice{a2, a3})...)
-
-	select {
-	case <-time.After(2 * opts.GroupInterval):
-		t.Fatalf("expected new batch after group interval but received none")
-	case batch := <-alertsCh:
-		lastCurMtx.Lock()
-		s := time.Since(last)
-		lastCurMtx.Unlock()
-		if s < opts.GroupInterval {
-			t.Fatalf("received batch too early after %v", s)
-		}
-		sort.Sort(batch)
-
-		if !reflect.DeepEqual(batch, exp) {
-			t.Fatalf("expected alerts %v but got %v", exp, batch)
-		}
-	}
+	last = receiveBatch(t, last, opts.GroupInterval, append(types.AlertSlice{&a1r}, removeEndsAt(types.AlertSlice{a2, a3})...))
 
 	// Resolve all remaining alerts, they should be removed after the next batch was sent.
 	// Do not add a1r as it should have been deleted following the previous batch.
@@ -265,27 +208,9 @@ func TestAggrGroup(t *testing.T) {
 		a.EndsAt = time.Now()
 		ag.insert(ctx, a)
 	}
-
-	select {
-	case <-time.After(2 * opts.GroupInterval):
-		t.Fatalf("expected new batch after group interval but received none")
-
-	case batch := <-alertsCh:
-		lastCurMtx.Lock()
-		s := time.Since(last)
-		lastCurMtx.Unlock()
-		if s < opts.GroupInterval {
-			t.Fatalf("received batch too early after %v", s)
-		}
-		sort.Sort(batch)
-
-		if !reflect.DeepEqual(batch, resolved) {
-			t.Fatalf("expected alerts %v but got %v", resolved, batch)
-		}
-
-		if !ag.empty() {
-			t.Fatalf("Expected aggregation group to be empty after resolving alerts: %v", ag)
-		}
+	receiveBatch(t, last, opts.GroupInterval, resolved)
+	if !ag.empty() {
+		t.Fatalf("Expected aggregation group to be empty after resolving alerts: %v", ag)
 	}
 
 	ag.stop()

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -209,9 +209,9 @@ func TestAggrGroup(t *testing.T) {
 		ag.insert(ctx, a)
 	}
 	receiveBatch(t, last, opts.GroupInterval, resolved)
-	if !ag.empty() {
-		t.Fatalf("Expected aggregation group to be empty after resolving alerts: %v", ag)
-	}
+	// ntfy unblocks before flush() finishes deleting resolved alerts, so poll.
+	require.Eventually(t, ag.empty, time.Second, 10*time.Millisecond,
+		"Expected aggregation group to be empty after resolving alerts: %v", ag)
 
 	ag.stop()
 }


### PR DESCRIPTION
- Reduce code duplication
- Use a channel to receive results
- Don't rely on subtracting a millisecond to "ensure" success

<!--
    - Please give your PR a title in the form "area: short description".  For example "dispatcher: improve performance"

    - Please sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Pull Request Checklist
Please check all the applicable boxes.

- Please list all open issue(s) discussed with maintainers related to this change
    - Fixes old and rare test race condition
    <!--
    If it applies.
    Automatically closes linked issue when PR is merged.
    Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
    More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
    -->
- Is this a bugfix?
    - [X] This solves a test error that I recently saw in CI
- [X] I have signed-off my commits
- [X] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/alertmanager/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by centralizing notification batching and timing checks.
  * Simplified sequencing of aggregation assertions to reduce flakiness across lifecycle events.
  * Updated final-resolution checks to wait for empty state stability before asserting completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->