### PR TITLE
doc: add notification_reason to docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1947,6 +1947,7 @@ endpoint:
   "commonLabels": <object>,
   "commonAnnotations": <object>,
   "externalURL": <string>,           // backlink to the Alertmanager.
+  "notification_reason": <string>,   // string represent the reason this notification was generated
   "alerts": [
     {
       "status": "<resolved|firing>",


### PR DESCRIPTION
#### Which user-facing changes does this PR introduce?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/alertmanager/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[BUGFIX] doc: fix missing `notification_reason` field in webhook documentation
```
