### PR TITLE
refactor(jira): move configuration types into jira package

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -34,6 +34,7 @@ import (
 	"github.com/prometheus/alertmanager/matcher/compat"
 	"github.com/prometheus/alertmanager/notify/discord"
 	"github.com/prometheus/alertmanager/notify/incidentio"
+	"github.com/prometheus/alertmanager/notify/jira"
 	"github.com/prometheus/alertmanager/notify/webhook"
 	"github.com/prometheus/alertmanager/timeinterval"
 	"github.com/prometheus/alertmanager/tracing"
@@ -956,7 +957,7 @@ type Receiver struct {
 	WebexConfigs      []*WebexConfig                 `yaml:"webex_configs,omitempty" json:"webex_configs,omitempty"`
 	MSTeamsConfigs    []*MSTeamsConfig               `yaml:"msteams_configs,omitempty" json:"msteams_configs,omitempty"`
 	MSTeamsV2Configs  []*MSTeamsV2Config             `yaml:"msteamsv2_configs,omitempty" json:"msteamsv2_configs,omitempty"`
-	JiraConfigs       []*JiraConfig                  `yaml:"jira_configs,omitempty" json:"jira_configs,omitempty"`
+	JiraConfigs       []*jira.JiraConfig             `yaml:"jira_configs,omitempty" json:"jira_configs,omitempty"`
 	RocketchatConfigs []*RocketchatConfig            `yaml:"rocketchat_configs,omitempty" json:"rocketchat_configs,omitempty"`
 	MattermostConfigs []*MattermostConfig            `yaml:"mattermost_configs,omitempty" json:"mattermost_configs,omitempty"`
 }

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -26,7 +26,6 @@ import (
 
 	amcommoncfg "github.com/prometheus/alertmanager/config/common"
 
-	"github.com/prometheus/common/model"
 	"github.com/prometheus/sigv4"
 )
 
@@ -181,20 +180,6 @@ var (
 		},
 		Title: `{{ template "msteamsv2.default.title" . }}`,
 		Text:  `{{ template "msteamsv2.default.text" . }}`,
-	}
-
-	DefaultJiraConfig = JiraConfig{
-		NotifierConfig: amcommoncfg.NotifierConfig{
-			VSendResolved: true,
-		},
-		APIType: "auto",
-		Summary: JiraFieldConfig{
-			Template: `{{ template "jira.default.summary" . }}`,
-		},
-		Description: JiraFieldConfig{
-			Template: `{{ template "jira.default.description" . }}`,
-		},
-		Priority: `{{ template "jira.default.priority" . }}`,
 	}
 
 	DefaultMattermostConfig = MattermostConfig{
@@ -878,78 +863,6 @@ func (c *MSTeamsV2Config) UnmarshalYAML(unmarshal func(any) error) error {
 		return errors.New("at most one of webhook_url & webhook_url_file must be configured")
 	}
 
-	return nil
-}
-
-type JiraFieldConfig struct {
-	// Template is the template string used to render the field.
-	Template string `yaml:"template,omitempty" json:"template,omitempty"`
-	// EnableUpdate indicates whether this field should be omitted when updating an existing issue.
-	EnableUpdate *bool `yaml:"enable_update,omitempty" json:"enable_update,omitempty"`
-}
-
-type JiraConfig struct {
-	amcommoncfg.NotifierConfig `yaml:",inline" json:",inline"`
-	HTTPConfig                 *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
-
-	APIURL  *amcommoncfg.URL `yaml:"api_url,omitempty" json:"api_url,omitempty"`
-	APIType string           `yaml:"api_type,omitempty" json:"api_type,omitempty"`
-
-	Project     string          `yaml:"project,omitempty" json:"project,omitempty"`
-	Summary     JiraFieldConfig `yaml:"summary,omitempty" json:"summary,omitempty"`
-	Description JiraFieldConfig `yaml:"description,omitempty" json:"description,omitempty"`
-	Labels      []string        `yaml:"labels,omitempty" json:"labels,omitempty"`
-	Priority    string          `yaml:"priority,omitempty" json:"priority,omitempty"`
-	IssueType   string          `yaml:"issue_type,omitempty" json:"issue_type,omitempty"`
-
-	ReopenTransition  string         `yaml:"reopen_transition,omitempty" json:"reopen_transition,omitempty"`
-	ResolveTransition string         `yaml:"resolve_transition,omitempty" json:"resolve_transition,omitempty"`
-	WontFixResolution string         `yaml:"wont_fix_resolution,omitempty" json:"wont_fix_resolution,omitempty"`
-	ReopenDuration    model.Duration `yaml:"reopen_duration,omitempty" json:"reopen_duration,omitempty"`
-
-	Fields map[string]any `yaml:"fields,omitempty" json:"custom_fields,omitempty"`
-}
-
-func (f *JiraFieldConfig) EnableUpdateValue() bool {
-	if f.EnableUpdate == nil {
-		return true
-	}
-	return *f.EnableUpdate
-}
-
-// Supports both the legacy string and the new object form.
-func (f *JiraFieldConfig) UnmarshalYAML(unmarshal func(any) error) error {
-	// Try simple string first (backward compatibility).
-	var s string
-	if err := unmarshal(&s); err == nil {
-		f.Template = s
-		// DisableUpdate stays false by default.
-		return nil
-	}
-
-	// Fallback to full object form.
-	type plain JiraFieldConfig
-	return unmarshal((*plain)(f))
-}
-
-func (c *JiraConfig) UnmarshalYAML(unmarshal func(any) error) error {
-	*c = DefaultJiraConfig
-	type plain JiraConfig
-	if err := unmarshal((*plain)(c)); err != nil {
-		return err
-	}
-
-	if c.Project == "" {
-		return errors.New("missing project in jira_config")
-	}
-	if c.IssueType == "" {
-		return errors.New("missing issue_type in jira_config")
-	}
-	if c.APIType != "auto" &&
-		c.APIType != "cloud" &&
-		c.APIType != "datacenter" {
-		return errors.New("unknown api_type on jira_config, must be auto, cloud or datacenter")
-	}
 	return nil
 }
 

