### PR TITLE
Fix Slack update_message global URL validation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -451,6 +451,9 @@ func (c *Config) UnmarshalYAML(unmarshal func(any) error) error {
 				}
 				sc.APIURL = (*amcommoncfg.SecretURL)(sc.AppURL)
 			}
+			if err := validateSlackUpdateMessageURL(sc); err != nil {
+				return err
+			}
 		}
 		for _, poc := range rcv.PushoverConfigs {
 			if poc == nil {

--- a/config/config.go
+++ b/config/config.go
@@ -460,6 +460,9 @@ func (c *Config) UnmarshalYAML(unmarshal func(any) error) error {
 				}
 				sc.APIURL = (*amcommoncfg.SecretURL)(sc.AppURL)
 			}
+			if err := validateSlackUpdateMessageURL(sc); err != nil {
+				return err
+			}
 		}
 		for _, poc := range rcv.PushoverConfigs {
 			if poc == nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1197,9 +1197,45 @@ func TestSlackUpdateMessageWebhookURL(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected an error parsing %s: %s", "testdata/conf.slack-update-message-and-webhook", err)
 	}
-	if err.Error() != "update_message can only be used with bot tokens. api_url must be set to https://slack.com/api/chat.postMessage" {
-		t.Errorf("Expected: %s\nGot: %s", "update_message can only be used with bot tokens. api_url must be set to https://slack.com/api/chat.postMessage", err.Error())
+	if err.Error() != slackUpdateMessageError {
+		t.Errorf("Expected: %s\nGot: %s", slackUpdateMessageError, err.Error())
 	}
+}
+
+func TestSlackUpdateMessageWithGlobalAPIURL(t *testing.T) {
+	in := `
+global:
+  slack_api_url: "https://slack.com/api/chat.postMessage"
+route:
+  receiver: foo
+receivers:
+  - name: foo
+    slack_configs:
+      - channel: bar-channel
+        update_message: true
+`
+
+	conf, err := Load(in)
+	require.NoError(t, err)
+	require.True(t, conf.Receivers[0].SlackConfigs[0].UpdateMessage)
+	require.Equal(t, slackUpdateMessageAPIURL, conf.Receivers[0].SlackConfigs[0].APIURL.String())
+}
+
+func TestSlackUpdateMessageWithGlobalWebhookURL(t *testing.T) {
+	in := `
+global:
+  slack_api_url: "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
+route:
+  receiver: foo
+receivers:
+  - name: foo
+    slack_configs:
+      - channel: bar-channel
+        update_message: true
+`
+
+	_, err := Load(in)
+	require.EqualError(t, err, slackUpdateMessageError)
 }
 
 func TestSlackGlobalAppToken(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1314,9 +1314,45 @@ func TestSlackUpdateMessageWebhookURL(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected an error parsing %s: %s", "testdata/conf.slack-update-message-and-webhook", err)
 	}
-	if err.Error() != "update_message can only be used with bot tokens. api_url must be set to https://slack.com/api/chat.postMessage" {
-		t.Errorf("Expected: %s\nGot: %s", "update_message can only be used with bot tokens. api_url must be set to https://slack.com/api/chat.postMessage", err.Error())
+	if err.Error() != slackUpdateMessageError {
+		t.Errorf("Expected: %s\nGot: %s", slackUpdateMessageError, err.Error())
 	}
+}
+
+func TestSlackUpdateMessageWithGlobalAPIURL(t *testing.T) {
+	in := `
+global:
+  slack_api_url: "https://slack.com/api/chat.postMessage"
+route:
+  receiver: foo
+receivers:
+  - name: foo
+    slack_configs:
+      - channel: bar-channel
+        update_message: true
+`
+
+	conf, err := Load(in)
+	require.NoError(t, err)
+	require.True(t, conf.Receivers[0].SlackConfigs[0].UpdateMessage)
+	require.Equal(t, slackUpdateMessageAPIURL, conf.Receivers[0].SlackConfigs[0].APIURL.String())
+}
+
+func TestSlackUpdateMessageWithGlobalWebhookURL(t *testing.T) {
+	in := `
+global:
+  slack_api_url: "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
+route:
+  receiver: foo
+receivers:
+  - name: foo
+    slack_configs:
+      - channel: bar-channel
+        update_message: true
+`
+
+	_, err := Load(in)
+	require.EqualError(t, err, slackUpdateMessageError)
 }
 
 func TestSlackGlobalAppToken(t *testing.T) {

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -472,6 +472,18 @@ type SlackConfig struct {
 	Timeout time.Duration `yaml:"timeout" json:"timeout"`
 }
 
+const (
+	slackUpdateMessageAPIURL = "https://slack.com/api/chat.postMessage"
+	slackUpdateMessageError  = "update_message can only be used with bot tokens. api_url must be set to https://slack.com/api/chat.postMessage"
+)
+
+func validateSlackUpdateMessageURL(c *SlackConfig) error {
+	if c.UpdateMessage && c.APIURL != nil && c.APIURL.String() != slackUpdateMessageAPIURL {
+		return errors.New(slackUpdateMessageError)
+	}
+	return nil
+}
+
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
 func (c *SlackConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	*c = DefaultSlackConfig
@@ -490,11 +502,7 @@ func (c *SlackConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		return errors.New("at most one of api_url/api_url_file & app_token/app_token_file must be configured")
 	}
 
-	if c.UpdateMessage && c.APIURL.String() != "https://slack.com/api/chat.postMessage" {
-		return errors.New("update_message can only be used with bot tokens. api_url must be set to https://slack.com/api/chat.postMessage")
-	}
-
-	return nil
+	return validateSlackUpdateMessageURL(c)
 }
 
 // WechatConfig configures notifications via Wechat.

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -341,6 +341,18 @@ type SlackConfig struct {
 	Timeout time.Duration `yaml:"timeout" json:"timeout"`
 }
 
+const (
+	slackUpdateMessageAPIURL = "https://slack.com/api/chat.postMessage"
+	slackUpdateMessageError  = "update_message can only be used with bot tokens. api_url must be set to https://slack.com/api/chat.postMessage"
+)
+
+func validateSlackUpdateMessageURL(c *SlackConfig) error {
+	if c.UpdateMessage && c.APIURL != nil && c.APIURL.String() != slackUpdateMessageAPIURL {
+		return errors.New(slackUpdateMessageError)
+	}
+	return nil
+}
+
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
 func (c *SlackConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	*c = DefaultSlackConfig
@@ -362,11 +374,7 @@ func (c *SlackConfig) Validate() error {
 		return errors.New("at most one of api_url/api_url_file & app_token/app_token_file must be configured")
 	}
 
-	if c.UpdateMessage && c.APIURL.String() != "https://slack.com/api/chat.postMessage" {
-		return errors.New("update_message can only be used with bot tokens. api_url must be set to https://slack.com/api/chat.postMessage")
-	}
-
-	return nil
+	return validateSlackUpdateMessageURL(c)
 }
 
 // WechatConfig configures notifications via Wechat.


### PR DESCRIPTION
Fixes #5164.

This keeps Slack update_message validation from dereferencing a missing local api_url during YAML unmarshalling, then validates again after global Slack defaults have been applied. That lets a global chat.postMessage URL work while still rejecting webhook URLs with the existing readable error.

Validation:
- go test ./config -run 'TestSlackUpdateMessage|TestSlackGlobalAppToken|TestSlackNoAPIURL|TestSlackGlobalAPIURLFile'
- go test ./config ./notify/slack
- go test ./config -run TestSlackUpdateMessageWithGlobalAPIURL -count=1
- go test ./... does not complete in this checkout because generated UI assets and the built alertmanager/amtool acceptance-test binaries are missing.
