### PR TITLE
backport e47ba08 to release-0.32

### DIFF
--- a/notify/email/email_test.go
+++ b/notify/email/email_test.go
@@ -575,7 +575,7 @@ func TestEmailNotifyWithAuthentication(t *testing.T) {
 				cfg.Hello = "invalid hello string"
 			},
 
-			errMsg: "501 Error",
+			errMsg: "501",
 			retry:  true,
 		},
 	} {
@@ -733,7 +733,8 @@ func TestEmailRejected(t *testing.T) {
 
 	// Send the alert to mock SMTP server.
 	retry, err := e.Notify(context.Background(), firingAlert)
-	require.ErrorContains(t, err, "501 5.5.4 Rejected!")
+	require.ErrorContains(t, err, "501")
+	require.ErrorContains(t, err, "5.5.4")
 	require.True(t, retry)
 	require.NoError(t, srv.Shutdown(ctx))
 


### PR DESCRIPTION
https://github.com/prometheus/alertmanager/commit/e47ba08a3fc2446cd65119471ebc502d4ebc083c fixes a bug in the tests when building with the go `1.26.4` compiler.

#### Which user-facing changes does this PR introduce?
```release-notes
NONE
```
