### PR TITLE
feat(template): add now function to template functions

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -92,6 +92,7 @@ templating.
 | join             | sep string, s []string     | [strings.Join](http://golang.org/pkg/strings/#Join), concatenates the elements of s to create a single string. The separator string sep is placed between elements in the resulting string. (note: argument order inverted for easier pipelining in templates.) |
 | list             | ...any                     | Returns the passed arguments as a slice of interfaces. |
 | match            | pattern, string            | [Regexp.MatchString](https://golang.org/pkg/regexp/#MatchString). Match a string using Regexp. |
+| now              |                            | [time.Now](https://pkg.go.dev/time#Now), returns the current local time. |
 | reReplaceAll     | pattern, replacement, text | [Regexp.ReplaceAllString](http://golang.org/pkg/regexp/#Regexp.ReplaceAllString) Regexp substitution, unanchored. |
 | safeHtml         | text string                | [html/template.HTML](https://golang.org/pkg/html/template/#HTML), Marks string as HTML not requiring auto-escaping. |
 | safeUrl          | text string                | [html/template.URL](https://golang.org/pkg/html/template/#URL), Marks string as URL not requiring auto-escaping. |

--- a/template/template.go
+++ b/template/template.go
@@ -215,6 +215,7 @@ var DefaultFuncs = FuncMap{
 		}
 		return t.In(loc), nil
 	},
+	"now":              time.Now,
 	"since":            time.Since,
 	"humanizeDuration": commonTemplates.HumanizeDuration,
 	"toJson": func(v any) (string, error) {

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -722,6 +722,37 @@ func TestTemplateFuncs(t *testing.T) {
 	}
 }
 
+func TestTemplateNow(t *testing.T) {
+	tmpl, err := FromGlobs([]string{})
+	require.NoError(t, err)
+
+	const (
+		layout   = "2006-01-02T15:04:05-0700"
+		tmplExpr = `{{ now | date "2006-01-02T15:04:05-0700" }}`
+		window   = 3 * time.Second
+	)
+
+	wg := sync.WaitGroup{}
+	for range 10 {
+		wg.Go(func() {
+			before := time.Now()
+			got, err := tmpl.ExecuteTextString(tmplExpr, nil)
+			require.NoError(t, err)
+
+			parsed, parseErr := time.Parse(layout, got)
+			require.NoError(t, parseErr)
+
+			// The rendered value is second-precision; allow up to 1s behind
+			// the captured start time, plus a forward execution window.
+			lowerBound := before.Add(-1 * time.Second)
+			upperBound := before.Add(window)
+			require.False(t, parsed.Before(lowerBound), "parsed now %v is before lower bound %v", parsed, lowerBound)
+			require.False(t, parsed.After(upperBound), "parsed now %v is after upper bound %v", parsed, upperBound)
+		})
+	}
+	wg.Wait()
+}
+
 func TestDeepCopyWithTemplate(t *testing.T) {
 	identity := TemplateFunc(func(s string) (string, error) { return s, nil })
 	withSuffix := TemplateFunc(func(s string) (string, error) { return s + "-templated", nil })


### PR DESCRIPTION
- Is this a new feature?
    - [x] I have added tests that test the new feature's functionality
- [x] I have added/updated the required documentation
- [x] I have signed-off my commits
- [x] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/alertmanager/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[ENHANCEMENT] TEMPLATE: Add now function to get current time
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Templates now support a `now` function to access the current local time in notification rendering.

* **Documentation**
  * Added documentation for the new `now` template function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->