### PR TITLE
chore: more reorganization of notify.go

### DIFF
--- a/notify/metrics.go
+++ b/notify/metrics.go
@@ -1,0 +1,140 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package notify
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/prometheus/alertmanager/featurecontrol"
+)
+
+type Metrics struct {
+	numNotifications                   *prometheus.CounterVec
+	numTotalFailedNotifications        *prometheus.CounterVec
+	numNotificationRequestsTotal       *prometheus.CounterVec
+	numNotificationRequestsFailedTotal *prometheus.CounterVec
+	numNotificationSuppressedTotal     *prometheus.CounterVec
+	notificationLatencySeconds         *prometheus.HistogramVec
+
+	ff featurecontrol.Flagger
+}
+
+func NewMetrics(r prometheus.Registerer, ff featurecontrol.Flagger) *Metrics {
+	labels := []string{"integration"}
+
+	if ff.EnableReceiverNamesInMetrics() {
+		labels = append(labels, "receiver_name")
+	}
+
+	m := &Metrics{
+		numNotifications: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Namespace: "alertmanager",
+			Name:      "notifications_total",
+			Help:      "The total number of attempted notifications.",
+		}, labels),
+		numTotalFailedNotifications: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Namespace: "alertmanager",
+			Name:      "notifications_failed_total",
+			Help:      "The total number of failed notifications.",
+		}, append(labels, "reason")),
+		numNotificationRequestsTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Namespace: "alertmanager",
+			Name:      "notification_requests_total",
+			Help:      "The total number of attempted notification requests.",
+		}, labels),
+		numNotificationRequestsFailedTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Namespace: "alertmanager",
+			Name:      "notification_requests_failed_total",
+			Help:      "The total number of failed notification requests.",
+		}, labels),
+		numNotificationSuppressedTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Namespace: "alertmanager",
+			Name:      "notifications_suppressed_total",
+			Help:      "The total number of notifications suppressed for being silenced, inhibited, outside of active time intervals or within muted time intervals.",
+		}, []string{"reason"}),
+		notificationLatencySeconds: promauto.With(r).NewHistogramVec(prometheus.HistogramOpts{
+			Namespace:                       "alertmanager",
+			Name:                            "notification_latency_seconds",
+			Help:                            "The latency of notifications in seconds.",
+			Buckets:                         []float64{1, 5, 10, 15, 20},
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: 1 * time.Hour,
+		}, labels),
+		ff: ff,
+	}
+
+	return m
+}
+
+func (m *Metrics) InitializeFor(receiver map[string][]Integration) {
+	if m.ff.EnableReceiverNamesInMetrics() {
+
+		// Reset the vectors to take into account receiver names changing after hot reloads.
+		m.numNotifications.Reset()
+		m.numNotificationRequestsTotal.Reset()
+		m.numNotificationRequestsFailedTotal.Reset()
+		m.notificationLatencySeconds.Reset()
+		m.numTotalFailedNotifications.Reset()
+
+		for name, integrations := range receiver {
+			for _, integration := range integrations {
+
+				m.numNotifications.WithLabelValues(integration.Name(), name)
+				m.numNotificationRequestsTotal.WithLabelValues(integration.Name(), name)
+				m.numNotificationRequestsFailedTotal.WithLabelValues(integration.Name(), name)
+				m.notificationLatencySeconds.WithLabelValues(integration.Name(), name)
+
+				for _, reason := range possibleFailureReasonCategory {
+					m.numTotalFailedNotifications.WithLabelValues(integration.Name(), name, reason)
+				}
+			}
+		}
+
+		return
+	}
+
+	// When the feature flag is not enabled, we just carry on registering _all_ the integrations.
+	for _, integration := range []string{
+		"email",
+		"pagerduty",
+		"wechat",
+		"pushover",
+		"slack",
+		"opsgenie",
+		"webhook",
+		"victorops",
+		"sns",
+		"telegram",
+		"discord",
+		"webex",
+		"msteams",
+		"msteamsv2",
+		"incidentio",
+		"jira",
+		"rocketchat",
+		"mattermost",
+	} {
+		m.numNotifications.WithLabelValues(integration)
+		m.numNotificationRequestsTotal.WithLabelValues(integration)
+		m.numNotificationRequestsFailedTotal.WithLabelValues(integration)
+		m.notificationLatencySeconds.WithLabelValues(integration)
+
+		for _, reason := range possibleFailureReasonCategory {
+			m.numTotalFailedNotifications.WithLabelValues(integration, reason)
+		}
+	}
+}

