### PR TITLE
notify/jira: include unresolved issues in wont_fix_resolution JQL

### DIFF
--- a/notify/jira/jira.go
+++ b/notify/jira/jira.go
@@ -218,7 +218,11 @@ func (n *Notifier) searchExistingIssue(ctx context.Context, logger *slog.Logger,
 	jql := strings.Builder{}
 
 	if n.conf.WontFixResolution != "" {
-		fmt.Fprintf(&jql, `resolution != %q and `, n.conf.WontFixResolution)
+		// JQL's != on resolution silently excludes issues whose resolution
+		// is EMPTY (unresolved). Use (resolution is EMPTY or resolution != X)
+		// so open issues remain in the candidate set and only the won't-fix
+		// resolved ones are filtered out. See prometheus/alertmanager#4295.
+		fmt.Fprintf(&jql, `(resolution is EMPTY or resolution != %q) and `, n.conf.WontFixResolution)
 	}
 
 	// If the group is firing, search for open issues. If a reopen transition is

--- a/notify/jira/jira_test.go
+++ b/notify/jira/jira_test.go
@@ -154,6 +154,18 @@ func TestSearchExistingIssue(t *testing.T) {
 			firing:      false,
 			expectedJQL: `statusCategory != Done and project="PROJ" and labels="ALERT{1}" order by status ASC,resolutiondate DESC`,
 		},
+		{
+			title: "search existing issue with wont_fix_resolution includes unresolved issues",
+			cfg: &JiraConfig{
+				Summary:           JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
+				Description:       JiraFieldConfig{Template: `{{ template "jira.default.description" . }}`},
+				Project:           `{{ .CommonLabels.project }}`,
+				WontFixResolution: "Won't Do",
+			},
+			groupKey:    "1",
+			firing:      true,
+			expectedJQL: `(resolution is EMPTY or resolution != "Won't Do") and statusCategory != Done and project="PROJ" and labels="ALERT{1}" order by status ASC,resolutiondate DESC`,
+		},
 	} {
 		t.Run(tc.title, func(t *testing.T) {
 			expectedJQL = tc.expectedJQL


### PR DESCRIPTION
## Summary

JQL's `!=` on the `resolution` field silently excludes issues whose resolution is `EMPTY` (unresolved). The generated clause

```
resolution != "Won't Do"
```

was filtering out every still-open Jira issue the alert would normally match, so the `searchExistingIssue` lookup returned nothing and Alertmanager kept creating duplicate issues against the same alert group.

## Fix

Rewrite the clause as

```
(resolution is EMPTY or resolution != "Won't Do")
```

so unresolved issues stay in the candidate set and only the actual "won't do"-style resolved issues are filtered. Documented by Atlassian at [confluence.atlassian.com/jirakb/...-635897091.html](https://confluence.atlassian.com/jirakb/using-not-equals-on-a-resolution-does-not-return-unresolved-issues-635897091.html).

## Fixes

Fixes #4295

## Test

- `go test ./notify/jira/... -count=1` passes.
- `gofmt` clean.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Jira issue search now correctly includes unresolved/open issues when matching existing issues, preventing them from being unintentionally excluded.
* **Tests**
  * Added coverage to ensure the Jira search behavior respects configured "wont-fix" resolution handling while still matching open/unresolved issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/prometheus/alertmanager/pull/5185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->