### PR TITLE
ci(mixin): cap `GITHUB_TOKEN` to `contents: read`

### DIFF
--- a/.github/workflows/mixin.yml
+++ b/.github/workflows/mixin.yml
@@ -4,6 +4,9 @@ on:
     paths:
       - "doc/alertmanager-mixin/**"
 
+permissions:
+  contents: read
+
 jobs:
   mixin:
     name: mixin-lint


### PR DESCRIPTION
The `mixin` workflow only validates the alertmanager mixin (jsonnet). No GitHub API writes, so workflow-level `contents: read` is the right cap for the default `GITHUB_TOKEN`.

Post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow security configuration.

---

**Note:** This release contains only internal infrastructure updates with no changes visible to end-users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/prometheus/alertmanager/pull/5255?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->