### PR TITLE
cmd/alertmanager: add --config.auto-reload-interval flag

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -15,12 +15,16 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/signal"
 	"runtime"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/KimMachineGun/automemlimit/memlimit"
 	"github.com/alecthomas/kingpin/v2"
@@ -48,15 +52,17 @@ func run() int {
 	}
 
 	var (
-		configFile                  = kingpin.Flag("config.file", "Alertmanager configuration file name.").Default("alertmanager.yml").String()
-		dataDir                     = kingpin.Flag("storage.path", "Base path for data storage.").Default("data/").String()
-		retention                   = kingpin.Flag("data.retention", "How long to keep data for.").Default("120h").Duration()
-		maintenanceInterval         = kingpin.Flag("data.maintenance-interval", "Interval between garbage collection and snapshotting to disk of the silences and the notification logs.").Default("15m").Duration()
-		maxSilences                 = kingpin.Flag("silences.max-silences", "Maximum number of silences, including expired silences. If negative or zero, no limit is set.").Default("0").Int()
-		maxSilenceSizeBytes         = kingpin.Flag("silences.max-silence-size-bytes", "Maximum silence size in bytes. If negative or zero, no limit is set.").Default("0").Int()
-		silenceLogging              = kingpin.Flag("log.silences", "Enable logging silences. If it is enabled, the status change of silence will be logged").Bool()
-		alertGCInterval             = kingpin.Flag("alerts.gc-interval", "Interval between alert GC.").Default("30m").Duration()
-		perAlertNameLimit           = kingpin.Flag("alerts.per-alertname-limit", "Maximum number of alerts per alertname. If negative or zero, no limit is set.").Default("0").Int()
+		configFile               = kingpin.Flag("config.file", "Alertmanager configuration file name.").Default("alertmanager.yml").String()
+		configAutoReloadInterval = kingpin.Flag("config.auto-reload-interval", "Interval for checking and automatically reloading the Alertmanager configuration file. Set to 0 to disable.").Default("0s").Duration()
+		dataDir                  = kingpin.Flag("storage.path", "Base path for data storage.").Default("data/").String()
+		retention                = kingpin.Flag("data.retention", "How long to keep data for.").Default("120h").Duration()
+		maintenanceInterval      = kingpin.Flag("data.maintenance-interval", "Interval between garbage collection and snapshotting to disk of the silences and the notification logs.").Default("15m").Duration()
+		maxSilences              = kingpin.Flag("silences.max-silences", "Maximum number of silences, including expired silences. If negative or zero, no limit is set.").Default("0").Int()
+		maxSilenceSizeBytes      = kingpin.Flag("silences.max-silence-size-bytes", "Maximum silence size in bytes. If negative or zero, no limit is set.").Default("0").Int()
+		silenceLogging           = kingpin.Flag("log.silences", "Enable logging silences. If it is enabled, the status change of silence will be logged").Bool()
+		alertGCInterval          = kingpin.Flag("alerts.gc-interval", "Interval between alert GC.").Default("30m").Duration()
+		perAlertNameLimit        = kingpin.Flag("alerts.per-alertname-limit", "Maximum number of alerts per alertname. If negative or zero, no limit is set.").Default("0").Int()
+
 		dispatchMaintenanceInterval = kingpin.Flag("dispatch.maintenance-interval", "Interval between maintenance of aggregation groups in the dispatcher.").Default("30s").Duration()
 		dispatchStartDelay          = kingpin.Flag("dispatch.start-delay", "Minimum amount of time to wait before dispatching alerts. This option should be synced with value of --rules.alert.resend-delay on Prometheus.").Default("0s").Duration()
 
@@ -151,6 +157,18 @@ func run() int {
 		}
 	}()
 
