### PR TITLE
docs: fix Alertmanager port in amtool config routes example

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ and it prints out all receivers the alert would match ordered and separated by `
 Example of usage:
 ```
 # View routing tree of remote Alertmanager
-$ amtool config routes --alertmanager.url=http://localhost:9090
+$ amtool config routes --alertmanager.url=http://localhost:9093
 
 # Test if alert matches expected receiver
 $ amtool config routes test --config.file=doc/examples/simple.yml --tree --verify.receivers=team-X-pager service=database owner=team-X


### PR DESCRIPTION
The "View routing tree of remote Alertmanager" example uses `--alertmanager.url=http://localhost:9090`, but 9090 is Prometheus's port — Alertmanager's default is 9093 (cmd/alertmanager/main.go, cli/root.go). Every other URL in the README uses 9093, so this line was the lone outlier.
