### PR TITLE
fix the release date for 0.32.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * [FEATURE] ...
 * [ENHANCEMENT] ...
 
-## 0.32.2 / 2026-05-25
+## 0.32.2 / 2026-06-05
 
 * [BUGFIX] Fix dispatcher goroutine leaks on destroyed alertgroup swap. #5241
 


### PR DESCRIPTION
The release got a bit delayed

#### Which user-facing changes does this PR introduce?

```release-notes
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the release date for version 0.32.2 in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->