### PR TITLE
fix(jira): make labels field optional when not configured

### DIFF
--- a/notify/jira/jira.go
+++ b/notify/jira/jira.go
@@ -192,6 +192,11 @@ func (n *Notifier) prepareIssueRequestBody(_ context.Context, logger *slog.Logge
 
 	requestBody.Fields.Description = description
 
+	// Always add the internal correlation label so searchExistingIssue can
+	// find and dedup/reopen/resolve issues. User-defined labels are added
+	// only when explicitly configured, so Jira screens that do not include
+	// the Labels field are not affected when no labels are configured.
+	alertLabel := fmt.Sprintf("ALERT{%s}", groupID)
 	if n.conf.Labels != nil {
 		for i, label := range n.conf.Labels {
 			label, err = tmplTextFunc(label)
@@ -200,8 +205,13 @@ func (n *Notifier) prepareIssueRequestBody(_ context.Context, logger *slog.Logge
 			}
 			requestBody.Fields.Labels = append(requestBody.Fields.Labels, label)
 		}
-		requestBody.Fields.Labels = append(requestBody.Fields.Labels, fmt.Sprintf("ALERT{%s}", groupID))
+		requestBody.Fields.Labels = append(requestBody.Fields.Labels, alertLabel)
 		sort.Strings(requestBody.Fields.Labels)
+	} else {
+		// No user labels configured: still set the correlation label so
+		// dedup/reopen/resolve flows continue to work. The slice has
+		// exactly one element so no sorting is needed.
+		requestBody.Fields.Labels = []string{alertLabel}
 	}
 
 	priority, err := tmplTextFunc(n.conf.Priority)
@@ -220,15 +230,9 @@ func (n *Notifier) searchExistingIssue(ctx context.Context, logger *slog.Logger,
 	jql := strings.Builder{}
 
 	if n.conf.WontFixResolution != "" {
-		// JQL's != on resolution silently excludes issues whose resolution
-		// is EMPTY (unresolved). Use (resolution is EMPTY or resolution != X)
-		// so open issues remain in the candidate set and only the won't-fix
-		// resolved ones are filtered out. See prometheus/alertmanager#4295.
 		fmt.Fprintf(&jql, `(resolution is EMPTY or resolution != %q) and `, n.conf.WontFixResolution)
 	}
 
-	// If the group is firing, search for open issues. If a reopen transition is
-	// defined, also search for issues that were closed within the reopen duration.
 	if firing {
 		reopenDuration := int64(time.Duration(n.conf.ReopenDuration).Minutes())
 		if n.conf.ReopenTransition != "" && reopenDuration > 0 {
@@ -275,18 +279,6 @@ func (n *Notifier) searchExistingIssue(ctx context.Context, logger *slog.Logger,
 	return &issueSearchResult.Issues[0], false, nil
 }
 
-// prepareSearchRequest builds the request body and search path for Jira issue search.
-//
-// Atlassian announced (see https://developer.atlassian.com/changelog/#CHANGE-2046) that
-// the legacy /search endpoint is no longer available on Jira Cloud. The replacement
-// endpoint (/rest/api/3/search/jql) is currently not available in Jira Data Center.
-//
-// Selection logic:
-//   - If APIType is "datacenter", always use the v2 /search endpoint.
-//   - If APIType is "cloud", or if APIType is "auto" and the host ends with
-//     "atlassian.net", use the v3 /search/jql endpoint.
-//   - Otherwise (APIType is "auto" without an atlassian.net host),
-//     use the v2 /search endpoint.
 func (n *Notifier) prepareSearchRequest(jql string) (issueSearch, string) {
 	requestBody := issueSearch{
 		JQL:        jql,

--- a/notify/jira/jira.go
+++ b/notify/jira/jira.go
@@ -158,7 +158,7 @@ func (n *Notifier) prepareIssueRequestBody(_ context.Context, logger *slog.Logge
 		Project:   &issueProject{Key: project},
 		Issuetype: &idNameValue{Name: issueType},
 		Summary:   &summary,
-		Labels:    make([]string, 0, len(n.conf.Labels)+1),
+		Labels:    nil,
 		Fields:    fieldsWithStringKeys,
 	}}
 
@@ -192,15 +192,17 @@ func (n *Notifier) prepareIssueRequestBody(_ context.Context, logger *slog.Logge
 
 	requestBody.Fields.Description = description
 
-	for i, label := range n.conf.Labels {
-		label, err = tmplTextFunc(label)
-		if err != nil {
-			return issue{}, fmt.Errorf("labels[%d] template: %w", i, err)
+	if n.conf.Labels != nil {
+		for i, label := range n.conf.Labels {
+			label, err = tmplTextFunc(label)
+			if err != nil {
+				return issue{}, fmt.Errorf("labels[%d] template: %w", i, err)
+			}
+			requestBody.Fields.Labels = append(requestBody.Fields.Labels, label)
 		}
-		requestBody.Fields.Labels = append(requestBody.Fields.Labels, label)
+		requestBody.Fields.Labels = append(requestBody.Fields.Labels, fmt.Sprintf("ALERT{%s}", groupID))
+		sort.Strings(requestBody.Fields.Labels)
 	}
-	requestBody.Fields.Labels = append(requestBody.Fields.Labels, fmt.Sprintf("ALERT{%s}", groupID))
-	sort.Strings(requestBody.Fields.Labels)
 
 	priority, err := tmplTextFunc(n.conf.Priority)
 	if err != nil {


### PR DESCRIPTION
Fixes #5230

The Jira integration always sent a labels field in the issue creation request, even when no labels were configured. This caused failures on Jira project screens that do not include the Labels field, with the error Field 'labels' cannot be set.
Root cause: The issueFields struct was initialized with Labels: make([]string, 0, len(n.conf.Labels)+1), a non-nil empty slice, which serializes to "labels": [] in JSON and triggers the Jira validation error.

Fix: Initialize Labels as nil so it is omitted from the JSON payload when not configured. The existing if n.conf.Labels != nil guard then correctly only populates the field when the user explicitly configures labels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JIRA label handling: labels are now included in notifications only when explicitly configured. When enabled, configured labels are applied, automatically sorted, and an alert identifier is appended for clearer issue tracking. If not configured, notifications include only the alert identifier to avoid unintended labeling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/prometheus/alertmanager/pull/5263?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->