### PR TITLE
fix(env): Remove deprecated `auto-gomaxprocs` flag

### DIFF
--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -224,10 +224,6 @@ func run() int {
 		}
 	}
 
-	if ff.EnableAutoGOMAXPROCS() {
-		logger.Warn("automaxprocs", "msg", "This flag is deprecated and will be removed in the next release")
-	}
-
 	err = os.MkdirAll(*dataDir, 0o777)
 	if err != nil {
 		logger.Error("Unable to create data directory", "err", err)

--- a/featurecontrol/featurecontrol.go
+++ b/featurecontrol/featurecontrol.go
@@ -27,7 +27,6 @@ const (
 	FeatureClassicMode           = "classic-mode"
 	FeatureUTF8StrictMode        = "utf8-strict-mode"
 	FeatureAutoGOMEMLIMIT        = "auto-gomemlimit"
-	FeatureAutoGOMAXPROCS        = "auto-gomaxprocs"
 	FeatureEventRecorder         = "event-recorder"
 )
 
@@ -38,7 +37,6 @@ var AllowedFlags = []string{
 	FeatureClassicMode,
 	FeatureUTF8StrictMode,
 	FeatureAutoGOMEMLIMIT,
-	FeatureAutoGOMAXPROCS,
 	FeatureEventRecorder,
 }
 
@@ -49,7 +47,6 @@ type Flagger interface {
 	ClassicMode() bool
 	UTF8StrictMode() bool
 	EnableAutoGOMEMLIMIT() bool
-	EnableAutoGOMAXPROCS() bool
 	EnableEventRecorder() bool
 }
 
@@ -61,7 +58,6 @@ type Flags struct {
 	classicMode                  bool
 	utf8StrictMode               bool
 	enableAutoGOMEMLIMIT         bool
-	enableAutoGOMAXPROCS         bool
 	enableEventRecorder          bool
 }
 
@@ -87,10 +83,6 @@ func (f *Flags) UTF8StrictMode() bool {
 
 func (f *Flags) EnableAutoGOMEMLIMIT() bool {
 	return f.enableAutoGOMEMLIMIT
-}
-
-func (f *Flags) EnableAutoGOMAXPROCS() bool {
-	return f.enableAutoGOMAXPROCS
 }
 
 func (f *Flags) EnableEventRecorder() bool {
@@ -126,12 +118,6 @@ func enableUTF8StrictMode() flagOption {
 func enableAutoGOMEMLIMIT() flagOption {
 	return func(configs *Flags) {
 		configs.enableAutoGOMEMLIMIT = true
-	}
-}
-
-func enableAutoGOMAXPROCS() flagOption {
-	return func(configs *Flags) {
-		configs.enableAutoGOMAXPROCS = true
 	}
 }
 
@@ -175,9 +161,6 @@ func NewFlags(logger *slog.Logger, features string) (Flagger, error) {
 		case FeatureAutoGOMEMLIMIT:
 			opts = append(opts, enableAutoGOMEMLIMIT())
 			logger.Warn("Automatically set GOMEMLIMIT to match the Linux container or system memory limit.")
-		case FeatureAutoGOMAXPROCS:
-			opts = append(opts, enableAutoGOMAXPROCS())
-			logger.Error("Deprecated: auto-gomaxprocs will be removed in v0.33. Removing this flag does not affect behavior, as Go 1.25+ natively handles container CPU quotas.")
 		case FeatureEventRecorder:
 			opts = append(opts, enableEventRecorder())
 			logger.Warn("Experimental event recorder enabled")
@@ -210,7 +193,5 @@ func (n NoopFlags) ClassicMode() bool { return false }
 func (n NoopFlags) UTF8StrictMode() bool { return false }
 
 func (n NoopFlags) EnableAutoGOMEMLIMIT() bool { return false }
-
-func (n NoopFlags) EnableAutoGOMAXPROCS() bool { return false }
 
 func (n NoopFlags) EnableEventRecorder() bool { return false }


### PR DESCRIPTION
The `auto-gomaxprocs` flag was deprecated in v0.32. It has had no effect
since v0.29, when we moved to Go 1.25, which natively handles container
CPU quotas without the need for the automaxprocs library.

See https://go.dev/blog/container-aware-gomaxprocs

Signed-off-by: Solomon Jacobs <solomonjacobs@protonmail.com>

<!--
    - Please give your PR a title in the form "area: short description".  For example "dispatcher: improve performance"

    - Please sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Pull Request Checklist
- Is this a breaking change?
    Yes.
- [x] I have signed-off my commits
- [x] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/alertmanager/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[CHANGE] The '--enable-feature=auto-gomaxprocs' option has been removed. This flag had no effect since v0.29 and was deprecated in v0.32. It can be safely removed from any startup scripts. #5090 
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the deprecated `auto-gomaxprocs` feature flag and associated startup deprecation warnings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/prometheus/alertmanager/pull/5251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->