### PR TITLE
chore: tune coderabbit messages

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,3 +2,13 @@
 # docs: https://docs.coderabbit.ai/reference/configuration
 reviews:
   poem: false
+  high_level_summary: false
+  estimated_code_review_effort: false
+  suggested_labels: false
+  suggested_reviewers: false
+  review_status: false
+  in_progress_fortune: false
+  pre_merge_checks:
+    enabled: false
+  finishing_tocuhes:
+    enabled: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -8,7 +8,3 @@ reviews:
   suggested_reviewers: false
   review_status: false
   in_progress_fortune: false
-  pre_merge_checks:
-    enabled: false
-  finishing_tocuhes:
-    enabled: false


### PR DESCRIPTION
Update the coderabbit configuration to reduce the amount of noise it generates on every PR:
1. stop it from editing PR summaries
2. remove some less useful fields from existing comments
3. stop it from positing 'in progress' messages that generate emails every time.

Also attempts to disabled the `pre_merge_checks` and `finishing_touches` sections of the coderabbit comment, but I'm not sure if that actually works.

#### Which user-facing changes does this PR introduce?
```release-notes
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded review configuration to include additional review metadata toggles (all disabled by default), refining how automated review summaries, effort estimates, suggested labels/reviewers, and status indicators are handled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->