### PR TITLE
refactor: move Slack types to their own file

### DIFF
--- a/notify/slack/slack.go
+++ b/notify/slack/slack.go
@@ -36,17 +36,6 @@ import (
 // https://api.slack.com/reference/messaging/attachments#legacy_fields - 1024, no units given, assuming runes or characters.
 const maxTitleLenRunes = 1024
 
-// Notifier implements a Notifier for Slack notifications.
-type Notifier struct {
-	conf    *config.SlackConfig
-	tmpl    *template.Template
-	logger  *slog.Logger
-	client  *http.Client
-	retrier *notify.Retrier
-
-	postJSONFunc func(ctx context.Context, client *http.Client, url string, body io.Reader) (*http.Response, error)
-}
-
 // New returns a new Slack notification handler.
 func New(c *config.SlackConfig, t *template.Template, l *slog.Logger, httpOpts ...commoncfg.HTTPClientOption) (*Notifier, error) {
 	client, err := notify.NewClientWithTracing(*c.HTTPConfig, "slack", httpOpts...)
@@ -62,43 +51,6 @@ func New(c *config.SlackConfig, t *template.Template, l *slog.Logger, httpOpts .
 		retrier:      &notify.Retrier{},
 		postJSONFunc: notify.PostJSON,
 	}, nil
-}
-
-// request is the request for sending a slack notification.
-type request struct {
-	Channel     string       `json:"channel,omitempty"`
-	Timestamp   string       `json:"ts,omitempty"`
-	Username    string       `json:"username,omitempty"`
-	IconEmoji   string       `json:"icon_emoji,omitempty"`
-	IconURL     string       `json:"icon_url,omitempty"`
-	LinkNames   bool         `json:"link_names,omitempty"`
-	Text        string       `json:"text,omitempty"`
-	Attachments []attachment `json:"attachments"`
-}
-
-// attachment is used to display a richly-formatted message block.
-type attachment struct {
-	Title      string               `json:"title,omitempty"`
-	TitleLink  string               `json:"title_link,omitempty"`
-	Pretext    string               `json:"pretext,omitempty"`
-	Text       string               `json:"text"`
-	Fallback   string               `json:"fallback"`
-	CallbackID string               `json:"callback_id"`
-	Fields     []config.SlackField  `json:"fields,omitempty"`
-	Actions    []config.SlackAction `json:"actions,omitempty"`
-	ImageURL   string               `json:"image_url,omitempty"`
-	ThumbURL   string               `json:"thumb_url,omitempty"`
-	Footer     string               `json:"footer"`
-	Color      string               `json:"color,omitempty"`
-	MrkdwnIn   []string             `json:"mrkdwn_in,omitempty"`
-}
-
-// slackResponse represents the response from Slack API.
-type slackResponse struct {
-	OK        bool   `json:"ok"`
-	Error     string `json:"error,omitempty"`
-	Channel   string `json:"channel,omitempty"`
-	Timestamp string `json:"ts,omitempty"`
 }
 
 // Notify implements the Notifier interface.

--- a/notify/slack/types.go
+++ b/notify/slack/types.go
@@ -1,0 +1,73 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package slack
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/prometheus/alertmanager/config"
+	"github.com/prometheus/alertmanager/notify"
+	"github.com/prometheus/alertmanager/template"
+)
+
+// Notifier implements a Notifier for Slack notifications.
+type Notifier struct {
+	conf    *config.SlackConfig
+	tmpl    *template.Template
+	logger  *slog.Logger
+	client  *http.Client
+	retrier *notify.Retrier
+
+	postJSONFunc func(ctx context.Context, client *http.Client, url string, body io.Reader) (*http.Response, error)
+}
+
+// request is the request for sending a Slack notification.
+type request struct {
+	Channel     string       `json:"channel,omitempty"`
+	Timestamp   string       `json:"ts,omitempty"`
+	Username    string       `json:"username,omitempty"`
+	IconEmoji   string       `json:"icon_emoji,omitempty"`
+	IconURL     string       `json:"icon_url,omitempty"`
+	LinkNames   bool         `json:"link_names,omitempty"`
+	Text        string       `json:"text,omitempty"`
+	Attachments []attachment `json:"attachments"`
+}
+
+// attachment is used to display a richly formatted message block.
+type attachment struct {
+	Title      string               `json:"title,omitempty"`
+	TitleLink  string               `json:"title_link,omitempty"`
+	Pretext    string               `json:"pretext,omitempty"`
+	Text       string               `json:"text"`
+	Fallback   string               `json:"fallback"`
+	CallbackID string               `json:"callback_id"`
+	Fields     []config.SlackField  `json:"fields,omitempty"`
+	Actions    []config.SlackAction `json:"actions,omitempty"`
+	ImageURL   string               `json:"image_url,omitempty"`
+	ThumbURL   string               `json:"thumb_url,omitempty"`
+	Footer     string               `json:"footer"`
+	Color      string               `json:"color,omitempty"`
+	MrkdwnIn   []string             `json:"mrkdwn_in,omitempty"`
+}
+
+// slackResponse represents the response from Slack API.
+type slackResponse struct {
+	OK        bool   `json:"ok"`
+	Error     string `json:"error,omitempty"`
+	Channel   string `json:"channel,omitempty"`
+	Timestamp string `json:"ts,omitempty"`
+}


### PR DESCRIPTION
This is the first in a series of PRs that together implement threaded message support for the Slack notifier. The full picture is available in #5150.

## Summary

Extracts the Slack notifier's internal types (`Notifier`, `request`, `attachment`, `slackResponse`) from `slack.go` into a dedicated `types.go` file. No behavioral changes.

### Doc-comment improvements

While moving the types, two doc comments were tightened:
- `request`: `"slack notification"` → `"Slack notification"`
- `attachment`: `"richly-formatted message block"` → `"richly formatted message block"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slack notification support added: configurable settings, template-based message rendering, logging, HTTP client and retry behavior, plus a pluggable delivery hook.
* **Refactor**
  * Notification module reorganized for clearer structure and maintainability; no changes to existing Slack delivery behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/prometheus/alertmanager/pull/5224?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->