+	// Start the auto-reload watcher if the interval is non-zero.
+	if *configAutoReloadInterval > 0 {
+		if *clusterBindAddr != "" {
+			// In cluster mode each node reloads independently, which can
+			// lead to nodes temporarily serving different configurations.
+			// Warn so operators can take this into account.
+			logger.Warn("--config.auto-reload-interval is set with cluster mode enabled; nodes may reload at different times and temporarily serve different configurations", "interval", *configAutoReloadInterval)
+		}
+		logger.Info("Auto-reload enabled: checking for configuration changes", "interval", *configAutoReloadInterval, "file", *configFile)
+		go runConfigWatcher(ctx, *configFile, *configAutoReloadInterval, reload, logger)
+	}
+
 	opts := app.Options{
 		ConfigFile:                  *configFile,
 		DataDir:                     *dataDir,
@@ -200,4 +218,75 @@ func run() int {
 	}
 	logger.Info("Received shutdown signal, exiting gracefully...")
 	return 0
+}
+
+// configFileChecksum reads the file at path and returns its SHA256 hex digest.
+// It returns an error if the file cannot be read.
+func configFileChecksum(path string) (string, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("reading config file for checksum: %w", err)
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// runConfigWatcher polls the config file checksum every interval and triggers
+// a reload via reloadCh when a change is detected. It exits when ctx is
+// cancelled. Interval must be > 0; callers are responsible for checking this.
+func runConfigWatcher(
+	ctx context.Context,
+	configFile string,
+	interval time.Duration,
+	reloadCh chan<- struct{},
+	logger *slog.Logger,
+) {
+	// Compute the initial checksum at startup so we only reload on *changes*,
+	// not on the first tick unconditionally.
+	lastChecksum, err := configFileChecksum(configFile)
+	hasChecksum := err == nil
+	if err != nil {
+		// Log but don't abort - the coordinator already validated the file at
+		// startup, so this is a transient read error. We'll retry next tick.
+		logger.Warn("Auto-reload: failed to compute initial config checksum", "file", configFile, "err", err)
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			logger.Info("Auto-reload: watcher stopped", "file", configFile)
+			return
+		case <-ticker.C:
+			checksum, err := configFileChecksum(configFile)
+			if err != nil {
+				logger.Warn("Auto-reload: failed to read config file", "file", configFile, "err", err)
+				continue // don't update lastChecksum; retry next tick
+			}
+
+			if !hasChecksum {
+				// Startup read failed; seed the baseline now without reloading.
+				lastChecksum = checksum
+				hasChecksum = true
+				continue
+			}
+
+			if checksum == lastChecksum {
+				continue // no change
+			}
+
+			logger.Info("Auto-reload: config file changed, reloading", "file", configFile)
+
+			// Trigger a reload via the same channel used by SIGHUP. Non-blocking
+			// send: if a reload is already queued, skip and try again next tick.
+			select {
+			case reloadCh <- struct{}{}:
+				lastChecksum = checksum
+			default:
+				// Reload already pending; try again on the next tick.
+			}
+		}
+	}
 }

--- a/cmd/alertmanager/main_test.go
+++ b/cmd/alertmanager/main_test.go
@@ -1,0 +1,194 @@
+// Copyright 2019 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigFileChecksum_ReturnsConsistentHash(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "alertmanager.yml")
+	require.NoError(t, os.WriteFile(path, []byte("content: a"), 0o644))
+
+	sum1, err := configFileChecksum(path)
+	require.NoError(t, err)
+	sum2, err := configFileChecksum(path)
+	require.NoError(t, err)
+
+	require.Equal(t, sum1, sum2, "same content should produce same checksum")
+}
+
+func TestConfigFileChecksum_DifferentContentDifferentHash(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "alertmanager.yml")
+
+	require.NoError(t, os.WriteFile(path, []byte("content: a"), 0o644))
+	sumA, err := configFileChecksum(path)
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(path, []byte("content: b"), 0o644))
+	sumB, err := configFileChecksum(path)
+	require.NoError(t, err)
+
+	require.NotEqual(t, sumA, sumB, "different content must produce different checksum")
+}
+
+func TestConfigFileChecksum_MissingFileReturnsError(t *testing.T) {
+	_, err := configFileChecksum("/nonexistent/path/alertmanager.yml")
+	require.Error(t, err)
+}
+
+func TestRunConfigWatcher_NoReloadWhenFileUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "alertmanager.yml")
+	require.NoError(t, os.WriteFile(path, []byte("route:\n  receiver: default\n"), 0o644))
+
+	reloadCh := make(chan struct{}, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	go runConfigWatcher(ctx, path, 50*time.Millisecond, reloadCh, slog.Default())
+
+	// Let the watcher run for at least 3 ticks.
+	<-ctx.Done()
+
+	// reloadCh must be empty - no reload should have been triggered.
+	require.Empty(t, reloadCh, "no reload expected when file is unchanged")
+}
+
+func TestRunConfigWatcher_TriggersReloadOnChange(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "alertmanager.yml")
+	require.NoError(t, os.WriteFile(path, []byte("original"), 0o644))
+
+	reloadCh := make(chan struct{}, 1)
+	ctx := t.Context()
+
+	go runConfigWatcher(ctx, path, 30*time.Millisecond, reloadCh, slog.Default())
+
+	// Wait one tick to let the initial checksum be set.
+	time.Sleep(50 * time.Millisecond)
+
+	// Change the file.
+	require.NoError(t, os.WriteFile(path, []byte("changed"), 0o644))
+
+	// Wait for the watcher to detect the change and send to reloadCh.
+	select {
+	case <-reloadCh:
+		// Reload triggered.
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("timed out waiting for reload signal after file change")
+	}
+}
+
+func TestRunConfigWatcher_DoesNotRetriggerAfterSuccessfulReload(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "alertmanager.yml")
+	require.NoError(t, os.WriteFile(path, []byte("original"), 0o644))
+
+	reloadCh := make(chan struct{}, 2) // buffer=2 to catch any spurious second reload
+	ctx := t.Context()
+
+	go runConfigWatcher(ctx, path, 30*time.Millisecond, reloadCh, slog.Default())
+
+	time.Sleep(50 * time.Millisecond) // allow initial checksum to be set
+
+	// Change the file once.
+	require.NoError(t, os.WriteFile(path, []byte("changed"), 0o644))
+
+	// Consume the first (expected) reload.
+	select {
+	case <-reloadCh:
+		// Reload received.
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("expected first reload not received")
+	}
+
+	// Let a few ticks pass - file is unchanged so no second reload should come.
+	time.Sleep(150 * time.Millisecond)
+
+	require.Empty(t, reloadCh, "no second reload expected after successful reload of same content")
+}
+
+func TestRunConfigWatcher_HandlesUnreadableFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "alertmanager.yml")
+	require.NoError(t, os.WriteFile(path, []byte("original"), 0o644))
+
+	reloadCh := make(chan struct{}, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	go runConfigWatcher(ctx, path, 30*time.Millisecond, reloadCh, slog.Default())
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Remove the file to simulate a transient read failure.
+	require.NoError(t, os.Remove(path))
+
+	// Watcher should log a warning but NOT send to reloadCh.
+	<-ctx.Done()
+	require.Empty(t, reloadCh, "no reload expected when file is unreadable")
+}
+
+func TestRunConfigWatcher_SeedsChecksumAfterStartupFailure(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "alertmanager.yml")
+
+	// The file does not exist at startup, so the initial checksum read will fail.
+	reloadCh := make(chan struct{}, 1)
+	ctx := t.Context()
+
+	go runConfigWatcher(ctx, path, 30*time.Millisecond, reloadCh, slog.Default())
+
+	// Create the file after the watcher has started.
+	time.Sleep(50 * time.Millisecond)
+	require.NoError(t, os.WriteFile(path, []byte("content"), 0o644))
+
+	// The first successful tick should seed the checksum without reloading.
+	time.Sleep(100 * time.Millisecond)
+	require.Empty(t, reloadCh, "no reload expected when seeding baseline after startup failure")
+}
+
+func TestRunConfigWatcher_ExitsWhenContextCancelled(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "alertmanager.yml")
+	require.NoError(t, os.WriteFile(path, []byte("content"), 0o644))
+
+	reloadCh := make(chan struct{}, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		runConfigWatcher(ctx, path, 30*time.Millisecond, reloadCh, slog.Default())
+		close(done)
+	}()
+
+	cancel() // Cancel immediately.
+
+	select {
+	case <-done:
+		// Watcher exited cleanly.
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("watcher goroutine did not exit after context cancellation")
+	}
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,6 +20,22 @@ is not well-formed, the changes will not be applied and an error is logged.
 A configuration reload is triggered by sending a `SIGHUP` to the process or
 sending an HTTP POST request to the `/-/reload` endpoint.
 
