### PR TITLE
email_test.go: fix tests

### DIFF
--- a/notify/email/email_test.go
+++ b/notify/email/email_test.go
@@ -575,7 +575,7 @@ func TestEmailNotifyWithAuthentication(t *testing.T) {
 				cfg.Hello = "invalid hello string"
 			},
 
-			errMsg: "501 Error",
+			errMsg: "501",
 			retry:  true,
 		},
 	} {
@@ -733,7 +733,8 @@ func TestEmailRejected(t *testing.T) {
 
 	// Send the alert to mock SMTP server.
 	retry, err := e.Notify(context.Background(), firingAlert)
-	require.ErrorContains(t, err, "501 5.5.4 Rejected!")
+	require.ErrorContains(t, err, "501")
+	require.ErrorContains(t, err, "5.5.4")
 	require.True(t, retry)
 	require.NoError(t, srv.Shutdown(ctx))
 


### PR DESCRIPTION
check the error message with a regexp allowing an optional quote introduced in go 1.26.4
#### Pull Request Checklist
Please check all the applicable boxes.

- Please list all open issue(s) discussed with maintainers related to this change
- Is this a bugfix?
    - [X] I have added tests that can reproduce the bug which pass with this bugfix applied, they were already there
```release-notes
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Relaxed assertions in email notification tests: tests now validate error codes/substrings instead of exact full error messages, reducing brittleness and improving resilience to SMTP message variations and minor wording changes. This strengthens test stability while preserving public behavior and introduces no public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->