### PR TITLE
docs: clarify KV Remove template usage

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -75,6 +75,13 @@ In addition to direct access of data (labels and annotations) stored as KV, ther
 | Names | - | []string | Returns the names of the label names in the LabelSet. |
 | Values | - | []string | Returns a list of the values in the LabelSet. |
 
+`Remove` expects a slice of strings. To remove literal keys in a template, use
+the `stringSlice` function:
+
+```
+{{ .Annotations.Remove (stringSlice "summary" "description" "runbook_url") }}
+```
+
 # Functions
 
 Note the [default

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -76,6 +76,13 @@ In addition to direct access of data (labels and annotations) stored as KV, ther
 | Names | - | []string | Returns the names of the label names in the LabelSet. |
 | Values | - | []string | Returns a list of the values in the LabelSet. |
 
+`Remove` expects a slice of strings. To remove literal keys in a template, use
+the `stringSlice` function:
+
+```
+{{ .Annotations.Remove (stringSlice "summary" "description" "runbook_url") }}
+```
+
 # Functions
 
 Note the [default


### PR DESCRIPTION
#### Pull Request Checklist

- Please list all open issue(s) discussed with maintainers related to this change
    - Fixes #3393
- Is this a new Receiver integration?
    - [ ] I have already tried to use the Webhook Receiver Integration and 3rd party integrations before adding this new Receiver Integration
- Is this a bugfix?
    - [ ] I have added tests that can reproduce the bug which pass with this bugfix applied
- Is this a new feature?
    - [ ] I have added tests that test the new feature's functionality
- Does this change affect performance?
    - [ ] I have provided benchmarks comparison that shows performance is improved or is not degraded
    - [ ] I have added new benchmarks if required or requested by maintainers
- Is this a breaking change?
    - [ ] My changes do not break the existing cluster messages
    - [ ] My changes do not break the existing api
- [x] I have added/updated the required documentation
- [x] I have signed-off my commits
- [x] I will follow best practices for contributing to this project

#### Which user-facing changes does this PR introduce?

```release-notes
NONE
```

#### Notes

This adds a short example showing how to use `KV.Remove` with literal template keys via `stringSlice`, as discussed in #3393.

Verification:
- `git diff --check HEAD~1..HEAD`
- `scripts/assert-cncf-github-identity.ps1 -RepoPath upstreams/prometheus/alertmanager`

Not run:
- `go test ./template` because Go is not installed in this local environment.