### PR TITLE
fix: cancel evicted group when it was swaped

### DIFF
--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -523,7 +523,9 @@ func (d *Dispatcher) groupAlert(ctx context.Context, alert *types.Alert, route *
 			// Try to store the new group in the map. If another goroutine has already created the same group, use the existing one.
 			swapped := d.routeGroupsSlice[route.Idx].groups.CompareAndSwap(fp, el, ag)
 			if swapped {
-				// We swapped the new group in, we can break and start it.
+				// Cancel the old destroyed group's goroutine since it's no longer
+				// reachable in the map and doMaintenance() won't find it to stop it.
+				el.(*aggrGroup).cancel()
 				break
 			}
 			loaded = false

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -825,6 +825,48 @@ func TestGroupAlert_RecoversWhenCASFails(t *testing.T) {
 	require.Positive(t, testutil.ToFloat64(metrics.aggrGroupCreationRetries), "contended CAS path was not exercised in %d rounds — scheduler is unusually serial", rounds)
 }
 
+// TestGroupAlert_CancelsDestroyedGroupOnCASSwap verifies that when groupAlert
+// replaces a destroyed aggrGroup in the map via CompareAndSwap, it calls
+// cancel() on the evicted group so its goroutine can exit cleanly.
+func TestGroupAlert_CancelsDestroyedGroupOnCASSwap(t *testing.T) {
+	logger := promslog.NewNopLogger()
+	reg := prometheus.NewRegistry()
+	marker := types.NewMarker(reg)
+
+	route := &Route{
+		RouteOpts: RouteOpts{
+			Receiver:       "test",
+			GroupBy:        map[model.LabelName]struct{}{"alertname": {}},
+			GroupWait:      time.Hour,
+			GroupInterval:  time.Hour,
+			RepeatInterval: time.Hour,
+		},
+		Idx: 0,
+	}
+	timeout := func(d time.Duration) time.Duration { return d }
+	recorder := &recordStage{alerts: make(map[string]map[model.Fingerprint]*types.Alert)}
+	dispatcher := NewDispatcher(nil, route, recorder, marker, timeout, testMaintenanceInterval, nil, logger, eventrecorder.NopRecorder(), NewDispatcherMetrics(false, reg))
+	dispatcher.routeGroupsSlice = []routeAggrGroups{{route: route}}
+	dispatcher.state.Store(DispatcherStateWaitingToStart)
+
+	groupLabels := model.LabelSet{"alertname": "TestAlert"}
+
+	// Create a destroyed aggrGroup and place it at the fingerprint.
+	destroyedAg := newAggrGroup(context.Background(), groupLabels, route, timeout, marker, eventrecorder.NopRecorder(), logger)
+	require.NoError(t, destroyedAg.alerts.DeleteIfNotModified(types.AlertSlice{}, true))
+	require.True(t, destroyedAg.destroyed(), "pre-condition: group must be destroyed")
+
+	dispatcher.routeGroupsSlice[0].groups.Store(destroyedAg.fingerprint(), destroyedAg)
+
+	// groupAlert must detect the destroyed group, create a replacement, and
+	// CAS it in — triggering cancel() on the evicted group.
+	alert := newAlert(model.LabelSet{"alertname": "TestAlert"})
+	dispatcher.groupAlert(context.Background(), alert, route)
+
+	require.ErrorIs(t, destroyedAg.ctx.Err(), context.Canceled,
+		"destroyed group's context must be cancelled after being CAS-swapped out")
+}
+
 func TestDispatcher_DeleteResolvedAlertsFromMarker(t *testing.T) {
 	t.Run("successful flush deletes markers for resolved alerts", func(t *testing.T) {
 		ctx := context.Background()


### PR DESCRIPTION
<!--
    - Please give your PR a title in the form "area: short description".  For example "dispatcher: improve performance"

    - Please sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Pull Request Checklist
Please check all the applicable boxes.

- Please list all open issue(s) discussed with maintainers related to this change
    - Fixes #5182
    <!--
    If it applies.
    Automatically closes linked issue when PR is merged.
    Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
    More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
    -->
- Is this a new Receiver integration?
    - [ ] I have already tried to use the [Webhook Receiver Integration](https://prometheus.io/docs/alerting/latest/configuration/#webhook_config) and [3rd party integrations](https://prometheus.io/docs/operating/integrations/#alertmanager-webhook-receiver) before adding this new Receiver Integration
- Is this a bugfix?
    - [ ] I have added tests that can reproduce the bug which pass with this bugfix applied
- [x] I have signed-off my commits
- [x] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/alertmanager/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[FIX] DISPATCH: go routines not cancelled
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Replaced aggregation groups are now stopped immediately when swapped out, preventing stray background work and improving stability and performance.

* **Tests**
  * Added a unit test that verifies replaced aggregation groups are properly canceled and do not continue running.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/prometheus/alertmanager/pull/5235)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->