### PR TITLE
notify/telegram: wrap Send error with notify.RedactURL

### DIFF
--- a/notify/telegram/telegram.go
+++ b/notify/telegram/telegram.go
@@ -119,7 +119,7 @@ func (n *Notifier) Notify(ctx context.Context, alert ...*types.Alert) (bool, err
 		ParseMode:             n.conf.ParseMode,
 	})
 	if err != nil {
-		return true, err
+		return true, notify.RedactURL(err)
 	}
 	logger.Debug("Telegram message successfully published", "message_id", message.ID, "chat_id", message.Chat.ID)
 

--- a/notify/telegram/telegram.go
+++ b/notify/telegram/telegram.go
@@ -119,7 +119,7 @@ func (n *Notifier) Notify(ctx context.Context, alert ...*types.Alert) (bool, err
 		ParseMode:             n.conf.ParseMode,
 	})
 	if err != nil {
-		return true, wrapWithFailureReason(err)
+		return true, wrapWithFailureReason(notify.RedactURL(err))
 	}
 	logger.Debug("Telegram message successfully published", "message_id", message.ID, "chat_id", message.Chat.ID)
 

--- a/notify/telegram/telegram_test.go
+++ b/notify/telegram/telegram_test.go
@@ -213,3 +213,76 @@ func TestTelegramNotify(t *testing.T) {
 		})
 	}
 }
+
+// TestTelegramNotifyRedactURL verifies that notify.RedactURL is applied to the
+// error returned by client.Send, so the bot token is never exposed in logs.
+func TestTelegramNotifyRedactURL(t *testing.T) {
+	token := "secret"
+
+	t.Run("transport error redacts URL", func(t *testing.T) {
+		// Point at a closed server so telebot returns a *url.Error with the full URL.
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		u, _ := url.Parse(srv.URL)
+		srv.Close() // closed immediately — next dial will fail
+
+		notifier, err := New(
+			&config.TelegramConfig{
+				HTTPConfig: &commoncfg.HTTPClientConfig{},
+				APIUrl:     &amcommoncfg.URL{URL: u},
+				BotToken:   commoncfg.Secret(token),
+			},
+			test.CreateTmpl(t),
+			promslog.NewNopLogger(),
+		)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		ctx = notify.WithGroupKey(ctx, "1")
+
+		retry, err := notifier.Notify(ctx, &types.Alert{
+			Alert: model.Alert{Labels: model.LabelSet{"alertname": "test"}},
+		})
+		require.True(t, retry)
+		require.Error(t, err)
+		// The token must not appear in the error string.
+		require.NotContains(t, err.Error(), token, "bot token leaked in transport error")
+		// The URL should be redacted.
+		require.Contains(t, err.Error(), "<redacted>")
+	})
+
+	t.Run("Telegram API error passes through without token", func(t *testing.T) {
+		// Return a Telegram API error response — telebot wraps this as its own
+		// error type (not *url.Error), so RedactURL is a no-op, but the token
+		// is not in the error string either.
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"ok":false,"description":"Bad Request: chat not found","error_code":400}`))
+		}))
+		defer srv.Close()
+		u, _ := url.Parse(srv.URL)
+
+		notifier, err := New(
+			&config.TelegramConfig{
+				HTTPConfig: &commoncfg.HTTPClientConfig{},
+				APIUrl:     &amcommoncfg.URL{URL: u},
+				BotToken:   commoncfg.Secret(token),
+			},
+			test.CreateTmpl(t),
+			promslog.NewNopLogger(),
+		)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		ctx = notify.WithGroupKey(ctx, "1")
+
+		retry, err := notifier.Notify(ctx, &types.Alert{
+			Alert: model.Alert{Labels: model.LabelSet{"alertname": "test"}},
+		})
+		require.True(t, retry)
+		require.Error(t, err)
+		require.NotContains(t, err.Error(), token, "bot token leaked in API error")
+	})
+}
+}

--- a/notify/telegram/telegram_test.go
+++ b/notify/telegram/telegram_test.go
@@ -280,3 +280,75 @@ func TestTelegramNotifyFailureReason(t *testing.T) {
 		})
 	}
 }
+
+// TestTelegramNotifyRedactURL verifies that notify.RedactURL is applied to the
+// error returned by client.Send, so the bot token is never exposed in logs.
+func TestTelegramNotifyRedactURL(t *testing.T) {
+	token := "secret"
+
+	t.Run("transport error redacts URL", func(t *testing.T) {
+		// Point at a closed server so telebot returns a *url.Error with the full URL.
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		u, _ := url.Parse(srv.URL)
+		srv.Close() // closed immediately — next dial will fail
+
+		notifier, err := New(
+			&TelegramConfig{
+				HTTPConfig: &commoncfg.HTTPClientConfig{},
+				APIUrl:     &amcommoncfg.URL{URL: u},
+				BotToken:   commoncfg.Secret(token),
+			},
+			test.CreateTmpl(t),
+			promslog.NewNopLogger(),
+		)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		ctx = notify.WithGroupKey(ctx, "1")
+
+		retry, err := notifier.Notify(ctx, &types.Alert{
+			Alert: model.Alert{Labels: model.LabelSet{"alertname": "test"}},
+		})
+		require.True(t, retry)
+		require.Error(t, err)
+		// The token must not appear in the error string.
+		require.NotContains(t, err.Error(), token, "bot token leaked in transport error")
+		// The URL should be redacted.
+		require.Contains(t, err.Error(), "<redacted>")
+	})
+
+	t.Run("Telegram API error passes through without token", func(t *testing.T) {
+		// Return a Telegram API error response — telebot wraps this as its own
+		// error type (not *url.Error), so RedactURL is a no-op, but the token
+		// is not in the error string either.
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"ok":false,"description":"Bad Request: chat not found","error_code":400}`))
+		}))
+		defer srv.Close()
+		u, _ := url.Parse(srv.URL)
+
+		notifier, err := New(
+			&TelegramConfig{
+				HTTPConfig: &commoncfg.HTTPClientConfig{},
+				APIUrl:     &amcommoncfg.URL{URL: u},
+				BotToken:   commoncfg.Secret(token),
+			},
+			test.CreateTmpl(t),
+			promslog.NewNopLogger(),
+		)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		ctx = notify.WithGroupKey(ctx, "1")
+
+		retry, err := notifier.Notify(ctx, &types.Alert{
+			Alert: model.Alert{Labels: model.LabelSet{"alertname": "test"}},
+		})
+		require.True(t, retry)
+		require.Error(t, err)
+		require.NotContains(t, err.Error(), token, "bot token leaked in API error")
+	})
+}


