### PR TITLE
refactor(discord): move configuration type into discord package

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -32,6 +32,7 @@ import (
 	amcommoncfg "github.com/prometheus/alertmanager/config/common"
 	"github.com/prometheus/alertmanager/eventrecorder"
 	"github.com/prometheus/alertmanager/matcher/compat"
+	"github.com/prometheus/alertmanager/notify/discord"
 	"github.com/prometheus/alertmanager/notify/webhook"
 	"github.com/prometheus/alertmanager/timeinterval"
 	"github.com/prometheus/alertmanager/tracing"
@@ -939,7 +940,7 @@ type Receiver struct {
 	// A unique identifier for this receiver.
 	Name string `yaml:"name" json:"name"`
 
-	DiscordConfigs    []*DiscordConfig         `yaml:"discord_configs,omitempty" json:"discord_configs,omitempty"`
+	DiscordConfigs    []*discord.DiscordConfig `yaml:"discord_configs,omitempty" json:"discord_configs,omitempty"`
 	EmailConfigs      []*EmailConfig           `yaml:"email_configs,omitempty" json:"email_configs,omitempty"`
 	IncidentioConfigs []*IncidentioConfig      `yaml:"incidentio_configs,omitempty" json:"incidentio_configs,omitempty"`
 	PagerdutyConfigs  []*PagerdutyConfig       `yaml:"pagerduty_configs,omitempty" json:"pagerduty_configs,omitempty"`

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -46,15 +46,6 @@ var (
 		Message: `{{ template "webex.default.message" . }}`,
 	}
 
-	// DefaultDiscordConfig defines default values for Discord configurations.
-	DefaultDiscordConfig = DiscordConfig{
-		NotifierConfig: amcommoncfg.NotifierConfig{
-			VSendResolved: true,
-		},
-		Title:   `{{ template "discord.default.title" . }}`,
-		Message: `{{ template "discord.default.message" . }}`,
-	}
-
 	// DefaultEmailConfig defines default values for Email configurations.
 	DefaultEmailConfig = EmailConfig{
 		NotifierConfig: amcommoncfg.NotifierConfig{
@@ -249,40 +240,6 @@ func (c *WebexConfig) UnmarshalYAML(unmarshal func(any) error) error {
 
 	if c.HTTPConfig == nil || c.HTTPConfig.Authorization == nil {
 		return errors.New("missing webex_configs.http_config.authorization")
-	}
-
-	return nil
-}
-
-// DiscordConfig configures notifications via Discord.
-type DiscordConfig struct {
-	amcommoncfg.NotifierConfig `yaml:",inline" json:",inline"`
-
-	HTTPConfig     *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
-	WebhookURL     *amcommoncfg.SecretURL      `yaml:"webhook_url,omitempty" json:"webhook_url,omitempty"`
-	WebhookURLFile string                      `yaml:"webhook_url_file,omitempty" json:"webhook_url_file,omitempty"`
-
-	Content   string `yaml:"content,omitempty" json:"content,omitempty"`
-	Title     string `yaml:"title,omitempty" json:"title,omitempty"`
-	Message   string `yaml:"message,omitempty" json:"message,omitempty"`
-	Username  string `yaml:"username,omitempty" json:"username,omitempty"`
-	AvatarURL string `yaml:"avatar_url,omitempty" json:"avatar_url,omitempty"`
-}
-
-// UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (c *DiscordConfig) UnmarshalYAML(unmarshal func(any) error) error {
-	*c = DefaultDiscordConfig
-	type plain DiscordConfig
-	if err := unmarshal((*plain)(c)); err != nil {
-		return err
-	}
-
-	if c.WebhookURL == nil && c.WebhookURLFile == "" {
-		return errors.New("one of webhook_url or webhook_url_file must be configured")
-	}
-
-	if c.WebhookURL != nil && len(c.WebhookURLFile) > 0 {
-		return errors.New("at most one of webhook_url & webhook_url_file must be configured")
 	}
 
 	return nil

--- a/notify/discord/config.go
+++ b/notify/discord/config.go
@@ -1,0 +1,65 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discord
+
+import (
+	"errors"
+
+	amcommoncfg "github.com/prometheus/alertmanager/config/common"
+
+	commoncfg "github.com/prometheus/common/config"
+)
+
+// defaultDiscordConfig defines default values for Discord configurations.
+var defaultDiscordConfig = DiscordConfig{
+	NotifierConfig: amcommoncfg.NotifierConfig{
+		VSendResolved: true,
+	},
+	Title:   `{{ template "discord.default.title" . }}`,
+	Message: `{{ template "discord.default.message" . }}`,
+}
+
+// DiscordConfig configures notifications via Discord.
+type DiscordConfig struct {
+	amcommoncfg.NotifierConfig `yaml:",inline" json:",inline"`
+
+	HTTPConfig     *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
+	WebhookURL     *amcommoncfg.SecretURL      `yaml:"webhook_url,omitempty" json:"webhook_url,omitempty"`
+	WebhookURLFile string                      `yaml:"webhook_url_file,omitempty" json:"webhook_url_file,omitempty"`
+
+	Content   string `yaml:"content,omitempty" json:"content,omitempty"`
+	Title     string `yaml:"title,omitempty" json:"title,omitempty"`
+	Message   string `yaml:"message,omitempty" json:"message,omitempty"`
+	Username  string `yaml:"username,omitempty" json:"username,omitempty"`
+	AvatarURL string `yaml:"avatar_url,omitempty" json:"avatar_url,omitempty"`
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (c *DiscordConfig) UnmarshalYAML(unmarshal func(any) error) error {
+	*c = defaultDiscordConfig
+	type plain DiscordConfig
+	if err := unmarshal((*plain)(c)); err != nil {
+		return err
+	}
+
+	if c.WebhookURL == nil && c.WebhookURLFile == "" {
+		return errors.New("one of webhook_url or webhook_url_file must be configured")
+	}
+
+	if c.WebhookURL != nil && len(c.WebhookURLFile) > 0 {
+		return errors.New("at most one of webhook_url & webhook_url_file must be configured")
+	}
+
+	return nil
+}

--- a/notify/discord/discord.go
+++ b/notify/discord/discord.go
@@ -29,7 +29,6 @@ import (
 
 	amcommoncfg "github.com/prometheus/alertmanager/config/common"
 
-	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/alertmanager/types"
@@ -52,7 +51,7 @@ const (
 
 // Notifier implements a Notifier for Discord notifications.
 type Notifier struct {
-	conf       *config.DiscordConfig
+	conf       *DiscordConfig
 	tmpl       *template.Template
 	logger     *slog.Logger
 	client     *http.Client
@@ -61,7 +60,7 @@ type Notifier struct {
 }
 
 // New returns a new Discord notifier.
-func New(c *config.DiscordConfig, t *template.Template, l *slog.Logger, httpOpts ...commoncfg.HTTPClientOption) (*Notifier, error) {
+func New(c *DiscordConfig, t *template.Template, l *slog.Logger, httpOpts ...commoncfg.HTTPClientOption) (*Notifier, error) {
 	client, err := notify.NewClientWithTracing(*c.HTTPConfig, "discord", httpOpts...)
 	if err != nil {
 		return nil, err

--- a/notify/discord/discord_test.go
+++ b/notify/discord/discord_test.go
@@ -31,7 +31,6 @@ import (
 
 	amcommoncfg "github.com/prometheus/alertmanager/config/common"
 
-	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/notify/test"
 	"github.com/prometheus/alertmanager/types"
@@ -42,7 +41,7 @@ var testWebhookURL, _ = url.Parse("https://discord.com/api/webhooks/971139602272
 
 func TestDiscordRetry(t *testing.T) {
 	notifier, err := New(
-		&config.DiscordConfig{
+		&DiscordConfig{
 			WebhookURL: &amcommoncfg.SecretURL{URL: testWebhookURL},
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 		},
@@ -71,14 +70,14 @@ func TestDiscordTemplating(t *testing.T) {
 
 	for _, tc := range []struct {
 		title string
-		cfg   *config.DiscordConfig
+		cfg   *DiscordConfig
 
 		retry  bool
 		errMsg string
 	}{
 		{
 			title: "full-blown message",
-			cfg: &config.DiscordConfig{
+			cfg: &DiscordConfig{
 				Title:   `{{ template "discord.default.title" . }}`,
 				Message: `{{ template "discord.default.message" . }}`,
 			},
@@ -86,14 +85,14 @@ func TestDiscordTemplating(t *testing.T) {
 		},
 		{
 			title: "title with templating errors",
-			cfg: &config.DiscordConfig{
+			cfg: &DiscordConfig{
 				Title: "{{ ",
 			},
 			errMsg: "template: :1: unclosed action",
 		},
 		{
 			title: "message with templating errors",
-			cfg: &config.DiscordConfig{
+			cfg: &DiscordConfig{
 				Title:   `{{ template "discord.default.title" . }}`,
 				Message: "{{ ",
 			},
@@ -137,7 +136,7 @@ func TestDiscordRedactedURL(t *testing.T) {
 
 	secret := "secret"
 	notifier, err := New(
-		&config.DiscordConfig{
+		&DiscordConfig{
 			WebhookURL: &amcommoncfg.SecretURL{URL: u},
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 		},
@@ -159,7 +158,7 @@ func TestDiscordReadingURLFromFile(t *testing.T) {
 	require.NoError(t, err, "writing to temp file failed")
 
 	notifier, err := New(
-		&config.DiscordConfig{
+		&DiscordConfig{
 			WebhookURLFile: f.Name(),
 			HTTPConfig:     &commoncfg.HTTPClientConfig{},
 		},
@@ -193,7 +192,7 @@ func TestDiscord_Notify(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a DiscordConfig with the WebhookURLFile set
-	cfg := &config.DiscordConfig{
+	cfg := &DiscordConfig{
 		WebhookURLFile: tempFile.Name(),
 		HTTPConfig:     &commoncfg.HTTPClientConfig{},
 		Title:          "Test Title",


### PR DESCRIPTION
#### Pull Request Checklist
- [x] I have signed-off my commits
- [x] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/alertmanager/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized Discord notification configuration handling to improve modularity and code organization.

No changes are visible to end-users. Discord notifications continue to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->