### PR TITLE
bugfix ensure legacy matchers field is populated in snapshots

### DIFF
--- a/silence/silence.go
+++ b/silence/silence.go
@@ -1366,9 +1366,11 @@ func (s state) MarshalBinary() ([]byte, error) {
 	var buf bytes.Buffer
 
 	for _, e := range s {
-		if _, err := protodelim.MarshalTo(&buf, e); err != nil {
+		b, err := marshalMeshSilence(e)
+		if err != nil {
 			return nil, err
 		}
+		buf.Write(b)
 	}
 	return buf.Bytes(), nil
 }

--- a/silence/silence.go
+++ b/silence/silence.go
@@ -1401,7 +1401,9 @@ func decodeState(r io.Reader) (state, error) {
 // the first matcher set to the matchers field for backward compatibility with
 // older alertmanager versions.
 func prepareSilenceForMarshalling(sil *pb.Silence) {
-	if len(sil.MatcherSets) > 0 {
+	// The nil check is here because of rare cases where this function
+	// is called on a nil silence. It's up to the caller to decide if it's a bug
+	if sil != nil && len(sil.MatcherSets) > 0 {
 		sil.Matchers = sil.MatcherSets[0].Matchers
 	}
 }

--- a/silence/state_test.go
+++ b/silence/state_test.go
@@ -13,10 +13,17 @@
 package silence
 
 import (
+	"bufio"
+	"bytes"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protodelim"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	pb "github.com/prometheus/alertmanager/silence/silencepb"
 )
 
 func TestCurrentState(t *testing.T) {
@@ -36,4 +43,45 @@ func TestCurrentState(t *testing.T) {
 
 	expected = CurrentState(pastStartTime, pastEndTime)
 	require.Equal(t, SilenceStateExpired, expected)
+}
+
+// TestStateMarshalBinaryPopulatesLegacyMatchers asserts that snapshots and
+// cluster local-state payloads written by state.MarshalBinary include the
+// deprecated Silence.Matchers field, so that older Alertmanagers that don't
+// understand MatcherSets still see the silence's first matcher set.
+func TestStateMarshalBinaryPopulatesLegacyMatchers(t *testing.T) {
+	now := time.Now()
+	matchers := []*pb.Matcher{
+		{Name: "alertname", Pattern: "Foo", Type: pb.Matcher_EQUAL},
+		{Name: "severity", Pattern: "warn|crit", Type: pb.Matcher_REGEXP},
+	}
+	sil := &pb.Silence{
+		Id:          "abc",
+		MatcherSets: []*pb.MatcherSet{{Matchers: matchers}},
+		StartsAt:    timestamppb.New(now),
+		EndsAt:      timestamppb.New(now.Add(time.Hour)),
+	}
+	st := state{sil.Id: &pb.MeshSilence{
+		Silence:   sil,
+		ExpiresAt: timestamppb.New(now.Add(2 * time.Hour)),
+	}}
+
+	b, err := st.MarshalBinary()
+	require.NoError(t, err)
+
+	require.Nil(t, sil.Matchers, "MarshalBinary must not mutate in-memory silences")
+
+	// Decode directly via protodelim, bypassing decodeState — decodeState
+	// strips the legacy field, but we want to observe the on-the-wire shape.
+	var got pb.MeshSilence
+	require.NoError(t, protodelim.UnmarshalFrom(bufio.NewReader(bytes.NewReader(b)), &got))
+
+	require.Len(t, got.Silence.MatcherSets, 1)
+	require.Len(t, got.Silence.Matchers, len(matchers))
+	for i, m := range matchers {
+		require.True(t, proto.Equal(m, got.Silence.Matchers[i]),
+			"legacy Matchers[%d] mismatch", i)
+		require.True(t, proto.Equal(m, got.Silence.MatcherSets[0].Matchers[i]),
+			"MatcherSets[0].Matchers[%d] mismatch", i)
+	}
 }


### PR DESCRIPTION
Changes `silences.state` to use `marshalMeshSilence` when writing a snapshot to match the behavior of sending a gossip message. `marhsalMeshSilence` ensures that the legacy `matchers` field is populated (which allows older Alertmanager versions to read the message). This fixes a bug when downgrading to older versions of Alertmanager that don't support the new fields. While downgrades are not generally supported, this specific case was meant to be backwards and forwards compatible. 

#### Pull Request Checklist
Please check all the applicable boxes.

- Please list all open issue(s) discussed with maintainers related to this change
    - Fixes #5326
    <!--
    If it applies.
    Automatically closes linked issue when PR is merged.
    Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
    More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
    -->
- Is this a bugfix?
    - [x] I have added tests that can reproduce the bug which pass with this bugfix applied
- [x] I have added/updated the required documentation
- [x] I have signed-off my commits
- [x] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/alertmanager/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[BUGFIX] silences: fix silences snapshot missing legacy matchers field. This caused a bug that prevented older alertmanager versions from reading newer snapshots unnecessarily. 
```
