### PR TITLE
refactor(eventrecorder): move configuration to eventrecorder package

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	amcommoncfg "github.com/prometheus/alertmanager/config/common"
+	"github.com/prometheus/alertmanager/eventrecorder"
 	"github.com/prometheus/alertmanager/matcher/compat"
 	"github.com/prometheus/alertmanager/timeinterval"
 	"github.com/prometheus/alertmanager/tracing"
@@ -277,56 +278,10 @@ type Config struct {
 
 	TracingConfig tracing.TracingConfig `yaml:"tracing,omitempty" json:"tracing,omitempty"`
 
-	EventRecorder EventRecorderConfig `yaml:"event_recorder,omitempty" json:"event_recorder,omitempty"`
+	EventRecorder eventrecorder.EventRecorderConfig `yaml:"event_recorder,omitempty" json:"event_recorder,omitempty"`
 
 	// original is the input from which the config was parsed.
 	original string
-}
-
-// EventRecorderConfig configures the event recorder feature.
-type EventRecorderConfig struct {
-	Outputs []EventRecorderOutput `yaml:"outputs,omitempty" json:"outputs,omitempty"`
-}
-
-// EventRecorderOutput configures a single event recorder output destination.
-type EventRecorderOutput struct {
-	Type       string                      `yaml:"type" json:"type"`
-	Path       string                      `yaml:"path,omitempty" json:"path,omitempty"`
-	URL        *amcommoncfg.SecretURL      `yaml:"url,omitempty" json:"url,omitempty"`
-	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
-	// Timeout for webhook HTTP requests (default 10s).
-	Timeout model.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty"`
-	// Workers is the number of concurrent webhook delivery goroutines
-	// (default 4).  Only applicable to webhook outputs.
-	Workers int `yaml:"workers,omitempty" json:"workers,omitempty"`
-	// MaxRetries is the maximum number of delivery attempts per event
-	// (default 3).  Only applicable to webhook outputs.
-	MaxRetries int `yaml:"max_retries,omitempty" json:"max_retries,omitempty"`
-	// RetryBackoff is the base backoff duration between retry attempts
-	// (default 500ms).  Successive attempts use exponential backoff
-	// (base * 2^attempt).  Only applicable to webhook outputs.
-	RetryBackoff model.Duration `yaml:"retry_backoff,omitempty" json:"retry_backoff,omitempty"`
-}
-
-// UnmarshalYAML implements the yaml.Unmarshaler interface for EventRecorderOutput.
-func (o *EventRecorderOutput) UnmarshalYAML(unmarshal func(any) error) error {
-	type plain EventRecorderOutput
-	if err := unmarshal((*plain)(o)); err != nil {
-		return err
-	}
-	switch o.Type {
-	case "file":
-		if o.Path == "" {
-			return errors.New("event_recorder file output requires a path")
-		}
-	case "webhook":
-		if o.URL == nil {
-			return errors.New("event_recorder webhook output requires a url")
-		}
-	default:
-		return fmt.Errorf("unknown event_recorder output type %q, must be \"file\" or \"webhook\"", o.Type)
-	}
-	return nil
 }
 
 func (c Config) String() string {

--- a/eventrecorder/config.go
+++ b/eventrecorder/config.go
@@ -1,0 +1,79 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package eventrecorder provides a structured event recorder for
+// significant Alertmanager events.  Events are serialized as JSON and
+// fanned out to one or more configured destinations (JSONL file,
+// webhook, etc.).
+//
+// RecordEvent never blocks the caller: events are serialized and
+// placed on a bounded in-memory queue.  A background goroutine
+// drains the queue and sends to destinations.  If the queue is full,
+// events are dropped and a metric is incremented.
+package eventrecorder
+
+import (
+	"errors"
+	"fmt"
+
+	commoncfg "github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
+
+	amcommoncfg "github.com/prometheus/alertmanager/config/common"
+)
+
+// EventRecorderConfig configures the event recorder feature.
+type EventRecorderConfig struct {
+	Outputs []EventRecorderOutput `yaml:"outputs,omitempty" json:"outputs,omitempty"`
+}
+
+// EventRecorderOutput configures a single event recorder output destination.
+type EventRecorderOutput struct {
+	Type       string                      `yaml:"type" json:"type"`
+	Path       string                      `yaml:"path,omitempty" json:"path,omitempty"`
+	URL        *amcommoncfg.SecretURL      `yaml:"url,omitempty" json:"url,omitempty"`
+	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
+	// Timeout for webhook HTTP requests (default 10s).
+	Timeout model.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty"`
+	// Workers is the number of concurrent webhook delivery goroutines
+	// (default 4).  Only applicable to webhook outputs.
+	Workers int `yaml:"workers,omitempty" json:"workers,omitempty"`
+	// MaxRetries is the maximum number of delivery attempts per event
+	// (default 3).  Only applicable to webhook outputs.
+	MaxRetries int `yaml:"max_retries,omitempty" json:"max_retries,omitempty"`
+	// RetryBackoff is the base backoff duration between retry attempts
+	// (default 500ms).  Successive attempts use exponential backoff
+	// (base * 2^attempt).  Only applicable to webhook outputs.
+	RetryBackoff model.Duration `yaml:"retry_backoff,omitempty" json:"retry_backoff,omitempty"`
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface for EventRecorderOutput.
+func (o *EventRecorderOutput) UnmarshalYAML(unmarshal func(any) error) error {
+	type plain EventRecorderOutput
+	if err := unmarshal((*plain)(o)); err != nil {
+		return err
+	}
+	switch o.Type {
+	case "file":
+		if o.Path == "" {
+			return errors.New("event_recorder file output requires a path")
+		}
+	case "webhook":
+		if o.URL == nil {
+			return errors.New("event_recorder webhook output requires a url")
+		}
+	default:
+		return fmt.Errorf("unknown event_recorder output type %q, must be \"file\" or \"webhook\"", o.Type)
+	}
+	return nil
+}

--- a/eventrecorder/eventrecorder.go
+++ b/eventrecorder/eventrecorder.go
@@ -38,7 +38,6 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/prometheus/alertmanager/cluster"
-	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/eventrecorder/eventrecorderpb"
 	"github.com/prometheus/alertmanager/pkg/labels"
 	silencepb "github.com/prometheus/alertmanager/silence/silencepb"
@@ -107,7 +106,7 @@ type sharedRecorder struct {
 // cfgUpdateMsg is sent to writeLoop to hot-reload the configuration.
 // The sender blocks until the writeLoop acknowledges by closing done.
 type cfgUpdateMsg struct {
-	cfg  config.EventRecorderConfig
+	cfg  EventRecorderConfig
 	done chan struct{}
 }
 
@@ -179,7 +178,7 @@ func newMetrics(r prometheus.Registerer) *metrics {
 // NewRecorderFromConfig builds a Recorder from the given configuration.
 // A background goroutine is started to drain the event queue; call
 // Close to stop it.
-func NewRecorderFromConfig(cfg config.EventRecorderConfig, instance string, logger *slog.Logger, r prometheus.Registerer) Recorder {
+func NewRecorderFromConfig(cfg EventRecorderConfig, instance string, logger *slog.Logger, r prometheus.Registerer) Recorder {
 	core := &sharedRecorder{
 		instance:  instance,
 		logger:    logger,
@@ -206,7 +205,7 @@ func NewRecorderFromConfig(cfg config.EventRecorderConfig, instance string, logg
 }
 
 // buildOutputs creates Destination implementations from the given config.
-func buildOutputs(cfgOutputs []config.EventRecorderOutput, m *metrics, logger *slog.Logger) []Destination {
+func buildOutputs(cfgOutputs []EventRecorderOutput, m *metrics, logger *slog.Logger) []Destination {
 	var outputs []Destination
 	for _, out := range cfgOutputs {
 		switch out.Type {
@@ -240,7 +239,7 @@ func buildOutputs(cfgOutputs []config.EventRecorderOutput, m *metrics, logger *s
 //
 // It runs until the done channel is closed, then drains remaining
 // events and closes all outputs before returning.
-func (c *sharedRecorder) writeLoop(outputs []Destination, currentCfg config.EventRecorderConfig) {
+func (c *sharedRecorder) writeLoop(outputs []Destination, currentCfg EventRecorderConfig) {
 	defer c.wg.Done()
 	defer func() {
 		for _, out := range outputs {
@@ -368,7 +367,7 @@ func (r Recorder) SetClusterPeer(peer *cluster.Peer) {
 
 // eventRecorderConfigEqual compares two EventRecorderConfig values by their
 // semantically significant fields.
-func eventRecorderConfigEqual(a, b config.EventRecorderConfig) bool {
+func eventRecorderConfigEqual(a, b EventRecorderConfig) bool {
 	if len(a.Outputs) != len(b.Outputs) {
 		return false
 	}
@@ -412,7 +411,7 @@ func eventRecorderConfigEqual(a, b config.EventRecorderConfig) bool {
 // ApplyConfig hot-reloads the event recorder configuration.  The update is
 // sent to the writeLoop goroutine, which owns the outputs; this method
 // blocks until the writeLoop has acknowledged the update.
-func (r Recorder) ApplyConfig(cfg config.EventRecorderConfig) {
+func (r Recorder) ApplyConfig(cfg EventRecorderConfig) {
 	if r.core == nil || r.core.cfgUpdate == nil {
 		return
 	}

--- a/eventrecorder/eventrecorder_test.go
+++ b/eventrecorder/eventrecorder_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
-	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/eventrecorder/eventrecorderpb"
 	"github.com/prometheus/alertmanager/pkg/labels"
 )
@@ -74,7 +73,7 @@ func newTestRecorder(outputs ...Destination) Recorder {
 		done:      make(chan struct{}),
 	}
 	core.wg.Add(1)
-	go core.writeLoop(outputs, config.EventRecorderConfig{})
+	go core.writeLoop(outputs, EventRecorderConfig{})
 	return Recorder{core: core}
 }
 
@@ -111,7 +110,7 @@ func TestRecordEventMultipleDestinations(t *testing.T) {
 func TestNopRecorderDoesNotPanic(t *testing.T) {
 	rec := NopRecorder()
 	rec.RecordEvent(recordCtx(), startupEvent())
-	rec.ApplyConfig(config.EventRecorderConfig{})
+	rec.ApplyConfig(EventRecorderConfig{})
 	rec.SetClusterPeer(nil)
 	require.NoError(t, rec.Close())
 }
@@ -119,7 +118,7 @@ func TestNopRecorderDoesNotPanic(t *testing.T) {
 func TestZeroRecorderDoesNotPanic(t *testing.T) {
 	var rec Recorder
 	rec.RecordEvent(recordCtx(), startupEvent())
-	rec.ApplyConfig(config.EventRecorderConfig{})
+	rec.ApplyConfig(EventRecorderConfig{})
 	rec.SetClusterPeer(nil)
 	require.NoError(t, rec.Close())
 }
@@ -151,7 +150,7 @@ func TestApplyConfig(t *testing.T) {
 	}, time.Second, 10*time.Millisecond)
 
 	// ApplyConfig with the same (zero) config should be a no-op.
-	rec.ApplyConfig(config.EventRecorderConfig{})
+	rec.ApplyConfig(EventRecorderConfig{})
 
 	// Events still flow to the same output after no-op reload.
 	rec.RecordEvent(recordCtx(), startupEvent())
@@ -235,13 +234,13 @@ func TestMatchersAsProto(t *testing.T) {
 }
 
 func TestEventRecorderConfigEqual(t *testing.T) {
-	a := config.EventRecorderConfig{
-		Outputs: []config.EventRecorderOutput{
+	a := EventRecorderConfig{
+		Outputs: []EventRecorderOutput{
 			{Type: "file", Path: "/tmp/events.jsonl"},
 		},
 	}
-	b := config.EventRecorderConfig{
-		Outputs: []config.EventRecorderOutput{
+	b := EventRecorderConfig{
+		Outputs: []EventRecorderOutput{
 			{Type: "file", Path: "/tmp/events.jsonl"},
 		},
 	}
@@ -251,6 +250,6 @@ func TestEventRecorderConfigEqual(t *testing.T) {
 	require.False(t, eventRecorderConfigEqual(a, b))
 
 	// Different number of outputs.
-	c := config.EventRecorderConfig{}
+	c := EventRecorderConfig{}
 	require.False(t, eventRecorderConfigEqual(a, c))
 }

--- a/eventrecorder/webhook.go
+++ b/eventrecorder/webhook.go
@@ -25,8 +25,6 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	commoncfg "github.com/prometheus/common/config"
-
-	"github.com/prometheus/alertmanager/config"
 )
 
 const (
@@ -59,7 +57,7 @@ type WebhookOutput struct {
 }
 
 // NewWebhookOutput creates a new webhook-based event recorder output.
-func NewWebhookOutput(cfg config.EventRecorderOutput, dropsCounter *prometheus.CounterVec, logger *slog.Logger) (*WebhookOutput, error) {
+func NewWebhookOutput(cfg EventRecorderOutput, dropsCounter *prometheus.CounterVec, logger *slog.Logger) (*WebhookOutput, error) {
 	httpCfg := commoncfg.DefaultHTTPClientConfig
 	if cfg.HTTPConfig != nil {
 		httpCfg = *cfg.HTTPConfig

--- a/eventrecorder/webhook_test.go
+++ b/eventrecorder/webhook_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
-	"github.com/prometheus/alertmanager/config"
 	amcommoncfg "github.com/prometheus/alertmanager/config/common"
 )
 
@@ -59,7 +58,7 @@ func TestWebhookOutput_SendEvent(t *testing.T) {
 	defer srv.Close()
 
 	u := mustParseURL(t, srv.URL)
-	cfg := config.EventRecorderOutput{
+	cfg := EventRecorderOutput{
 		Type: "webhook",
 		URL:  u,
 	}
@@ -93,7 +92,7 @@ func TestWebhookOutput_MultipleWorkers(t *testing.T) {
 	defer srv.Close()
 
 	u := mustParseURL(t, srv.URL)
-	cfg := config.EventRecorderOutput{
+	cfg := EventRecorderOutput{
 		Type:    "webhook",
 		URL:     u,
 		Workers: 8,
@@ -125,7 +124,7 @@ func TestWebhookOutput_RetryOnFailure(t *testing.T) {
 	defer srv.Close()
 
 	u := mustParseURL(t, srv.URL)
-	cfg := config.EventRecorderOutput{
+	cfg := EventRecorderOutput{
 		Type:         "webhook",
 		URL:          u,
 		MaxRetries:   3,
@@ -151,7 +150,7 @@ func TestWebhookOutput_DropsAfterMaxRetries(t *testing.T) {
 	defer srv.Close()
 
 	u := mustParseURL(t, srv.URL)
-	cfg := config.EventRecorderOutput{
+	cfg := EventRecorderOutput{
 		Type:         "webhook",
 		URL:          u,
 		MaxRetries:   2,
@@ -177,7 +176,7 @@ func TestWebhookOutput_CloseFlushesQueue(t *testing.T) {
 	defer srv.Close()
 
 	u := mustParseURL(t, srv.URL)
-	cfg := config.EventRecorderOutput{
+	cfg := EventRecorderOutput{
 		Type:    "webhook",
 		URL:     u,
 		Workers: 1,


### PR DESCRIPTION
#### Pull Request Checklist
- [x] I have signed-off my commits
- [x] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/alertmanager/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized event recorder configuration to a dedicated module for improved code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->