--- a/notify/mute.go
+++ b/notify/mute.go
@@ -31,6 +31,13 @@ import (
 	"github.com/prometheus/alertmanager/silence"
 )
 
+const (
+	SuppressedReasonSilence            = "silence"
+	SuppressedReasonInhibition         = "inhibition"
+	SuppressedReasonMuteTimeInterval   = "mute_time_interval"
+	SuppressedReasonActiveTimeInterval = "active_time_interval"
+)
+
 // A Muter determines whether a given label set is muted. Implementers that
 // maintain an underlying AlertMarker are expected to update it during a call of
 // Mutes.

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/cespare/xxhash/v2"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -144,124 +143,6 @@ func (f StageFunc) Exec(ctx context.Context, l *slog.Logger, alerts ...*alert.Al
 type NotificationLog interface {
 	Log(r *nflogpb.Receiver, gkey string, firingAlerts, resolvedAlerts []uint64, store *nflog.Store, expiry time.Duration) error
 	Query(params ...nflog.QueryParam) ([]*nflogpb.Entry, error)
-}
-
-type Metrics struct {
-	numNotifications                   *prometheus.CounterVec
-	numTotalFailedNotifications        *prometheus.CounterVec
-	numNotificationRequestsTotal       *prometheus.CounterVec
-	numNotificationRequestsFailedTotal *prometheus.CounterVec
-	numNotificationSuppressedTotal     *prometheus.CounterVec
-	notificationLatencySeconds         *prometheus.HistogramVec
-
-	ff featurecontrol.Flagger
-}
-
-func NewMetrics(r prometheus.Registerer, ff featurecontrol.Flagger) *Metrics {
-	labels := []string{"integration"}
-
-	if ff.EnableReceiverNamesInMetrics() {
-		labels = append(labels, "receiver_name")
-	}
-
-	m := &Metrics{
-		numNotifications: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
-			Namespace: "alertmanager",
-			Name:      "notifications_total",
-			Help:      "The total number of attempted notifications.",
-		}, labels),
-		numTotalFailedNotifications: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
-			Namespace: "alertmanager",
-			Name:      "notifications_failed_total",
-			Help:      "The total number of failed notifications.",
-		}, append(labels, "reason")),
-		numNotificationRequestsTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
-			Namespace: "alertmanager",
-			Name:      "notification_requests_total",
-			Help:      "The total number of attempted notification requests.",
-		}, labels),
-		numNotificationRequestsFailedTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
-			Namespace: "alertmanager",
-			Name:      "notification_requests_failed_total",
-			Help:      "The total number of failed notification requests.",
-		}, labels),
-		numNotificationSuppressedTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
-			Namespace: "alertmanager",
-			Name:      "notifications_suppressed_total",
-			Help:      "The total number of notifications suppressed for being silenced, inhibited, outside of active time intervals or within muted time intervals.",
-		}, []string{"reason"}),
-		notificationLatencySeconds: promauto.With(r).NewHistogramVec(prometheus.HistogramOpts{
-			Namespace:                       "alertmanager",
-			Name:                            "notification_latency_seconds",
-			Help:                            "The latency of notifications in seconds.",
-			Buckets:                         []float64{1, 5, 10, 15, 20},
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: 1 * time.Hour,
-		}, labels),
-		ff: ff,
-	}
-
-	return m
-}
-
-func (m *Metrics) InitializeFor(receiver map[string][]Integration) {
-	if m.ff.EnableReceiverNamesInMetrics() {
-
-		// Reset the vectors to take into account receiver names changing after hot reloads.
-		m.numNotifications.Reset()
-		m.numNotificationRequestsTotal.Reset()
-		m.numNotificationRequestsFailedTotal.Reset()
-		m.notificationLatencySeconds.Reset()
-		m.numTotalFailedNotifications.Reset()
-
-		for name, integrations := range receiver {
-			for _, integration := range integrations {
-
-				m.numNotifications.WithLabelValues(integration.Name(), name)
-				m.numNotificationRequestsTotal.WithLabelValues(integration.Name(), name)
-				m.numNotificationRequestsFailedTotal.WithLabelValues(integration.Name(), name)
-				m.notificationLatencySeconds.WithLabelValues(integration.Name(), name)
-
-				for _, reason := range possibleFailureReasonCategory {
-					m.numTotalFailedNotifications.WithLabelValues(integration.Name(), name, reason)
-				}
-			}
-		}
-
-		return
-	}
-
-	// When the feature flag is not enabled, we just carry on registering _all_ the integrations.
-	for _, integration := range []string{
-		"email",
-		"pagerduty",
-		"wechat",
-		"pushover",
-		"slack",
-		"opsgenie",
-		"webhook",
-		"victorops",
-		"sns",
-		"telegram",
-		"discord",
-		"webex",
-		"msteams",
-		"msteamsv2",
-		"incidentio",
-		"jira",
-		"rocketchat",
-		"mattermost",
-	} {
-		m.numNotifications.WithLabelValues(integration)
-		m.numNotificationRequestsTotal.WithLabelValues(integration)
-		m.numNotificationRequestsFailedTotal.WithLabelValues(integration)
-		m.notificationLatencySeconds.WithLabelValues(integration)
-
-		for _, reason := range possibleFailureReasonCategory {
-			m.numTotalFailedNotifications.WithLabelValues(integration, reason)
-		}
-	}
 }
 
 type PipelineBuilder struct {
@@ -409,12 +290,40 @@ func (fs FanoutStage) Exec(ctx context.Context, l *slog.Logger, alerts ...*alert
 	return ctx, alerts, errs
 }
 
+type NotifyReason int
+
 const (
-	SuppressedReasonSilence            = "silence"
-	SuppressedReasonInhibition         = "inhibition"
-	SuppressedReasonMuteTimeInterval   = "mute_time_interval"
-	SuppressedReasonActiveTimeInterval = "active_time_interval"
+	ReasonDoNotNotify NotifyReason = iota
+	ReasonFirstNotification
+	ReasonNewAlertsInGroup
+	ReasonNewResolvedAlerts
+	ReasonAllAlertsResolved
+	ReasonRepeatIntervalElapsed
+	ReasonUnknown
 )
+
+func (r NotifyReason) shouldNotify() bool {
+	return r != ReasonDoNotNotify
+}
+
+func (r NotifyReason) String() string {
+	switch r {
+	case ReasonDoNotNotify:
+		return "none"
+	case ReasonFirstNotification:
+		return "first notification"
+	case ReasonNewAlertsInGroup:
+		return "new alerts added"
+	case ReasonNewResolvedAlerts:
+		return "some alerts resolved"
+	case ReasonAllAlertsResolved:
+		return "all alerts resolved"
+	case ReasonRepeatIntervalElapsed:
+		return "repeat interval elapsed"
+	default:
+		return "unknown"
+	}
+}
 
 func utcNow() time.Time {
 	return time.Now().UTC()
@@ -453,39 +362,4 @@ func hashAlert(a *alert.Alert) uint64 {
 	hash := xxhash.Sum64(b)
 
 	return hash
-}
-
-type NotifyReason int
-
-const (
-	ReasonDoNotNotify NotifyReason = iota
-	ReasonFirstNotification
-	ReasonNewAlertsInGroup
-	ReasonNewResolvedAlerts
-	ReasonAllAlertsResolved
-	ReasonRepeatIntervalElapsed
-	ReasonUnknown
-)
-
-func (r NotifyReason) shouldNotify() bool {
-	return r != ReasonDoNotNotify
-}
-
-func (r NotifyReason) String() string {
-	switch r {
-	case ReasonDoNotNotify:
-		return "none"
-	case ReasonFirstNotification:
-		return "first notification"
-	case ReasonNewAlertsInGroup:
-		return "new alerts added"
-	case ReasonNewResolvedAlerts:
-		return "some alerts resolved"
-	case ReasonAllAlertsResolved:
-		return "all alerts resolved"
-	case ReasonRepeatIntervalElapsed:
-		return "repeat interval elapsed"
-	default:
-		return "unknown"
-	}
 }


### PR DESCRIPTION
This is part 6 of breaking up notify.go into a few separate files. I'm generally going to aim to

1. move each stage implementation into its own file, or at least a file of related stages
2. keep common types and utilities in notify.go
    
I'm motivated to do this because making changes in notify.go is becoming difficult because of its length and the number of repeated symbols.

I'm going to do this one piece at a time so the reviews are easier. This PR 
* moves the `notify.Metrics` type into a `metrics.go` file
* moves the `SuppressedReason` enum to `mute.go` because that's the only place it's referenced
* does a small reorganization of what's left in `notify.go` so that the various free-functions are below the types and receiver functions.

Nothing about the code or behavior changes.

I _think_ this is the last one of these I'll make for a little while.

See #5287 for the previous change.

```release-notes
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added comprehensive notification metrics for monitoring attempts, failures, suppression tracking, and latency measurement to enhance observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->