### PR DESCRIPTION
#### Pull Request Checklist

This PR addresses a small inconsistency left over from #3887.

- Is this a bugfix?
    - [x] I have added tests that can reproduce the bug which pass with this bugfix applied
- [x] I have signed-off my commits
- [x] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?

```release-notes
[SECURITY] notify/telegram: redact bot token from Send errors
```

#### Context

#3887 introduced `notify.RedactURL` and applied it to every notifier's HTTP error return path so that bot tokens, webhook URLs, and other secrets embedded in `*url.Error` are stripped before the error is logged.

`notify/telegram/telegram.go` was the only notifier that was missed. When `telebot.Bot.Send` fails for transport reasons (dial timeout, connection refused, TLS handshake error, etc.), the underlying `http.Client` returns a `*url.Error` whose `URL` field is the full Telegram API URL — which contains the bot token as a path segment:

```
https://api.telegram.org/bot123456789:ABCdefGHIjklMNOpqrSTUvwxYZ/sendMessage
```

That error is returned verbatim from `Notify`, then logged by the surrounding `notify.RetryStage` (`l.Warn("Notify attempt failed, will retry later", "err", err)`) and `dispatch.aggrGroup` (`logger.Error("Notify for alerts failed")`). The result is that the bot token ends up in operator logs on every transport failure — observed in production with alertmanager v0.28.1 going through a flaky outbound link.

#### Change

One-line fix at the only relevant call site:

```diff
 	if err != nil {
-		return true, err
+		return true, notify.RedactURL(err)
 	}
```

Other return paths in `Notify` were checked and do not need wrapping:

* `getBotToken` and `getChatID` errors come from `os.ReadFile` on local files and contain no URL.
* `createTelegramClient` runs `telebot.NewBot` with `Offline: true`, so it never contacts the API and never returns a `*url.Error`. (Constructor errors don't go through `Notify` anyway.)

#### Tests

`TestTelegramNotifyRedactURL` covers both error paths:

1. **Transport error (`*url.Error`)**: a `httptest.Server` is started and immediately closed so the next `Send` call fails to dial. The test asserts the bot token is absent from the returned error and that the URL is replaced with `<redacted>`.
2. **Telegram API error (non-`*url.Error`)**: a fake server returns `{"ok":false,"description":"Bad Request: chat not found"}`. `telebot` wraps this in its own error type that does not contain `*url.Error`, so `notify.RedactURL` is a no-op — but the token is also not present in the resulting error string (telebot's API error formatter doesn't include the URL). The test asserts the token is absent in this path too.

#### Notes

`notify.RedactURL` uses `errors.As(err, *url.Error)` and is a no-op when the error chain doesn't include `*url.Error`, so this change is safe for the API-error path and does not depend on assumptions about telebot's internal error wrapping.