### PR TITLE
fix(eventrecorder): skip building discarded mute events on the alert …

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -265,19 +265,23 @@ func (a *App) setup() error {
 	a.onStop("event recorder", eventRec.Close)
 
 	recordCtx := eventrecorder.WithEventRecording(context.Background())
-	eventRec.RecordEvent(recordCtx, &eventrecorderpb.EventData{
-		EventType: &eventrecorderpb.EventData_AlertmanagerStartupEvent{
-			AlertmanagerStartupEvent: &eventrecorderpb.AlertmanagerStartupEvent{
-				Version:      version.Version,
-				BuildContext: version.BuildContext(),
+	eventRec.RecordEvent(recordCtx, func() *eventrecorderpb.EventData {
+		return &eventrecorderpb.EventData{
+			EventType: &eventrecorderpb.EventData_AlertmanagerStartupEvent{
+				AlertmanagerStartupEvent: &eventrecorderpb.AlertmanagerStartupEvent{
+					Version:      version.Version,
+					BuildContext: version.BuildContext(),
+				},
 			},
-		},
+		}
 	})
 	a.onStop("shutdown event", func() error {
-		eventRec.RecordEvent(recordCtx, &eventrecorderpb.EventData{
-			EventType: &eventrecorderpb.EventData_AlertmanagerShutdownEvent{
-				AlertmanagerShutdownEvent: &eventrecorderpb.AlertmanagerShutdownEvent{},
-			},
+		eventRec.RecordEvent(recordCtx, func() *eventrecorderpb.EventData {
+			return &eventrecorderpb.EventData{
+				EventType: &eventrecorderpb.EventData_AlertmanagerShutdownEvent{
+					AlertmanagerShutdownEvent: &eventrecorderpb.AlertmanagerShutdownEvent{},
+				},
+			}
 		})
 		return nil
 	})

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -771,7 +771,9 @@ func (ag *aggrGroup) insert(ctx context.Context, alert *alert.Alert) bool {
 		span.RecordError(err)
 		ag.logger.Error(message, "err", err)
 	} else {
-		ag.recorder.RecordEvent(ctx, notify.NewAlertGroupedEvent(ag.alertGroupInfo(), alert))
+		ag.recorder.RecordEvent(ctx, func() *eventrecorderpb.EventData {
+			return notify.NewAlertGroupedEvent(ag.alertGroupInfo(), alert)
+		})
 	}
 	return true
 }
@@ -839,7 +841,9 @@ func (ag *aggrGroup) recordResolvedEvents(resolved types.AlertSlice) {
 	}
 	groupInfo := ag.alertGroupInfo()
 	for _, a := range resolved {
-		ag.recorder.RecordEvent(ag.ctx, notify.NewAlertResolvedEvent(groupInfo, a))
+		ag.recorder.RecordEvent(ag.ctx, func() *eventrecorderpb.EventData {
+			return notify.NewAlertResolvedEvent(groupInfo, a)
+		})
 	}
 }
 

--- a/eventrecorder/recorder.go
+++ b/eventrecorder/recorder.go
@@ -302,10 +302,16 @@ func (c *sharedRecorder) marshalAndSend(req writeRequest, outputs []Destination)
 // event is dropped (never blocks the caller).  Recording only occurs
 // when the context has been decorated with WithEventRecording.
 //
+// The event is supplied as a builder function rather than a value so
+// that callers on hot read paths do not pay to construct an event
+// (protobuf conversions, fingerprint slices, etc.) that would only be
+// discarded when recording is disabled.  The builder is invoked only
+// after the recording gates pass, and exactly once.
+//
 // The expensive protojson.Marshal call is deferred to the write-loop
 // goroutine so that the caller's hot path only pays for the proto
 // wrapping and a channel send.
-func (r Recorder) RecordEvent(ctx context.Context, event *eventrecorderpb.EventData) {
+func (r Recorder) RecordEvent(ctx context.Context, build func() *eventrecorderpb.EventData) {
 	if r.core == nil || r.core.events == nil {
 		return
 	}
@@ -313,6 +319,7 @@ func (r Recorder) RecordEvent(ctx context.Context, event *eventrecorderpb.EventD
 		return
 	}
 
+	event := build()
 	eventType := extractEventType(event)
 
 	wrappedEvent := &eventrecorderpb.Event{

--- a/eventrecorder/recorder_test.go
+++ b/eventrecorder/recorder_test.go
@@ -84,7 +84,7 @@ func TestRecordEvent(t *testing.T) {
 	rec := newTestRecorder(out)
 	defer rec.Close()
 
-	rec.RecordEvent(recordCtx(), startupEvent())
+	rec.RecordEvent(recordCtx(), startupEvent)
 
 	// Wait for the event to be delivered.
 	require.Eventually(t, func() bool {
@@ -98,7 +98,7 @@ func TestRecordEventMultipleDestinations(t *testing.T) {
 	rec := newTestRecorder(out1, out2)
 	defer rec.Close()
 
-	rec.RecordEvent(recordCtx(), startupEvent())
+	rec.RecordEvent(recordCtx(), startupEvent)
 
 	require.Eventually(t, func() bool {
 		return out1.eventCount() == 1 && out2.eventCount() == 1
@@ -107,7 +107,7 @@ func TestRecordEventMultipleDestinations(t *testing.T) {
 
 func TestNopRecorderDoesNotPanic(t *testing.T) {
 	rec := NopRecorder()
-	rec.RecordEvent(recordCtx(), startupEvent())
+	rec.RecordEvent(recordCtx(), startupEvent)
 	rec.ApplyConfig(Config{})
 	rec.SetClusterPeer(nil)
 	require.NoError(t, rec.Close())
@@ -115,7 +115,7 @@ func TestNopRecorderDoesNotPanic(t *testing.T) {
 
 func TestZeroRecorderDoesNotPanic(t *testing.T) {
 	var rec Recorder
-	rec.RecordEvent(recordCtx(), startupEvent())
+	rec.RecordEvent(recordCtx(), startupEvent)
 	rec.ApplyConfig(Config{})
 	rec.SetClusterPeer(nil)
 	require.NoError(t, rec.Close())
@@ -128,7 +128,7 @@ func TestZeroRecorderDoesNotPanic(t *testing.T) {
 func TestNewRecorderFromConfig_NilLogger(t *testing.T) {
 	require.NotPanics(t, func() {
 		rec := NewRecorderFromConfig(Config{}, "test-host", nil, nil)
-		rec.RecordEvent(recordCtx(), startupEvent())
+		rec.RecordEvent(recordCtx(), startupEvent)
 		rec.ApplyConfig(Config{})
 		require.NoError(t, rec.Close())
 	})
@@ -140,10 +140,10 @@ func TestRecordingNotEnabledByDefault(t *testing.T) {
 	defer rec.Close()
 
 	// Without WithEventRecording, events should be silently discarded.
-	rec.RecordEvent(context.Background(), startupEvent())
+	rec.RecordEvent(context.Background(), startupEvent)
 
 	// Record an event with recording enabled to flush the queue.
-	rec.RecordEvent(recordCtx(), startupEvent())
+	rec.RecordEvent(recordCtx(), startupEvent)
 	require.Eventually(t, func() bool {
 		return out.eventCount() == 1
 	}, time.Second, 10*time.Millisecond)
@@ -155,7 +155,7 @@ func TestApplyConfig(t *testing.T) {
 	defer rec.Close()
 
 	// Record one event to the initial destination.
-	rec.RecordEvent(recordCtx(), startupEvent())
+	rec.RecordEvent(recordCtx(), startupEvent)
 	require.Eventually(t, func() bool {
 		return out1.eventCount() == 1
 	}, time.Second, 10*time.Millisecond)
@@ -164,7 +164,7 @@ func TestApplyConfig(t *testing.T) {
 	rec.ApplyConfig(Config{})
 
 	// Events still flow to the same output after no-op reload.
-	rec.RecordEvent(recordCtx(), startupEvent())
+	rec.RecordEvent(recordCtx(), startupEvent)
 	require.Eventually(t, func() bool {
 		return out1.eventCount() == 2
 	}, time.Second, 10*time.Millisecond)
@@ -194,7 +194,7 @@ func TestMarshalAndSend_DeliversEvent(t *testing.T) {
 	rec := newTestRecorder(out)
 	defer rec.Close()
 
-	rec.RecordEvent(recordCtx(), startupEvent())
+	rec.RecordEvent(recordCtx(), startupEvent)
 
 	require.Eventually(t, func() bool {
 		out.mu.Lock()

--- a/inhibit/inhibit.go
+++ b/inhibit/inhibit.go
@@ -223,11 +223,13 @@ func (ih *Inhibitor) Mutes(ctx context.Context, lset model.LabelSet) bool {
 				),
 			)
 
-			ih.recorder.RecordEvent(ctx, eventrecorder.NewInhibitionMutedAlertEvent(
-				[]*eventrecorderpb.InhibitRule{eventrecorder.InhibitRuleAsProto(r.SourceMatchers, r.TargetMatchers, r.Equal)},
-				fp, lset,
-				[]model.Fingerprint{inhibitedByFP},
-			))
+			ih.recorder.RecordEvent(ctx, func() *eventrecorderpb.EventData {
+				return eventrecorder.NewInhibitionMutedAlertEvent(
+					[]*eventrecorderpb.InhibitRule{eventrecorder.InhibitRuleAsProto(r.SourceMatchers, r.TargetMatchers, r.Equal)},
+					fp, lset,
+					[]model.Fingerprint{inhibitedByFP},
+				)
+			})
 			return true
 		}
 	}

--- a/notify/retry_stage.go
+++ b/notify/retry_stage.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/prometheus/alertmanager/alert"
 	"github.com/prometheus/alertmanager/eventrecorder"
+	"github.com/prometheus/alertmanager/eventrecorder/eventrecorderpb"
 )
 
 // RetryStage notifies via passed integration with exponential backoff until it
@@ -178,7 +179,9 @@ func (r RetryStage) exec(ctx context.Context, l *slog.Logger, alerts ...*alert.A
 					l.Info("Notify success")
 				}
 
-				r.recorder.RecordEvent(ctx, NewNotificationEvent(ctx, sent, r.integration))
+				r.recorder.RecordEvent(ctx, func() *eventrecorderpb.EventData {
+					return NewNotificationEvent(ctx, sent, r.integration)
+				})
 				return ctx, alerts, nil
 			}
 		case <-ctx.Done():

--- a/provider/mem/mem.go
+++ b/provider/mem/mem.go
@@ -29,6 +29,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/prometheus/alertmanager/eventrecorder"
+	"github.com/prometheus/alertmanager/eventrecorder/eventrecorderpb"
 	"github.com/prometheus/alertmanager/featurecontrol"
 	"github.com/prometheus/alertmanager/provider"
 	"github.com/prometheus/alertmanager/store"
@@ -347,7 +348,9 @@ func (a *Alerts) Put(ctx context.Context, alerts ...*types.Alert) error {
 		a.callback.PostStore(alert, existing)
 
 		if !existing {
-			a.recorder.RecordEvent(ctx, eventrecorder.NewAlertCreatedEvent(alert))
+			a.recorder.RecordEvent(ctx, func() *eventrecorderpb.EventData {
+				return eventrecorder.NewAlertCreatedEvent(alert)
+			})
 		}
 
 		metadata := map[string]string{}

--- a/silence/silence.go
+++ b/silence/silence.go
@@ -48,6 +48,7 @@ import (
 	"github.com/prometheus/alertmanager/alert"
 	"github.com/prometheus/alertmanager/cluster"
 	"github.com/prometheus/alertmanager/eventrecorder"
+	"github.com/prometheus/alertmanager/eventrecorder/eventrecorderpb"
 	"github.com/prometheus/alertmanager/marker"
 	"github.com/prometheus/alertmanager/matcher/compat"
 	"github.com/prometheus/alertmanager/pkg/labels"
@@ -285,9 +286,11 @@ func (s *Silencer) Mutes(ctx context.Context, lset model.LabelSet) bool {
 				activeIDs = append(activeIDs, sil.Id)
 				allIDs = append(allIDs, sil.Id)
 
-				s.recorder.RecordEvent(ctx, eventrecorder.NewSilenceMutedAlertEvent(
-					eventrecorder.SilenceAsProto(sil), fp, lset,
-				))
+				s.recorder.RecordEvent(ctx, func() *eventrecorderpb.EventData {
+					return eventrecorder.NewSilenceMutedAlertEvent(
+						eventrecorder.SilenceAsProto(sil), fp, lset,
+					)
+				})
 			default:
 				// Do nothing, silence has expired in the meantime.
 			}
@@ -877,9 +880,11 @@ func (s *Silences) Set(ctx context.Context, sil *pb.Silence) error {
 			return err
 		}
 		if changed {
-			s.recorder.RecordEvent(ctx, eventrecorder.NewSilenceUpdatedEvent(
-				eventrecorder.SilenceAsProto(sil),
-			))
+			s.recorder.RecordEvent(ctx, func() *eventrecorderpb.EventData {
+				return eventrecorder.NewSilenceUpdatedEvent(
+					eventrecorder.SilenceAsProto(sil),
+				)
+			})
 		}
 		return nil
 	}
@@ -925,9 +930,11 @@ func (s *Silences) Set(ctx context.Context, sil *pb.Silence) error {
 		return err
 	}
 	if added {
-		s.recorder.RecordEvent(ctx, eventrecorder.NewSilenceCreatedEvent(
-			eventrecorder.SilenceAsProto(sil),
-		))
+		s.recorder.RecordEvent(ctx, func() *eventrecorderpb.EventData {
+			return eventrecorder.NewSilenceCreatedEvent(
+				eventrecorder.SilenceAsProto(sil),
+			)
+		})
 	}
 	return nil
 }


### PR DESCRIPTION
The `GET /api/v2/alerts` and `/api/v2/alerts/groups` handlers run the silencer and inhibitor over every alert to compute its silenced and inhibited status.  When an alert is actively silenced or inhibited, `Silencer.Mutes` and `Inhibitor.Mutes` build a `SilenceMutedAlert` or `InhibitionMutedAlert` protobuf event and pass it to `RecordEvent`.  On the read path event recording is not enabled on the context, so `RecordEvent` discards the event, but the proto conversions and fingerprint slices are still built for every muted alert on every request.

Change `RecordEvent` to take a builder function (`func() *eventrecorderpb.EventData`) instead of an already-constructed event, and invoke it only after the recording gates pass.  Callers on hot read paths now pass a closure, so the proto conversions and fingerprint slices are built only when recording is enabled.  Folding the gate into `RecordEvent` keeps the gating logic in one place, so callers cannot forget to check it and no separate predicate can drift out of sync with `RecordEvent`.  When recording is enabled the behavior is unchanged.

#### Pull Request Checklist
Please check all the applicable boxes.

- Please list all open issue(s) discussed with maintainers related to this change
    - None
- Is this a new Receiver integration? No
- [ ] I have added/updated the required documentation - no changes needed
- [ ] I have signed-off my commits - yes
- [ ] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source) - yes

#### Which user-facing changes does this PR introduce?

```release-notes
- Fixed a minor performance regression when the event recorder is enabled
```