### PR TITLE
cluster: use hostname for TLS validation instead of resolved IP

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -62,6 +62,7 @@ type Peer struct {
 
 	resolvedPeers       []string
 	resolvePeersTimeout time.Duration
+	tlsTransport        *TLSTransport
 
 	mtx    sync.RWMutex
 	states map[string]State
@@ -173,7 +174,7 @@ func Create(
 
 	ctx, cancel := context.WithTimeout(context.Background(), resolveTimeout)
 	defer cancel()
-	resolvedPeers, err := resolvePeers(ctx, knownPeers, advertiseAddr, &net.Resolver{}, waitIfEmpty)
+	resolvedPeers, peerHostnames, err := resolvePeers(ctx, knownPeers, advertiseAddr, &net.Resolver{}, waitIfEmpty)
 	if err != nil {
 		return nil, fmt.Errorf("resolve peers: %w", err)
 	}
@@ -248,10 +249,13 @@ func Create(
 
 	if tlsTransportConfig != nil {
 		l.Info("using TLS for gossip")
-		cfg.Transport, err = NewTLSTransport(context.Background(), l, reg, cfg.BindAddr, cfg.BindPort, tlsTransportConfig)
-		if err != nil {
-			return nil, fmt.Errorf("tls transport: %w", err)
+		t, tErr := NewTLSTransport(context.Background(), l, reg, cfg.BindAddr, cfg.BindPort, tlsTransportConfig)
+		if tErr != nil {
+			return nil, fmt.Errorf("tls transport: %w", tErr)
 		}
+		t.SetPeerHostnames(peerHostnames)
+		cfg.Transport = t
+		p.tlsTransport = t
 	}
 
 	ml, err := memberlist.Create(cfg)
@@ -450,10 +454,14 @@ func (p *Peer) refresh() {
 
 	ctx, cancel := context.WithTimeout(context.Background(), p.resolvePeersTimeout)
 	defer cancel()
-	resolvedPeers, err := resolvePeers(ctx, p.knownPeers, p.advertiseAddr, &net.Resolver{}, false)
+	resolvedPeers, peerHostnames, err := resolvePeers(ctx, p.knownPeers, p.advertiseAddr, &net.Resolver{}, false)
 	if err != nil {
 		logger.Debug(fmt.Sprintf("%v", p.knownPeers), "err", err)
 		return
+	}
+
+	if p.tlsTransport != nil {
+		p.tlsTransport.SetPeerHostnames(peerHostnames)
 	}
 
 	members := p.mlist.Members()
@@ -729,13 +737,14 @@ func (b simpleBroadcast) Message() []byte                       { return []byte(
 func (b simpleBroadcast) Invalidates(memberlist.Broadcast) bool { return false }
 func (b simpleBroadcast) Finished()                             {}
 
-func resolvePeers(ctx context.Context, peers []string, myAddress string, res *net.Resolver, waitIfEmpty bool) ([]string, error) {
+func resolvePeers(ctx context.Context, peers []string, myAddress string, res *net.Resolver, waitIfEmpty bool) ([]string, map[string]string, error) {
 	var resolvedPeers []string
+	hostnames := make(map[string]string)
 
 	for _, peer := range peers {
 		host, port, err := net.SplitHostPort(peer)
 		if err != nil {
-			return nil, fmt.Errorf("split host/port for peer %s: %w", peer, err)
+			return nil, nil, fmt.Errorf("split host/port for peer %s: %w", peer, err)
 		}
 
 		retryCtx, cancel := context.WithCancel(ctx)
@@ -774,16 +783,18 @@ func resolvePeers(ctx context.Context, peers []string, myAddress string, res *ne
 				return nil
 			})
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 		}
 
 		for _, ip := range ips {
-			resolvedPeers = append(resolvedPeers, net.JoinHostPort(ip.String(), port))
+			resolved := net.JoinHostPort(ip.String(), port)
+			resolvedPeers = append(resolvedPeers, resolved)
+			hostnames[resolved] = host
 		}
 	}
 
-	return resolvedPeers, nil
+	return resolvedPeers, hostnames, nil
 }
 
 func removeMyAddr(ips []net.IPAddr, targetPort, myAddr string) []net.IPAddr {

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -15,6 +15,7 @@ package cluster
 
 import (
 	"context"
+	"net"
 	"testing"
 	"time"
 
@@ -437,4 +438,31 @@ func testPeerNames(t *testing.T, name1, name2 string) {
 		require.Eventually(t, func() bool { return p2.ClusterSize() == 2 }, 5*time.Second, time.Second)
 		require.NotEqual(t, p1.Name(), p2.Name(), "peers should have different names")
 	}
+}
+
+func TestResolvePeersHostnameMapping(t *testing.T) {
+	ctx := context.Background()
+	res := &net.Resolver{}
+
+	t.Run("IPAddressPeers", func(t *testing.T) {
+		peers := []string{"192.168.1.1:9094", "10.0.0.2:9094"}
+		resolved, hostnames, err := resolvePeers(ctx, peers, "", res, false)
+		require.NoError(t, err)
+		require.Equal(t, peers, resolved)
+		// IP addresses get mapped back to themselves; this is harmless since
+		// TLS will still use IP SAN validation when ServerName is an IP.
+		require.Equal(t, "192.168.1.1", hostnames["192.168.1.1:9094"])
+		require.Equal(t, "10.0.0.2", hostnames["10.0.0.2:9094"])
+	})
+
+	t.Run("LocalhostPeer", func(t *testing.T) {
+		peers := []string{"localhost:9094"}
+		resolved, hostnames, err := resolvePeers(ctx, peers, "", res, false)
+		require.NoError(t, err)
+		require.NotEmpty(t, resolved)
+		// localhost resolves to an IP; the mapping should point back to "localhost".
+		for _, r := range resolved {
+			require.Equal(t, "localhost", hostnames[r])
+		}
+	})
 }

--- a/cluster/connection_pool.go
+++ b/cluster/connection_pool.go
@@ -48,7 +48,9 @@ func newConnectionPool(tlsClientCfg *tls.Config) (*connectionPool, error) {
 
 // borrowConnection returns a *tlsConn from the pool. The connection does not
 // need to be returned to the pool because each connection has its own locking.
-func (pool *connectionPool) borrowConnection(addr string, timeout time.Duration) (*tlsConn, error) {
+// If hostname is non-empty, it is used as the TLS ServerName for certificate
+// validation instead of the IP address from addr.
+func (pool *connectionPool) borrowConnection(addr string, timeout time.Duration, hostname string) (*tlsConn, error) {
 	pool.mtx.Lock()
 	defer pool.mtx.Unlock()
 	if pool.cache == nil {
@@ -59,7 +61,13 @@ func (pool *connectionPool) borrowConnection(addr string, timeout time.Duration)
 	if exists && conn.alive() {
 		return conn, nil
 	}
-	conn, err := dialTLSConn(addr, timeout, pool.tlsConfig)
+	tlsCfg := pool.tlsConfig
+	if hostname != "" {
+		clone := tlsCfg.Clone()
+		clone.ServerName = hostname
+		tlsCfg = clone
+	}
+	conn, err := dialTLSConn(addr, timeout, tlsCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/cluster/tls_transport.go
+++ b/cluster/tls_transport.go
@@ -57,6 +57,12 @@ type TLSTransport struct {
 	tlsServerCfg *tls.Config
 	tlsClientCfg *tls.Config
 
+	// peerHostnames maps resolved IP:port addresses back to the original
+	// hostname provided by the user. This is used to set the TLS ServerName
+	// to the hostname instead of the IP, enabling proper certificate
+	// validation against DNS SANs.
+	peerHostnames map[string]string
+
 	packetsSent prometheus.Counter
 	packetsRcvd prometheus.Counter
 	streamsSent prometheus.Counter
@@ -136,6 +142,13 @@ func NewTLSTransport(
 	return t, nil
 }
 
+// SetPeerHostnames sets the mapping from resolved IP:port addresses to the
+// original hostname provided by the user. This allows the TLS transport to
+// use the hostname for certificate verification instead of the IP address.
+func (t *TLSTransport) SetPeerHostnames(hostnames map[string]string) {
+	t.peerHostnames = hostnames
+}
+
 // FinalAdvertiseAddr is given the user's configured values (which
 // might be empty) and returns the desired IP and port to advertise to
 // the rest of the cluster.
@@ -204,7 +217,7 @@ func (t *TLSTransport) Shutdown() error {
 // from the pool, and writes to it. It also returns a timestamp of when
 // the packet was written.
 func (t *TLSTransport) WriteTo(b []byte, addr string) (time.Time, error) {
-	conn, err := t.connPool.borrowConnection(addr, DefaultTCPTimeout)
+	conn, err := t.connPool.borrowConnection(addr, DefaultTCPTimeout, t.peerHostnames[addr])
 	if err != nil {
 		t.writeErrs.WithLabelValues("packet").Inc()
 		return time.Now(), fmt.Errorf("failed to dial: %w", err)
@@ -222,7 +235,16 @@ func (t *TLSTransport) WriteTo(b []byte, addr string) (time.Time, error) {
 // DialTimeout is used to create a connection that allows memberlist
 // to perform two-way communications with a peer.
 func (t *TLSTransport) DialTimeout(addr string, timeout time.Duration) (net.Conn, error) {
-	conn, err := dialTLSConn(addr, timeout, t.tlsClientCfg)
+	tlsCfg := t.tlsClientCfg
+	if host, ok := t.peerHostnames[addr]; ok {
+		// Clone the TLS config and set ServerName to the original hostname
+		// so that certificate validation checks against DNS SANs instead of
+		// IP SANs. See https://github.com/prometheus/alertmanager/issues/5112.
+		clone := tlsCfg.Clone()
+		clone.ServerName = host
+		tlsCfg = clone
+	}
+	conn, err := dialTLSConn(addr, timeout, tlsCfg)
 	if err != nil {
 		t.writeErrs.WithLabelValues("stream").Inc()
 		return nil, fmt.Errorf("failed to dial: %w", err)


### PR DESCRIPTION
## Problem

When `--cluster.peer` specifies a hostname (e.g. `myhost.example.com:9094`), the `resolvePeers` function resolves it to an IP address. The TLS transport then validates the peer's certificate against this IP, requiring IP SANs. This fails for certificates that only have DNS SANs — which is the common case.

```
tls: failed to verify certificate: x509: cannot validate certificate for 49.12.57.136 because it doesn't contain any IP SANs
```

Users are forced to configure `tls_client_config.server_name` as a workaround, even though the hostname was already provided to `--cluster.peer`.

## Fix

Track the mapping from resolved IP:port back to the original hostname during `resolvePeers`. When dialing via TLS, set `ServerName` to the original hostname so certificate validation checks against DNS SANs.

The mapping is maintained across peer refresh cycles so reconnections also use the correct hostname.

**Changes:**
- `cluster/cluster.go`: `resolvePeers` now returns a `map[string]string` mapping resolved IP:port to original hostname. The `Peer` struct stores a reference to the TLS transport to update the mapping on refresh.
- `cluster/tls_transport.go`: Added `peerHostnames` field and `SetPeerHostnames` method. `DialTimeout` and `WriteTo` use the hostname for TLS `ServerName` when available.
- `cluster/connection_pool.go`: `borrowConnection` accepts an optional hostname parameter for TLS `ServerName`.
- `cluster/cluster_test.go`: Added `TestResolvePeersHostnameMapping` test.

Fixes #5112


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced TLS peer hostname mapping and validation for secure cluster communication
  * Improved peer resolution with hostname tracking and updates

* **Tests**
  * Added test coverage for peer hostname mapping validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->