### PR TITLE
refactor(eventrecorder): rename EventRecorderConfig/Output and introduce output-type constants

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -220,7 +220,7 @@ func resolveFilepaths(baseDir string, cfg *Config) {
 	}
 
 	for i, out := range cfg.EventRecorder.Outputs {
-		if out.Type == "file" {
+		if out.Type == eventrecorder.OutputFile {
 			cfg.EventRecorder.Outputs[i].Path = join(out.Path)
 		}
 		if out.HTTPConfig != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -278,7 +278,7 @@ type Config struct {
 
 	TracingConfig tracing.TracingConfig `yaml:"tracing,omitempty" json:"tracing,omitempty"`
 
-	EventRecorder eventrecorder.EventRecorderConfig `yaml:"event_recorder,omitempty" json:"event_recorder,omitempty"`
+	EventRecorder eventrecorder.Config `yaml:"event_recorder,omitempty" json:"event_recorder,omitempty"`
 
 	// original is the input from which the config was parsed.
 	original string

--- a/eventrecorder/config.go
+++ b/eventrecorder/config.go
@@ -32,13 +32,13 @@ import (
 	amcommoncfg "github.com/prometheus/alertmanager/config/common"
 )
 
-// EventRecorderConfig configures the event recorder feature.
-type EventRecorderConfig struct {
-	Outputs []EventRecorderOutput `yaml:"outputs,omitempty" json:"outputs,omitempty"`
+// Config configures the event recorder feature.
+type Config struct {
+	Outputs []Output `yaml:"outputs,omitempty" json:"outputs,omitempty"`
 }
 
-// EventRecorderOutput configures a single event recorder output destination.
-type EventRecorderOutput struct {
+// Output configures a single event recorder output destination.
+type Output struct {
 	Type       string                      `yaml:"type" json:"type"`
 	Path       string                      `yaml:"path,omitempty" json:"path,omitempty"`
 	URL        *amcommoncfg.SecretURL      `yaml:"url,omitempty" json:"url,omitempty"`
@@ -57,9 +57,9 @@ type EventRecorderOutput struct {
 	RetryBackoff model.Duration `yaml:"retry_backoff,omitempty" json:"retry_backoff,omitempty"`
 }
 
-// UnmarshalYAML implements the yaml.Unmarshaler interface for EventRecorderOutput.
-func (o *EventRecorderOutput) UnmarshalYAML(unmarshal func(any) error) error {
-	type plain EventRecorderOutput
+// UnmarshalYAML implements the yaml.Unmarshaler interface for Output.
+func (o *Output) UnmarshalYAML(unmarshal func(any) error) error {
+	type plain Output
 	if err := unmarshal((*plain)(o)); err != nil {
 		return err
 	}

--- a/eventrecorder/config.go
+++ b/eventrecorder/config.go
@@ -64,16 +64,16 @@ func (o *Output) UnmarshalYAML(unmarshal func(any) error) error {
 		return err
 	}
 	switch o.Type {
-	case "file":
+	case OutputFile:
 		if o.Path == "" {
 			return errors.New("event_recorder file output requires a path")
 		}
-	case "webhook":
+	case OutputWebhook:
 		if o.URL == nil {
 			return errors.New("event_recorder webhook output requires a url")
 		}
 	default:
-		return fmt.Errorf("unknown event_recorder output type %q, must be \"file\" or \"webhook\"", o.Type)
+		return fmt.Errorf("unknown event_recorder output type %q, must be %q or %q", o.Type, OutputFile, OutputWebhook)
 	}
 	return nil
 }

--- a/eventrecorder/config.go
+++ b/eventrecorder/config.go
@@ -25,6 +25,7 @@ package eventrecorder
 import (
 	"errors"
 	"fmt"
+	"reflect"
 
 	commoncfg "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
@@ -76,4 +77,47 @@ func (o *Output) UnmarshalYAML(unmarshal func(any) error) error {
 		return fmt.Errorf("unknown event_recorder output type %q, must be %q or %q", o.Type, OutputFile, OutputWebhook)
 	}
 	return nil
+}
+
+// eventRecorderConfigEqual compares two Config values by their
+// semantically significant fields.
+func eventRecorderConfigEqual(a, b Config) bool {
+	if len(a.Outputs) != len(b.Outputs) {
+		return false
+	}
+	for i := range a.Outputs {
+		oa, ob := a.Outputs[i], b.Outputs[i]
+		if oa.Type != ob.Type {
+			return false
+		}
+		if oa.Path != ob.Path {
+			return false
+		}
+		if oa.Timeout != ob.Timeout {
+			return false
+		}
+		aURL, bURL := "", ""
+		if oa.URL != nil {
+			aURL = oa.URL.String()
+		}
+		if ob.URL != nil {
+			bURL = ob.URL.String()
+		}
+		if aURL != bURL {
+			return false
+		}
+		if oa.Workers != ob.Workers {
+			return false
+		}
+		if oa.MaxRetries != ob.MaxRetries {
+			return false
+		}
+		if oa.RetryBackoff != ob.RetryBackoff {
+			return false
+		}
+		if !reflect.DeepEqual(oa.HTTPConfig, ob.HTTPConfig) {
+			return false
+		}
+	}
+	return true
 }

--- a/eventrecorder/config.go
+++ b/eventrecorder/config.go
@@ -79,9 +79,9 @@ func (o *Output) UnmarshalYAML(unmarshal func(any) error) error {
 	return nil
 }
 
-// eventRecorderConfigEqual compares two Config values by their
+// configEqual compares two Config values by their
 // semantically significant fields.
-func eventRecorderConfigEqual(a, b Config) bool {
+func configEqual(a, b Config) bool {
 	if len(a.Outputs) != len(b.Outputs) {
 		return false
 	}

--- a/eventrecorder/eventrecorder.go
+++ b/eventrecorder/eventrecorder.go
@@ -258,7 +258,7 @@ func (c *sharedRecorder) writeLoop(outputs []Destination, currentCfg Config) {
 		case req := <-c.events:
 			c.marshalAndSend(req, outputs)
 		case update := <-c.cfgUpdate:
-			if !eventRecorderConfigEqual(update.cfg, currentCfg) {
+			if !configEqual(update.cfg, currentCfg) {
 				newOutputs := buildOutputs(update.cfg.Outputs, c.metrics, c.logger)
 				if len(newOutputs) != len(update.cfg.Outputs) {
 					// Some outputs failed to initialize.  Keep the existing

--- a/eventrecorder/eventrecorder.go
+++ b/eventrecorder/eventrecorder.go
@@ -26,7 +26,6 @@ import (
 	"context"
 	"io"
 	"log/slog"
-	"reflect"
 	"slices"
 	"strings"
 	"sync"
@@ -368,49 +367,6 @@ func (r Recorder) SetClusterPeer(peer *cluster.Peer) {
 		return
 	}
 	r.core.peer.Store(peer)
-}
-
-// eventRecorderConfigEqual compares two Config values by their
-// semantically significant fields.
-func eventRecorderConfigEqual(a, b Config) bool {
-	if len(a.Outputs) != len(b.Outputs) {
-		return false
-	}
-	for i := range a.Outputs {
-		oa, ob := a.Outputs[i], b.Outputs[i]
-		if oa.Type != ob.Type {
-			return false
-		}
-		if oa.Path != ob.Path {
-			return false
-		}
-		if oa.Timeout != ob.Timeout {
-			return false
-		}
-		aURL, bURL := "", ""
-		if oa.URL != nil {
-			aURL = oa.URL.String()
-		}
-		if ob.URL != nil {
-			bURL = ob.URL.String()
-		}
-		if aURL != bURL {
-			return false
-		}
-		if oa.Workers != ob.Workers {
-			return false
-		}
-		if oa.MaxRetries != ob.MaxRetries {
-			return false
-		}
-		if oa.RetryBackoff != ob.RetryBackoff {
-			return false
-		}
-		if !reflect.DeepEqual(oa.HTTPConfig, ob.HTTPConfig) {
-			return false
-		}
-	}
-	return true
 }
 
 // ApplyConfig hot-reloads the event recorder configuration.  The update is

--- a/eventrecorder/eventrecorder.go
+++ b/eventrecorder/eventrecorder.go
@@ -106,7 +106,7 @@ type sharedRecorder struct {
 // cfgUpdateMsg is sent to writeLoop to hot-reload the configuration.
 // The sender blocks until the writeLoop acknowledges by closing done.
 type cfgUpdateMsg struct {
-	cfg  EventRecorderConfig
+	cfg  Config
 	done chan struct{}
 }
 
@@ -178,7 +178,7 @@ func newMetrics(r prometheus.Registerer) *metrics {
 // NewRecorderFromConfig builds a Recorder from the given configuration.
 // A background goroutine is started to drain the event queue; call
 // Close to stop it.
-func NewRecorderFromConfig(cfg EventRecorderConfig, instance string, logger *slog.Logger, r prometheus.Registerer) Recorder {
+func NewRecorderFromConfig(cfg Config, instance string, logger *slog.Logger, r prometheus.Registerer) Recorder {
 	core := &sharedRecorder{
 		instance:  instance,
 		logger:    logger,
@@ -205,7 +205,7 @@ func NewRecorderFromConfig(cfg EventRecorderConfig, instance string, logger *slo
 }
 
 // buildOutputs creates Destination implementations from the given config.
-func buildOutputs(cfgOutputs []EventRecorderOutput, m *metrics, logger *slog.Logger) []Destination {
+func buildOutputs(cfgOutputs []Output, m *metrics, logger *slog.Logger) []Destination {
 	var outputs []Destination
 	for _, out := range cfgOutputs {
 		switch out.Type {
@@ -239,7 +239,7 @@ func buildOutputs(cfgOutputs []EventRecorderOutput, m *metrics, logger *slog.Log
 //
 // It runs until the done channel is closed, then drains remaining
 // events and closes all outputs before returning.
-func (c *sharedRecorder) writeLoop(outputs []Destination, currentCfg EventRecorderConfig) {
+func (c *sharedRecorder) writeLoop(outputs []Destination, currentCfg Config) {
 	defer c.wg.Done()
 	defer func() {
 		for _, out := range outputs {
@@ -365,9 +365,9 @@ func (r Recorder) SetClusterPeer(peer *cluster.Peer) {
 	r.core.peer.Store(peer)
 }
 
-// eventRecorderConfigEqual compares two EventRecorderConfig values by their
+// eventRecorderConfigEqual compares two Config values by their
 // semantically significant fields.
-func eventRecorderConfigEqual(a, b EventRecorderConfig) bool {
+func eventRecorderConfigEqual(a, b Config) bool {
 	if len(a.Outputs) != len(b.Outputs) {
 		return false
 	}
@@ -411,7 +411,7 @@ func eventRecorderConfigEqual(a, b EventRecorderConfig) bool {
 // ApplyConfig hot-reloads the event recorder configuration.  The update is
 // sent to the writeLoop goroutine, which owns the outputs; this method
 // blocks until the writeLoop has acknowledged the update.
-func (r Recorder) ApplyConfig(cfg EventRecorderConfig) {
+func (r Recorder) ApplyConfig(cfg Config) {
 	if r.core == nil || r.core.cfgUpdate == nil {
 		return
 	}

--- a/eventrecorder/eventrecorder.go
+++ b/eventrecorder/eventrecorder.go
@@ -44,8 +44,8 @@ import (
 )
 
 const (
-	OutputFile    string = "file"
-	OutputWebhook string = "webhook"
+	OutputFile    = "file"
+	OutputWebhook = "webhook"
 )
 
 const (

--- a/eventrecorder/eventrecorder.go
+++ b/eventrecorder/eventrecorder.go
@@ -45,6 +45,11 @@ import (
 )
 
 const (
+	OutputFile    string = "file"
+	OutputWebhook string = "webhook"
+)
+
+const (
 	// Maximum number of events buffered before new events are dropped.
 	// At ~500 bytes per event this caps memory usage at roughly 4 MB.
 	eventQueueSize = 8192
@@ -209,14 +214,14 @@ func buildOutputs(cfgOutputs []Output, m *metrics, logger *slog.Logger) []Destin
 	var outputs []Destination
 	for _, out := range cfgOutputs {
 		switch out.Type {
-		case "file":
+		case OutputFile:
 			fo, err := NewFileOutput(out.Path, logger)
 			if err != nil {
 				logger.Error("Failed to create file event recorder output", "path", out.Path, "err", err)
 				continue
 			}
 			outputs = append(outputs, fo)
-		case "webhook":
+		case OutputWebhook:
 			wo, err := NewWebhookOutput(out, m.webhookDrops, logger)
 			if err != nil {
 				logger.Error("Failed to create webhook event recorder output", "url", out.URL, "err", err)

--- a/eventrecorder/eventrecorder_test.go
+++ b/eventrecorder/eventrecorder_test.go
@@ -236,20 +236,20 @@ func TestMatchersAsProto(t *testing.T) {
 func TestEventRecorderConfigEqual(t *testing.T) {
 	a := Config{
 		Outputs: []Output{
-			{Type: "file", Path: "/tmp/events.jsonl"},
+			{Type: OutputFile, Path: "/tmp/events.jsonl"},
 		},
 	}
 	b := Config{
 		Outputs: []Output{
-			{Type: "file", Path: "/tmp/events.jsonl"},
+			{Type: OutputFile, Path: "/tmp/events.jsonl"},
 		},
 	}
-	require.True(t, eventRecorderConfigEqual(a, b))
+	require.True(t, configEqual(a, b))
 
 	b.Outputs[0].Path = "/tmp/other.jsonl"
-	require.False(t, eventRecorderConfigEqual(a, b))
+	require.False(t, configEqual(a, b))
 
 	// Different number of outputs.
 	c := Config{}
-	require.False(t, eventRecorderConfigEqual(a, c))
+	require.False(t, configEqual(a, c))
 }

--- a/eventrecorder/eventrecorder_test.go
+++ b/eventrecorder/eventrecorder_test.go
@@ -73,7 +73,7 @@ func newTestRecorder(outputs ...Destination) Recorder {
 		done:      make(chan struct{}),
 	}
 	core.wg.Add(1)
-	go core.writeLoop(outputs, EventRecorderConfig{})
+	go core.writeLoop(outputs, Config{})
 	return Recorder{core: core}
 }
 
@@ -110,7 +110,7 @@ func TestRecordEventMultipleDestinations(t *testing.T) {
 func TestNopRecorderDoesNotPanic(t *testing.T) {
 	rec := NopRecorder()
 	rec.RecordEvent(recordCtx(), startupEvent())
-	rec.ApplyConfig(EventRecorderConfig{})
+	rec.ApplyConfig(Config{})
 	rec.SetClusterPeer(nil)
 	require.NoError(t, rec.Close())
 }
@@ -118,7 +118,7 @@ func TestNopRecorderDoesNotPanic(t *testing.T) {
 func TestZeroRecorderDoesNotPanic(t *testing.T) {
 	var rec Recorder
 	rec.RecordEvent(recordCtx(), startupEvent())
-	rec.ApplyConfig(EventRecorderConfig{})
+	rec.ApplyConfig(Config{})
 	rec.SetClusterPeer(nil)
 	require.NoError(t, rec.Close())
 }
@@ -150,7 +150,7 @@ func TestApplyConfig(t *testing.T) {
 	}, time.Second, 10*time.Millisecond)
 
 	// ApplyConfig with the same (zero) config should be a no-op.
-	rec.ApplyConfig(EventRecorderConfig{})
+	rec.ApplyConfig(Config{})
 
 	// Events still flow to the same output after no-op reload.
 	rec.RecordEvent(recordCtx(), startupEvent())
@@ -234,13 +234,13 @@ func TestMatchersAsProto(t *testing.T) {
 }
 
 func TestEventRecorderConfigEqual(t *testing.T) {
-	a := EventRecorderConfig{
-		Outputs: []EventRecorderOutput{
+	a := Config{
+		Outputs: []Output{
 			{Type: "file", Path: "/tmp/events.jsonl"},
 		},
 	}
-	b := EventRecorderConfig{
-		Outputs: []EventRecorderOutput{
+	b := Config{
+		Outputs: []Output{
 			{Type: "file", Path: "/tmp/events.jsonl"},
 		},
 	}
@@ -250,6 +250,6 @@ func TestEventRecorderConfigEqual(t *testing.T) {
 	require.False(t, eventRecorderConfigEqual(a, b))
 
 	// Different number of outputs.
-	c := EventRecorderConfig{}
+	c := Config{}
 	require.False(t, eventRecorderConfigEqual(a, c))
 }

--- a/eventrecorder/webhook.go
+++ b/eventrecorder/webhook.go
@@ -57,7 +57,7 @@ type WebhookOutput struct {
 }
 
 // NewWebhookOutput creates a new webhook-based event recorder output.
-func NewWebhookOutput(cfg EventRecorderOutput, dropsCounter *prometheus.CounterVec, logger *slog.Logger) (*WebhookOutput, error) {
+func NewWebhookOutput(cfg Output, dropsCounter *prometheus.CounterVec, logger *slog.Logger) (*WebhookOutput, error) {
 	httpCfg := commoncfg.DefaultHTTPClientConfig
 	if cfg.HTTPConfig != nil {
 		httpCfg = *cfg.HTTPConfig

--- a/eventrecorder/webhook_test.go
+++ b/eventrecorder/webhook_test.go
@@ -58,7 +58,7 @@ func TestWebhookOutput_SendEvent(t *testing.T) {
 	defer srv.Close()
 
 	u := mustParseURL(t, srv.URL)
-	cfg := EventRecorderOutput{
+	cfg := Output{
 		Type: "webhook",
 		URL:  u,
 	}
@@ -92,7 +92,7 @@ func TestWebhookOutput_MultipleWorkers(t *testing.T) {
 	defer srv.Close()
 
 	u := mustParseURL(t, srv.URL)
-	cfg := EventRecorderOutput{
+	cfg := Output{
 		Type:    "webhook",
 		URL:     u,
 		Workers: 8,
@@ -124,7 +124,7 @@ func TestWebhookOutput_RetryOnFailure(t *testing.T) {
 	defer srv.Close()
 
 	u := mustParseURL(t, srv.URL)
-	cfg := EventRecorderOutput{
+	cfg := Output{
 		Type:         "webhook",
 		URL:          u,
 		MaxRetries:   3,
@@ -150,7 +150,7 @@ func TestWebhookOutput_DropsAfterMaxRetries(t *testing.T) {
 	defer srv.Close()
 
 	u := mustParseURL(t, srv.URL)
-	cfg := EventRecorderOutput{
+	cfg := Output{
 		Type:         "webhook",
 		URL:          u,
 		MaxRetries:   2,
@@ -176,7 +176,7 @@ func TestWebhookOutput_CloseFlushesQueue(t *testing.T) {
 	defer srv.Close()
 
 	u := mustParseURL(t, srv.URL)
-	cfg := EventRecorderOutput{
+	cfg := Output{
 		Type:    "webhook",
 		URL:     u,
 		Workers: 1,


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "dispatcher: improve performance"

    - Please sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Pull Request Checklist
Please check all the applicable boxes.

- Please list all open issue(s) discussed with maintainers related to this change
    - Fixes #<issue number>
    <!--
    If it applies.
    Automatically closes linked issue when PR is merged.
    Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
    More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
    -->
- Is this a new Receiver integration?
    - [ ] I have already tried to use the [Webhook Receiver Integration](https://prometheus.io/docs/alerting/latest/configuration/#webhook_config) and [3rd party integrations](https://prometheus.io/docs/operating/integrations/#alertmanager-webhook-receiver) before adding this new Receiver Integration
- Is this a bugfix?
    - [ ] I have added tests that can reproduce the bug which pass with this bugfix applied
- Is this a new feature?
    - [ ] I have added tests that test the new feature's functionality
- Does this change affect performance?
    - [ ] I have provided benchmarks comparison that shows performance is improved or is not degraded
        - You can use [`benchstat`](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat) to compare benchmarks
    - [ ] I have added new benchmarks if required or requested by maintainers
- Is this a breaking change?
    - [ ] My changes do not break the existing cluster messages
    - [ ] My changes do not break the existing api
- [ ] I have added/updated the required documentation
- [ ] I have signed-off my commits
- [ ] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/alertmanager/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Restructured event recorder configuration types and output handling for clearer, more maintainable config management.
  * Replaced literal type checks with named output constants and centralized validation, improving robustness of output selection.
  * Hot-reload logic for the event recorder now uses a semantic config comparison to avoid unnecessary rebuilds; no change to public behavior or configuration format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->