+## Auto-reload
+
+To have Alertmanager automatically reload its configuration when the file
+changes on disk, set `--config.auto-reload-interval` to a non-zero duration.
+Alertmanager will poll the file for changes at that interval and apply the new
+configuration if it detects a difference. The feature is off by default.
+
+```bash
+alertmanager --config.file=alertmanager.yml --config.auto-reload-interval=30s
+```
+
+This is especially useful in Kubernetes where ConfigMaps and Secrets are
+updated through mounted files. The reload follows the same code path as
+`SIGHUP` and `POST /-/reload`, so an invalid configuration is rejected and
+logged without affecting the running configuration.
+
 ## Limits
 
 Alertmanager supports a number of configurable limits via command-line flags.

--- a/docs/management_api.md
+++ b/docs/management_api.md
@@ -35,3 +35,7 @@ POST /-/reload
 This endpoint triggers a reload of the Alertmanager configuration file.
 
 An alternative way to trigger a configuration reload is by sending a `SIGHUP` to the Alertmanager process.
+
+Configuration can also be reloaded automatically on file change using the
+`--config.auto-reload-interval` flag. See the
+[configuration documentation](configuration.md) for details.


### PR DESCRIPTION
## Description

Adds a `--config.auto-reload-interval` flag. When set to a non-zero duration, a background goroutine polls the SHA256 checksum of the config file at the given interval and writes to the existing `webReload` channel on a detected change — the same path taken by `SIGHUP` and `POST /-/reload` — so no new reload logic is introduced.

**Why polling instead of fsnotify?**
Kubernetes `kubelet` uses `AtomicWriter` to update ConfigMap and Secret volume mounts via symlink swaps, which causes fsnotify to stop receiving events after the first update since the original inode is replaced. SHA256 polling works correctly regardless of how the underlying file is updated, which is also why Prometheus uses polling for its equivalent feature.

## Behaviour

- Default is `0s` (disabled). Existing deployments are completely unaffected.
- On a detected change, the reload follows the same code path as `SIGHUP`/`POST /-/reload`: invalid configs are rejected and logged without disrupting the running instance.
- If a reload fails, `lastChecksum` is not updated, so the watcher retries on every subsequent tick until the configuration is valid again.
- The watcher goroutine exits cleanly on `SIGTERM`.

## Changes

| File | Description |
|---|---|
| `cmd/alertmanager/main.go` | New flag, `configFileChecksum()` helper, `runConfigWatcher()` goroutine, watcher start block in `run()` |
| `cmd/alertmanager/main_test.go` | 8 unit tests covering all edge cases |
| `docs/configuration.md` | New auto-reload section |
| `docs/management_api.md` | Cross-reference added under the reload section |

fixes #5197