### PR TITLE
prep release v0.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,12 @@
 * [CHANGE] Remove `alertmanager_marked_alerts`. #5047
 * [CHANGE] Remove the following from `types` package: `MemMarker`, `AlertState*`, `AlertStatus`. #5047
 * [FEATURE] Introduce per aggregation group AlertMarkers and drop Global Alert Marker. #5047
-* [FEATURE] UI: Add support for silence annotations. #5017
+* [FEATURE] ui: Add support for silence annotations. #5017
 * [FEATURE] api: Add receiver labels and `receiver_matchers` filter to `/api/v2/receivers`, `/api/v2/alerts`, and `/api/v2/alerts/groups`. #5152
 * [FEATURE] eventrecorder: Add structured event recorder behind `--enable-feature=event-recorder`, with file, webhook, and kafka outputs. #5072, #5246
 * [ENHANCEMENT] Add the `use_aws_http_client` config option to the sns notifier. #5178
 * [ENHANCEMENT] Alertmanager: Push docker images to ghcr docker registry. #5260
-* [ENHANCEMENT] TEMPLATE: Add now function to get current time. #5188
+* [ENHANCEMENT] template: Add now function to get current time. #5188
 * [ENHANCEMENT] docs: Clarify YAML quoting vs matcher token quoting in UTF-8 matchers section. #5264
 * [BUGFIX] jira: Allow disabling the resolve transition when `resolve_transition` is not set. #4821
 * [BUGFIX] jira: Include unresolved issues in `wont_fix_resolution` JQL to prevent duplicate issue creation. #5185

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * [FEATURE] ...
 * [ENHANCEMENT] ...
 
-## 0.33.0-rc.0 / 2026-06-10
+## 0.33.0-rc.0 / 2026-06-11
 
 * [CHANGE] The '--enable-feature=auto-gomaxprocs' option has been removed. This flag had no effect since v0.29 and was deprecated in v0.32. It can be safely removed from any startup scripts. #5090, #5251
 * [CHANGE] Add `group-key-in-metrics` feature flag. #5047

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@
 * [FEATURE] api: Add receiver labels and `receiver_matchers` filter to `/api/v2/receivers`, `/api/v2/alerts`, and `/api/v2/alerts/groups`. #5152
 * [FEATURE] eventrecorder: Add structured event recorder behind `--enable-feature=event-recorder`, with file, webhook, and kafka outputs. #5072, #5246
 * [ENHANCEMENT] Add the `use_aws_http_client` config option to the sns notifier. #5178
-* [ENHANCEMENT] Alertmanager: Push docker images to ghcr docker registry. #5260
 * [ENHANCEMENT] template: Add now function to get current time. #5188
 * [ENHANCEMENT] docs: Clarify YAML quoting vs matcher token quoting in UTF-8 matchers section. #5264
 * [BUGFIX] jira: Allow disabling the resolve transition when `resolve_transition` is not set. #4821

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * [FEATURE] ...
 * [ENHANCEMENT] ...
 
-## 0.33.0-rc.0 / 2026-06-11
+## 0.33.0 / 2026-06-11
 
 * [CHANGE] The '--enable-feature=auto-gomaxprocs' option has been removed. This flag had no effect since v0.29 and was deprecated in v0.32. It can be safely removed from any startup scripts. #5090, #5251
 * [CHANGE] Add `group-key-in-metrics` feature flag. #5047

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * [FEATURE] Introduce per aggregation group AlertMarkers and drop Global Alert Marker. #5047
 * [FEATURE] UI: Add support for silence annotations. #5017
 * [FEATURE] api: Add receiver labels and `receiver_matchers` filter to `/api/v2/receivers`, `/api/v2/alerts`, and `/api/v2/alerts/groups`. #5152
-* [FEATURE] eventrecorder: Add structured event recorder behind `--enable-feature=event-recorder`, with file and webhook, and kafka outputs. #5072, #5246
+* [FEATURE] eventrecorder: Add structured event recorder behind `--enable-feature=event-recorder`, with file, webhook, and kafka outputs. #5072, #5246
 * [ENHANCEMENT] Add the `use_aws_http_client` config option to the sns notifier. #5178
 * [ENHANCEMENT] Alertmanager: Push docker images to ghcr docker registry. #5260
 * [ENHANCEMENT] TEMPLATE: Add now function to get current time. #5188

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@
 * [FEATURE] ...
 * [ENHANCEMENT] ...
 
