### PR TITLE
feat(eventrecorder): include inhibition rule name in muted alert events

### DIFF
--- a/eventrecorder/eventrecorderpb/eventrecorder.pb.go
+++ b/eventrecorder/eventrecorderpb/eventrecorder.pb.go
@@ -1700,7 +1700,9 @@ type InhibitRule struct {
 	TargetMatchers []*Matcher `protobuf:"bytes,2,rep,name=target_matchers,json=targetMatchers,proto3" json:"target_matchers,omitempty"`
 	// Label names whose values must be equal between source and target
 	// alerts for the inhibition to take effect.
-	EqualLabels   []string `protobuf:"bytes,3,rep,name=equal_labels,json=equalLabels,proto3" json:"equal_labels,omitempty"`
+	EqualLabels []string `protobuf:"bytes,3,rep,name=equal_labels,json=equalLabels,proto3" json:"equal_labels,omitempty"`
+	// Name is the optional name of the inhibition rule.
+	Name          string `protobuf:"bytes,4,opt,name=name,proto3" json:"name,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1754,6 +1756,13 @@ func (x *InhibitRule) GetEqualLabels() []string {
 		return x.EqualLabels
 	}
 	return nil
+}
+
+func (x *InhibitRule) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
 }
 
 // InhibitionMutedAlertEvent is emitted when one or more inhibition
@@ -1938,11 +1947,12 @@ const file_eventrecorder_proto_rawDesc = "" +
 	"\x16SilenceMutedAlertEvent\x122\n" +
 	"\asilence\x18\x01 \x01(\v2\x18.eventrecorderpb.SilenceR\asilence\x12<\n" +
 	"\vmuted_alert\x18\x02 \x01(\v2\x1b.eventrecorderpb.MutedAlertR\n" +
-	"mutedAlert\"\xb6\x01\n" +
+	"mutedAlert\"\xca\x01\n" +
 	"\vInhibitRule\x12A\n" +
 	"\x0fsource_matchers\x18\x01 \x03(\v2\x18.eventrecorderpb.MatcherR\x0esourceMatchers\x12A\n" +
 	"\x0ftarget_matchers\x18\x02 \x03(\v2\x18.eventrecorderpb.MatcherR\x0etargetMatchers\x12!\n" +
-	"\fequal_labels\x18\x03 \x03(\tR\vequalLabels\"\xd5\x01\n" +
+	"\fequal_labels\x18\x03 \x03(\tR\vequalLabels\x12\x12\n" +
+	"\x04name\x18\x04 \x01(\tR\x04name\"\xd5\x01\n" +
 	"\x19InhibitionMutedAlertEvent\x12A\n" +
 	"\rinhibit_rules\x18\x01 \x03(\v2\x1c.eventrecorderpb.InhibitRuleR\finhibitRules\x12<\n" +
 	"\vmuted_alert\x18\x02 \x01(\v2\x1b.eventrecorderpb.MutedAlertR\n" +

--- a/eventrecorder/eventrecorderpb/eventrecorder.proto
+++ b/eventrecorder/eventrecorderpb/eventrecorder.proto
@@ -373,6 +373,9 @@ message InhibitRule {
   // Label names whose values must be equal between source and target
   // alerts for the inhibition to take effect.
   repeated string equal_labels = 3;
+
+  // Name is the optional name of the inhibition rule.
+  string name = 4;
 }
 
 // InhibitionMutedAlertEvent is emitted when one or more inhibition

--- a/eventrecorder/events.go
+++ b/eventrecorder/events.go
@@ -174,13 +174,14 @@ func SilenceAsProto(sil *silencepb.Silence) *eventrecorderpb.Silence {
 // InhibitRuleAsProto converts inhibit rule fields to an
 // eventrecorderpb.InhibitRule.  It accepts the individual fields rather
 // than the InhibitRule struct to avoid an import cycle.
-func InhibitRuleAsProto(sourceMatchers, targetMatchers labels.Matchers, equal map[model.LabelName]struct{}) *eventrecorderpb.InhibitRule {
+func InhibitRuleAsProto(name string, sourceMatchers, targetMatchers labels.Matchers, equal map[model.LabelName]struct{}) *eventrecorderpb.InhibitRule {
 	equalLabels := make([]string, 0, len(equal))
 	for label := range equal {
 		equalLabels = append(equalLabels, string(label))
 	}
 	slices.Sort(equalLabels)
 	return &eventrecorderpb.InhibitRule{
+		Name:           name,
 		SourceMatchers: MatchersAsProto(sourceMatchers),
 		TargetMatchers: MatchersAsProto(targetMatchers),
 		EqualLabels:    equalLabels,

--- a/eventrecorder/events_test.go
+++ b/eventrecorder/events_test.go
@@ -101,3 +101,20 @@ func TestMatchersAsProto(t *testing.T) {
 	require.Equal(t, eventrecorderpb.Matcher_TYPE_EQUAL, protos[0].Type)
 	require.Equal(t, eventrecorderpb.Matcher_TYPE_NOT_EQUAL, protos[1].Type)
 }
+
+func TestInhibitRuleAsProto(t *testing.T) {
+	source, err := labels.NewMatcher(labels.MatchEqual, "severity", "critical")
+	require.NoError(t, err)
+	target, err := labels.NewMatcher(labels.MatchEqual, "severity", "warning")
+	require.NoError(t, err)
+	equal := map[model.LabelName]struct{}{"cluster": {}, "alertname": {}}
+
+	proto := InhibitRuleAsProto("my-rule", labels.Matchers{source}, labels.Matchers{target}, equal)
+
+	require.Equal(t, "my-rule", proto.Name)
+	require.Len(t, proto.SourceMatchers, 1)
+	require.Equal(t, "severity", proto.SourceMatchers[0].Name)
+	require.Len(t, proto.TargetMatchers, 1)
+	require.Equal(t, "severity", proto.TargetMatchers[0].Name)
+	require.Equal(t, []string{"alertname", "cluster"}, proto.EqualLabels)
+}

--- a/inhibit/inhibit.go
+++ b/inhibit/inhibit.go
@@ -225,7 +225,7 @@ func (ih *Inhibitor) Mutes(ctx context.Context, lset model.LabelSet) bool {
 
 			ih.recorder.RecordEvent(ctx, func() *eventrecorderpb.EventData {
 				return eventrecorder.NewInhibitionMutedAlertEvent(
-					[]*eventrecorderpb.InhibitRule{eventrecorder.InhibitRuleAsProto(r.SourceMatchers, r.TargetMatchers, r.Equal)},
+					[]*eventrecorderpb.InhibitRule{eventrecorder.InhibitRuleAsProto(r.Name, r.SourceMatchers, r.TargetMatchers, r.Equal)},
 					fp, lset,
 					[]model.Fingerprint{inhibitedByFP},
 				)


### PR DESCRIPTION
The inhibition rule name was available at runtime and emitted in tracing spans, but the recorded inhibition_muted_alert events identified rules only by their matchers and equal labels.
Add a name field to the InhibitRule proto message and propagate the rule's configured name through InhibitRuleAsProto so recorded events carry it.

<!--
    - Please give your PR a title in the form "area: short description".  For example "dispatcher: improve performance"

    - Please sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Pull Request Checklist
Please check all the applicable boxes.

- Please list all open issue(s) discussed with maintainers related to this change
    - Fixes #<issue number>
    <!--
    If it applies.
    Automatically closes linked issue when PR is merged.
    Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
    More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
    -->
- Is this a new Receiver integration?
    - [ ] I have already tried to use the [Webhook Receiver Integration](https://prometheus.io/docs/alerting/latest/configuration/#webhook_config) and [3rd party integrations](https://prometheus.io/docs/operating/integrations/#alertmanager-webhook-receiver) before adding this new Receiver Integration
- Is this a bugfix?
    - [ ] I have added tests that can reproduce the bug which pass with this bugfix applied
- Is this a new feature?
    - [x] I have added tests that test the new feature's functionality
- Does this change affect performance?
    - [ ] I have provided benchmarks comparison that shows performance is improved or is not degraded
        - You can use [`benchstat`](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat) to compare benchmarks
    - [ ] I have added new benchmarks if required or requested by maintainers
- Is this a breaking change?
    - [ ] My changes do not break the existing cluster messages
    - [ ] My changes do not break the existing api
- [ ] I have added/updated the required documentation
- [x] I have signed-off my commits
- [x] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/alertmanager/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[FEATURE] add inhibit rule names to inhibition_muted_alert events
```
