### PR TITLE
ci: pin contents: read on mixin, publish, release, ui-ci

### DIFF
--- a/.github/workflows/mixin.yml
+++ b/.github/workflows/mixin.yml
@@ -4,6 +4,9 @@ on:
     paths:
       - "doc/alertmanager-mixin/**"
 
+permissions:
+  contents: read
+
 jobs:
   mixin:
     name: mixin-lint

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,10 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - main
+# Docker Hub + Quay pushes use their own secrets.
+permissions:
+  contents: read
+
 jobs:
   ci:
     name: Run ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,11 @@ on:  # yamllint disable-line rule:truthy
   push:
     tags:
       - v*
+# Docker Hub + Quay pushes use their own secrets; GitHub release publish
+# uses PROMBOT_GITHUB_TOKEN.
+permissions:
+  contents: read
+
 jobs:
   ci:
     name: Run ci

--- a/.github/workflows/ui-ci.yml
+++ b/.github/workflows/ui-ci.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test_mantine_ui:
     name: Test mantine-ui


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to read-only on the four workflows still inheriting org defaults. All four are read-only from GitHub's perspective:

- `mixin.yml` — `make -C doc/alertmanager-mixin lint`.
- `publish.yml` — main-branch build + Docker Hub / Quay image push using `docker_hub_login`/`docker_hub_password` + `quay_io_login`/`quay_io_password`.
- `release.yml` — tag build + image push (same creds), plus a GitHub release via `PROMBOT_GITHUB_TOKEN`.
- `ui-ci.yml` — `npm run test` for the mantine-ui workspace.

No dependency on the default `GITHUB_TOKEN` for writes. YAML validated locally.