### PR TITLE
fix(ci): stale comments in release/publish workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,6 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - main
-# Docker Hub + Quay pushes use their own secrets.
 permissions:
   contents: read
 
@@ -29,7 +28,7 @@ jobs:
     name: Publish main branch artefacts
     runs-on: ubuntu-latest
     permissions:
-      packages: write
+      packages: write  # push the image to GHCR via github.token
     needs: build
     steps:
       - uses: prometheus/promci/publish_main@d9d4f5688814f0b77bf003d07fb8c00507390634 # v0.8.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ on:  # yamllint disable-line rule:truthy
   push:
     tags:
       - v*
-# Docker Hub + Quay pushes use their own secrets; GitHub release publish
-# uses PROMBOT_GITHUB_TOKEN.
 permissions:
   contents: read
 
@@ -37,8 +35,8 @@ jobs:
     name: Publish release artefacts
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      packages: write
+      contents: write  # create the GitHub release
+      packages: write  # push the image to GHCR via github.token
     needs: build
     steps:
       - uses: prometheus/promci/publish_release@d9d4f5688814f0b77bf003d07fb8c00507390634 # v0.8.2


### PR DESCRIPTION
The release.yml top-level comment claimed the GitHub release publish step "uses PROMBOT_GITHUB_TOKEN". That was no longer true, as of PR #5257.

#### Which user-facing changes does this PR introduce?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/alertmanager/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
