### PR TITLE
fix(ui): Provide prebuilt UI assets in release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,15 +22,29 @@ jobs:
       - run: make assets
       - run: make apiv2
       - run: git diff --exit-code
+      - run: make assets-tarball
+      - uses: prometheus/promci-artifacts/save@f9a587dbc0b2c78a0c54f8ad1cde71ea29a4b76f # v0.1.0
+        with:
+          directory: .tarballs
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v4.6.2
+        with:
+          name: ui-dist
+          path: ui/app/dist
+          include-hidden-files: true
 
   build:
     name: Build Alertmanager for common architectures
+    needs: [test_frontend]
     runs-on: ubuntu-latest
     strategy:
       matrix:
         thread: [0, 1, 2]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.0.0
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: ui-dist
+          path: ui/app/dist
       - uses: prometheus/promci/build@42c3c84c865e5c1ab78543b929f7341eb2ef6123 # v0.6.1
         with:
           promu_opts: "-p linux/amd64 -p windows/amd64 -p linux/arm64 -p darwin/amd64 -p darwin/arm64 -p linux/386"
@@ -40,6 +54,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    needs: [test_frontend]
     # Whenever the Go version is updated here, .promu.yml
     # should also be updated.
     container:
@@ -58,14 +73,10 @@ jobs:
       EMAIL_AUTH_CONFIG: testdata/auth.yml
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - id: cache-paths
-        run: echo "npm-cache=$(npm config get cache)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
-          path: ${{ steps.cache-paths.outputs.npm-cache }}
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          name: ui-dist
+          path: ui/app/dist
       - uses: prometheus/promci-setup@5af30ba8c199a91d6c04ebdc3c48e630e355f62d # v0.1.0
       - run: make
       - run: git diff --exit-code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,10 @@ jobs:
     needs: ci
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: ui-dist
+          path: ui/app/dist
       - uses: prometheus/promci/build@42c3c84c865e5c1ab78543b929f7341eb2ef6123 # v0.6.1
         with:
           parallelism: 12

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,11 @@ lint: ui-elm common-lint
 .PHONY: assets
 assets: $(FRONTEND_DIR)/src/Data ui-elm template/email.tmpl
 
+.PHONY: assets-tarball
+assets-tarball: ui-elm
+	mkdir -p .tarballs
+	tar czf ".tarballs/alertmanager-web-ui-$(file <VERSION).tar.gz" -C ui/app dist
+
 .PHONY: ui-elm
 ui-elm:
 	cd $(FRONTEND_DIR) && $(MAKE) build

--- a/ui/app/Makefile
+++ b/ui/app/Makefile
@@ -82,12 +82,13 @@ else
 endif
 
 .PHONY: build
-build: .build_stamp
+build: dist/.build_stamp
 
-.build_stamp: $(ELM_FILES) index.html vite.config.mjs node_modules
+dist/.build_stamp: $(ELM_FILES) index.html vite.config.mjs package-lock.json
 	@echo ">> building frontend"
+	$(MAKE) node_modules
 	$(NPM) run build
-	@touch .build_stamp
+	@touch dist/.build_stamp
 
 src/Data: ../../api/v2/openapi.yaml
 	-rm -rf src/Data src/DateTime.elm
@@ -98,8 +99,8 @@ src/Data: ../../api/v2/openapi.yaml
 	  -v ${PWD}/src:/output/src \
 	  $(OPENAPI_GEN_IMAGE) \
 	  -c 'java -jar /opt/openapi-generator/modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -i /local/api/v2/openapi.yaml -g elm -o /tmp/openapi-gen && cp -r /tmp/openapi-gen/src/Data /output/src/Data && cp /tmp/openapi-gen/src/DateTime.elm /output/src/DateTime.elm'
-	make format
+	$(MAKE) format
 
 .PHONY: clean
 clean:
-	- @rm -rf .build_stamp dist elm-stuff src/Data src/DateTime.elm openapi-* elm-*
+	- @rm -rf dist node_modules elm-stuff src/Data src/DateTime.elm openapi-* elm-*


### PR DESCRIPTION
In https://github.com/prometheus/alertmanager/pull/5113 I removed the build artifacts from our source repo. This complicated the packaging process for downstream maintainers significantly.

We will still not check the artifacts into our repo directly, since this is a burden to the review process and opens us up to attacks such as the https://en.wikipedia.org/wiki/XZ_Utils_backdoor .

Instead we provide two new mechanisms to obtain the artifacts:

* alertmanager-web-ui-(file <VERSION).tar.gz will provide the `dist` folder needed for calling `make build`.
* We will upload artifacts via actions/upload-artifact. These can then be easily retrieved for 90 days using `gh`.

Finally, this commit also ensures that `ui/app/dist` is always available during build steps. The reason is that caching `npm` dependencies is not sufficient: `Elm` will download its files again anyway, since it stores them in `~/.elm`. This causes unnecessary network calls.

Technical approach:

* By moving the validation `.build_stamp` to `dist/`, we don't have to upload that file seperately. `embed` will exclude that file.
* Storing artifacts in `.tarballs` is our method for including files in the release. This approach was directly taken from `prometheus/prometheus`.

#### Pull Request Checklist
- Please list all open issue(s) discussed with maintainers related to this change
    - Relates-to: #5173 Fixes: #5163
- Is this a bugfix?
    - [ ] I have added tests that can reproduce the bug which pass with this bugfix applied
    (Only a manual test on my end).
- [x] I have signed-off my commits
- [x] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

```release-notes
FIX: Provide prebuilt UI assets in release via alertmanager-web-ui-(file <VERSION).tar.gz
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now builds and uploads a reusable frontend distribution artifact used by test, build, and release jobs instead of relying on npm cache.
  * Release workflow downloads and reuses the frontend artifact prior to packaging.
  * Added a Makefile target to produce versioned frontend tarballs for distribution.
  * Frontend build recipes and clean steps updated to track builds reliably and avoid stale artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->