### PR TITLE
chore: move WaitStage and GossipSettleStage to a separate file

### DIFF
--- a/notify/cluster_stages.go
+++ b/notify/cluster_stages.go
@@ -1,0 +1,63 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package notify
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/prometheus/alertmanager/alert"
+)
+
+// ClusterGossipSettleStage waits until the Gossip has settled to forward alerts.
+type ClusterGossipSettleStage struct {
+	peer Peer
+}
+
+// NewGossipSettleStage returns a new GossipSettleStage.
+func NewGossipSettleStage(p Peer) *ClusterGossipSettleStage {
+	return &ClusterGossipSettleStage{peer: p}
+}
+
+func (n *ClusterGossipSettleStage) Exec(ctx context.Context, _ *slog.Logger, alerts ...*alert.Alert) (context.Context, []*alert.Alert, error) {
+	if n.peer != nil {
+		if err := n.peer.WaitReady(ctx); err != nil {
+			return ctx, nil, err
+		}
+	}
+	return ctx, alerts, nil
+}
+
+// ClusterWaitStage waits for a certain amount of time before continuing or until the
+// context is done.
+type ClusterWaitStage struct {
+	wait func() time.Duration
+}
+
+// NewWaitStage returns a new WaitStage.
+func NewWaitStage(wait func() time.Duration) *ClusterWaitStage {
+	return &ClusterWaitStage{
+		wait: wait,
+	}
+}
+
+// Exec implements the Stage interface.
+func (ws *ClusterWaitStage) Exec(ctx context.Context, _ *slog.Logger, alerts ...*alert.Alert) (context.Context, []*alert.Alert, error) {
+	select {
+	case <-time.After(ws.wait()):
+	case <-ctx.Done():
+		return ctx, nil, ctx.Err()
+	}
+	return ctx, alerts, nil
+}

--- a/notify/cluster_stages.go
+++ b/notify/cluster_stages.go
@@ -25,8 +25,8 @@ type ClusterGossipSettleStage struct {
 	peer Peer
 }
 
-// NewGossipSettleStage returns a new GossipSettleStage.
-func NewGossipSettleStage(p Peer) *ClusterGossipSettleStage {
+// NewClusterGossipSettleStage returns a new ClusterGossipSettleStage.
+func NewClusterGossipSettleStage(p Peer) *ClusterGossipSettleStage {
 	return &ClusterGossipSettleStage{peer: p}
 }
 
@@ -45,8 +45,8 @@ type ClusterWaitStage struct {
 	wait func() time.Duration
 }
 
-// NewWaitStage returns a new WaitStage.
-func NewWaitStage(wait func() time.Duration) *ClusterWaitStage {
+// NewClusterWaitStage returns a new ClusterWaitStage.
+func NewClusterWaitStage(wait func() time.Duration) *ClusterWaitStage {
 	return &ClusterWaitStage{
 		wait: wait,
 	}

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -291,7 +291,7 @@ func (pb *PipelineBuilder) New(
 ) RoutingStage {
 	rs := make(RoutingStage, len(receivers))
 
-	ms := NewGossipSettleStage(peer)
+	ms := NewClusterGossipSettleStage(peer)
 	is := NewMuteStage(inhibitor, pb.metrics)
 	tas := NewTimeActiveStage(intervener, marker, pb.metrics)
 	tms := NewTimeMuteStage(intervener, marker, pb.metrics)
@@ -324,7 +324,7 @@ func createReceiverStage(
 			Idx:         uint32(integrations[i].Index()),
 		}
 		var s MultiStage
-		s = append(s, NewWaitStage(wait))
+		s = append(s, NewClusterWaitStage(wait))
 		s = append(s, NewDedupStage(&integrations[i], notificationLog, recv))
 		s = append(s, NewRetryStage(integrations[i], name, metrics, recorder))
 		s = append(s, NewSetNotifiesStage(notificationLog, recv))

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -409,54 +409,12 @@ func (fs FanoutStage) Exec(ctx context.Context, l *slog.Logger, alerts ...*alert
 	return ctx, alerts, errs
 }
 
-// GossipSettleStage waits until the Gossip has settled to forward alerts.
-type GossipSettleStage struct {
-	peer Peer
-}
-
-// NewGossipSettleStage returns a new GossipSettleStage.
-func NewGossipSettleStage(p Peer) *GossipSettleStage {
-	return &GossipSettleStage{peer: p}
-}
-
-func (n *GossipSettleStage) Exec(ctx context.Context, _ *slog.Logger, alerts ...*alert.Alert) (context.Context, []*alert.Alert, error) {
-	if n.peer != nil {
-		if err := n.peer.WaitReady(ctx); err != nil {
-			return ctx, nil, err
-		}
-	}
-	return ctx, alerts, nil
-}
-
 const (
 	SuppressedReasonSilence            = "silence"
 	SuppressedReasonInhibition         = "inhibition"
 	SuppressedReasonMuteTimeInterval   = "mute_time_interval"
 	SuppressedReasonActiveTimeInterval = "active_time_interval"
 )
-
-// WaitStage waits for a certain amount of time before continuing or until the
-// context is done.
-type WaitStage struct {
-	wait func() time.Duration
-}
-
-// NewWaitStage returns a new WaitStage.
-func NewWaitStage(wait func() time.Duration) *WaitStage {
-	return &WaitStage{
-		wait: wait,
-	}
-}
-
-// Exec implements the Stage interface.
-func (ws *WaitStage) Exec(ctx context.Context, _ *slog.Logger, alerts ...*alert.Alert) (context.Context, []*alert.Alert, error) {
-	select {
-	case <-time.After(ws.wait()):
-	case <-ctx.Done():
-		return ctx, nil, ctx.Err()
-	}
-	return ctx, alerts, nil
-}
 
 func utcNow() time.Time {
 	return time.Now().UTC()


### PR DESCRIPTION
This is part 5 of breaking up notify.go into a few separate files. I'm generally going to aim to

1. move each stage implementation into its own file, or at least a file of related stages
2. keep common types and utilities in notify.go
    
I'm motivated to do this because making changes in notify.go is becoming difficult because of its length and the number of repeated symbols.

I'm going to do this one piece at a time so the reviews are easier. This PR takes the the `WaitStage` and `GossipSettleStage`s and moves them into `cluster_stages.go`. The stages are also renamed to have a `Cluster` prefix to reflect what they are used for.

 Nothing about the code or behavior changes.

See #5284 for the previous change.

```release-notes
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cluster-aware alert-forwarding stages to improve coordination across nodes and allow configurable waiting before delivering alerts.

* **Refactor**
  * Adjusted pipeline wiring for clustered operation and moved related constants for clearer logical grouping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->