--- a/notify/jira/config.go
+++ b/notify/jira/config.go
@@ -1,0 +1,109 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jira
+
+import (
+	"errors"
+
+	amcommoncfg "github.com/prometheus/alertmanager/config/common"
+
+	commoncfg "github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
+)
+
+var DefaultJiraConfig = JiraConfig{
+	NotifierConfig: amcommoncfg.NotifierConfig{
+		VSendResolved: true,
+	},
+	APIType: "auto",
+	Summary: JiraFieldConfig{
+		Template: `{{ template "jira.default.summary" . }}`,
+	},
+	Description: JiraFieldConfig{
+		Template: `{{ template "jira.default.description" . }}`,
+	},
+	Priority: `{{ template "jira.default.priority" . }}`,
+}
+
+type JiraFieldConfig struct {
+	// Template is the template string used to render the field.
+	Template string `yaml:"template,omitempty" json:"template,omitempty"`
+	// EnableUpdate indicates whether this field should be omitted when updating an existing issue.
+	EnableUpdate *bool `yaml:"enable_update,omitempty" json:"enable_update,omitempty"`
+}
+
+type JiraConfig struct {
+	amcommoncfg.NotifierConfig `yaml:",inline" json:",inline"`
+	HTTPConfig                 *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
+
+	APIURL  *amcommoncfg.URL `yaml:"api_url,omitempty" json:"api_url,omitempty"`
+	APIType string           `yaml:"api_type,omitempty" json:"api_type,omitempty"`
+
+	Project     string          `yaml:"project,omitempty" json:"project,omitempty"`
+	Summary     JiraFieldConfig `yaml:"summary,omitempty" json:"summary,omitempty"`
+	Description JiraFieldConfig `yaml:"description,omitempty" json:"description,omitempty"`
+	Labels      []string        `yaml:"labels,omitempty" json:"labels,omitempty"`
+	Priority    string          `yaml:"priority,omitempty" json:"priority,omitempty"`
+	IssueType   string          `yaml:"issue_type,omitempty" json:"issue_type,omitempty"`
+
+	ReopenTransition  string         `yaml:"reopen_transition,omitempty" json:"reopen_transition,omitempty"`
+	ResolveTransition string         `yaml:"resolve_transition,omitempty" json:"resolve_transition,omitempty"`
+	WontFixResolution string         `yaml:"wont_fix_resolution,omitempty" json:"wont_fix_resolution,omitempty"`
+	ReopenDuration    model.Duration `yaml:"reopen_duration,omitempty" json:"reopen_duration,omitempty"`
+
+	Fields map[string]any `yaml:"fields,omitempty" json:"custom_fields,omitempty"`
+}
+
+func (f *JiraFieldConfig) EnableUpdateValue() bool {
+	if f.EnableUpdate == nil {
+		return true
+	}
+	return *f.EnableUpdate
+}
+
+// Supports both the legacy string and the new object form.
+func (f *JiraFieldConfig) UnmarshalYAML(unmarshal func(any) error) error {
+	// Try simple string first (backward compatibility).
+	var s string
+	if err := unmarshal(&s); err == nil {
+		f.Template = s
+		// DisableUpdate stays false by default.
+		return nil
+	}
+
+	// Fallback to full object form.
+	type plain JiraFieldConfig
+	return unmarshal((*plain)(f))
+}
+
+func (c *JiraConfig) UnmarshalYAML(unmarshal func(any) error) error {
+	*c = DefaultJiraConfig
+	type plain JiraConfig
+	if err := unmarshal((*plain)(c)); err != nil {
+		return err
+	}
+
+	if c.Project == "" {
+		return errors.New("missing project in jira_config")
+	}
+	if c.IssueType == "" {
+		return errors.New("missing issue_type in jira_config")
+	}
+	if c.APIType != "auto" &&
+		c.APIType != "cloud" &&
+		c.APIType != "datacenter" {
+		return errors.New("unknown api_type on jira_config, must be auto, cloud or datacenter")
+	}
+	return nil
+}