+## 0.33.0-rc.0 / 2026-06-10
+
+* [CHANGE] The '--enable-feature=auto-gomaxprocs' option has been removed. This flag had no effect since v0.29 and was deprecated in v0.32. It can be safely removed from any startup scripts. #5090, #5251
+* [CHANGE] Add `group-key-in-metrics` feature flag. #5047
+* [CHANGE] Move `AlertMarker`, `GroupMarker` to `marker` package. #5047
+* [CHANGE] Remove `alertmanager_marked_alerts`. #5047
+* [CHANGE] Remove the following from `types` package: `MemMarker`, `AlertState*`, `AlertStatus`. #5047
+* [FEATURE] Introduce per aggregation group AlertMarkers and drop Global Alert Marker. #5047
+* [FEATURE] UI: Add support for silence annotations. #5017
+* [FEATURE] api: Add receiver labels and `receiver_matchers` filter to `/api/v2/receivers`, `/api/v2/alerts`, and `/api/v2/alerts/groups`. #5152
+* [FEATURE] eventrecorder: Add structured event recorder behind `--enable-feature=event-recorder`, with file and webhook, and kafka outputs. #5072, #5246
+* [ENHANCEMENT] Add the `use_aws_http_client` config option to the sns notifier. #5178
+* [ENHANCEMENT] Alertmanager: Push docker images to ghcr docker registry. #5260
+* [ENHANCEMENT] TEMPLATE: Add now function to get current time. #5188
+* [ENHANCEMENT] docs: Clarify YAML quoting vs matcher token quoting in UTF-8 matchers section. #5264
+* [BUGFIX] jira: Allow disabling the resolve transition when `resolve_transition` is not set. #4821
+* [BUGFIX] jira: Include unresolved issues in `wont_fix_resolution` JQL to prevent duplicate issue creation. #5185
+* [BUGFIX] sns: Support the `AWS_CA_BUNDLE` env variable for the sns notifier. #5178
+
 ## 0.32.2 / 2026-06-05
 
 * [BUGFIX] Fix dispatcher goroutine leaks on destroyed alertgroup swap. #5241


### PR DESCRIPTION
Updates changelog with the following new entries:

* [CHANGE] The '--enable-feature=auto-gomaxprocs' option has been removed. This flag had no effect since v0.29 and was deprecated in v0.32. It can be safely removed from any startup scripts. #5090, #5251
* [CHANGE] Add `group-key-in-metrics` feature flag. #5047
* [CHANGE] Move `AlertMarker`, `GroupMarker` to `marker` package. #5047
* [CHANGE] Remove `alertmanager_marked_alerts`. #5047
* [CHANGE] Remove the following from `types` package: `MemMarker`, `AlertState*`, `AlertStatus`. #5047
* [FEATURE] Introduce per aggregation group AlertMarkers and drop Global Alert Marker. #5047
* [FEATURE] UI: Add support for silence annotations. #5017
* [FEATURE] api: Add receiver labels and `receiver_matchers` filter to `/api/v2/receivers`, `/api/v2/alerts`, and `/api/v2/alerts/groups`. #5152
* [FEATURE] eventrecorder: Add structured event recorder behind `--enable-feature=event-recorder`, with file and webhook, and kafka outputs. #5072, #5246
* [ENHANCEMENT] Add the `use_aws_http_client` config option to the sns notifier. #5178
* [ENHANCEMENT] Alertmanager: Push docker images to ghcr docker registry. #5260
* [ENHANCEMENT] TEMPLATE: Add now function to get current time. #5188
* [ENHANCEMENT] docs: Clarify YAML quoting vs matcher token quoting in UTF-8 matchers section. #5264
* [BUGFIX] jira: Allow disabling the resolve transition when `resolve_transition` is not set. #4821
* [BUGFIX] jira: Include unresolved issues in `wont_fix_resolution` JQL to prevent duplicate issue creation. #5185
* [BUGFIX] sns: Support the `AWS_CA_BUNDLE` env variable for the sns notifier. #5178
