### PR TITLE
docs: clarify YAML quoting vs matcher token quoting

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -636,18 +636,19 @@ Double-quoted strings can contain all UTF-8 characters. Unlike unquoted literals
 
 > **Note: YAML quoting vs. matcher token quoting**
 >
-> Each entry in a `matchers:` list is a single YAML value. YAML quoting applies
-> to the *entire* matcher string — it does not parse or protect individual tokens
+> Each entry in a `matchers:` list is a single YAML string that Alertmanager
+> parses after the YAML file has been processed. YAML quoting applies to the
+> *entire* matcher string — it does not parse or protect individual tokens
 > within it. The double-quoting described above is handled by Alertmanager's own
 > parser after YAML has already processed the input.
 >
-> - **Plain style** (no surrounding quotes): works when the matcher contains no
+> - **[Plain style](https://yaml.org/spec/1.2.2/#plain-style)** (no surrounding quotes): works when the matcher contains no
 >   YAML special characters (`{`, `}`, `[`, `]`, `,`, `#`, `|`, `>`, `:`).
 >   Example: `env !~ preprod`
-> - **Single-quoted style** (recommended): protects against all YAML special
+> - **[Single-quoted style](https://yaml.org/spec/1.2.2/#single-quoted-style)**: protects against all YAML special
 >   characters and allows literal double quotes inside the matcher.
 >   Example: `'env =~ "prod|staging"'`
-> - **Double-quoted style**: supports YAML escape sequences; literal double quotes
+> - **[Double-quoted style](https://yaml.org/spec/1.2.2/#double-quoted-style)**: supports YAML escape sequences; literal double quotes
 >   inside the value must be escaped as `\"`.
 >   Example: `"env !~ \"uat\""`
 >

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -633,6 +633,29 @@ Unquoted literals can contain all UTF-8 characters other than the reserved chara
 
 Double-quoted strings can contain all UTF-8 characters. Unlike unquoted literals, there are no reserved characters. However, literal double quotes and backslashes must be escaped with a single backslash. For example, to match the regular expression `\d+` the backslash must be escaped `"\\d+"`. This is because double-quoted strings follow the same rules as Go's [string literals](https://go.dev/ref/spec#String_literals). Double-quoted strings also support UTF-8 code points. For example, `"foo!"`, `"bar,baz"`, `"\"baz qux\""` and `"\xf0\x9f\x99\x82"`.
 
+
+> **Note: YAML quoting vs. matcher token quoting**
+>
+> Each entry in a `matchers:` list is a single YAML value. YAML quoting applies
+> to the *entire* matcher string — it does not parse or protect individual tokens
+> within it. The double-quoting described above is handled by Alertmanager's own
+> parser after YAML has already processed the input.
+>
+> - **Plain style** (no surrounding quotes): works when the matcher contains no
+>   YAML special characters (`{`, `}`, `[`, `]`, `,`, `#`, `|`, `>`, `:`).
+>   Example: `env !~ preprod`
+> - **Single-quoted style** (recommended): protects against all YAML special
+>   characters and allows literal double quotes inside the matcher.
+>   Example: `'env =~ "prod|staging"'`
+> - **Double-quoted style**: supports YAML escape sequences; literal double quotes
+>   inside the value must be escaped as `\"`.
+>   Example: `"env !~ \"uat\""`
+>
+> Writing `env =~ "prod"` without surrounding YAML quotes is valid plain-style
+> YAML. The inner double quotes are stripped by Alertmanager's parser and provide
+> **no** protection against YAML special characters. Always quote the entire
+> matcher at the YAML level when the value may contain special characters.
+
 #### Classic matchers
 
 A classic matcher is a string with a syntax inspired by PromQL and OpenMetrics. The syntax of a classic matcher consists of three tokens:


### PR DESCRIPTION
Fixes #5099

Adds a note under the "UTF-8 matchers" section clarifying the distinction between YAML quoting and matcher token quoting.

Problem: The documentation describes double-quoting of individual matcher tokens (label name, label value) but does not explain that this quoting is handled by Alertmanager's own parser, not by YAML. Users writing env =~ "prod" without surrounding YAML quotes may believe the inner double quotes protect against YAML special characters, which they do not.

Change: Added a blockquote note explaining the three YAML quoting styles (plain, single-quoted, double-quoted) with examples, and explicitly clarifying that inner double quotes on matcher tokens provide no YAML-level protection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified YAML quoting behavior for matcher entries in configuration docs, explaining when to use plain, single-quoted, or double-quoted scalars and warning that quoting must be applied at the YAML level to protect against YAML special characters and ensure matchers are interpreted as intended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->