### PR TITLE
refactor(incidentio): move configuration type into incidentio package

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,7 @@ import (
 	"github.com/prometheus/alertmanager/eventrecorder"
 	"github.com/prometheus/alertmanager/matcher/compat"
 	"github.com/prometheus/alertmanager/notify/discord"
+	"github.com/prometheus/alertmanager/notify/incidentio"
 	"github.com/prometheus/alertmanager/notify/webhook"
 	"github.com/prometheus/alertmanager/timeinterval"
 	"github.com/prometheus/alertmanager/tracing"
@@ -940,24 +941,24 @@ type Receiver struct {
 	// A unique identifier for this receiver.
 	Name string `yaml:"name" json:"name"`
 
-	DiscordConfigs    []*discord.DiscordConfig `yaml:"discord_configs,omitempty" json:"discord_configs,omitempty"`
-	EmailConfigs      []*EmailConfig           `yaml:"email_configs,omitempty" json:"email_configs,omitempty"`
-	IncidentioConfigs []*IncidentioConfig      `yaml:"incidentio_configs,omitempty" json:"incidentio_configs,omitempty"`
-	PagerdutyConfigs  []*PagerdutyConfig       `yaml:"pagerduty_configs,omitempty" json:"pagerduty_configs,omitempty"`
-	SlackConfigs      []*SlackConfig           `yaml:"slack_configs,omitempty" json:"slack_configs,omitempty"`
-	WebhookConfigs    []*webhook.WebhookConfig `yaml:"webhook_configs,omitempty" json:"webhook_configs,omitempty"`
-	OpsGenieConfigs   []*OpsGenieConfig        `yaml:"opsgenie_configs,omitempty" json:"opsgenie_configs,omitempty"`
-	WechatConfigs     []*WechatConfig          `yaml:"wechat_configs,omitempty" json:"wechat_configs,omitempty"`
-	PushoverConfigs   []*PushoverConfig        `yaml:"pushover_configs,omitempty" json:"pushover_configs,omitempty"`
-	VictorOpsConfigs  []*VictorOpsConfig       `yaml:"victorops_configs,omitempty" json:"victorops_configs,omitempty"`
-	SNSConfigs        []*SNSConfig             `yaml:"sns_configs,omitempty" json:"sns_configs,omitempty"`
-	TelegramConfigs   []*TelegramConfig        `yaml:"telegram_configs,omitempty" json:"telegram_configs,omitempty"`
-	WebexConfigs      []*WebexConfig           `yaml:"webex_configs,omitempty" json:"webex_configs,omitempty"`
-	MSTeamsConfigs    []*MSTeamsConfig         `yaml:"msteams_configs,omitempty" json:"msteams_configs,omitempty"`
-	MSTeamsV2Configs  []*MSTeamsV2Config       `yaml:"msteamsv2_configs,omitempty" json:"msteamsv2_configs,omitempty"`
-	JiraConfigs       []*JiraConfig            `yaml:"jira_configs,omitempty" json:"jira_configs,omitempty"`
-	RocketchatConfigs []*RocketchatConfig      `yaml:"rocketchat_configs,omitempty" json:"rocketchat_configs,omitempty"`
-	MattermostConfigs []*MattermostConfig      `yaml:"mattermost_configs,omitempty" json:"mattermost_configs,omitempty"`
+	DiscordConfigs    []*discord.DiscordConfig       `yaml:"discord_configs,omitempty" json:"discord_configs,omitempty"`
+	EmailConfigs      []*EmailConfig                 `yaml:"email_configs,omitempty" json:"email_configs,omitempty"`
+	IncidentioConfigs []*incidentio.IncidentioConfig `yaml:"incidentio_configs,omitempty" json:"incidentio_configs,omitempty"`
+	PagerdutyConfigs  []*PagerdutyConfig             `yaml:"pagerduty_configs,omitempty" json:"pagerduty_configs,omitempty"`
+	SlackConfigs      []*SlackConfig                 `yaml:"slack_configs,omitempty" json:"slack_configs,omitempty"`
+	WebhookConfigs    []*webhook.WebhookConfig       `yaml:"webhook_configs,omitempty" json:"webhook_configs,omitempty"`
+	OpsGenieConfigs   []*OpsGenieConfig              `yaml:"opsgenie_configs,omitempty" json:"opsgenie_configs,omitempty"`
+	WechatConfigs     []*WechatConfig                `yaml:"wechat_configs,omitempty" json:"wechat_configs,omitempty"`
+	PushoverConfigs   []*PushoverConfig              `yaml:"pushover_configs,omitempty" json:"pushover_configs,omitempty"`
+	VictorOpsConfigs  []*VictorOpsConfig             `yaml:"victorops_configs,omitempty" json:"victorops_configs,omitempty"`
+	SNSConfigs        []*SNSConfig                   `yaml:"sns_configs,omitempty" json:"sns_configs,omitempty"`
+	TelegramConfigs   []*TelegramConfig              `yaml:"telegram_configs,omitempty" json:"telegram_configs,omitempty"`
+	WebexConfigs      []*WebexConfig                 `yaml:"webex_configs,omitempty" json:"webex_configs,omitempty"`
+	MSTeamsConfigs    []*MSTeamsConfig               `yaml:"msteams_configs,omitempty" json:"msteams_configs,omitempty"`
+	MSTeamsV2Configs  []*MSTeamsV2Config             `yaml:"msteamsv2_configs,omitempty" json:"msteamsv2_configs,omitempty"`
+	JiraConfigs       []*JiraConfig                  `yaml:"jira_configs,omitempty" json:"jira_configs,omitempty"`
+	RocketchatConfigs []*RocketchatConfig            `yaml:"rocketchat_configs,omitempty" json:"rocketchat_configs,omitempty"`
+	MattermostConfigs []*MattermostConfig            `yaml:"mattermost_configs,omitempty" json:"mattermost_configs,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for Receiver.

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -31,12 +31,6 @@ import (
 )
 
 var (
-	// DefaultIncidentioConfig defines default values for Incident.io configurations.
-	DefaultIncidentioConfig = IncidentioConfig{
-		NotifierConfig: amcommoncfg.NotifierConfig{
-			VSendResolved: true,
-		},
-	}
 
 	// DefaultWebexConfig defines default values for Webex configurations.
 	DefaultWebexConfig = WebexConfig{
@@ -536,58 +530,6 @@ func (c *SlackConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		return errors.New("update_message can only be used with bot tokens. api_url must be set to https://slack.com/api/chat.postMessage")
 	}
 
-	return nil
-}
-
-// IncidentioConfig configures notifications via incident.io.
-type IncidentioConfig struct {
-	amcommoncfg.NotifierConfig `yaml:",inline" json:",inline"`
-
-	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
-
-	// URL to send POST request to.
-	URL     *amcommoncfg.URL `yaml:"url" json:"url"`
-	URLFile string           `yaml:"url_file" json:"url_file"`
-
-	// AlertSourceToken is the key used to authenticate with the alert source in incident.io.
-	AlertSourceToken     commoncfg.Secret `yaml:"alert_source_token,omitempty" json:"alert_source_token,omitempty"`
-	AlertSourceTokenFile string           `yaml:"alert_source_token_file,omitempty" json:"alert_source_token_file,omitempty"`
-
-	// MaxAlerts is the maximum number of alerts to be sent per incident.io message.
-	// Alerts exceeding this threshold will be truncated. Setting this to 0
-	// allows an unlimited number of alerts. Note that if the payload exceeds
-	// incident.io's size limits, you will receive a 429 response and alerts
-	// will not be ingested.
-	MaxAlerts uint64 `yaml:"max_alerts" json:"max_alerts"`
-
-	// Timeout is the maximum time allowed to invoke incident.io. Setting this to 0
-	// does not impose a timeout.
-	Timeout time.Duration `yaml:"timeout" json:"timeout"`
-}
-
-// UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (c *IncidentioConfig) UnmarshalYAML(unmarshal func(any) error) error {
-	*c = DefaultIncidentioConfig
-	type plain IncidentioConfig
-	if err := unmarshal((*plain)(c)); err != nil {
-		return err
-	}
-	if c.URL == nil && c.URLFile == "" {
-		return errors.New("one of url or url_file must be configured")
-	}
-	if c.URL != nil && c.URLFile != "" {
-		return errors.New("at most one of url & url_file must be configured")
-	}
-	if c.AlertSourceToken != "" && c.AlertSourceTokenFile != "" {
-		return errors.New("at most one of alert_source_token & alert_source_token_file must be configured")
-	}
-	if c.HTTPConfig != nil && c.HTTPConfig.Authorization != nil && (c.AlertSourceToken != "" || c.AlertSourceTokenFile != "") {
-		return errors.New("cannot specify alert_source_token or alert_source_token_file when using http_config.authorization")
-	}
-
-	if (c.HTTPConfig != nil && c.HTTPConfig.Authorization == nil) && c.AlertSourceToken == "" && c.AlertSourceTokenFile == "" {
-		return errors.New("at least one of alert_source_token, alert_source_token_file or http_config.authorization must be configured")
-	}
 	return nil
 }
 

--- a/notify/incidentio/config.go
+++ b/notify/incidentio/config.go
@@ -1,0 +1,82 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package incidentio
+
+import (
+	"errors"
+	"time"
+
+	amcommoncfg "github.com/prometheus/alertmanager/config/common"
+
+	commoncfg "github.com/prometheus/common/config"
+)
+
+// defaultIncidentioConfig defines default values for Incident.io configurations.
+var defaultIncidentioConfig = IncidentioConfig{
+	NotifierConfig: amcommoncfg.NotifierConfig{
+		VSendResolved: true,
+	},
+}
+
+// IncidentioConfig configures notifications via incident.io.
+type IncidentioConfig struct {
+	amcommoncfg.NotifierConfig `yaml:",inline" json:",inline"`
+
+	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
+
+	// URL to send POST request to.
+	URL     *amcommoncfg.URL `yaml:"url" json:"url"`
+	URLFile string           `yaml:"url_file" json:"url_file"`
+
+	// AlertSourceToken is the key used to authenticate with the alert source in incident.io.
+	AlertSourceToken     commoncfg.Secret `yaml:"alert_source_token,omitempty" json:"alert_source_token,omitempty"`
+	AlertSourceTokenFile string           `yaml:"alert_source_token_file,omitempty" json:"alert_source_token_file,omitempty"`
+
+	// MaxAlerts is the maximum number of alerts to be sent per incident.io message.
+	// Alerts exceeding this threshold will be truncated. Setting this to 0
+	// allows an unlimited number of alerts. Note that if the payload exceeds
+	// incident.io's size limits, you will receive a 429 response and alerts
+	// will not be ingested.
+	MaxAlerts uint64 `yaml:"max_alerts" json:"max_alerts"`
+
+	// Timeout is the maximum time allowed to invoke incident.io. Setting this to 0
+	// does not impose a timeout.
+	Timeout time.Duration `yaml:"timeout" json:"timeout"`
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (c *IncidentioConfig) UnmarshalYAML(unmarshal func(any) error) error {
+	*c = defaultIncidentioConfig
+	type plain IncidentioConfig
+	if err := unmarshal((*plain)(c)); err != nil {
+		return err
+	}
+	if c.URL == nil && c.URLFile == "" {
+		return errors.New("one of url or url_file must be configured")
+	}
+	if c.URL != nil && c.URLFile != "" {
+		return errors.New("at most one of url & url_file must be configured")
+	}
+	if c.AlertSourceToken != "" && c.AlertSourceTokenFile != "" {
+		return errors.New("at most one of alert_source_token & alert_source_token_file must be configured")
+	}
+	if c.HTTPConfig != nil && c.HTTPConfig.Authorization != nil && (c.AlertSourceToken != "" || c.AlertSourceTokenFile != "") {
+		return errors.New("cannot specify alert_source_token or alert_source_token_file when using http_config.authorization")
+	}
+
+	if (c.HTTPConfig != nil && c.HTTPConfig.Authorization == nil) && c.AlertSourceToken == "" && c.AlertSourceTokenFile == "" {
+		return errors.New("at least one of alert_source_token, alert_source_token_file or http_config.authorization must be configured")
+	}
+	return nil
+}

--- a/notify/incidentio/incidentio.go
+++ b/notify/incidentio/incidentio.go
@@ -26,7 +26,6 @@ import (
 
 	commoncfg "github.com/prometheus/common/config"
 
-	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/alertmanager/types"
@@ -39,7 +38,7 @@ const (
 
 // Notifier implements a Notifier for incident.io.
 type Notifier struct {
-	conf    *config.IncidentioConfig
+	conf    *IncidentioConfig
 	tmpl    *template.Template
 	logger  *slog.Logger
 	client  *http.Client
@@ -47,7 +46,7 @@ type Notifier struct {
 }
 
 // New returns a new incident.io notifier.
-func New(conf *config.IncidentioConfig, t *template.Template, l *slog.Logger, httpOpts ...commoncfg.HTTPClientOption) (*Notifier, error) {
+func New(conf *IncidentioConfig, t *template.Template, l *slog.Logger, httpOpts ...commoncfg.HTTPClientOption) (*Notifier, error) {
 	// conf.HTTPConfig is likely to be the global shared HTTPConfig, so we take a
 	// copy to avoid modifying it.
 	httpConfig := *conf.HTTPConfig

--- a/notify/incidentio/incidentio_test.go
+++ b/notify/incidentio/incidentio_test.go
@@ -32,7 +32,6 @@ import (
 
 	amcommoncfg "github.com/prometheus/alertmanager/config/common"
 
-	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/notify/test"
 	"github.com/prometheus/alertmanager/types"
@@ -40,7 +39,7 @@ import (
 
 func TestIncidentIORetry(t *testing.T) {
 	notifier, err := New(
-		&config.IncidentioConfig{
+		&IncidentioConfig{
 			URL:              &amcommoncfg.URL{URL: &url.URL{Scheme: "https", Host: "example.com"}},
 			HTTPConfig:       &commoncfg.HTTPClientConfig{},
 			AlertSourceToken: "test-token",
@@ -62,7 +61,7 @@ func TestIncidentIORedactedURL(t *testing.T) {
 	defer fn()
 
 	notifier, err := New(
-		&config.IncidentioConfig{
+		&IncidentioConfig{
 			URL:              &amcommoncfg.URL{URL: u},
 			HTTPConfig:       &commoncfg.HTTPClientConfig{},
 			AlertSourceToken: "test-token",
@@ -85,7 +84,7 @@ func TestIncidentIOURLFromFile(t *testing.T) {
 	require.NoError(t, err, "writing to temp file failed")
 
 	notifier, err := New(
-		&config.IncidentioConfig{
+		&IncidentioConfig{
 			URLFile:          f.Name(),
 			HTTPConfig:       &commoncfg.HTTPClientConfig{},
 			AlertSourceToken: "test-token",
@@ -138,7 +137,7 @@ func TestIncidentIONotify(t *testing.T) {
 	require.NoError(t, err)
 
 	notifier, err := New(
-		&config.IncidentioConfig{
+		&IncidentioConfig{
 			URL:              &amcommoncfg.URL{URL: u},
 			HTTPConfig:       &commoncfg.HTTPClientConfig{},
 			AlertSourceToken: "test-token",
@@ -219,7 +218,7 @@ func TestIncidentIORetryScenarios(t *testing.T) {
 			require.NoError(t, err)
 
 			notifier, err := New(
-				&config.IncidentioConfig{
+				&IncidentioConfig{
 					URL:              &amcommoncfg.URL{URL: u},
 					HTTPConfig:       &commoncfg.HTTPClientConfig{},
 					AlertSourceToken: "test-token",
@@ -308,7 +307,7 @@ func TestIncidentIOPayloadTruncation(t *testing.T) {
 	logger := promslog.NewNopLogger()
 
 	notifier, err := New(
-		&config.IncidentioConfig{
+		&IncidentioConfig{
 			URL:              &amcommoncfg.URL{URL: &url.URL{Scheme: "https", Host: "example.com"}},
 			HTTPConfig:       &commoncfg.HTTPClientConfig{},
 			AlertSourceToken: "test-token",
@@ -384,7 +383,7 @@ func TestIncidentIOPayloadTruncationWithLabelTruncation(t *testing.T) {
 	logger := promslog.NewNopLogger()
 
 	notifier, err := New(
-		&config.IncidentioConfig{
+		&IncidentioConfig{
 			URL:              &amcommoncfg.URL{URL: &url.URL{Scheme: "https", Host: "example.com"}},
 			HTTPConfig:       &commoncfg.HTTPClientConfig{},
 			AlertSourceToken: "test-token",


### PR DESCRIPTION
#### Pull Request Checklist
- [x] I have signed-off my commits
- [x] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/alertmanager/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized Incident.io notifier configuration into a dedicated module, moving defaults and validation to the notifier package while preserving existing behavior.

* **Bug Fixes / Validation**
  * Tightened config validation: require exactly one endpoint, enforce token-source exclusivity, and reject conflicting auth settings to prevent misconfiguration.

* **Tests**
  * Updated notifier tests to match the new configuration placement without changing runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->