--- a/notify/jira/jira.go
+++ b/notify/jira/jira.go
@@ -28,7 +28,6 @@ import (
 	commoncfg "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 
-	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/alertmanager/types"
@@ -41,14 +40,14 @@ const (
 
 // Notifier implements a Notifier for JIRA notifications.
 type Notifier struct {
-	conf    *config.JiraConfig
+	conf    *JiraConfig
 	tmpl    *template.Template
 	logger  *slog.Logger
 	client  *http.Client
 	retrier *notify.Retrier
 }
 
-func New(c *config.JiraConfig, t *template.Template, l *slog.Logger, httpOpts ...commoncfg.HTTPClientOption) (*Notifier, error) {
+func New(c *JiraConfig, t *template.Template, l *slog.Logger, httpOpts ...commoncfg.HTTPClientOption) (*Notifier, error) {
 	client, err := notify.NewClientWithTracing(*c.HTTPConfig, "jira", httpOpts...)
 	if err != nil {
 		return nil, err

--- a/notify/jira/jira_test.go
+++ b/notify/jira/jira_test.go
@@ -31,7 +31,6 @@ import (
 
 	amcommoncfg "github.com/prometheus/alertmanager/config/common"
 
-	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/notify/test"
 	"github.com/prometheus/alertmanager/template"
@@ -52,7 +51,7 @@ func boolPtr(v bool) *bool {
 
 func TestJiraRetry(t *testing.T) {
 	notifier, err := New(
-		&config.JiraConfig{
+		&JiraConfig{
 			APIURL: &amcommoncfg.URL{
 				URL: &url.URL{
 					Scheme: "https",
@@ -112,7 +111,7 @@ func TestSearchExistingIssue(t *testing.T) {
 
 	for _, tc := range []struct {
 		title         string
-		cfg           *config.JiraConfig
+		cfg           *JiraConfig
 		groupKey      string
 		firing        bool
 		expectedJQL   string
@@ -122,9 +121,9 @@ func TestSearchExistingIssue(t *testing.T) {
 	}{
 		{
 			title: "search existing issue with project template for firing alert",
-			cfg: &config.JiraConfig{
-				Summary:     config.JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
-				Description: config.JiraFieldConfig{Template: `{{ template "jira.default.description" . }}`},
+			cfg: &JiraConfig{
+				Summary:     JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
+				Description: JiraFieldConfig{Template: `{{ template "jira.default.description" . }}`},
 				Project:     `{{ .CommonLabels.project }}`,
 			},
 			groupKey:    "1",
@@ -133,9 +132,9 @@ func TestSearchExistingIssue(t *testing.T) {
 		},
 		{
 			title: "search existing issue with reopen duration for firing alert",
-			cfg: &config.JiraConfig{
-				Summary:          config.JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
-				Description:      config.JiraFieldConfig{Template: `{{ template "jira.default.description" . }}`},
+			cfg: &JiraConfig{
+				Summary:          JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
+				Description:      JiraFieldConfig{Template: `{{ template "jira.default.description" . }}`},
 				Project:          `{{ .CommonLabels.project }}`,
 				ReopenDuration:   model.Duration(60 * time.Minute),
 				ReopenTransition: "REOPEN",
@@ -146,9 +145,9 @@ func TestSearchExistingIssue(t *testing.T) {
 		},
 		{
 			title: "search existing issue for resolved alert",
-			cfg: &config.JiraConfig{
-				Summary:     config.JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
-				Description: config.JiraFieldConfig{Template: `{{ template "jira.default.description" . }}`},
+			cfg: &JiraConfig{
+				Summary:     JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
+				Description: JiraFieldConfig{Template: `{{ template "jira.default.description" . }}`},
 				Project:     `{{ .CommonLabels.project }}`,
 			},
 			groupKey:    "1",
@@ -201,7 +200,7 @@ func TestSearchExistingIssue(t *testing.T) {
 func TestPrepareSearchRequest(t *testing.T) {
 	for _, tc := range []struct {
 		title           string
-		cfg             *config.JiraConfig
+		cfg             *JiraConfig
 		jql             string
 		expectedBody    any
 		expectedURL     string
@@ -209,7 +208,7 @@ func TestPrepareSearchRequest(t *testing.T) {
 	}{
 		{
 			title: "cloud API type",
-			cfg: &config.JiraConfig{
+			cfg: &JiraConfig{
 				APIType: "cloud",
 				APIURL: &amcommoncfg.URL{
 					URL: &url.URL{
@@ -230,7 +229,7 @@ func TestPrepareSearchRequest(t *testing.T) {
 		},
 		{
 			title: "auto API type with atlassian.net url",
-			cfg: &config.JiraConfig{
+			cfg: &JiraConfig{
 				APIType: "auto",
 				APIURL: &amcommoncfg.URL{
 					URL: &url.URL{
@@ -251,7 +250,7 @@ func TestPrepareSearchRequest(t *testing.T) {
 		},
 		{
 			title: "auto API type without atlassian.net url",
-			cfg: &config.JiraConfig{
+			cfg: &JiraConfig{
 				APIType: "auto",
 				APIURL: &amcommoncfg.URL{
 					URL: &url.URL{
@@ -272,7 +271,7 @@ func TestPrepareSearchRequest(t *testing.T) {
 		},
 		{
 			title: "atlassian.net URL suffix but datacenter api type",
-			cfg: &config.JiraConfig{
+			cfg: &JiraConfig{
 				APIType: "datacenter",
 				APIURL: &amcommoncfg.URL{
 					URL: &url.URL{
@@ -293,7 +292,7 @@ func TestPrepareSearchRequest(t *testing.T) {
 		},
 		{
 			title: "datacenter API type",
-			cfg: &config.JiraConfig{
+			cfg: &JiraConfig{
 				APIType: "datacenter",
 				APIURL: &amcommoncfg.URL{
 					URL: &url.URL{
@@ -351,7 +350,7 @@ func TestJiraTemplating(t *testing.T) {
 
 	for _, tc := range []struct {
 		title string
-		cfg   *config.JiraConfig
+		cfg   *JiraConfig
 
 		retry              bool
 		errMsg             string
@@ -360,9 +359,9 @@ func TestJiraTemplating(t *testing.T) {
 	}{
 		{
 			title: "full-blown message with templated custom field",
-			cfg: &config.JiraConfig{
-				Summary:     config.JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
-				Description: config.JiraFieldConfig{Template: `{{ template "jira.default.description" . }}`},
+			cfg: &JiraConfig{
+				Summary:     JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
+				Description: JiraFieldConfig{Template: `{{ template "jira.default.description" . }}`},
 				Fields: map[string]any{
 					"customfield_14400": `{{ template "jira.host" . }}`,
 				},
@@ -373,42 +372,42 @@ func TestJiraTemplating(t *testing.T) {
 		},
 		{
 			title: "template project",
-			cfg: &config.JiraConfig{
+			cfg: &JiraConfig{
 				Project:     `{{ .CommonLabels.lbl1 }}`,
-				Summary:     config.JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
-				Description: config.JiraFieldConfig{Template: `{{ template "jira.default.description" . }}`},
+				Summary:     JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
+				Description: JiraFieldConfig{Template: `{{ template "jira.default.description" . }}`},
 			},
 			retry: false,
 		},
 		{
 			title: "template issue type",
-			cfg: &config.JiraConfig{
+			cfg: &JiraConfig{
 				IssueType:   `{{ .CommonLabels.lbl1 }}`,
-				Summary:     config.JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
-				Description: config.JiraFieldConfig{Template: `{{ template "jira.default.description" . }}`},
+				Summary:     JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
+				Description: JiraFieldConfig{Template: `{{ template "jira.default.description" . }}`},
 			},
 			retry: false,
 		},
 		{
 			title: "summary with templating errors",
-			cfg: &config.JiraConfig{
-				Summary: config.JiraFieldConfig{Template: "{{ "},
+			cfg: &JiraConfig{
+				Summary: JiraFieldConfig{Template: "{{ "},
 			},
 			errMsg: "template: :1: unclosed action",
 		},
 		{
 			title: "description with templating errors",
-			cfg: &config.JiraConfig{
-				Summary:     config.JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
-				Description: config.JiraFieldConfig{Template: "{{ "},
+			cfg: &JiraConfig{
+				Summary:     JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
+				Description: JiraFieldConfig{Template: "{{ "},
 			},
 			errMsg: "template: :1: unclosed action",
 		},
 		{
 			title: "priority with templating errors",
-			cfg: &config.JiraConfig{
-				Summary:     config.JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
-				Description: config.JiraFieldConfig{Template: `{{ template "jira.default.description" . }}`},
+			cfg: &JiraConfig{
+				Summary:     JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
+				Description: JiraFieldConfig{Template: `{{ template "jira.default.description" . }}`},
 				Priority:    "{{ ",
 			},
 			errMsg: "template: :1: unclosed action",
@@ -469,7 +468,7 @@ func TestJiraTemplating(t *testing.T) {
 func TestJiraNotify(t *testing.T) {
 	for _, tc := range []struct {
 		title string
-		cfg   *config.JiraConfig
+		cfg   *JiraConfig
 
 		alert *types.Alert
 
@@ -480,9 +479,9 @@ func TestJiraNotify(t *testing.T) {
 	}{
 		{
 			title: "create new issue",
-			cfg: &config.JiraConfig{
-				Summary:           config.JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
-				Description:       config.JiraFieldConfig{Template: `{{ template "jira.default.description" . }}`},
+			cfg: &JiraConfig{
+				Summary:           JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
+				Description:       JiraFieldConfig{Template: `{{ template "jira.default.description" . }}`},
 				IssueType:         "Incident",
 				Project:           "OPS",
 				Priority:          `{{ template "jira.default.priority" . }}`,
@@ -522,12 +521,12 @@ func TestJiraNotify(t *testing.T) {
 		},
 		{
 			title: "update existing issue with disabled summary and description",
-			cfg: &config.JiraConfig{
-				Summary: config.JiraFieldConfig{
+			cfg: &JiraConfig{
+				Summary: JiraFieldConfig{
 					Template:     `{{ template "jira.default.summary" . }}`,
 					EnableUpdate: boolPtr(false),
 				},
-				Description: config.JiraFieldConfig{
+				Description: JiraFieldConfig{
 					Template:     `{{ template "jira.default.description" . }}`,
 					EnableUpdate: boolPtr(false),
 				},
@@ -593,9 +592,9 @@ func TestJiraNotify(t *testing.T) {
 		},
 		{
 			title: "create new issue with template project and issue type",
-			cfg: &config.JiraConfig{
-				Summary:           config.JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
-				Description:       config.JiraFieldConfig{Template: `{{ template "jira.default.description" . }}`},
+			cfg: &JiraConfig{
+				Summary:           JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
+				Description:       JiraFieldConfig{Template: `{{ template "jira.default.description" . }}`},
 				IssueType:         "{{ .CommonLabels.issue_type }}",
 				Project:           "{{ .CommonLabels.project }}",
 				Priority:          `{{ template "jira.default.priority" . }}`,
@@ -637,9 +636,9 @@ func TestJiraNotify(t *testing.T) {
 		},
 		{
 			title: "create new issue with custom field and too long summary",
-			cfg: &config.JiraConfig{
-				Summary:     config.JiraFieldConfig{Template: strings.Repeat("A", maxSummaryLenRunes+10)},
-				Description: config.JiraFieldConfig{Template: `{{ template "jira.default.description" . }}`},
+			cfg: &JiraConfig{
+				Summary:     JiraFieldConfig{Template: strings.Repeat("A", maxSummaryLenRunes+10)},
+				Description: JiraFieldConfig{Template: `{{ template "jira.default.description" . }}`},
 				IssueType:   "Incident",
 				Project:     "OPS",
 				Priority:    `{{ template "jira.default.priority" . }}`,
@@ -702,9 +701,9 @@ func TestJiraNotify(t *testing.T) {
 		},
 		{
 			title: "reopen issue",
-			cfg: &config.JiraConfig{
-				Summary:           config.JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
-				Description:       config.JiraFieldConfig{Template: `{{ template "jira.default.description" . }}`},
+			cfg: &JiraConfig{
+				Summary:           JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
+				Description:       JiraFieldConfig{Template: `{{ template "jira.default.description" . }}`},
 				IssueType:         "Incident",
 				Project:           "OPS",
 				Priority:          `{{ template "jira.default.priority" . }}`,
@@ -757,9 +756,9 @@ func TestJiraNotify(t *testing.T) {
 		},
 		{
 			title: "error resolve transition not found",
-			cfg: &config.JiraConfig{
-				Summary:           config.JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
-				Description:       config.JiraFieldConfig{Template: `{{ template "jira.default.description" . }}`},
+			cfg: &JiraConfig{
+				Summary:           JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
+				Description:       JiraFieldConfig{Template: `{{ template "jira.default.description" . }}`},
 				IssueType:         "Incident",
 				Project:           "OPS",
 				Priority:          `{{ template "jira.default.priority" . }}`,
@@ -811,9 +810,9 @@ func TestJiraNotify(t *testing.T) {
 		},
 		{
 			title: "error reopen transition not found",
-			cfg: &config.JiraConfig{
-				Summary:           config.JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
-				Description:       config.JiraFieldConfig{Template: `{{ template "jira.default.description" . }}`},
+			cfg: &JiraConfig{
+				Summary:           JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
+				Description:       JiraFieldConfig{Template: `{{ template "jira.default.description" . }}`},
 				IssueType:         "Incident",
 				Project:           "OPS",
 				Priority:          `{{ template "jira.default.priority" . }}`,
@@ -1265,9 +1264,9 @@ func TestPrepareIssueRequestBodyAPIv3DescriptionValidation(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			cfg := &config.JiraConfig{
-				Summary:     config.JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
-				Description: config.JiraFieldConfig{Template: tc.descriptionTemplate},
+			cfg := &JiraConfig{
+				Summary:     JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
+				Description: JiraFieldConfig{Template: tc.descriptionTemplate},
 				IssueType:   "Incident",
 				Project:     "OPS",
 				Labels:      []string{"alertmanager"},


### PR DESCRIPTION
#### Pull Request Checklist
- [x] I have signed-off my commits
- [x] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/alertmanager/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized Jira notification configuration handling into a dedicated module for improved code maintainability and modularity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->