### PR TITLE
[RFC] Implement route labels

### DIFF
--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -512,9 +512,10 @@ func (api *API) getAlertGroupsHandler(params alertgroup_ops.GetAlertGroupsParams
 		}
 
 		ag := &open_api_models.AlertGroup{
-			Receiver: &open_api_models.ReceiverReference{Name: &alertGroup.Receiver},
-			Labels:   ModelLabelSetToAPILabelSet(alertGroup.Labels),
-			Alerts:   make([]*open_api_models.GettableAlert, 0, len(alertGroup.Alerts)),
+			Receiver:    &open_api_models.ReceiverReference{Name: &alertGroup.Receiver},
+			Labels:      ModelLabelSetToAPILabelSet(alertGroup.Labels),
+			RouteLabels: ModelLabelSetToAPILabelSet(alertGroup.RouteLabels),
+			Alerts:      make([]*open_api_models.GettableAlert, 0, len(alertGroup.Alerts)),
 		}
 
 		for _, alert := range alertGroup.Alerts {

--- a/api/v2/api_test.go
+++ b/api/v2/api_test.go
@@ -35,10 +35,12 @@ import (
 
 	"github.com/prometheus/alertmanager/alert"
 	open_api_models "github.com/prometheus/alertmanager/api/v2/models"
+	alertgroup_ops "github.com/prometheus/alertmanager/api/v2/restapi/operations/alertgroup"
 	general_ops "github.com/prometheus/alertmanager/api/v2/restapi/operations/general"
 	receiver_ops "github.com/prometheus/alertmanager/api/v2/restapi/operations/receiver"
 	silence_ops "github.com/prometheus/alertmanager/api/v2/restapi/operations/silence"
 	"github.com/prometheus/alertmanager/config"
+	"github.com/prometheus/alertmanager/dispatch"
 	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/prometheus/alertmanager/silence"
 	"github.com/prometheus/alertmanager/silence/silencepb"
@@ -943,4 +945,63 @@ func TestPostSilences_QuotedMatchers(t *testing.T) {
 	require.Len(t, silProto.MatcherSets, 1)
 	require.Len(t, silProto.MatcherSets[0].Matchers, 1)
 	require.Equal(t, "\"bar\"", silProto.MatcherSets[0].Matchers[0].Pattern)
+}
+
+func TestGetAlertGroupsHandlerRouteLabels(t *testing.T) {
+	in := `
+route:
+    receiver: team-X
+    routes:
+      - receiver: team-X
+        labels:
+          team: X
+
+receivers:
+- name: 'team-X'
+`
+	cfg, err := config.Load(in)
+	require.NoError(t, err)
+
+	group := &dispatch.AlertGroup{
+		Labels:      model.LabelSet{"alertname": "Foo"},
+		RouteLabels: model.LabelSet{"team": "X"},
+		Receiver:    "team-X",
+		GroupKey:    "key",
+		RouteID:     "route",
+	}
+
+	api := API{
+		uptime: time.Now(),
+		logger: promslog.NewNopLogger(),
+		alertGroups: func(context.Context, func(*dispatch.Route) bool, func(*alert.Alert, time.Time) bool) (dispatch.AlertGroups, map[model.Fingerprint][]string, error) {
+			return dispatch.AlertGroups{group}, map[model.Fingerprint][]string{}, nil
+		},
+		groupMutedFunc: func(routeID, groupKey string) ([]string, bool) {
+			return nil, false
+		},
+	}
+	api.Update(cfg, func(context.Context, model.LabelSet) {})
+
+	r, err := http.NewRequest("GET", "/api/v2/alerts/groups", nil)
+	require.NoError(t, err)
+
+	truePtr := true
+	responder := api.getAlertGroupsHandler(alertgroup_ops.GetAlertGroupsParams{
+		HTTPRequest: r,
+		Active:      &truePtr,
+		Silenced:    &truePtr,
+		Inhibited:   &truePtr,
+		Muted:       &truePtr,
+	})
+
+	w := httptest.NewRecorder()
+	responder.WriteResponse(w, runtime.JSONProducer())
+	require.Equal(t, 200, w.Code)
+
+	body, _ := io.ReadAll(w.Result().Body)
+
+	var groups open_api_models.AlertGroups
+	require.NoError(t, json.Unmarshal(body, &groups))
+	require.Len(t, groups, 1)
+	require.Equal(t, open_api_models.LabelSet{"team": "X"}, groups[0].RouteLabels)
 }

--- a/api/v2/models/alert_group.go
+++ b/api/v2/models/alert_group.go
@@ -46,6 +46,10 @@ type AlertGroup struct {
 	// receiver
 	// Required: true
 	Receiver *ReceiverReference `json:"receiver"`
+
+	// route labels
+	// Required: true
+	RouteLabels LabelSet `json:"routeLabels"`
 }
 
 // Validate validates this alert group
@@ -61,6 +65,10 @@ func (m *AlertGroup) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateReceiver(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateRouteLabels(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -149,6 +157,30 @@ func (m *AlertGroup) validateReceiver(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *AlertGroup) validateRouteLabels(formats strfmt.Registry) error {
+
+	if err := validate.Required("routeLabels", "body", m.RouteLabels); err != nil {
+		return err
+	}
+
+	if m.RouteLabels != nil {
+		if err := m.RouteLabels.Validate(formats); err != nil {
+			ve := new(errors.Validation)
+			if stderrors.As(err, &ve) {
+				return ve.ValidateName("routeLabels")
+			}
+			ce := new(errors.CompositeError)
+			if stderrors.As(err, &ce) {
+				return ce.ValidateName("routeLabels")
+			}
+
+			return err
+		}
+	}
+
+	return nil
+}
+
 // ContextValidate validate this alert group based on the context it is used
 func (m *AlertGroup) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	var res []error
@@ -162,6 +194,10 @@ func (m *AlertGroup) ContextValidate(ctx context.Context, formats strfmt.Registr
 	}
 
 	if err := m.contextValidateReceiver(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateRouteLabels(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -234,6 +270,24 @@ func (m *AlertGroup) contextValidateReceiver(ctx context.Context, formats strfmt
 
 			return err
 		}
+	}
+
+	return nil
+}
+
+func (m *AlertGroup) contextValidateRouteLabels(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := m.RouteLabels.ContextValidate(ctx, formats); err != nil {
+		ve := new(errors.Validation)
+		if stderrors.As(err, &ve) {
+			return ve.ValidateName("routeLabels")
+		}
+		ce := new(errors.CompositeError)
+		if stderrors.As(err, &ce) {
+			return ce.ValidateName("routeLabels")
+		}
+
+		return err
 	}
 
 	return nil

--- a/api/v2/openapi.yaml
+++ b/api/v2/openapi.yaml
@@ -501,6 +501,8 @@ definitions:
     properties:
       labels:
         $ref: '#/definitions/labelSet'
+      routeLabels:
+        $ref: '#/definitions/labelSet'
       receiver:
         $ref: '#/definitions/receiverReference'
       alerts:
@@ -509,6 +511,7 @@ definitions:
           $ref: '#/definitions/gettableAlert'
     required:
       - labels
+      - routeLabels
       - receiver
       - alerts
   alertStatus:

--- a/api/v2/restapi/embedded_spec.go
+++ b/api/v2/restapi/embedded_spec.go
@@ -425,6 +425,7 @@ func init() {
       "type": "object",
       "required": [
         "labels",
+        "routeLabels",
         "receiver",
         "alerts"
       ],
@@ -440,6 +441,9 @@ func init() {
         },
         "receiver": {
           "$ref": "#/definitions/receiverReference"
+        },
+        "routeLabels": {
+          "$ref": "#/definitions/labelSet"
         }
       }
     },
@@ -1330,6 +1334,7 @@ func init() {
       "type": "object",
       "required": [
         "labels",
+        "routeLabels",
         "receiver",
         "alerts"
       ],
@@ -1345,6 +1350,9 @@ func init() {
         },
         "receiver": {
           "$ref": "#/definitions/receiverReference"
+        },
+        "routeLabels": {
+          "$ref": "#/definitions/labelSet"
         }
       }
     },

--- a/app/reloader.go
+++ b/app/reloader.go
@@ -206,6 +206,7 @@ func (r *reloader) reload(conf *config.Config) error {
 		r.logger,
 		r.eventRecorder,
 		r.dispatcherMetrics,
+		tmpl,
 	)
 	routes.Walk(func(rt *dispatch.Route) {
 		if rt.RouteOpts.RepeatInterval > r.retention {

--- a/config/config.go
+++ b/config/config.go
@@ -913,6 +913,12 @@ func (r *Route) UnmarshalYAML(unmarshal func(any) error) error {
 		}
 	}
 
+	for k := range r.Labels {
+		if !compat.IsValidLabelName(k) {
+			return fmt.Errorf("invalid label name %q in route labels", k)
+		}
+	}
+
 	for _, l := range r.GroupByStr {
 		if l == "..." {
 			r.GroupByAll = true

--- a/config/config.go
+++ b/config/config.go
@@ -893,6 +893,10 @@ type Route struct {
 	GroupInterval  *model.Duration `yaml:"group_interval,omitempty" json:"group_interval,omitempty"`
 	RepeatInterval *model.Duration `yaml:"repeat_interval,omitempty" json:"repeat_interval,omitempty"`
 
+	// Labels are attached to a route and inherited by child routes.
+	// Values may be Go templates rendered against the current alert group's
+	// data. Notification-specific fields such as .NotificationReason are
+	// not available; use notification templates for reason-dependent content.
 	Labels model.LabelSet `yaml:"labels,omitempty" json:"labels,omitempty"`
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -892,6 +892,8 @@ type Route struct {
 	GroupWait      *model.Duration `yaml:"group_wait,omitempty" json:"group_wait,omitempty"`
 	GroupInterval  *model.Duration `yaml:"group_interval,omitempty" json:"group_interval,omitempty"`
 	RepeatInterval *model.Duration `yaml:"repeat_interval,omitempty" json:"repeat_interval,omitempty"`
+
+	Labels model.LabelSet `yaml:"labels,omitempty" json:"labels,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for Route.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -447,6 +447,41 @@ receivers:
 	}
 }
 
+func TestRouteLabelsInvalidLabelName(t *testing.T) {
+	in := `
+route:
+  receiver: team-X-mails
+  labels:
+    "-invalid-": value
+receivers:
+- name: 'team-X-mails'
+`
+	_, err := Load(in)
+
+	expected := `invalid label name "-invalid-" in route labels`
+
+	if err == nil {
+		t.Fatalf("no error returned, expected:\n%q", expected)
+	}
+	if err.Error() != expected {
+		t.Errorf("\nexpected:\n%q\ngot:\n%q", expected, err.Error())
+	}
+}
+
+func TestRouteLabelsValidLabelName(t *testing.T) {
+	in := `
+route:
+  receiver: team-X-mails
+  labels:
+    team: team-X
+    severity: "{{ .GroupLabels.severity }}"
+receivers:
+- name: 'team-X-mails'
+`
+	_, err := Load(in)
+	require.NoError(t, err)
+}
+
 func TestRootRouteExists(t *testing.T) {
 	in := `
 receivers:

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -714,6 +714,7 @@ func (ag *aggrGroup) renderRouteLabels(alerts ...*alert.Alert) model.LabelSet {
 
 	renderedRouteLabels := make(model.LabelSet, len(ag.opts.Labels))
 
+	// The notification reason is not available to route labels and is passed as ReasonUnknown.
 	data := ag.tmpl.Data(ag.opts.Receiver, ag.labels, ag.opts.Labels, notify.ReasonUnknown.String(), alerts...)
 
 	logger := ag.logger.With("data", data)

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -628,13 +628,26 @@ type aggrGroup struct {
 	running  atomic.Bool
 	flushIdx uint64
 
-	// mtx guards routeLabels and routeLabelsDirty.
-	mtx sync.RWMutex
-	// routeLabels holds the route labels rendered against the group's current
-	// alerts. They only change when alerts are inserted or deleted, so they are
-	// rendered lazily: routeLabelsDirty marks when a re-render is needed.
-	routeLabels      model.LabelSet
-	routeLabelsDirty bool
+	// routeLabels caches the route labels rendered against the group's current
+	// alerts, for the /api/v2/alerts/groups read path. It is rendered lazily and
+	// kept up to date with a generation counter rather than a lock, so that
+	// invalidation on the hot alert-ingestion path is a single atomic add.
+	//
+	// routeLabelsGen is bumped (by invalidateRouteLabels) whenever the alert set
+	// changes. Each cached render is tagged with the generation it was computed
+	// at; RouteLabels() treats the cache as valid only if its tag still equals
+	// the current generation. A render that races an invalidation is therefore
+	// tagged with a now-stale generation: it may be stored, but the next reader
+	// sees the mismatch and re-renders, so a stale value is never served.
+	routeLabels    atomic.Pointer[renderedRouteLabels]
+	routeLabelsGen atomic.Uint64
+}
+
+// renderedRouteLabels is a cached route-label render tagged with the alert-set
+// generation it was computed at. See aggrGroup.routeLabels.
+type renderedRouteLabels struct {
+	gen    uint64
+	labels model.LabelSet
 }
 
 // newAggrGroup returns a new aggregation group.
@@ -651,19 +664,18 @@ func newAggrGroup(
 		to = func(d time.Duration) time.Duration { return d }
 	}
 	ag := &aggrGroup{
-		labels:      labels,
-		routeID:     r.ID(),
-		routeKey:    r.Key(),
-		matchers:    r.Matchers,
-		opts:        &r.RouteOpts,
-		timeout:     to,
-		alerts:      store.NewAlerts(),
-		marker:      marker.NewAlertMarker(),
-		recorder:    recorder,
-		tmpl:        tmpl,
-		done:        make(chan struct{}),
-		flushIdx:    1,
-		routeLabels: model.LabelSet{},
+		labels:   labels,
+		routeID:  r.ID(),
+		routeKey: r.Key(),
+		matchers: r.Matchers,
+		opts:     &r.RouteOpts,
+		timeout:  to,
+		alerts:   store.NewAlerts(),
+		marker:   marker.NewAlertMarker(),
+		recorder: recorder,
+		tmpl:     tmpl,
+		done:     make(chan struct{}),
+		flushIdx: 1,
 	}
 	ag.ctx, ag.cancel = context.WithCancel(ctx)
 
@@ -697,7 +709,7 @@ func (ag *aggrGroup) String() string {
 // allows it to reference group labels, other route labels, etc.
 func (ag *aggrGroup) renderRouteLabels(alerts ...*alert.Alert) model.LabelSet {
 	if ag.tmpl == nil {
-		return ag.routeLabels
+		return model.LabelSet{}
 	}
 
 	renderedRouteLabels := make(model.LabelSet, len(ag.opts.Labels))
@@ -720,40 +732,51 @@ func (ag *aggrGroup) renderRouteLabels(alerts ...*alert.Alert) model.LabelSet {
 }
 
 // RouteLabels returns the route labels rendered against the group's current
-// alerts. Rendering is lazy: it only happens when the set of alerts has changed
-// since the last render (tracked by routeLabelsDirty).
+// alerts, caching the result. Both the read and the cache update are lock-free.
+// The cache is invalidated by invalidateRouteLabels (a generation bump) after
+// the alert set changes.
+//
+// Concurrent callers that all miss may render redundantly; that is acceptable
+// because the only caller is the (cold) /alerts/groups API path. What must not
+// happen — serving a render that predates an invalidation — is prevented by the
+// generation tag.
 func (ag *aggrGroup) RouteLabels() model.LabelSet {
-	upgradedLock := false
-
-	ag.mtx.RLock()
-
-	defer func() {
-		if upgradedLock {
-			ag.mtx.Unlock()
-		} else {
-			ag.mtx.RUnlock()
-		}
-	}()
-
-	if ag.routeLabelsDirty {
-		// Upgrade the lock because we need to update routeLabels.
-		upgradedLock = true
-		ag.mtx.RUnlock()
-		ag.mtx.Lock()
-
-		if ag.routeLabelsDirty {
-			alerts := ag.alerts.List()
-			if len(alerts) > 0 {
-				ag.routeLabels = ag.renderRouteLabels(alerts...)
-			}
-			// If alerts is empty (all resolved/deleted), keep the previously
-			// rendered routeLabels. The group will be garbage-collected on the
-			// next maintenance cycle.
-			ag.routeLabelsDirty = false
-		}
+	// Load the cached value before the generation: if an invalidation happens
+	// between these two loads, we read the newer generation and treat the cache
+	// as a miss, which is safe. (Loading gen first could let us pair an old gen
+	// with a value cached for that gen and wrongly accept a stale render.)
+	cached := ag.routeLabels.Load()
+	gen := ag.routeLabelsGen.Load()
+	if cached != nil && cached.gen == gen {
+		return cached.labels
 	}
 
-	return ag.routeLabels
+	alerts := ag.alerts.List()
+
+	var labels model.LabelSet
+	if len(alerts) == 0 {
+		// Nothing to render against: e.g. all alerts resolved and deleted and
+		// the group is awaiting GC. Rendering route-label templates that
+		// reference .Alerts against an empty set would only log errors, and
+		// empty groups are excluded from the API response anyway.
+		labels = model.LabelSet{}
+	} else {
+		labels = ag.renderRouteLabels(alerts...)
+	}
+
+	// Tag the render with the generation we observed before reading the alerts.
+	// If an invalidation raced this render, gen is already stale, so the next
+	// reader will see the mismatch and re-render rather than serve stale labels.
+	ag.routeLabels.Store(&renderedRouteLabels{gen: gen, labels: labels})
+	return labels
+}
+
+// invalidateRouteLabels marks the cached route labels stale. It must be called
+// after the group's alert set has changed and the change is visible via
+// ag.alerts, so that any render still in flight is tagged with a generation
+// older than this one and will not be served.
+func (ag *aggrGroup) invalidateRouteLabels() {
+	ag.routeLabelsGen.Add(1)
 }
 
 func (ag *aggrGroup) run(nf notifyFunc) {
@@ -861,9 +884,8 @@ func (ag *aggrGroup) insert(ctx context.Context, alert *alert.Alert) bool {
 		ag.recorder.RecordEvent(ctx, func() *eventrecorderpb.EventData {
 			return notify.NewAlertGroupedEvent(ag.alertGroupInfo(), alert)
 		})
-		ag.mtx.Lock()
-		ag.routeLabelsDirty = true
-		ag.mtx.Unlock()
+		// The alert set changed; the alert is already visible via ag.alerts.
+		ag.invalidateRouteLabels()
 	}
 	return true
 }
@@ -915,9 +937,9 @@ func (ag *aggrGroup) flush(notify func(...*alert.Alert) bool) {
 			ag.logger.Error("error on delete alerts", "err", err)
 		} else {
 			if len(resolvedSlice) > 0 {
-				ag.mtx.Lock()
-				ag.routeLabelsDirty = true
-				ag.mtx.Unlock()
+				// The alert set changed; the deletion is already visible via
+				// ag.alerts.
+				ag.invalidateRouteLabels()
 			}
 			// Delete markers for resolved alerts that are not in the store.
 			for _, alert := range resolvedSlice {

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -718,13 +718,16 @@ func (ag *aggrGroup) renderRouteLabels(alerts ...*alert.Alert) model.LabelSet {
 
 	logger := ag.logger.With("data", data)
 
+	// Render every label through a single shared resolver so a label that
+	// cross-references another (via {{ routeLabels "x" }}) reuses the rendered
+	// value instead of re-rendering it per loop iteration.
+	render := ag.tmpl.RouteLabelRenderer(data)
 	for label, value := range ag.opts.Labels {
-		v := string(value)
-		if rendered, err := ag.tmpl.ExecuteTextString(v, data); err == nil {
+		if rendered, err := render(string(label)); err == nil {
 			renderedRouteLabels[label] = model.LabelValue(rendered)
 			logger.Debug("rendered route label", "label", label, "value", rendered)
 		} else {
-			logger.Error("failed to render route label", "label", label, "value", v, "err", err)
+			logger.Error("failed to render route label", "label", label, "value", string(value), "err", err)
 		}
 	}
 

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -315,6 +315,7 @@ func (d *Dispatcher) LoadingDone() <-chan struct{} {
 type AlertGroup struct {
 	Alerts        alert.AlertSlice
 	Labels        model.LabelSet
+	RouteLabels   model.LabelSet
 	Receiver      string
 	GroupKey      string
 	RouteID       string
@@ -368,10 +369,11 @@ func (d *Dispatcher) Groups(ctx context.Context, routeFilter func(*Route) bool, 
 		// Process the snapshot without holding sync.Map locks
 		for _, ag := range snapshot {
 			alertGroup := &AlertGroup{
-				Labels:   ag.labels,
-				Receiver: receiver,
-				GroupKey: ag.GroupKey(),
-				RouteID:  ag.routeID,
+				Labels:      ag.labels,
+				RouteLabels: ag.RouteLabels(),
+				Receiver:    receiver,
+				GroupKey:    ag.GroupKey(),
+				RouteID:     ag.routeID,
 			}
 
 			alerts := ag.alerts.List()

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -368,14 +368,6 @@ func (d *Dispatcher) Groups(ctx context.Context, routeFilter func(*Route) bool, 
 
 		// Process the snapshot without holding sync.Map locks
 		for _, ag := range snapshot {
-			alertGroup := &AlertGroup{
-				Labels:      ag.labels,
-				RouteLabels: ag.RouteLabels(),
-				Receiver:    receiver,
-				GroupKey:    ag.GroupKey(),
-				RouteID:     ag.routeID,
-			}
-
 			alerts := ag.alerts.List()
 			filteredAlerts := make([]*alert.Alert, 0, len(alerts))
 			for _, a := range alerts {
@@ -398,6 +390,17 @@ func (d *Dispatcher) Groups(ctx context.Context, routeFilter func(*Route) bool, 
 			}
 			if len(filteredAlerts) == 0 {
 				continue
+			}
+
+			// Compute RouteLabels() only now that the group will be returned:
+			// it may render templates on a cache miss, which is wasted work for
+			// groups filtered out above.
+			alertGroup := &AlertGroup{
+				Labels:      ag.labels,
+				RouteLabels: ag.RouteLabels(),
+				Receiver:    receiver,
+				GroupKey:    ag.GroupKey(),
+				RouteID:     ag.routeID,
 			}
 			alertGroup.Alerts = filteredAlerts
 			alertGroup.AlertStatuses = make(map[model.Fingerprint]alert.AlertStatus, len(filteredAlerts))

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -694,6 +694,7 @@ func (ag *aggrGroup) run(nf notifyFunc) {
 			// Populate context with information needed along the pipeline.
 			ctx = notify.WithGroupKey(ctx, ag.GroupKey())
 			ctx = notify.WithGroupLabels(ctx, ag.labels)
+			ctx = notify.WithRouteLabels(ctx, ag.opts.Labels)
 			ctx = notify.WithReceiverName(ctx, ag.opts.Receiver)
 			ctx = notify.WithRepeatInterval(ctx, ag.opts.RepeatInterval)
 			ctx = notify.WithMuteTimeIntervals(ctx, ag.opts.MuteTimeIntervals)

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -40,6 +40,7 @@ import (
 	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/prometheus/alertmanager/provider"
 	"github.com/prometheus/alertmanager/store"
+	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/alertmanager/tracing"
 	"github.com/prometheus/alertmanager/types"
 )
@@ -79,6 +80,7 @@ type Dispatcher struct {
 
 	logger   *slog.Logger
 	recorder eventrecorder.Recorder
+	tmpl     *template.Template
 
 	startTimer *time.Timer
 	state      atomic.Int32
@@ -110,6 +112,7 @@ func NewDispatcher(
 	logger *slog.Logger,
 	recorder eventrecorder.Recorder,
 	metrics *DispatcherMetrics,
+	tmpl *template.Template,
 ) *Dispatcher {
 	if limits == nil {
 		limits = nilLimits{}
@@ -133,6 +136,7 @@ func NewDispatcher(
 		recorder:            recorder,
 		metrics:             metrics,
 		limits:              limits,
+		tmpl:                tmpl,
 		propagator:          otel.GetTextMapPropagator(),
 	}
 	disp.state.Store(DispatcherStateUnknown)
@@ -478,7 +482,7 @@ func (d *Dispatcher) groupAlert(ctx context.Context, alert *alert.Alert, route *
 		return
 	}
 
-	ag := newAggrGroup(d.ctx, groupLabels, route, d.timeout, d.recorder, d.logger)
+	ag := newAggrGroup(d.ctx, groupLabels, route, d.timeout, d.recorder, d.logger, d.tmpl)
 	// Insert the 1st alert in the group before starting the group's run()
 	// function, to make sure that when the run() will be executed the 1st
 	// alert is already there.
@@ -613,6 +617,7 @@ type aggrGroup struct {
 	alerts   *store.Alerts
 	marker   marker.AlertMarker
 	recorder eventrecorder.Recorder
+	tmpl     *template.Template
 	ctx      context.Context
 	cancel   func()
 	done     chan struct{}
@@ -620,6 +625,14 @@ type aggrGroup struct {
 	timeout  func(time.Duration) time.Duration
 	running  atomic.Bool
 	flushIdx uint64
+
+	// mtx guards routeLabels and routeLabelsDirty.
+	mtx sync.RWMutex
+	// routeLabels holds the route labels rendered against the group's current
+	// alerts. They only change when alerts are inserted or deleted, so they are
+	// rendered lazily: routeLabelsDirty marks when a re-render is needed.
+	routeLabels      model.LabelSet
+	routeLabelsDirty bool
 }
 
 // newAggrGroup returns a new aggregation group.
@@ -630,22 +643,25 @@ func newAggrGroup(
 	to func(time.Duration) time.Duration,
 	recorder eventrecorder.Recorder,
 	logger *slog.Logger,
+	tmpl *template.Template,
 ) *aggrGroup {
 	if to == nil {
 		to = func(d time.Duration) time.Duration { return d }
 	}
 	ag := &aggrGroup{
-		labels:   labels,
-		routeID:  r.ID(),
-		routeKey: r.Key(),
-		matchers: r.Matchers,
-		opts:     &r.RouteOpts,
-		timeout:  to,
-		alerts:   store.NewAlerts(),
-		marker:   marker.NewAlertMarker(),
-		recorder: recorder,
-		done:     make(chan struct{}),
-		flushIdx: 1,
+		labels:      labels,
+		routeID:     r.ID(),
+		routeKey:    r.Key(),
+		matchers:    r.Matchers,
+		opts:        &r.RouteOpts,
+		timeout:     to,
+		alerts:      store.NewAlerts(),
+		marker:      marker.NewAlertMarker(),
+		recorder:    recorder,
+		tmpl:        tmpl,
+		done:        make(chan struct{}),
+		flushIdx:    1,
+		routeLabels: model.LabelSet{},
 	}
 	ag.ctx, ag.cancel = context.WithCancel(ctx)
 
@@ -672,6 +688,70 @@ func (ag *aggrGroup) GroupKey() string {
 
 func (ag *aggrGroup) String() string {
 	return ag.GroupKey()
+}
+
+// renderRouteLabels renders the route's labels as templates against the given
+// alerts and the group's data. A route label value may be a template, so this
+// allows it to reference group labels, other route labels, etc.
+func (ag *aggrGroup) renderRouteLabels(alerts ...*alert.Alert) model.LabelSet {
+	if ag.tmpl == nil {
+		return ag.routeLabels
+	}
+
+	renderedRouteLabels := make(model.LabelSet, len(ag.opts.Labels))
+
+	data := ag.tmpl.Data(ag.opts.Receiver, ag.labels, ag.opts.Labels, notify.ReasonUnknown.String(), alerts...)
+
+	logger := ag.logger.With("data", data)
+
+	for label, value := range ag.opts.Labels {
+		v := string(value)
+		if rendered, err := ag.tmpl.ExecuteTextString(v, data); err == nil {
+			renderedRouteLabels[label] = model.LabelValue(rendered)
+			logger.Debug("rendered route label", "label", label, "value", rendered)
+		} else {
+			logger.Error("failed to render route label", "label", label, "value", v, "err", err)
+		}
+	}
+
+	return renderedRouteLabels
+}
+
+// RouteLabels returns the route labels rendered against the group's current
+// alerts. Rendering is lazy: it only happens when the set of alerts has changed
+// since the last render (tracked by routeLabelsDirty).
+func (ag *aggrGroup) RouteLabels() model.LabelSet {
+	upgradedLock := false
+
+	ag.mtx.RLock()
+
+	defer func() {
+		if upgradedLock {
+			ag.mtx.Unlock()
+		} else {
+			ag.mtx.RUnlock()
+		}
+	}()
+
+	if ag.routeLabelsDirty {
+		// Upgrade the lock because we need to update routeLabels.
+		upgradedLock = true
+		ag.mtx.RUnlock()
+		ag.mtx.Lock()
+
+		if ag.routeLabelsDirty {
+			alerts := ag.alerts.List()
+			if len(alerts) > 0 {
+				ag.routeLabels = ag.renderRouteLabels(alerts...)
+			}
+			// If alerts is empty (all resolved/deleted), keep the previously
+			// rendered routeLabels. The group will be garbage-collected on the
+			// next maintenance cycle.
+			ag.routeLabelsDirty = false
+		}
+	}
+
+	return ag.routeLabels
 }
 
 func (ag *aggrGroup) run(nf notifyFunc) {
@@ -718,6 +798,10 @@ func (ag *aggrGroup) run(nf notifyFunc) {
 					trace.WithSpanKind(trace.SpanKindInternal),
 				)
 				defer span.End()
+
+				// Render route labels against the batch of alerts that we are
+				// about to notify about.
+				ctx = notify.WithRouteLabels(ctx, ag.renderRouteLabels(alerts...))
 
 				success := nf(ctx, alerts...)
 				if !success {
@@ -775,6 +859,9 @@ func (ag *aggrGroup) insert(ctx context.Context, alert *alert.Alert) bool {
 		ag.recorder.RecordEvent(ctx, func() *eventrecorderpb.EventData {
 			return notify.NewAlertGroupedEvent(ag.alertGroupInfo(), alert)
 		})
+		ag.mtx.Lock()
+		ag.routeLabelsDirty = true
+		ag.mtx.Unlock()
 	}
 	return true
 }
@@ -825,6 +912,11 @@ func (ag *aggrGroup) flush(notify func(...*alert.Alert) bool) {
 		if err := ag.alerts.DeleteIfNotModified(resolvedSlice, true); err != nil {
 			ag.logger.Error("error on delete alerts", "err", err)
 		} else {
+			if len(resolvedSlice) > 0 {
+				ag.mtx.Lock()
+				ag.routeLabelsDirty = true
+				ag.mtx.Unlock()
+			}
 			// Delete markers for resolved alerts that are not in the store.
 			for _, alert := range resolvedSlice {
 				_, err := ag.alerts.Get(alert.Fingerprint())

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -711,7 +711,9 @@ func (ag *aggrGroup) String() string {
 // alerts and the group's data. A route label value may be a template, so this
 // allows it to reference group labels, other route labels, etc.
 func (ag *aggrGroup) renderRouteLabels(alerts ...*alert.Alert) model.LabelSet {
-	if ag.tmpl == nil {
+	// Nothing to render when the route has no labels (the common case) or there
+	// is no template engine. Skip building template data, which is O(n_alerts).
+	if len(ag.opts.Labels) == 0 || ag.tmpl == nil {
 		return model.LabelSet{}
 	}
 

--- a/dispatch/dispatch_bench_test.go
+++ b/dispatch/dispatch_bench_test.go
@@ -151,7 +151,7 @@ func setupDispatcher(b *testing.B, route *Route) (*Dispatcher, *mem.Alerts, *rec
 	timeout := func(d time.Duration) time.Duration { return time.Duration(0) }
 	metrics := NewDispatcherMetrics(false, reg, nil)
 
-	dispatcher := NewDispatcher(alerts, route, recorder, marker, timeout, 30*time.Second, nil, logger, eventrecorder.NopRecorder(), metrics)
+	dispatcher := NewDispatcher(alerts, route, recorder, marker, timeout, 30*time.Second, nil, logger, eventrecorder.NopRecorder(), metrics, nil)
 
 	return dispatcher, alerts, recorder
 }

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -361,10 +361,13 @@ route:
 	)
 
 	// Each group should have pre-computed AlertStatuses. Verify and then
-	// nil them out so the struct comparison below works.
+	// nil them out so the struct comparison below works. The routes in this
+	// test define no labels, so RouteLabels is an empty set; nil it out too.
 	for _, ag := range alertGroups {
 		require.NotNil(t, ag.AlertStatuses)
 		ag.AlertStatuses = nil
+		require.Empty(t, ag.RouteLabels)
+		ag.RouteLabels = nil
 	}
 
 	require.Equal(t, AlertGroups{

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -1279,9 +1279,9 @@ func BenchmarkGetGroupLabels(b *testing.B) {
 }
 
 // TestRouteLabelsAfterAllAlertsResolved verifies that calling RouteLabels()
-// after all alerts have been resolved and deleted does not panic or return
-// incorrect results. This exercises the race between flush() emptying the
-// alerts store and RouteLabels() attempting to re-render.
+// after all alerts have been resolved and deleted does not panic. This
+// exercises the cache invalidation in flush() racing RouteLabels() re-rendering
+// against a now-empty alerts store.
 func TestRouteLabelsAfterAllAlertsResolved(t *testing.T) {
 	lset := model.LabelSet{"alertname": "test"}
 	opts := &RouteOpts{
@@ -1346,13 +1346,15 @@ func TestRouteLabelsAfterAllAlertsResolved(t *testing.T) {
 		t.Fatal("timed out waiting for resolved flush")
 	}
 
-	// After flush deletes resolved alerts, RouteLabels() must not panic and
-	// should return the last successfully rendered labels.
+	// After flush deletes resolved alerts, RouteLabels() must not panic when it
+	// re-renders against the now-empty group. The template references
+	// .Alerts[0], so with no alerts it renders to an empty value rather than
+	// erroring out the caller.
 	require.NotPanics(t, func() {
 		rl = ag.RouteLabels()
 	}, "RouteLabels() must not panic after all alerts are deleted")
-	require.Equal(t, model.LabelValue("test"), rl["description"],
-		"route label should retain last rendered value after alerts are deleted")
+	require.Empty(t, rl["description"],
+		"route label renders empty once the group has no alerts")
 }
 
 // TestRouteLabelsInsertConcurrentWithRouteLabels verifies that concurrent
@@ -1381,7 +1383,7 @@ func TestRouteLabelsInsertConcurrentWithRouteLabels(t *testing.T) {
 	ctx := context.Background()
 
 	// Hammer insert() and RouteLabels() concurrently. Under -race this will
-	// flag any data race on routeLabels/routeLabelsDirty.
+	// flag any data race on the routeLabels cache or its generation counter.
 	var wg sync.WaitGroup
 	const goroutines = 10
 	const iterations = 100

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -1357,6 +1357,66 @@ func TestRouteLabelsAfterAllAlertsResolved(t *testing.T) {
 		"route label renders empty once the group has no alerts")
 }
 
+// TestRouteLabelsInNotifyContext verifies that the flush path puts the rendered
+// route labels on the notification context, so notify.RouteLabels(ctx) inside
+// the notify function returns them rendered against the flushed batch.
+func TestRouteLabelsInNotifyContext(t *testing.T) {
+	lset := model.LabelSet{"alertname": "test"}
+	opts := &RouteOpts{
+		Receiver:       "test-receiver",
+		GroupBy:        map[model.LabelName]struct{}{"alertname": {}},
+		GroupWait:      10 * time.Millisecond,
+		GroupInterval:  10 * time.Millisecond,
+		RepeatInterval: 1 * time.Hour,
+		Labels: model.LabelSet{
+			"team": "ops",
+			"name": "{{ (index .Alerts 0).Labels.alertname }}",
+		},
+	}
+	route := &Route{RouteOpts: *opts}
+
+	tmpl, err := template.FromGlobs([]string{})
+	require.NoError(t, err)
+	tmpl.ExternalURL = &url.URL{Scheme: "http", Host: "example.com"}
+
+	ag := newAggrGroup(context.Background(), lset, route, nil,
+		eventrecorder.NopRecorder(), promslog.NewNopLogger(), tmpl)
+
+	type result struct {
+		labels model.LabelSet
+		ok     bool
+	}
+	resultCh := make(chan result, 1)
+	ntfy := func(ctx context.Context, alerts ...*alert.Alert) bool {
+		rl, ok := notify.RouteLabels(ctx)
+		select {
+		case resultCh <- result{labels: rl, ok: ok}:
+		default:
+		}
+		return true
+	}
+	go ag.run(ntfy)
+	defer ag.stop()
+
+	ag.insert(context.Background(), &alert.Alert{
+		Alert: model.Alert{
+			Labels:   model.LabelSet{"alertname": "test", "instance": "a"},
+			StartsAt: time.Now().Add(-time.Hour),
+			EndsAt:   time.Now().Add(time.Hour),
+		},
+		UpdatedAt: time.Now(),
+	})
+
+	select {
+	case got := <-resultCh:
+		require.True(t, got.ok, "route labels missing from notify context")
+		require.Equal(t, model.LabelValue("ops"), got.labels["team"], "static route label")
+		require.Equal(t, model.LabelValue("test"), got.labels["name"], "templated route label rendered against the batch")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for flush")
+	}
+}
+
 // TestRouteLabelsInsertConcurrentWithRouteLabels verifies that concurrent
 // insert() and RouteLabels() calls don't have race conditions. Run with -race.
 func TestRouteLabelsInsertConcurrentWithRouteLabels(t *testing.T) {

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -1417,3 +1417,51 @@ func TestRouteLabelsInsertConcurrentWithRouteLabels(t *testing.T) {
 
 	wg.Wait()
 }
+
+// TestRouteLabelsPerGroupOverride verifies that route label rendering is scoped
+// to a single aggregation group: a label that references another label via
+// routeLabels resolves against that group's own (possibly overridden) label
+// set, with no memoization leaking between groups.
+func TestRouteLabelsPerGroupOverride(t *testing.T) {
+	tmpl, err := template.FromGlobs([]string{})
+	require.NoError(t, err)
+	tmpl.ExternalURL = &url.URL{Scheme: "http", Host: "example.com"}
+
+	// "description" references "team" via routeLabels. The two groups differ
+	// only in the merged value of "team", as a parent route and a child route
+	// that overrides it would.
+	newGroup := func(team string) *aggrGroup {
+		route := &Route{RouteOpts: RouteOpts{
+			Receiver: "r",
+			GroupBy:  map[model.LabelName]struct{}{"alertname": {}},
+			Labels: model.LabelSet{
+				"team":        model.LabelValue(team),
+				"description": `team is {{ routeLabels "team" }}`,
+			},
+		}}
+		ag := newAggrGroup(context.Background(), model.LabelSet{"alertname": "x"},
+			route, nil, eventrecorder.NopRecorder(), promslog.NewNopLogger(), tmpl)
+		ag.insert(context.Background(), &alert.Alert{
+			Alert: model.Alert{
+				Labels:   model.LabelSet{"alertname": "x"},
+				StartsAt: time.Now(),
+				EndsAt:   time.Now().Add(time.Hour),
+			},
+			UpdatedAt: time.Now(),
+		})
+		return ag
+	}
+
+	parent := newGroup("A")
+	child := newGroup("B")
+
+	// Render the child first, then the parent, to make sure neither group's
+	// resolution is influenced by the other's.
+	childLabels := child.RouteLabels()
+	parentLabels := parent.RouteLabels()
+
+	require.Equal(t, model.LabelValue("B"), childLabels["team"])
+	require.Equal(t, model.LabelValue("team is B"), childLabels["description"])
+	require.Equal(t, model.LabelValue("A"), parentLabels["team"])
+	require.Equal(t, model.LabelValue("team is A"), parentLabels["description"])
+}

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"reflect"
 	"runtime"
 	"sort"
@@ -37,6 +38,7 @@ import (
 	"github.com/prometheus/alertmanager/marker"
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/provider/mem"
+	"github.com/prometheus/alertmanager/template"
 )
 
 const testMaintenanceInterval = 30 * time.Second
@@ -163,7 +165,7 @@ func TestAggrGroup(t *testing.T) {
 
 	// Test regular situation where we wait for group_wait to send out alerts.
 	createdAt := time.Now()
-	ag := newAggrGroup(context.Background(), lset, route, nil, eventrecorder.NopRecorder(), promslog.NewNopLogger())
+	ag := newAggrGroup(context.Background(), lset, route, nil, eventrecorder.NopRecorder(), promslog.NewNopLogger(), nil)
 	go ag.run(ntfy)
 
 	ctx := context.Background()
@@ -182,7 +184,7 @@ func TestAggrGroup(t *testing.T) {
 	// Finally, set all alerts to be resolved. After successful notify the aggregation group
 	// should empty itself.
 	createdAt = time.Now()
-	ag = newAggrGroup(context.Background(), lset, route, nil, eventrecorder.NopRecorder(), promslog.NewNopLogger())
+	ag = newAggrGroup(context.Background(), lset, route, nil, eventrecorder.NopRecorder(), promslog.NewNopLogger(), nil)
 	go ag.run(ntfy)
 
 	ag.insert(ctx, a1)
@@ -324,7 +326,7 @@ route:
 
 	timeout := func(d time.Duration) time.Duration { return time.Duration(0) }
 	recorder := &recordStage{alerts: make(map[string]map[model.Fingerprint]*alert.Alert)}
-	dispatcher := NewDispatcher(alerts, route, recorder, marker, timeout, testMaintenanceInterval, nil, logger, eventrecorder.NopRecorder(), NewDispatcherMetrics(false, reg, nil))
+	dispatcher := NewDispatcher(alerts, route, recorder, marker, timeout, testMaintenanceInterval, nil, logger, eventrecorder.NopRecorder(), NewDispatcherMetrics(false, reg, nil), nil)
 	go dispatcher.Run(time.Now())
 	defer dispatcher.Stop()
 
@@ -484,7 +486,7 @@ route:
 	recorder := &recordStage{alerts: make(map[string]map[model.Fingerprint]*alert.Alert)}
 	lim := limits{groups: 6}
 	m := NewDispatcherMetrics(true, reg, nil)
-	dispatcher := NewDispatcher(alerts, route, recorder, marker, timeout, testMaintenanceInterval, lim, logger, eventrecorder.NopRecorder(), m)
+	dispatcher := NewDispatcher(alerts, route, recorder, marker, timeout, testMaintenanceInterval, lim, logger, eventrecorder.NopRecorder(), m, nil)
 	go dispatcher.Run(time.Now())
 	defer dispatcher.Stop()
 
@@ -604,7 +606,7 @@ func TestDispatcherRace(t *testing.T) {
 
 	timeout := func(d time.Duration) time.Duration { return time.Duration(0) }
 	route := &Route{}
-	dispatcher := NewDispatcher(alerts, route, nil, marker, timeout, testMaintenanceInterval, nil, logger, eventrecorder.NopRecorder(), NewDispatcherMetrics(false, reg, nil))
+	dispatcher := NewDispatcher(alerts, route, nil, marker, timeout, testMaintenanceInterval, nil, logger, eventrecorder.NopRecorder(), NewDispatcherMetrics(false, reg, nil), nil)
 	go dispatcher.Run(time.Now())
 	dispatcher.Stop()
 }
@@ -633,7 +635,7 @@ func TestDispatcherRaceOnFirstAlertNotDeliveredWhenGroupWaitIsZero(t *testing.T)
 
 	timeout := func(d time.Duration) time.Duration { return d }
 	recorder := &recordStage{alerts: make(map[string]map[model.Fingerprint]*alert.Alert)}
-	dispatcher := NewDispatcher(alerts, route, recorder, marker, timeout, testMaintenanceInterval, nil, logger, eventrecorder.NopRecorder(), NewDispatcherMetrics(false, reg, nil))
+	dispatcher := NewDispatcher(alerts, route, recorder, marker, timeout, testMaintenanceInterval, nil, logger, eventrecorder.NopRecorder(), NewDispatcherMetrics(false, reg, nil), nil)
 	go dispatcher.Run(time.Now())
 	defer dispatcher.Stop()
 
@@ -686,7 +688,7 @@ func TestDispatcher_DoMaintenance(t *testing.T) {
 	recorder := &recordStage{alerts: make(map[string]map[model.Fingerprint]*alert.Alert)}
 
 	ctx := context.Background()
-	dispatcher := NewDispatcher(alerts, route, recorder, marker, timeout, testMaintenanceInterval, nil, promslog.NewNopLogger(), eventrecorder.NopRecorder(), NewDispatcherMetrics(false, r, nil))
+	dispatcher := NewDispatcher(alerts, route, recorder, marker, timeout, testMaintenanceInterval, nil, promslog.NewNopLogger(), eventrecorder.NopRecorder(), NewDispatcherMetrics(false, r, nil), nil)
 	// Manually create the routeAggrGroups structure since we are not calling Run().
 	dispatcher.routeGroupsSlice = make([]routeAggrGroups, route.Idx+1)
 	dispatcher.routeGroupsSlice[route.Idx] = routeAggrGroups{
@@ -695,7 +697,7 @@ func TestDispatcher_DoMaintenance(t *testing.T) {
 
 	// Insert an aggregation group with one resolved alert.
 	labels := model.LabelSet{"alertname": "1"}
-	aggrGroup1 := newAggrGroup(ctx, labels, route, timeout, eventrecorder.NopRecorder(), promslog.NewNopLogger())
+	aggrGroup1 := newAggrGroup(ctx, labels, route, timeout, eventrecorder.NopRecorder(), promslog.NewNopLogger(), nil)
 	dispatcher.routeGroupsSlice[route.Idx].groups.Store(aggrGroup1.fingerprint(), aggrGroup1)
 
 	// Add a resolved alert
@@ -773,7 +775,7 @@ func TestGroupAlert_RecoversWhenCASFails(t *testing.T) {
 	timeout := func(d time.Duration) time.Duration { return d }
 	recorder := &recordStage{alerts: make(map[string]map[model.Fingerprint]*alert.Alert)}
 	metrics := NewDispatcherMetrics(false, reg, featurecontrol.NoopFlags{})
-	dispatcher := NewDispatcher(alerts, route, recorder, marker.NewGroupMarker(), timeout, testMaintenanceInterval, nil, logger, eventrecorder.NopRecorder(), metrics)
+	dispatcher := NewDispatcher(alerts, route, recorder, marker.NewGroupMarker(), timeout, testMaintenanceInterval, nil, logger, eventrecorder.NopRecorder(), metrics, nil)
 	// Don't call Run — put the dispatcher manually in  the DispatcherStateWaitingToStart
 	// state so groupAlert's final switch falls through the default branch and the
 	// aggregation group's run goroutine is never started.
@@ -782,7 +784,7 @@ func TestGroupAlert_RecoversWhenCASFails(t *testing.T) {
 	rounds := 0
 	for rounds < maxRounds && testutil.ToFloat64(metrics.aggrGroupCreationRetries) == 0 {
 		groupLabels := model.LabelSet{"alertname": model.LabelValue(fmt.Sprintf("shared-%d", rounds))}
-		destroyedAg := newAggrGroup(context.Background(), groupLabels, route, timeout, eventrecorder.NopRecorder(), logger)
+		destroyedAg := newAggrGroup(context.Background(), groupLabels, route, timeout, eventrecorder.NopRecorder(), logger, nil)
 		// Mark the store destroyed: empty store + destroyIfEmpty=true.
 		require.NoError(t, destroyedAg.alerts.DeleteIfNotModified(alert.AlertSlice{}, true))
 		require.True(t, destroyedAg.destroyed())
@@ -858,14 +860,14 @@ func TestGroupAlert_DisplacedAggrGroupGoroutineExits(t *testing.T) {
 	}
 	timeout := func(d time.Duration) time.Duration { return d }
 	recorder := &recordStage{alerts: make(map[string]map[model.Fingerprint]*alert.Alert)}
-	dispatcher := NewDispatcher(alerts, route, recorder, marker.NewGroupMarker(), timeout, testMaintenanceInterval, nil, logger, eventrecorder.NopRecorder(), NewDispatcherMetrics(false, reg, featurecontrol.NoopFlags{}))
+	dispatcher := NewDispatcher(alerts, route, recorder, marker.NewGroupMarker(), timeout, testMaintenanceInterval, nil, logger, eventrecorder.NopRecorder(), NewDispatcherMetrics(false, reg, featurecontrol.NoopFlags{}), nil)
 	dispatcher.routeGroupsSlice = []routeAggrGroups{{route: route}}
 	// WaitingToStart so groupAlert won't auto-start the new ag — keeps the
 	// test focused on the displaced group.
 	dispatcher.state.Store(DispatcherStateWaitingToStart)
 
 	groupLabels := model.LabelSet{"alertname": "displaced"}
-	displaced := newAggrGroup(context.Background(), groupLabels, route, timeout, eventrecorder.NopRecorder(), logger)
+	displaced := newAggrGroup(context.Background(), groupLabels, route, timeout, eventrecorder.NopRecorder(), logger, nil)
 	// Mark destroyed so groupAlert can't insert into it and is forced down
 	// the CAS-replace path.
 	require.NoError(t, displaced.alerts.DeleteIfNotModified(alert.AlertSlice{}, true))
@@ -909,7 +911,7 @@ func TestDispatcher_DeleteResolvedAlertsFromMarker(t *testing.T) {
 		logger := promslog.NewNopLogger()
 
 		// Create an aggregation group
-		ag := newAggrGroup(ctx, labels, route, timeout, eventrecorder.NopRecorder(), logger)
+		ag := newAggrGroup(ctx, labels, route, timeout, eventrecorder.NopRecorder(), logger, nil)
 
 		// Create test alerts: one active and one resolved
 		now := time.Now()
@@ -977,7 +979,7 @@ func TestDispatcher_DeleteResolvedAlertsFromMarker(t *testing.T) {
 		logger := promslog.NewNopLogger()
 
 		// Create an aggregation group
-		ag := newAggrGroup(ctx, labels, route, timeout, eventrecorder.NopRecorder(), logger)
+		ag := newAggrGroup(ctx, labels, route, timeout, eventrecorder.NopRecorder(), logger, nil)
 
 		// Create a resolved alert
 		now := time.Now()
@@ -1030,7 +1032,7 @@ func TestDispatcher_DeleteResolvedAlertsFromMarker(t *testing.T) {
 		logger := promslog.NewNopLogger()
 
 		// Create an aggregation group
-		ag := newAggrGroup(ctx, labels, route, timeout, eventrecorder.NopRecorder(), logger)
+		ag := newAggrGroup(ctx, labels, route, timeout, eventrecorder.NopRecorder(), logger, nil)
 
 		// Create a resolved alert
 		now := time.Now()
@@ -1111,7 +1113,7 @@ func TestDispatchOnStartup(t *testing.T) {
 	now := time.Now()
 	startDelay := 2 * time.Second
 	startTime := time.Now().Add(startDelay)
-	dispatcher := NewDispatcher(alerts, route, recorder, marker, timeout, testMaintenanceInterval, nil, logger, eventrecorder.NopRecorder(), NewDispatcherMetrics(false, reg, nil))
+	dispatcher := NewDispatcher(alerts, route, recorder, marker, timeout, testMaintenanceInterval, nil, logger, eventrecorder.NopRecorder(), NewDispatcherMetrics(false, reg, nil), nil)
 	go dispatcher.Run(startTime)
 	defer dispatcher.Stop()
 
@@ -1271,4 +1273,142 @@ func BenchmarkGetGroupLabels(b *testing.B) {
 			_ = getGroupLabels(alert, route)
 		}
 	})
+}
+
+// TestRouteLabelsAfterAllAlertsResolved verifies that calling RouteLabels()
+// after all alerts have been resolved and deleted does not panic or return
+// incorrect results. This exercises the race between flush() emptying the
+// alerts store and RouteLabels() attempting to re-render.
+func TestRouteLabelsAfterAllAlertsResolved(t *testing.T) {
+	lset := model.LabelSet{"alertname": "test"}
+	opts := &RouteOpts{
+		Receiver:       "test-receiver",
+		GroupBy:        map[model.LabelName]struct{}{"alertname": {}},
+		GroupWait:      10 * time.Millisecond,
+		GroupInterval:  10 * time.Millisecond,
+		RepeatInterval: 1 * time.Hour,
+		Labels: model.LabelSet{
+			"description": "{{ (index .Alerts 0).Labels.alertname }}",
+		},
+	}
+	route := &Route{RouteOpts: *opts}
+
+	tmpl, err := template.FromGlobs([]string{})
+	require.NoError(t, err)
+	tmpl.ExternalURL = &url.URL{Scheme: "http", Host: "example.com"}
+
+	ag := newAggrGroup(context.Background(), lset, route, nil,
+		eventrecorder.NopRecorder(), promslog.NewNopLogger(), tmpl)
+
+	alertsCh := make(chan alert.AlertSlice)
+	ntfy := func(ctx context.Context, alerts ...*alert.Alert) bool {
+		alertsCh <- alert.AlertSlice(alerts)
+		return true
+	}
+	go ag.run(ntfy)
+	defer ag.stop()
+
+	ctx := context.Background()
+
+	// Insert a firing alert and wait for the first flush.
+	a1 := &alert.Alert{
+		Alert: model.Alert{
+			Labels:   model.LabelSet{"alertname": "test", "instance": "a"},
+			StartsAt: time.Now().Add(-time.Hour),
+			EndsAt:   time.Now().Add(time.Hour),
+		},
+		UpdatedAt: time.Now(),
+	}
+	ag.insert(ctx, a1)
+
+	select {
+	case <-alertsCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first flush")
+	}
+
+	// Route labels should be rendered from the alert.
+	rl := ag.RouteLabels()
+	require.Equal(t, model.LabelValue("test"), rl["description"],
+		"route label should be rendered from alert")
+
+	// Now resolve the alert and wait for the flush that deletes it.
+	a1r := *a1
+	a1r.EndsAt = time.Now()
+	ag.insert(ctx, &a1r)
+
+	select {
+	case <-alertsCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for resolved flush")
+	}
+
+	// After flush deletes resolved alerts, RouteLabels() must not panic and
+	// should return the last successfully rendered labels.
+	require.NotPanics(t, func() {
+		rl = ag.RouteLabels()
+	}, "RouteLabels() must not panic after all alerts are deleted")
+	require.Equal(t, model.LabelValue("test"), rl["description"],
+		"route label should retain last rendered value after alerts are deleted")
+}
+
+// TestRouteLabelsInsertConcurrentWithRouteLabels verifies that concurrent
+// insert() and RouteLabels() calls don't have race conditions. Run with -race.
+func TestRouteLabelsInsertConcurrentWithRouteLabels(t *testing.T) {
+	lset := model.LabelSet{"alertname": "test"}
+	opts := &RouteOpts{
+		Receiver:       "test-receiver",
+		GroupBy:        map[model.LabelName]struct{}{"alertname": {}},
+		GroupWait:      1 * time.Hour, // don't flush
+		GroupInterval:  1 * time.Hour,
+		RepeatInterval: 1 * time.Hour,
+		Labels: model.LabelSet{
+			"info": "static-value",
+		},
+	}
+	route := &Route{RouteOpts: *opts}
+
+	tmpl, err := template.FromGlobs([]string{})
+	require.NoError(t, err)
+	tmpl.ExternalURL = &url.URL{Scheme: "http", Host: "example.com"}
+
+	ag := newAggrGroup(context.Background(), lset, route, nil,
+		eventrecorder.NopRecorder(), promslog.NewNopLogger(), tmpl)
+
+	ctx := context.Background()
+
+	// Hammer insert() and RouteLabels() concurrently. Under -race this will
+	// flag any data race on routeLabels/routeLabelsDirty.
+	var wg sync.WaitGroup
+	const goroutines = 10
+	const iterations = 100
+
+	for range goroutines {
+		wg.Go(func() {
+			for i := range iterations {
+				a := &alert.Alert{
+					Alert: model.Alert{
+						Labels: model.LabelSet{
+							"alertname": "test",
+							"i":         model.LabelValue(fmt.Sprintf("%d", i)),
+						},
+						StartsAt: time.Now(),
+						EndsAt:   time.Now().Add(time.Hour),
+					},
+					UpdatedAt: time.Now(),
+				}
+				ag.insert(ctx, a)
+			}
+		})
+	}
+
+	for range goroutines {
+		wg.Go(func() {
+			for range iterations {
+				ag.RouteLabels()
+			}
+		})
+	}
+
+	wg.Wait()
 }

--- a/dispatch/route.go
+++ b/dispatch/route.go
@@ -16,6 +16,7 @@ package dispatch
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"sort"
 	"strconv"
 	"strings"
@@ -36,6 +37,7 @@ var DefaultRouteOpts = RouteOpts{
 	GroupBy:           map[model.LabelName]struct{}{},
 	GroupByAll:        false,
 	MuteTimeIntervals: []string{},
+	Labels:            model.LabelSet{},
 }
 
 // A Route is a node that contains definitions of how to handle alerts.
@@ -70,6 +72,15 @@ func newRoute(cr *config.Route, parent *Route, counter *int) *Route {
 	opts := DefaultRouteOpts
 	if parent != nil {
 		opts = parent.RouteOpts
+	}
+
+	// Merge parent route labels and cr.Labels into opts.Labels. Always merge
+	// into a fresh LabelSet so we never mutate the parent's map.
+	if len(cr.Labels) != 0 {
+		merged := model.LabelSet{}
+		maps.Copy(merged, opts.Labels)
+		maps.Copy(merged, cr.Labels)
+		opts.Labels = merged
 	}
 
 	if cr.Receiver != "" {
@@ -249,6 +260,9 @@ type RouteOpts struct {
 
 	// A list of time intervals for which the route is active.
 	ActiveTimeIntervals []string
+
+	// Merged labels from this route and all of its parent routes.
+	Labels model.LabelSet
 }
 
 func (ro *RouteOpts) String() string {

--- a/dispatch/route_test.go
+++ b/dispatch/route_test.go
@@ -114,6 +114,7 @@ routes:
 					GroupWait:      def.GroupWait,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
+					Labels:         def.Labels,
 				},
 			},
 			keys: []string{"{}/{owner=\"team-A\"}"},
@@ -131,6 +132,7 @@ routes:
 					GroupWait:      def.GroupWait,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
+					Labels:         def.Labels,
 				},
 			},
 			keys: []string{"{}/{owner=\"team-A\"}"},
@@ -147,6 +149,7 @@ routes:
 					GroupWait:      2 * time.Minute,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
+					Labels:         def.Labels,
 				},
 			},
 			keys: []string{"{}/{owner=~\"^(?:team-(B|C))$\"}"},
@@ -164,6 +167,7 @@ routes:
 					GroupWait:      def.GroupWait,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
+					Labels:         def.Labels,
 				},
 			},
 			keys: []string{"{}/{owner=\"team-A\"}/{env=\"testing\"}"},
@@ -181,6 +185,7 @@ routes:
 					GroupWait:      1 * time.Minute,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
+					Labels:         def.Labels,
 				},
 				{
 					Receiver:       "notify-productionB",
@@ -189,6 +194,7 @@ routes:
 					GroupWait:      30 * time.Second,
 					GroupInterval:  5 * time.Minute,
 					RepeatInterval: 1 * time.Hour,
+					Labels:         def.Labels,
 				},
 			},
 			keys: []string{
@@ -208,6 +214,7 @@ routes:
 					GroupWait:      def.GroupWait,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
+					Labels:         def.Labels,
 				},
 			},
 			keys: []string{"{}/{group_by=\"role\"}"},
@@ -225,6 +232,7 @@ routes:
 					GroupWait:      def.GroupWait,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
+					Labels:         def.Labels,
 				},
 			},
 			keys: []string{"{}/{group_by=\"role\"}/{env=\"testing\"}"},
@@ -243,6 +251,7 @@ routes:
 					GroupWait:      2 * time.Minute,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
+					Labels:         def.Labels,
 				},
 			},
 			keys: []string{"{}/{group_by=\"role\"}/{env=\"testing\"}/{wait=\"long\"}"},
@@ -464,6 +473,7 @@ routes:
 					GroupWait:      def.GroupWait,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
+					Labels:         def.Labels,
 				},
 			},
 			keys: []string{"{}/{level!=\"critical\",owner=\"team-A\"}"},
@@ -481,6 +491,7 @@ routes:
 					GroupWait:      def.GroupWait,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
+					Labels:         def.Labels,
 				},
 			},
 			keys: []string{"{}/{level!=\"critical\",owner=\"team-A\"}"},
@@ -497,6 +508,7 @@ routes:
 					GroupWait:      2 * time.Minute,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
+					Labels:         def.Labels,
 				},
 			},
 			keys: []string{"{}/{owner=~\"team-(B|C)\"}"},
@@ -514,6 +526,7 @@ routes:
 					GroupWait:      def.GroupWait,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
+					Labels:         def.Labels,
 				},
 			},
 			keys: []string{"{}/{level!=\"critical\",owner=\"team-A\"}/{baz!~\".*quux\",env=\"testing\"}"},
@@ -531,6 +544,7 @@ routes:
 					GroupWait:      1 * time.Minute,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
+					Labels:         def.Labels,
 				},
 				{
 					Receiver:       "notify-productionB",
@@ -539,6 +553,7 @@ routes:
 					GroupWait:      30 * time.Second,
 					GroupInterval:  5 * time.Minute,
 					RepeatInterval: 1 * time.Hour,
+					Labels:         def.Labels,
 				},
 			},
 			keys: []string{
@@ -558,6 +573,7 @@ routes:
 					GroupWait:      def.GroupWait,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
+					Labels:         def.Labels,
 				},
 			},
 			keys: []string{"{}/{group_by=\"role\"}"},
@@ -575,6 +591,7 @@ routes:
 					GroupWait:      def.GroupWait,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
+					Labels:         def.Labels,
 				},
 			},
 			keys: []string{"{}/{group_by=\"role\"}/{env=\"testing\"}"},
@@ -593,6 +610,7 @@ routes:
 					GroupWait:      2 * time.Minute,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
+					Labels:         def.Labels,
 				},
 			},
 			keys: []string{"{}/{group_by=\"role\"}/{env=\"testing\"}/{wait=\"long\"}"},
@@ -700,6 +718,7 @@ routes:
 					GroupWait:      def.GroupWait,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
+					Labels:         def.Labels,
 				},
 			},
 			keys: []string{"{}/{level!=\"critical\",owner=\"team-A\"}"},
@@ -717,6 +736,7 @@ routes:
 					GroupWait:      def.GroupWait,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
+					Labels:         def.Labels,
 				},
 			},
 			keys: []string{"{}/{level!=\"critical\",owner=\"team-A\"}"},
@@ -733,6 +753,7 @@ routes:
 					GroupWait:      2 * time.Minute,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
+					Labels:         def.Labels,
 				},
 			},
 			keys: []string{"{}/{owner=~\"^(?:team-(B|C))$\"}"},
@@ -750,6 +771,7 @@ routes:
 					GroupWait:      def.GroupWait,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
+					Labels:         def.Labels,
 				},
 			},
 			keys: []string{"{}/{level!=\"critical\",owner=\"team-A\"}/{baz!~\".*quux\",env=\"testing\"}"},
@@ -767,6 +789,7 @@ routes:
 					GroupWait:      1 * time.Minute,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
+					Labels:         def.Labels,
 				},
 				{
 					Receiver:       "notify-productionB",
@@ -775,6 +798,7 @@ routes:
 					GroupWait:      30 * time.Second,
 					GroupInterval:  5 * time.Minute,
 					RepeatInterval: 1 * time.Hour,
+					Labels:         def.Labels,
 				},
 			},
 			keys: []string{
@@ -794,6 +818,7 @@ routes:
 					GroupWait:      def.GroupWait,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
+					Labels:         def.Labels,
 				},
 			},
 			keys: []string{"{}/{group_by=\"role\"}"},
@@ -811,6 +836,7 @@ routes:
 					GroupWait:      def.GroupWait,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
+					Labels:         def.Labels,
 				},
 			},
 			keys: []string{"{}/{group_by=\"role\"}/{env=\"testing\"}"},
@@ -829,6 +855,7 @@ routes:
 					GroupWait:      2 * time.Minute,
 					GroupInterval:  def.GroupInterval,
 					RepeatInterval: def.RepeatInterval,
+					Labels:         def.Labels,
 				},
 			},
 			keys: []string{"{}/{group_by=\"role\"}/{env=\"testing\"}/{wait=\"long\"}"},
@@ -850,6 +877,96 @@ routes:
 
 		if !reflect.DeepEqual(keys, test.keys) {
 			t.Errorf("\nexpected:\n%v\ngot:\n%v", test.keys, keys)
+		}
+	}
+}
+
+func TestRouteLabelsLoading(t *testing.T) {
+	in := `
+receiver: "notify-def"
+
+routes:
+  - matchers: ['{owner="team-A"}', '{level!="critical"}']
+    labels:
+      team: "team-A"
+    receiver: "notify-A"
+
+    routes:
+      - matchers: ['{env="testing"}', '{baz!~".*quux"}']
+        labels:
+          team: "team-A-testing"
+
+      - matchers: ['{env="production"}']
+        labels:
+          severity: "production"
+  - matchers: ['{owner="team-B"}']
+    receiver: "notify-B"
+`
+
+	var ctree config.Route
+	if err := yaml.UnmarshalStrict([]byte(in), &ctree); err != nil {
+		t.Logf("original yaml:\n%s", in)
+		t.Fatal(err)
+	}
+	tree := NewRoute(&ctree, nil)
+
+	tests := []struct {
+		input               model.LabelSet
+		expectedRouteLabels model.LabelSet
+	}{
+		{
+			input: model.LabelSet{
+				"owner": "team-A",
+			},
+			expectedRouteLabels: model.LabelSet{
+				"team": "team-A",
+			},
+		},
+		{
+			input: model.LabelSet{
+				"owner": "team-A",
+				"env":   "testing",
+			},
+			expectedRouteLabels: model.LabelSet{
+				"team": "team-A-testing",
+			},
+		},
+		{
+			input: model.LabelSet{
+				"owner": "team-A",
+				"env":   "production",
+			},
+			expectedRouteLabels: model.LabelSet{
+				"team":     "team-A",
+				"severity": "production",
+			},
+		},
+		{
+			input: model.LabelSet{
+				"owner": "team-B",
+				"env":   "production",
+			},
+			expectedRouteLabels: model.LabelSet{},
+		},
+	}
+
+	for _, test := range tests {
+		var matches []*RouteOpts
+
+		for _, r := range tree.Match(test.input) {
+			matches = append(matches, &r.RouteOpts)
+		}
+
+		// This is just to simplify the tests: we construct the tests with only
+		// one route matching on purpose. In general we can have multiple matches
+		// and multiple route labels, and that is tested in previous unit tests.
+		if len(matches) != 1 {
+			t.Errorf("expected one route, got %d", len(matches))
+			continue
+		}
+
+		if !reflect.DeepEqual(matches[0].Labels, test.expectedRouteLabels) {
+			t.Errorf("\nexpected:\n%v\ngot:\n%v", test.expectedRouteLabels, matches[0].Labels)
 		}
 	}
 }

--- a/doc/examples/route_labels.yml
+++ b/doc/examples/route_labels.yml
@@ -1,0 +1,62 @@
+# Example showing route `labels`.
+#
+# Route labels are attached to a route, inherited by child routes, and may be
+# overridden per route. They are rendered per alert group and exposed to
+# notification templates via the `routeLabels` function (and in the
+# `routeLabels` field of the /api/v2/alerts/groups API response).
+#
+# The pattern shown here: a `description` is composed once at the root from a
+# `reason` sub-label. Each subtree overrides only `reason`, computing it from
+# the labels that branch matched on. The shared description picks up the new
+# reason automatically, so the per-branch routes never restate the surrounding
+# wording.
+
+templates:
+  - '/etc/alertmanager/template/*.tmpl'
+
+route:
+  group_by: ['alertname']
+  receiver: default
+  # `description` is defined once and built from `reason`. Child routes only
+  # override `reason`; they inherit this description unchanged.
+  labels:
+    reason: '{{ .GroupLabels.alertname }}'
+    description: '{{ .GroupLabels.alertname }} firing ({{ routeLabels "reason" }})'
+  routes:
+    # Database alerts are grouped by the affected database, so the reason can be
+    # computed from that branch's grouping label.
+    - matchers:
+        - service="database"
+      receiver: dba
+      group_by: ['alertname', 'database']
+      labels:
+        reason: 'database {{ .GroupLabels.database }}'
+
+    # Network link alerts match on both endpoints; the reason names the link.
+    - matchers:
+        - link_a_device=~".+"
+        - link_z_device=~".+"
+      receiver: network
+      group_by: ['alertname', 'link_a_device', 'link_z_device']
+      labels:
+        reason: '{{ .GroupLabels.link_a_device }} <-> {{ .GroupLabels.link_z_device }}'
+
+receivers:
+  # The webhook payload includes the rendered route labels under "routeLabels".
+  - name: default
+    webhook_configs:
+      - url: 'http://127.0.0.1:5001/'
+  - name: dba
+    webhook_configs:
+      - url: 'http://127.0.0.1:5001/'
+  - name: network
+    webhook_configs:
+      - url: 'http://127.0.0.1:5001/'
+
+# A notification template just renders the shared description:
+#
+#   {{ define "route_labels.text" }}{{ routeLabels "description" }}{{ end }}
+#
+# For a generic alert this renders e.g. "HighLatency firing (HighLatency)";
+# for the database branch "DiskFull firing (database orders)"; for the link
+# branch "LinkDown firing (switch-a <-> switch-b)" -- only `reason` changed.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -249,6 +249,18 @@ matchers:
 # reason-dependent content.
 labels:
   [ <labelname>: <tmpl_string>, ... ]
+# Example: `description` is composed once from a `reason` sub-label. A sub-route
+# overrides only `reason`, computing it from the labels that branch matched on,
+# and the inherited description picks it up automatically:
+#   route:
+#     labels:
+#       reason: '{{ .GroupLabels.alertname }}'
+#       description: '{{ .GroupLabels.alertname }} firing ({{ routeLabels "reason" }})'
+#     routes:
+#       - matchers: [ service="database" ]
+#         group_by: [ alertname, database ]
+#         labels:
+#           reason: 'database {{ .GroupLabels.database }}'
 
 # How long to wait before sending the first notification for a new group of
 # alerts. Allows to wait for alerts to arrive from other rule groups or

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -240,6 +240,13 @@ matchers:
 # Label values may themselves be templates that are rendered against the
 # notification data of each alert group (so they can reference group labels,
 # other route labels, etc.).
+#
+# Route labels are rendered per alert group, independently of any individual
+# notification (they are also exposed via the API, where there is no
+# notification at all). Fields that are only meaningful for a specific
+# notification are therefore not available: in particular `.NotificationReason`
+# is always "unknown" in route label templates. Use notification templates for
+# reason-dependent content.
 labels:
   [ <labelname>: <tmpl_string>, ... ]
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -230,6 +230,19 @@ match_re:
 matchers:
   [ - <matcher> ... ]
 
+# A set of labels that are attached to the route and made available to
+# notification templates via the `routeLabels` template function (and to the
+# `routeLabels` field of the `/api/v2/alerts/groups` API response). Route labels
+# are merged from parent to child routes: a child route inherits its parent's
+# route labels and may override individual labels by redefining them. Unlike
+# group_by, route labels do not affect how alerts are grouped.
+#
+# Label values may themselves be templates that are rendered against the
+# notification data of each alert group (so they can reference group labels,
+# other route labels, etc.).
+labels:
+  [ <labelname>: <tmpl_string>, ... ]
+
 # How long to wait before sending the first notification for a new group of
 # alerts. Allows to wait for alerts to arrive from other rule groups or
 # Prometheus servers, and for one or more inhibiting alerts to arrive and mute

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -27,6 +27,7 @@ Note that some fields are evaluated as text, and others as HTML which will affec
 | GroupLabels | [KV](#kv) | The labels these alerts were grouped by. |
 | CommonLabels | [KV](#kv) | The labels common to all of the alerts. |
 | CommonAnnotations | [KV](#kv) | Set of common annotations to all of the alerts. Used for longer additional strings of information about the alert. |
+| RouteLabels | [KV](#kv) | The route [`labels`](configuration.md#route) attached to this alert group. Usually accessed via the `routeLabels` function below. |
 | ExternalURL | string | Backlink to the Alertmanager that sent the notification. |
 
 The `Alerts` type exposes functions for filtering alerts:
@@ -94,6 +95,7 @@ templating.
 | match            | pattern, string            | [Regexp.MatchString](https://golang.org/pkg/regexp/#MatchString). Match a string using Regexp. |
 | now              |                            | [time.Now](https://pkg.go.dev/time#Now), returns the current local time. |
 | reReplaceAll     | pattern, replacement, text | [Regexp.ReplaceAllString](http://golang.org/pkg/regexp/#Regexp.ReplaceAllString) Regexp substitution, unanchored. |
+| routeLabels      | name string                | Returns the value of the named route [label](configuration.md#route) for this alert group, or "" if unset. |
 | safeHtml         | text string                | [html/template.HTML](https://golang.org/pkg/html/template/#HTML), Marks string as HTML not requiring auto-escaping. |
 | safeUrl          | text string                | [html/template.URL](https://golang.org/pkg/html/template/#URL), Marks string as URL not requiring auto-escaping. |
 | since            | time.Time                  | [time.Since](https://pkg.go.dev/time#Since), returns the duration of how much time passed from the provided time till the current system time. |

--- a/notify/context.go
+++ b/notify/context.go
@@ -43,6 +43,7 @@ const (
 	keyAggrGroupID
 	keyFlushID
 	keyGroupMatchers
+	keyRouteLabels
 )
 
 // WithReceiverName populates a context with a receiver name.
@@ -68,6 +69,11 @@ func WithResolvedAlerts(ctx context.Context, alerts []uint64) context.Context {
 // WithGroupLabels populates a context with grouping labels.
 func WithGroupLabels(ctx context.Context, lset model.LabelSet) context.Context {
 	return context.WithValue(ctx, keyGroupLabels, lset)
+}
+
+// WithRouteLabels populates a context with route labels.
+func WithRouteLabels(ctx context.Context, rl model.LabelSet) context.Context {
+	return context.WithValue(ctx, keyRouteLabels, rl)
 }
 
 // WithNow populates a context with a now timestamp.
@@ -125,6 +131,13 @@ func GroupKey(ctx context.Context) (string, bool) {
 // second argument is false.
 func GroupLabels(ctx context.Context) (model.LabelSet, bool) {
 	v, ok := ctx.Value(keyGroupLabels).(model.LabelSet)
+	return v, ok
+}
+
+// RouteLabels extracts route labels from the context. Iff none exists, the
+// second argument is false.
+func RouteLabels(ctx context.Context) (model.LabelSet, bool) {
+	v, ok := ctx.Value(keyRouteLabels).(model.LabelSet)
 	return v, ok
 }
 

--- a/notify/jira/jira_test.go
+++ b/notify/jira/jira_test.go
@@ -1242,7 +1242,7 @@ func TestJiraPriority(t *testing.T) {
 			tmpl.ExternalURL = u
 
 			var (
-				data = tmpl.Data("jira", model.LabelSet{}, notify.ReasonFirstNotification.String(), tc.alerts...)
+				data = tmpl.Data("jira", model.LabelSet{}, nil, notify.ReasonFirstNotification.String(), tc.alerts...)
 
 				tmplTextErr  error
 				tmplText     = notify.TmplText(tmpl, data, &tmplTextErr)

--- a/notify/util.go
+++ b/notify/util.go
@@ -204,10 +204,9 @@ func GetTemplateData(ctx context.Context, tmpl *template.Template, alerts []*typ
 	if !ok {
 		l.Error("Missing group labels")
 	}
-	routeLabels, ok := RouteLabels(ctx)
-	if !ok {
-		l.Error("Missing route labels")
-	}
+	// Route labels are optional (a route may have none, and some callers omit
+	// them); absence is not an error and a nil LabelSet is handled downstream.
+	routeLabels, _ := RouteLabels(ctx)
 	notificationReason, ok := NotificationReason(ctx)
 	if !ok {
 		l.Error("Missing notification reason")

--- a/notify/util.go
+++ b/notify/util.go
@@ -204,12 +204,16 @@ func GetTemplateData(ctx context.Context, tmpl *template.Template, alerts []*typ
 	if !ok {
 		l.Error("Missing group labels")
 	}
+	routeLabels, ok := RouteLabels(ctx)
+	if !ok {
+		l.Error("Missing route labels")
+	}
 	notificationReason, ok := NotificationReason(ctx)
 	if !ok {
 		l.Error("Missing notification reason")
 		notificationReason = ReasonUnknown
 	}
-	return tmpl.Data(recv, groupLabels, notificationReason.String(), alerts...)
+	return tmpl.Data(recv, groupLabels, routeLabels, notificationReason.String(), alerts...)
 }
 
 func readAll(r io.Reader) string {

--- a/notify/util.go
+++ b/notify/util.go
@@ -214,7 +214,7 @@ func GetTemplateData(ctx context.Context, tmpl *template.Template, alerts []*typ
 	}
 	data := tmpl.Data(recv, groupLabels, routeLabels, notificationReason.String(), alerts...)
 	// Route labels are pre-rendered by the dispatcher; don't execute them again.
-	template.MarkRouteLabelsResolved(data)
+	template.MarkRouteLabelsRendered(data)
 	return data
 }
 

--- a/notify/util.go
+++ b/notify/util.go
@@ -212,7 +212,10 @@ func GetTemplateData(ctx context.Context, tmpl *template.Template, alerts []*typ
 		l.Error("Missing notification reason")
 		notificationReason = ReasonUnknown
 	}
-	return tmpl.Data(recv, groupLabels, routeLabels, notificationReason.String(), alerts...)
+	data := tmpl.Data(recv, groupLabels, routeLabels, notificationReason.String(), alerts...)
+	// Route labels are pre-rendered by the dispatcher; don't execute them again.
+	template.MarkRouteLabelsResolved(data)
+	return data
 }
 
 func readAll(r io.Reader) string {

--- a/notify/util_test.go
+++ b/notify/util_test.go
@@ -15,15 +15,21 @@ package notify
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"path"
 	"reflect"
 	"runtime"
 	"testing"
 
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/alertmanager/template"
 )
 
 func TestTruncate(t *testing.T) {
@@ -215,4 +221,34 @@ func TestRetrierCheck(t *testing.T) {
 			require.EqualError(t, err, tc.expectedErr)
 		})
 	}
+}
+
+func TestGetTemplateDataWithRouteLabels(t *testing.T) {
+	tmpl, err := template.New()
+	require.NoError(t, err)
+	tmpl.ExternalURL = &url.URL{Scheme: "http", Host: "example.com"}
+
+	// A route label value containing template metacharacters: the dispatcher
+	// has already rendered route labels, so GetTemplateData must mark them
+	// resolved and the routeLabels function must return them verbatim rather
+	// than executing them a second time.
+	ctx := context.Background()
+	ctx = WithReceiverName(ctx, "test-receiver")
+	ctx = WithGroupKey(ctx, "test-key")
+	ctx = WithGroupLabels(ctx, model.LabelSet{"alertname": "Test"})
+	ctx = WithNotificationReason(ctx, ReasonFirstNotification)
+	ctx = WithRouteLabels(ctx, model.LabelSet{
+		"team": "ops",
+		"desc": "value is {{ $value }}",
+	})
+
+	data := GetTemplateData(ctx, tmpl, nil, promslog.NewNopLogger())
+
+	require.Equal(t, "ops", data.RouteLabels["team"])
+	require.Equal(t, "value is {{ $value }}", data.RouteLabels["desc"])
+
+	// The routeLabels template function returns the values verbatim.
+	got, err := tmpl.ExecuteTextString(`{{ routeLabels "team" }}|{{ routeLabels "desc" }}`, data)
+	require.NoError(t, err)
+	require.Equal(t, "ops|value is {{ $value }}", got)
 }

--- a/notify/util_test.go
+++ b/notify/util_test.go
@@ -230,7 +230,7 @@ func TestGetTemplateDataWithRouteLabels(t *testing.T) {
 
 	// A route label value containing template metacharacters: the dispatcher
 	// has already rendered route labels, so GetTemplateData must mark them
-	// resolved and the routeLabels function must return them verbatim rather
+	// rendered and the routeLabels function must return them verbatim rather
 	// than executing them a second time.
 	ctx := context.Background()
 	ctx = WithReceiverName(ctx, "test-receiver")

--- a/template/template.go
+++ b/template/template.go
@@ -136,28 +136,76 @@ func (t *Template) FromGlob(path string) error {
 	return nil
 }
 
-// makeRouteLabelFunc returns a routeLabels template function bound to the given
-// data and execute function. Looking up a route label renders its value as a
-// template, so route label values may themselves reference group labels, other
-// route labels, etc. (including recursively).
-func makeRouteLabelFunc(data any, executeFunc func(string, any) (string, error)) func(string) (string, error) {
-	// The data may be passed either by value or by pointer, so handle both.
-	var castData *Data
-	if d, ok := data.(Data); ok {
-		castData = &d
-	} else if d, ok := data.(*Data); ok {
-		castData = d
+// routeLabelsOf extracts the route labels from template data, which may be
+// passed either by value or by pointer.
+func routeLabelsOf(data any) KV {
+	switch d := data.(type) {
+	case *Data:
+		return d.RouteLabels
+	case Data:
+		return d.RouteLabels
+	default:
+		return nil
 	}
-	return func(name string) (string, error) {
-		if castData == nil {
-			return "", nil
-		}
-		lv, ok := castData.RouteLabels[name]
-		if !ok {
-			return "", nil
-		}
-		return executeFunc(lv, data)
+}
+
+// routeLabelResolver backs the routeLabels template function for a single
+// top-level render. A route label value may itself be a template that
+// references group labels, other route labels, etc., so resolving one can
+// recurse. The resolver renders each label at most once (memo) and tracks which
+// labels are currently being rendered (inProgress) so that a cyclic reference
+// returns a descriptive error instead of recursing until the goroutine stack
+// overflows (which is a fatal, unrecoverable runtime error in Go).
+type routeLabelResolver struct {
+	raw        KV  // raw (possibly templated) label values
+	data       any // data to render label values against
+	exec       func(text string, data any, r *routeLabelResolver) (string, error)
+	memo       map[string]string
+	inProgress map[string]struct{}
+	stack      []string // labels currently being rendered, for the cycle error
+}
+
+func newRouteLabelResolver(data any, exec func(string, any, *routeLabelResolver) (string, error)) *routeLabelResolver {
+	// memo and inProgress are allocated lazily on the first resolve() call, so a
+	// template that never references routeLabels (the common case) pays nothing.
+	return &routeLabelResolver{
+		raw:  routeLabelsOf(data),
+		data: data,
+		exec: exec,
 	}
+}
+
+// resolve renders the named route label, recursing through any routeLabels
+// references it contains. Unknown labels render to the empty string.
+func (r *routeLabelResolver) resolve(name string) (string, error) {
+	raw, ok := r.raw[name]
+	if !ok {
+		return "", nil
+	}
+	if v, ok := r.memo[name]; ok {
+		return v, nil
+	}
+	if _, busy := r.inProgress[name]; busy {
+		cycle := strings.Join(append(append([]string{}, r.stack...), name), " -> ")
+		return "", fmt.Errorf("route label cycle detected: %s", cycle)
+	}
+
+	if r.memo == nil {
+		r.memo = map[string]string{}
+		r.inProgress = map[string]struct{}{}
+	}
+
+	r.inProgress[name] = struct{}{}
+	r.stack = append(r.stack, name)
+	v, err := r.exec(raw, r.data, r)
+	r.stack = r.stack[:len(r.stack)-1]
+	delete(r.inProgress, name)
+	if err != nil {
+		return "", err
+	}
+
+	r.memo[name] = v
+	return v, nil
 }
 
 // ExecuteTextString needs a meaningful doc comment (TODO(fabxc)).
@@ -165,14 +213,16 @@ func (t *Template) ExecuteTextString(text string, data any) (string, error) {
 	if text == "" {
 		return "", nil
 	}
+	return t.execText(text, data, newRouteLabelResolver(data, t.execText))
+}
+
+func (t *Template) execText(text string, data any, r *routeLabelResolver) (string, error) {
 	tmpl, err := t.text.Clone()
 	if err != nil {
 		return "", err
 	}
 
-	funcs := tmpltext.FuncMap{
-		"routeLabels": makeRouteLabelFunc(data, t.ExecuteTextString),
-	}
+	funcs := tmpltext.FuncMap{"routeLabels": r.resolve}
 
 	tmpl, err = tmpl.New("").Option("missingkey=zero").Funcs(funcs).Parse(text)
 	if err != nil {
@@ -188,14 +238,16 @@ func (t *Template) ExecuteHTMLString(html string, data any) (string, error) {
 	if html == "" {
 		return "", nil
 	}
+	return t.execHTML(html, data, newRouteLabelResolver(data, t.execHTML))
+}
+
+func (t *Template) execHTML(html string, data any, r *routeLabelResolver) (string, error) {
 	tmpl, err := t.html.Clone()
 	if err != nil {
 		return "", err
 	}
 
-	funcs := tmplhtml.FuncMap{
-		"routeLabels": makeRouteLabelFunc(data, t.ExecuteHTMLString),
-	}
+	funcs := tmplhtml.FuncMap{"routeLabels": r.resolve}
 
 	tmpl, err = tmpl.New("").Option("missingkey=zero").Funcs(funcs).Parse(html)
 	if err != nil {

--- a/template/template.go
+++ b/template/template.go
@@ -136,6 +136,30 @@ func (t *Template) FromGlob(path string) error {
 	return nil
 }
 
+// makeRouteLabelFunc returns a routeLabels template function bound to the given
+// data and execute function. Looking up a route label renders its value as a
+// template, so route label values may themselves reference group labels, other
+// route labels, etc. (including recursively).
+func makeRouteLabelFunc(data any, executeFunc func(string, any) (string, error)) func(string) (string, error) {
+	// The data may be passed either by value or by pointer, so handle both.
+	var castData *Data
+	if d, ok := data.(Data); ok {
+		castData = &d
+	} else if d, ok := data.(*Data); ok {
+		castData = d
+	}
+	return func(name string) (string, error) {
+		if castData == nil {
+			return "", nil
+		}
+		lv, ok := castData.RouteLabels[name]
+		if !ok {
+			return "", nil
+		}
+		return executeFunc(lv, data)
+	}
+}
+
 // ExecuteTextString needs a meaningful doc comment (TODO(fabxc)).
 func (t *Template) ExecuteTextString(text string, data any) (string, error) {
 	if text == "" {
@@ -145,7 +169,12 @@ func (t *Template) ExecuteTextString(text string, data any) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	tmpl, err = tmpl.New("").Option("missingkey=zero").Parse(text)
+
+	funcs := tmpltext.FuncMap{
+		"routeLabels": makeRouteLabelFunc(data, t.ExecuteTextString),
+	}
+
+	tmpl, err = tmpl.New("").Option("missingkey=zero").Funcs(funcs).Parse(text)
 	if err != nil {
 		return "", err
 	}
@@ -163,7 +192,12 @@ func (t *Template) ExecuteHTMLString(html string, data any) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	tmpl, err = tmpl.New("").Option("missingkey=zero").Parse(html)
+
+	funcs := tmplhtml.FuncMap{
+		"routeLabels": makeRouteLabelFunc(data, t.ExecuteHTMLString),
+	}
+
+	tmpl, err = tmpl.New("").Option("missingkey=zero").Funcs(funcs).Parse(html)
 	if err != nil {
 		return "", err
 	}
@@ -202,6 +236,12 @@ var DefaultFuncs = FuncMap{
 	},
 	"stringSlice": func(s ...string) []string {
 		return s
+	},
+	// routeLabels is a placeholder needed so templates referencing it parse
+	// successfully. It is replaced dynamically with the real implementation in
+	// ExecuteTextString and ExecuteHTMLString.
+	"routeLabels": func(name string) (string, error) {
+		return "", nil
 	},
 	// date returns the text representation of the time in the specified format.
 	"date": func(fmt string, t time.Time) string {
@@ -261,21 +301,21 @@ type Pair struct {
 type Pairs []Pair
 
 // Names returns a list of names of the pairs.
-func (ps Pairs) Names() []string {
+func (ps Pairs) Names() Strings {
 	ns := make([]string, 0, len(ps))
 	for _, p := range ps {
 		ns = append(ns, p.Name)
 	}
-	return ns
+	return Strings(ns)
 }
 
 // Values returns a list of values of the pairs.
-func (ps Pairs) Values() []string {
+func (ps Pairs) Values() Strings {
 	vs := make([]string, 0, len(ps))
 	for _, p := range ps {
 		vs = append(vs, p.Value)
 	}
-	return vs
+	return Strings(vs)
 }
 
 func (ps Pairs) String() string {
@@ -289,6 +329,15 @@ func (ps Pairs) String() string {
 		}
 	}
 	return b.String()
+}
+
+// Strings is a list of strings exposed to templates.
+type Strings []string
+
+// Join makes strings.Join accessible from templates, e.g.
+// {{ .GroupLabels.Values.Join ":" }}.
+func (s Strings) Join(sep string) string {
+	return strings.Join(s, sep)
 }
 
 // KV is a set of key/value string pairs.
@@ -334,12 +383,12 @@ func (kv KV) Remove(keys []string) KV {
 }
 
 // Names returns the names of the label names in the LabelSet.
-func (kv KV) Names() []string {
+func (kv KV) Names() Strings {
 	return kv.SortedPairs().Names()
 }
 
 // Values returns a list of the values in the LabelSet.
-func (kv KV) Values() []string {
+func (kv KV) Values() Strings {
 	return kv.SortedPairs().Values()
 }
 
@@ -361,6 +410,7 @@ type Data struct {
 	GroupLabels       KV `json:"groupLabels"`
 	CommonLabels      KV `json:"commonLabels"`
 	CommonAnnotations KV `json:"commonAnnotations"`
+	RouteLabels       KV `json:"routeLabels"`
 
 	ExternalURL string `json:"externalURL"`
 }
@@ -402,7 +452,7 @@ func (as Alerts) Resolved() []Alert {
 }
 
 // Data assembles data for template expansion.
-func (t *Template) Data(recv string, groupLabels model.LabelSet, notificationReason string, alerts ...*types.Alert) *Data {
+func (t *Template) Data(recv string, groupLabels, routeLabels model.LabelSet, notificationReason string, alerts ...*types.Alert) *Data {
 	typedAlerts := types.Alerts(alerts...)
 
 	data := &Data{
@@ -413,6 +463,7 @@ func (t *Template) Data(recv string, groupLabels model.LabelSet, notificationRea
 		GroupLabels:        KV{},
 		CommonLabels:       KV{},
 		CommonAnnotations:  KV{},
+		RouteLabels:        KV{},
 		ExternalURL:        t.ExternalURL.String(),
 	}
 
@@ -439,6 +490,10 @@ func (t *Template) Data(recv string, groupLabels model.LabelSet, notificationRea
 
 	for k, v := range groupLabels {
 		data.GroupLabels[string(k)] = string(v)
+	}
+
+	for k, v := range routeLabels {
+		data.RouteLabels[string(k)] = string(v)
 	}
 
 	if len(alerts) >= 1 {

--- a/template/template.go
+++ b/template/template.go
@@ -139,12 +139,12 @@ func (t *Template) FromGlob(path string) error {
 // routeLabelsOf extracts the route labels from template data, which may be
 // passed either by value or by pointer, along with whether those values are
 // already rendered (and so must be returned verbatim rather than executed).
-func routeLabelsOf(data any) (labels KV, resolved bool) {
+func routeLabelsOf(data any) (labels KV, rendered bool) {
 	switch d := data.(type) {
 	case *Data:
-		return d.RouteLabels, d.routeLabelsResolved
+		return d.RouteLabels, d.routeLabelsRendered
 	case Data:
-		return d.RouteLabels, d.routeLabelsResolved
+		return d.RouteLabels, d.routeLabelsRendered
 	default:
 		return nil, false
 	}
@@ -159,7 +159,7 @@ func routeLabelsOf(data any) (labels KV, resolved bool) {
 // overflows (which is a fatal, unrecoverable runtime error in Go).
 type routeLabelResolver struct {
 	raw        KV   // raw (possibly templated) label values
-	resolved   bool // if true, raw values are already rendered; return verbatim
+	rendered   bool // if true, raw values are already rendered; return verbatim
 	data       any  // data to render label values against
 	exec       func(text string, data any, r *routeLabelResolver) (string, error)
 	memo       map[string]string
@@ -170,10 +170,10 @@ type routeLabelResolver struct {
 func newRouteLabelResolver(data any, exec func(string, any, *routeLabelResolver) (string, error)) *routeLabelResolver {
 	// memo and inProgress are allocated lazily on the first resolve() call, so a
 	// template that never references routeLabels (the common case) pays nothing.
-	labels, resolved := routeLabelsOf(data)
+	labels, rendered := routeLabelsOf(data)
 	return &routeLabelResolver{
 		raw:      labels,
-		resolved: resolved,
+		rendered: rendered,
 		data:     data,
 		exec:     exec,
 	}
@@ -181,14 +181,14 @@ func newRouteLabelResolver(data any, exec func(string, any, *routeLabelResolver)
 
 // resolve renders the named route label, recursing through any routeLabels
 // references it contains. Unknown labels render to the empty string. If the
-// values are already rendered (resolved), they are returned verbatim without a
-// second execution.
+// values are already rendered, they are returned verbatim without a second
+// execution.
 func (r *routeLabelResolver) resolve(name string) (string, error) {
 	raw, ok := r.raw[name]
 	if !ok {
 		return "", nil
 	}
-	if r.resolved {
+	if r.rendered {
 		return raw, nil
 	}
 	if v, ok := r.memo[name]; ok {
@@ -485,18 +485,18 @@ type Data struct {
 
 	ExternalURL string `json:"externalURL"`
 
-	// routeLabelsResolved: if true, routeLabels returns RouteLabels values
+	// routeLabelsRendered: if true, routeLabels returns RouteLabels values
 	// verbatim instead of executing them as templates. Set via
-	// MarkRouteLabelsResolved. Unexported so it is not reachable from templates
+	// MarkRouteLabelsRendered. Unexported so it is not reachable from templates
 	// or serialized into JSON webhooks.
-	routeLabelsResolved bool
+	routeLabelsRendered bool
 }
 
-// MarkRouteLabelsResolved marks d.RouteLabels as already-rendered, so the
+// MarkRouteLabelsRendered marks d.RouteLabels as already-rendered, so the
 // routeLabels template function returns the values verbatim rather than
 // executing them a second time.
-func MarkRouteLabelsResolved(d *Data) {
-	d.routeLabelsResolved = true
+func MarkRouteLabelsRendered(d *Data) {
+	d.routeLabelsRendered = true
 }
 
 // Alert holds one alert for notification templates.

--- a/template/template.go
+++ b/template/template.go
@@ -137,15 +137,16 @@ func (t *Template) FromGlob(path string) error {
 }
 
 // routeLabelsOf extracts the route labels from template data, which may be
-// passed either by value or by pointer.
-func routeLabelsOf(data any) KV {
+// passed either by value or by pointer, along with whether those values are
+// already rendered (and so must be returned verbatim rather than executed).
+func routeLabelsOf(data any) (labels KV, resolved bool) {
 	switch d := data.(type) {
 	case *Data:
-		return d.RouteLabels
+		return d.RouteLabels, d.routeLabelsResolved
 	case Data:
-		return d.RouteLabels
+		return d.RouteLabels, d.routeLabelsResolved
 	default:
-		return nil
+		return nil, false
 	}
 }
 
@@ -157,8 +158,9 @@ func routeLabelsOf(data any) KV {
 // returns a descriptive error instead of recursing until the goroutine stack
 // overflows (which is a fatal, unrecoverable runtime error in Go).
 type routeLabelResolver struct {
-	raw        KV  // raw (possibly templated) label values
-	data       any // data to render label values against
+	raw        KV   // raw (possibly templated) label values
+	resolved   bool // if true, raw values are already rendered; return verbatim
+	data       any  // data to render label values against
 	exec       func(text string, data any, r *routeLabelResolver) (string, error)
 	memo       map[string]string
 	inProgress map[string]struct{}
@@ -168,19 +170,26 @@ type routeLabelResolver struct {
 func newRouteLabelResolver(data any, exec func(string, any, *routeLabelResolver) (string, error)) *routeLabelResolver {
 	// memo and inProgress are allocated lazily on the first resolve() call, so a
 	// template that never references routeLabels (the common case) pays nothing.
+	labels, resolved := routeLabelsOf(data)
 	return &routeLabelResolver{
-		raw:  routeLabelsOf(data),
-		data: data,
-		exec: exec,
+		raw:      labels,
+		resolved: resolved,
+		data:     data,
+		exec:     exec,
 	}
 }
 
 // resolve renders the named route label, recursing through any routeLabels
-// references it contains. Unknown labels render to the empty string.
+// references it contains. Unknown labels render to the empty string. If the
+// values are already rendered (resolved), they are returned verbatim without a
+// second execution.
 func (r *routeLabelResolver) resolve(name string) (string, error) {
 	raw, ok := r.raw[name]
 	if !ok {
 		return "", nil
+	}
+	if r.resolved {
+		return raw, nil
 	}
 	if v, ok := r.memo[name]; ok {
 		return v, nil
@@ -465,6 +474,19 @@ type Data struct {
 	RouteLabels       KV `json:"routeLabels"`
 
 	ExternalURL string `json:"externalURL"`
+
+	// routeLabelsResolved: if true, routeLabels returns RouteLabels values
+	// verbatim instead of executing them as templates. Set via
+	// MarkRouteLabelsResolved. Unexported so it is not reachable from templates
+	// or serialized into JSON webhooks.
+	routeLabelsResolved bool
+}
+
+// MarkRouteLabelsResolved marks d.RouteLabels as already-rendered, so the
+// routeLabels template function returns the values verbatim rather than
+// executing them a second time.
+func MarkRouteLabelsResolved(d *Data) {
+	d.routeLabelsResolved = true
 }
 
 // Alert holds one alert for notification templates.

--- a/template/template.go
+++ b/template/template.go
@@ -217,6 +217,16 @@ func (r *routeLabelResolver) resolve(name string) (string, error) {
 	return v, nil
 }
 
+// RouteLabelRenderer returns a function that renders a route label by name from
+// data.RouteLabels. All returned renders share a single resolver, so each label
+// — and any label it cross-references via {{ routeLabels "x" }} — is rendered at
+// most once per call to RouteLabelRenderer (and cycles are still detected).
+// It is used by the dispatch-time expansion of a group's route labels, where
+// many labels are rendered against the same data and may reference each other.
+func (t *Template) RouteLabelRenderer(data *Data) func(name string) (string, error) {
+	return newRouteLabelResolver(data, t.execText).resolve
+}
+
 // ExecuteTextString needs a meaningful doc comment (TODO(fabxc)).
 func (t *Template) ExecuteTextString(text string, data any) (string, error) {
 	if text == "" {

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -654,6 +654,42 @@ func TestRouteLabelsUnresolvedExecuted(t *testing.T) {
 	require.Equal(t, `[v]`, got)
 }
 
+// TestRouteLabelRendererSharesResolver checks that rendering a group's route
+// labels through a single RouteLabelRenderer renders each label — and any label
+// it cross-references — at most once, rather than re-rendering per label.
+func TestRouteLabelRendererSharesResolver(t *testing.T) {
+	var leafRenders int
+	countLeaf := func() string {
+		leafRenders++
+		return "leaf"
+	}
+	tmpl, err := New(func(text *tmpltext.Template, html *tmplhtml.Template) {
+		text.Funcs(tmpltext.FuncMap{"countLeaf": countLeaf})
+		html.Funcs(tmplhtml.FuncMap{"countLeaf": countLeaf})
+	})
+	require.NoError(t, err)
+
+	// a and b both reference leaf; leaf calls the counter once when rendered.
+	data := &Data{
+		RouteLabels: KV{
+			"a":    `{{ routeLabels "leaf" }}`,
+			"b":    `{{ routeLabels "leaf" }}`,
+			"leaf": `{{ countLeaf }}`,
+		},
+	}
+
+	render := tmpl.RouteLabelRenderer(data)
+	out := map[string]string{}
+	for name := range data.RouteLabels {
+		v, err := render(name)
+		require.NoError(t, err)
+		out[name] = v
+	}
+
+	require.Equal(t, map[string]string{"a": "leaf", "b": "leaf", "leaf": "leaf"}, out)
+	require.Equal(t, 1, leafRenders, "leaf should be rendered exactly once across all labels")
+}
+
 func TestTemplateExpansionWithOptions(t *testing.T) {
 	testOptionWithAdditionalFuncs := func(funcs FuncMap) Option {
 		return func(text *tmpltext.Template, html *tmplhtml.Template) {

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -618,10 +618,10 @@ func TestTemplateExpansion(t *testing.T) {
 	}
 }
 
-// TestRouteLabelsResolvedNotReExecuted checks that resolved route labels (the
-// notification path) are returned verbatim, so a rendered value containing
+// TestRouteLabelsRenderedNotReExecuted checks that already-rendered route labels
+// (the notification path) are returned verbatim, so a rendered value containing
 // template metacharacters like {{ $value }} is not executed a second time.
-func TestRouteLabelsResolvedNotReExecuted(t *testing.T) {
+func TestRouteLabelsRenderedNotReExecuted(t *testing.T) {
 	tmpl, err := New()
 	require.NoError(t, err)
 
@@ -631,16 +631,16 @@ func TestRouteLabelsResolvedNotReExecuted(t *testing.T) {
 			"desc": `disk usage is {{ $value | humanize }}`,
 		},
 	}
-	MarkRouteLabelsResolved(&data)
+	MarkRouteLabelsRendered(&data)
 
 	got, err := tmpl.ExecuteTextString(`[{{ routeLabels "desc" }}]`, data)
 	require.NoError(t, err)
 	require.Equal(t, `[disk usage is {{ $value | humanize }}]`, got)
 }
 
-// TestRouteLabelsUnresolvedExecuted checks the dispatch-time default: unresolved
-// route label values are executed as templates.
-func TestRouteLabelsUnresolvedExecuted(t *testing.T) {
+// TestRouteLabelsUnrenderedExecuted checks the dispatch-time default:
+// not-yet-rendered route label values are executed as templates.
+func TestRouteLabelsUnrenderedExecuted(t *testing.T) {
 	tmpl, err := New()
 	require.NoError(t, err)
 

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -34,7 +34,7 @@ func TestPairNames(t *testing.T) {
 		{"name3", "value3"},
 	}
 
-	expected := []string{"name1", "name2", "name3"}
+	expected := Strings{"name1", "name2", "name3"}
 	require.Equal(t, expected, pairs.Names())
 }
 
@@ -45,7 +45,7 @@ func TestPairValues(t *testing.T) {
 		{"name3", "value3"},
 	}
 
-	expected := []string{"value1", "value2", "value3"}
+	expected := Strings{"value1", "value2", "value3"}
 	require.Equal(t, expected, pairs.Values())
 }
 
@@ -97,7 +97,7 @@ func TestKVRemove(t *testing.T) {
 
 	kv = kv.Remove([]string{"key2", "key4"})
 
-	expected := []string{"key1", "key3"}
+	expected := Strings{"key1", "key3"}
 	require.Equal(t, expected, kv.Names())
 }
 
@@ -143,6 +143,7 @@ func TestData(t *testing.T) {
 	for _, tc := range []struct {
 		receiver    string
 		groupLabels model.LabelSet
+		routeLabels model.LabelSet
 		alerts      []*types.Alert
 
 		exp *Data
@@ -280,9 +281,39 @@ func TestData(t *testing.T) {
 				ExternalURL:        u.String(),
 			},
 		},
+		{
+			// test that route labels are passed through
+			groupLabels: model.LabelSet{
+				"label_a": "a",
+				"label_b": "b",
+			},
+			routeLabels: model.LabelSet{
+				"rlabel_a":     "rvalue a",
+				"rlabel_plain": "plain {}",
+			},
+			exp: &Data{
+				Status:             "resolved",
+				Alerts:             Alerts{},
+				NotificationReason: "first notification",
+				GroupLabels: KV{
+					"label_a": "a",
+					"label_b": "b",
+				},
+				RouteLabels: KV{
+					"rlabel_a":     "rvalue a",
+					"rlabel_plain": "plain {}",
+				},
+				CommonLabels:      KV{},
+				CommonAnnotations: KV{},
+				ExternalURL:       u.String(),
+			},
+		},
 	} {
 		t.Run("", func(t *testing.T) {
-			got := tmpl.Data(tc.receiver, tc.groupLabels, "first notification", tc.alerts...)
+			got := tmpl.Data(tc.receiver, tc.groupLabels, tc.routeLabels, "first notification", tc.alerts...)
+			if tc.exp.RouteLabels == nil {
+				tc.exp.RouteLabels = KV{}
+			}
 			require.Equal(t, tc.exp, got)
 		})
 	}
@@ -508,6 +539,24 @@ func TestTemplateExpansion(t *testing.T) {
 			},
 			in:  `{{- $newList := list -}}{{ range .Alerts }}{{ $m := dict "status" .Status "labels" .Labels }}{{ $newList = append $newList $m }}{{ end }}{{ toJson $newList }}`,
 			exp: `[{"labels":null,"status":"firing"},{"labels":null,"status":"resolved"}]`,
+		},
+		{
+			title: "Template using routeLabels",
+			in:    `Simple: {{ routeLabels "rl1" }} - Templated: {{ routeLabels "rl2" }} - Recursive: {{ routeLabels "rl3" }}`,
+			data: Data{
+				GroupLabels: KV{
+					"key1": "key1",
+					"key2": "key2",
+					"key3": "key3",
+					"key4": "key4",
+				},
+				RouteLabels: KV{
+					"rl1": "rl1",
+					"rl2": `{{ .GroupLabels.key1 }}`,
+					"rl3": `{{ routeLabels "rl2" }} recursive`,
+				},
+			},
+			exp: "Simple: rl1 - Templated: key1 - Recursive: key1 recursive",
 		},
 	} {
 		t.Run(tc.title, func(t *testing.T) {
@@ -868,7 +917,7 @@ func BenchmarkTemplateData(b *testing.B) {
 
 	b.ResetTimer()
 	for b.Loop() {
-		tmpl.Data("receiver", groupLabels, "firing", alerts...)
+		tmpl.Data("receiver", groupLabels, nil, "firing", alerts...)
 	}
 }
 

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -558,6 +558,49 @@ func TestTemplateExpansion(t *testing.T) {
 			},
 			exp: "Simple: rl1 - Templated: key1 - Recursive: key1 recursive",
 		},
+		{
+			title: "routeLabels unknown name renders empty",
+			in:    `[{{ routeLabels "nope" }}]`,
+			data: Data{
+				RouteLabels: KV{"rl1": "rl1"},
+			},
+			exp: "[]",
+		},
+		{
+			title: "routeLabels direct cycle is detected, not a stack overflow",
+			in:    `{{ routeLabels "rl1" }}`,
+			data: Data{
+				RouteLabels: KV{
+					"rl1": `{{ routeLabels "rl2" }}`,
+					"rl2": `{{ routeLabels "rl1" }}`,
+				},
+			},
+			fail: true,
+		},
+		{
+			title: "routeLabels self cycle is detected",
+			in:    `{{ routeLabels "rl1" }}`,
+			data: Data{
+				RouteLabels: KV{
+					"rl1": `{{ routeLabels "rl1" }}`,
+				},
+			},
+			fail: true,
+		},
+		{
+			title: "routeLabels diamond reference renders once per branch",
+			in:    `{{ routeLabels "top" }}`,
+			data: Data{
+				GroupLabels: KV{"x": "v"},
+				RouteLabels: KV{
+					"top":  `{{ routeLabels "a" }}-{{ routeLabels "b" }}`,
+					"a":    `{{ routeLabels "leaf" }}`,
+					"b":    `{{ routeLabels "leaf" }}`,
+					"leaf": `{{ .GroupLabels.x }}`,
+				},
+			},
+			exp: "v-v",
+		},
 	} {
 		t.Run(tc.title, func(t *testing.T) {
 			f := tmpl.ExecuteTextString

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -618,6 +618,42 @@ func TestTemplateExpansion(t *testing.T) {
 	}
 }
 
+// TestRouteLabelsResolvedNotReExecuted checks that resolved route labels (the
+// notification path) are returned verbatim, so a rendered value containing
+// template metacharacters like {{ $value }} is not executed a second time.
+func TestRouteLabelsResolvedNotReExecuted(t *testing.T) {
+	tmpl, err := New()
+	require.NoError(t, err)
+
+	data := Data{
+		RouteLabels: KV{
+			// An already-rendered value containing template metacharacters.
+			"desc": `disk usage is {{ $value | humanize }}`,
+		},
+	}
+	MarkRouteLabelsResolved(&data)
+
+	got, err := tmpl.ExecuteTextString(`[{{ routeLabels "desc" }}]`, data)
+	require.NoError(t, err)
+	require.Equal(t, `[disk usage is {{ $value | humanize }}]`, got)
+}
+
+// TestRouteLabelsUnresolvedExecuted checks the dispatch-time default: unresolved
+// route label values are executed as templates.
+func TestRouteLabelsUnresolvedExecuted(t *testing.T) {
+	tmpl, err := New()
+	require.NoError(t, err)
+
+	data := Data{
+		GroupLabels: KV{"x": "v"},
+		RouteLabels: KV{"desc": `{{ .GroupLabels.x }}`},
+	}
+
+	got, err := tmpl.ExecuteTextString(`[{{ routeLabels "desc" }}]`, data)
+	require.NoError(t, err)
+	require.Equal(t, `[v]`, got)
+}
+
 func TestTemplateExpansionWithOptions(t *testing.T) {
 	testOptionWithAdditionalFuncs := func(funcs FuncMap) Option {
 		return func(text *tmpltext.Template, html *tmplhtml.Template) {

--- a/ui/app/src/Data/AlertGroup.elm
+++ b/ui/app/src/Data/AlertGroup.elm
@@ -22,6 +22,7 @@ import Json.Encode as Encode
 
 type alias AlertGroup =
     { labels : Dict String String
+    , routeLabels : Dict String String
     , receiver : ReceiverReference
     , alerts : List GettableAlert
     }
@@ -31,6 +32,7 @@ decoder : Decoder AlertGroup
 decoder =
     Decode.succeed AlertGroup
         |> required "labels" (Decode.dict Decode.string)
+        |> required "routeLabels" (Decode.dict Decode.string)
         |> required "receiver" ReceiverReference.decoder
         |> required "alerts" (Decode.list GettableAlert.decoder)
 
@@ -39,6 +41,7 @@ encoder : AlertGroup -> Encode.Value
 encoder model =
     Encode.object
         [ ( "labels", Encode.dict identity Encode.string model.labels )
+        , ( "routeLabels", Encode.dict identity Encode.string model.routeLabels )
         , ( "receiver", ReceiverReference.encoder model.receiver )
         , ( "alerts", Encode.list GettableAlert.encoder model.alerts )
         ]

--- a/ui/app/src/Views/AlertList/Updates.elm
+++ b/ui/app/src/Views/AlertList/Updates.elm
@@ -45,7 +45,7 @@ update msg ({ groupBar, alerts, filterBar, receiverBar, alertGroups } as model) 
                                         |> Dict.toList
                                         |> List.map
                                             (\( labels, alerts_ ) ->
-                                                AlertGroup (Dict.fromList labels) (ReceiverReference "unknown") alerts_
+                                                AlertGroup (Dict.fromList labels) Dict.empty (ReceiverReference "unknown") alerts_
                                             )
 
                                 newGroupBar =

--- a/ui/app/src/Views/AlertList/Views.elm
+++ b/ui/app/src/Views/AlertList/Views.elm
@@ -93,25 +93,25 @@ defaultAlertGroups activeId activeGroups expandAll groups =
         [] ->
             Utils.Views.error "No alert groups found"
 
-        [ { labels, receiver, alerts } ] ->
+        [ { labels, routeLabels, receiver, alerts } ] ->
             let
                 labels_ =
                     Dict.toList labels
             in
-            alertGroup activeId (Set.singleton 0) receiver labels_ alerts 0 expandAll
+            alertGroup activeId (Set.singleton 0) receiver labels_ (Dict.toList routeLabels) alerts 0 expandAll
 
         _ ->
             div [ class "pl-5" ]
                 (List.indexedMap
                     (\index group ->
-                        alertGroup activeId activeGroups group.receiver (Dict.toList group.labels) group.alerts index expandAll
+                        alertGroup activeId activeGroups group.receiver (Dict.toList group.labels) (Dict.toList group.routeLabels) group.alerts index expandAll
                     )
                     groups
                 )
 
 
-alertGroup : Maybe String -> Set Int -> ReceiverReference -> Labels -> List GettableAlert -> Int -> Bool -> Html Msg
-alertGroup activeId activeGroups receiver labels alerts groupId expandAll =
+alertGroup : Maybe String -> Set Int -> ReceiverReference -> Labels -> Labels -> List GettableAlert -> Int -> Bool -> Html Msg
+alertGroup activeId activeGroups receiver labels routeLabels alerts groupId expandAll =
     let
         groupActive =
             expandAll || Set.member groupId activeGroups
@@ -143,6 +143,21 @@ alertGroup activeId activeGroups receiver labels alerts groupId expandAll =
                         )
                         labels
 
+        routeLabels_ =
+            List.map
+                (\( key, value ) ->
+                    span
+                        [ class "btn btn-light text-muted mr-1 mb-1"
+                        , style "user-select" "initial"
+                        , style "-moz-user-select" "initial"
+                        , style "-webkit-user-select" "initial"
+                        , style "border-color" "#adb5bd"
+                        , title "Route label"
+                        ]
+                        [ text (key ++ "=\"" ++ value ++ "\"") ]
+                )
+                routeLabels
+
         expandButton =
             expandAlertGroup groupActive groupId receiver
                 |> Html.map (\msg -> MsgForAlertList (ActiveGroups msg))
@@ -161,7 +176,7 @@ alertGroup activeId activeGroups receiver labels alerts groupId expandAll =
             [ span [ class "ml-1 mb-0", style "white-space" "nowrap" ] [ text alertText ] ]
     in
     div []
-        [ div [ class "mb-3" ] (expandButton :: labels_ ++ alertEl)
+        [ div [ class "mb-3" ] (expandButton :: labels_ ++ routeLabels_ ++ alertEl)
         , if groupActive then
             ul [ class "list-group mb-0" ] (List.map (AlertView.view labels activeId) alerts)
 

--- a/ui/mantine-ui/src/data/groups.ts
+++ b/ui/mantine-ui/src/data/groups.ts
@@ -3,6 +3,7 @@ import { useSuspenseAPIQuery } from '@/data/api';
 type Group = {
   alerts: Alert[];
   labels: Record<string, string>;
+  routeLabels: Record<string, string>;
   receiver: Receiver;
 };
 


### PR DESCRIPTION
This change adds templatable lables to a Route, which are then inherited and overridable in children routes.
These are shared with notifiers, and also available via the /groups call, and thus can be displayed consistently between the notifications and the UI. They are calculated on the fly at notification time, and calculated but then cached on Groups() calls. When the alerts list is changed, in the dispatcher, the cache is invalidated.

#### Pull Request Checklist
Please check all the applicable boxes.

- Is this a new feature?
    - [X] I have added tests that test the new feature's functionality
- Is this a breaking change?
    - [X] My changes do not break the existing cluster messages
    - [X] My changes do not break the existing api
- [X] I have added/updated the required documentation
- [X] I have signed-off my commits
- [X] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?

```release-notes
[FEATURE] Add optional templatable lables to alert routes
```
