### PR TITLE
refactor(msteams): move configuration types into msteams package

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -36,6 +36,7 @@ import (
 	"github.com/prometheus/alertmanager/notify/incidentio"
 	"github.com/prometheus/alertmanager/notify/jira"
 	"github.com/prometheus/alertmanager/notify/mattermost"
+	"github.com/prometheus/alertmanager/notify/msteams"
 	"github.com/prometheus/alertmanager/notify/webhook"
 	"github.com/prometheus/alertmanager/timeinterval"
 	"github.com/prometheus/alertmanager/tracing"
@@ -956,7 +957,7 @@ type Receiver struct {
 	SNSConfigs        []*SNSConfig                   `yaml:"sns_configs,omitempty" json:"sns_configs,omitempty"`
 	TelegramConfigs   []*TelegramConfig              `yaml:"telegram_configs,omitempty" json:"telegram_configs,omitempty"`
 	WebexConfigs      []*WebexConfig                 `yaml:"webex_configs,omitempty" json:"webex_configs,omitempty"`
-	MSTeamsConfigs    []*MSTeamsConfig               `yaml:"msteams_configs,omitempty" json:"msteams_configs,omitempty"`
+	MSTeamsConfigs    []*msteams.MSTeamsConfig       `yaml:"msteams_configs,omitempty" json:"msteams_configs,omitempty"`
 	MSTeamsV2Configs  []*MSTeamsV2Config             `yaml:"msteamsv2_configs,omitempty" json:"msteamsv2_configs,omitempty"`
 	JiraConfigs       []*jira.JiraConfig             `yaml:"jira_configs,omitempty" json:"jira_configs,omitempty"`
 	RocketchatConfigs []*RocketchatConfig            `yaml:"rocketchat_configs,omitempty" json:"rocketchat_configs,omitempty"`

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -165,15 +165,6 @@ var (
 		ParseMode:            "HTML",
 	}
 
-	DefaultMSTeamsConfig = MSTeamsConfig{
-		NotifierConfig: amcommoncfg.NotifierConfig{
-			VSendResolved: true,
-		},
-		Title:   `{{ template "msteams.default.title" . }}`,
-		Summary: `{{ template "msteams.default.summary" . }}`,
-		Text:    `{{ template "msteams.default.text" . }}`,
-	}
-
 	DefaultMSTeamsV2Config = MSTeamsV2Config{
 		NotifierConfig: amcommoncfg.NotifierConfig{
 			VSendResolved: true,
@@ -794,35 +785,6 @@ func (c *TelegramConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		c.ParseMode != "HTML" {
 		return errors.New("unknown parse_mode on telegram_config, must be Markdown, MarkdownV2, HTML or empty string")
 	}
-	return nil
-}
-
-type MSTeamsConfig struct {
-	amcommoncfg.NotifierConfig `yaml:",inline" json:",inline"`
-	HTTPConfig                 *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
-	WebhookURL                 *amcommoncfg.SecretURL      `yaml:"webhook_url,omitempty" json:"webhook_url,omitempty"`
-	WebhookURLFile             string                      `yaml:"webhook_url_file,omitempty" json:"webhook_url_file,omitempty"`
-
-	Title   string `yaml:"title,omitempty" json:"title,omitempty"`
-	Summary string `yaml:"summary,omitempty" json:"summary,omitempty"`
-	Text    string `yaml:"text,omitempty" json:"text,omitempty"`
-}
-
-func (c *MSTeamsConfig) UnmarshalYAML(unmarshal func(any) error) error {
-	*c = DefaultMSTeamsConfig
-	type plain MSTeamsConfig
-	if err := unmarshal((*plain)(c)); err != nil {
-		return err
-	}
-
-	if c.WebhookURL == nil && c.WebhookURLFile == "" {
-		return errors.New("one of webhook_url or webhook_url_file must be configured")
-	}
-
-	if c.WebhookURL != nil && len(c.WebhookURLFile) > 0 {
-		return errors.New("at most one of webhook_url & webhook_url_file must be configured")
-	}
-
 	return nil
 }
 

--- a/notify/msteams/config.go
+++ b/notify/msteams/config.go
@@ -1,0 +1,60 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package msteams
+
+import (
+	"errors"
+
+	amcommoncfg "github.com/prometheus/alertmanager/config/common"
+
+	commoncfg "github.com/prometheus/common/config"
+)
+
+var DefaultMSTeamsConfig = MSTeamsConfig{
+	NotifierConfig: amcommoncfg.NotifierConfig{
+		VSendResolved: true,
+	},
+	Title:   `{{ template "msteams.default.title" . }}`,
+	Summary: `{{ template "msteams.default.summary" . }}`,
+	Text:    `{{ template "msteams.default.text" . }}`,
+}
+
+type MSTeamsConfig struct {
+	amcommoncfg.NotifierConfig `yaml:",inline" json:",inline"`
+	HTTPConfig                 *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
+	WebhookURL                 *amcommoncfg.SecretURL      `yaml:"webhook_url,omitempty" json:"webhook_url,omitempty"`
+	WebhookURLFile             string                      `yaml:"webhook_url_file,omitempty" json:"webhook_url_file,omitempty"`
+
+	Title   string `yaml:"title,omitempty" json:"title,omitempty"`
+	Summary string `yaml:"summary,omitempty" json:"summary,omitempty"`
+	Text    string `yaml:"text,omitempty" json:"text,omitempty"`
+}
+
+func (c *MSTeamsConfig) UnmarshalYAML(unmarshal func(any) error) error {
+	*c = DefaultMSTeamsConfig
+	type plain MSTeamsConfig
+	if err := unmarshal((*plain)(c)); err != nil {
+		return err
+	}
+
+	if c.WebhookURL == nil && c.WebhookURLFile == "" {
+		return errors.New("one of webhook_url or webhook_url_file must be configured")
+	}
+
+	if c.WebhookURL != nil && len(c.WebhookURLFile) > 0 {
+		return errors.New("at most one of webhook_url & webhook_url_file must be configured")
+	}
+
+	return nil
+}

--- a/notify/msteams/msteams.go
+++ b/notify/msteams/msteams.go
@@ -29,7 +29,6 @@ import (
 
 	amcommoncfg "github.com/prometheus/alertmanager/config/common"
 
-	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/alertmanager/types"
@@ -42,7 +41,7 @@ const (
 )
 
 type Notifier struct {
-	conf         *config.MSTeamsConfig
+	conf         *MSTeamsConfig
 	tmpl         *template.Template
 	logger       *slog.Logger
 	client       *http.Client
@@ -62,7 +61,7 @@ type teamsMessage struct {
 }
 
 // New returns a new notifier that uses the Microsoft Teams Webhook API.
-func New(c *config.MSTeamsConfig, t *template.Template, l *slog.Logger, httpOpts ...commoncfg.HTTPClientOption) (*Notifier, error) {
+func New(c *MSTeamsConfig, t *template.Template, l *slog.Logger, httpOpts ...commoncfg.HTTPClientOption) (*Notifier, error) {
 	client, err := notify.NewClientWithTracing(*c.HTTPConfig, "msteams", httpOpts...)
 	if err != nil {
 		return nil, err

--- a/notify/msteams/msteams_test.go
+++ b/notify/msteams/msteams_test.go
@@ -31,7 +31,6 @@ import (
 
 	amcommoncfg "github.com/prometheus/alertmanager/config/common"
 
-	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/notify/test"
 	"github.com/prometheus/alertmanager/types"
@@ -42,7 +41,7 @@ var testWebhookURL, _ = url.Parse("https://example.webhook.office.com/webhookb2/
 
 func TestMSTeamsRetry(t *testing.T) {
 	notifier, err := New(
-		&config.MSTeamsConfig{
+		&MSTeamsConfig{
 			WebhookURL: &amcommoncfg.SecretURL{URL: testWebhookURL},
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 		},
@@ -71,14 +70,14 @@ func TestMSTeamsTemplating(t *testing.T) {
 
 	for _, tc := range []struct {
 		title string
-		cfg   *config.MSTeamsConfig
+		cfg   *MSTeamsConfig
 
 		retry  bool
 		errMsg string
 	}{
 		{
 			title: "full-blown message",
-			cfg: &config.MSTeamsConfig{
+			cfg: &MSTeamsConfig{
 				Title:   `{{ template "msteams.default.title" . }}`,
 				Summary: `{{ template "msteams.default.summary" . }}`,
 				Text:    `{{ template "msteams.default.text" . }}`,
@@ -87,14 +86,14 @@ func TestMSTeamsTemplating(t *testing.T) {
 		},
 		{
 			title: "title with templating errors",
-			cfg: &config.MSTeamsConfig{
+			cfg: &MSTeamsConfig{
 				Title: "{{ ",
 			},
 			errMsg: "template: :1: unclosed action",
 		},
 		{
 			title: "summary with templating errors",
-			cfg: &config.MSTeamsConfig{
+			cfg: &MSTeamsConfig{
 				Title:   `{{ template "msteams.default.title" . }}`,
 				Summary: "{{ ",
 			},
@@ -102,7 +101,7 @@ func TestMSTeamsTemplating(t *testing.T) {
 		},
 		{
 			title: "message with templating errors",
-			cfg: &config.MSTeamsConfig{
+			cfg: &MSTeamsConfig{
 				Title:   `{{ template "msteams.default.title" . }}`,
 				Summary: `{{ template "msteams.default.summary" . }}`,
 				Text:    "{{ ",
@@ -159,7 +158,7 @@ func TestNotifier_Notify_WithReason(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			notifier, err := New(
-				&config.MSTeamsConfig{
+				&MSTeamsConfig{
 					WebhookURL: &amcommoncfg.SecretURL{URL: testWebhookURL},
 					HTTPConfig: &commoncfg.HTTPClientConfig{},
 				},
@@ -201,7 +200,7 @@ func TestMSTeamsRedactedURL(t *testing.T) {
 
 	secret := "secret"
 	notifier, err := New(
-		&config.MSTeamsConfig{
+		&MSTeamsConfig{
 			WebhookURL: &amcommoncfg.SecretURL{URL: u},
 			HTTPConfig: &commoncfg.HTTPClientConfig{},
 		},
@@ -223,7 +222,7 @@ func TestMSTeamsReadingURLFromFile(t *testing.T) {
 	require.NoError(t, err, "writing to temp file failed")
 
 	notifier, err := New(
-		&config.MSTeamsConfig{
+		&MSTeamsConfig{
 			WebhookURLFile: f.Name(),
 			HTTPConfig:     &commoncfg.HTTPClientConfig{},
 		},


### PR DESCRIPTION
#### Pull Request Checklist
Please check all the applicable boxes.

- [x] I have signed-off my commits
- [x] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/alertmanager/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized Microsoft Teams notifier configuration handling into a dedicated external package for improved maintainability and code clarity.

* **Chores**
  * Removed deprecated legacy Microsoft Teams configuration support; users relying on the old format must migrate to the current configuration structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/prometheus/alertmanager/pull/5240)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->