### PR TITLE
feat(notify): distinguish auth and rate-limit failure reasons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 ## main / (unreleased)
 
-* [CHANGE] ...
-* [FEATURE] ...
-* [ENHANCEMENT] ...
+* [CHANGE] notify: The `reason` label on `alertmanager_notifications_failed_total` now distinguishes `authError` (HTTP 401/403) and `rateLimited` (HTTP 429) from the generic `clientError`. Dashboards/alerts matching `reason="clientError"` for these codes must be updated.
+* [ENHANCEMENT] notify: The discord and webex integrations now report a failure `reason` on `alertmanager_notifications_failed_total`.
 * [BUGFIX] webhook: Keep custom `payload` string values verbatim instead of reinterpreting JSON leaves that look like YAML (e.g. values ending with a colon). #5302
 
 ## 0.33.0 / 2026-06-12

--- a/notify/discord/discord.go
+++ b/notify/discord/discord.go
@@ -178,7 +178,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 
 	shouldRetry, err := n.retrier.Check(resp.StatusCode, resp.Body)
 	if err != nil {
-		return shouldRetry, err
+		return shouldRetry, notify.NewErrorWithReason(notify.GetFailureReasonFromStatusCode(resp.StatusCode), err)
 	}
 	return false, nil
 }

--- a/notify/slack/slack_test.go
+++ b/notify/slack/slack_test.go
@@ -130,7 +130,7 @@ func TestNotifier_Notify_WithReason(t *testing.T) {
 		{
 			name:           "with a 4xx status code",
 			statusCode:     http.StatusUnauthorized,
-			expectedReason: notify.ClientErrorReason,
+			expectedReason: notify.AuthErrorReason,
 			expectedRetry:  false,
 			expectedErr:    "unexpected status code 401",
 		},

--- a/notify/util.go
+++ b/notify/util.go
@@ -290,6 +290,8 @@ const (
 	ServerErrorReason
 	ContextCanceledReason
 	ContextDeadlineExceededReason
+	AuthErrorReason
+	RateLimitedReason
 )
 
 func (s Reason) String() string {
@@ -304,16 +306,34 @@ func (s Reason) String() string {
 		return "contextCanceled"
 	case ContextDeadlineExceededReason:
 		return "contextDeadlineExceeded"
+	case AuthErrorReason:
+		return "authError"
+	case RateLimitedReason:
+		return "rateLimited"
 	default:
 		panic(fmt.Sprintf("unknown Reason: %d", s))
 	}
 }
 
 // possibleFailureReasonCategory is a list of possible failure reason.
-var possibleFailureReasonCategory = []string{DefaultReason.String(), ClientErrorReason.String(), ServerErrorReason.String(), ContextCanceledReason.String(), ContextDeadlineExceededReason.String()}
+var possibleFailureReasonCategory = []string{
+	DefaultReason.String(),
+	ClientErrorReason.String(),
+	ServerErrorReason.String(),
+	ContextCanceledReason.String(),
+	ContextDeadlineExceededReason.String(),
+	AuthErrorReason.String(),
+	RateLimitedReason.String(),
+}
 
 // GetFailureReasonFromStatusCode returns the reason for the failure based on the status code provided.
 func GetFailureReasonFromStatusCode(statusCode int) Reason {
+	switch statusCode {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return AuthErrorReason
+	case http.StatusTooManyRequests:
+		return RateLimitedReason
+	}
 	if statusCode/100 == 4 {
 		return ClientErrorReason
 	}

--- a/notify/util_test.go
+++ b/notify/util_test.go
@@ -252,3 +252,24 @@ func TestGetTemplateDataWithRouteLabels(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "ops|value is {{ $value }}", got)
 }
+
+func TestGetFailureReasonFromStatusCode(t *testing.T) {
+	for _, tc := range []struct {
+		statusCode int
+		expected   Reason
+	}{
+		{http.StatusUnauthorized, AuthErrorReason},
+		{http.StatusForbidden, AuthErrorReason},
+		{http.StatusTooManyRequests, RateLimitedReason},
+		{http.StatusBadRequest, ClientErrorReason},
+		{http.StatusNotFound, ClientErrorReason},
+		{http.StatusInternalServerError, ServerErrorReason},
+		{http.StatusServiceUnavailable, ServerErrorReason},
+		{http.StatusOK, DefaultReason},
+		{http.StatusMovedPermanently, DefaultReason},
+	} {
+		t.Run(http.StatusText(tc.statusCode), func(t *testing.T) {
+			require.Equal(t, tc.expected, GetFailureReasonFromStatusCode(tc.statusCode))
+		})
+	}
+}

--- a/notify/webex/webex.go
+++ b/notify/webex/webex.go
@@ -108,7 +108,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 
 	shouldRetry, err := n.retrier.Check(resp.StatusCode, resp.Body)
 	if err != nil {
-		return shouldRetry, err
+		return shouldRetry, notify.NewErrorWithReason(notify.GetFailureReasonFromStatusCode(resp.StatusCode), err)
 	}
 
 	return false, nil


### PR DESCRIPTION
Authentication errors (HTTP 401/403) and rate limiting (HTTP 429) previously surfaced as the generic "clientError" reason on the alertmanager_notifications_failed_total metric, making it impossible to tell these apart for PagerDuty and other receivers.

Add two new failure reasons, "authError" (401/403) and "rateLimited" (429), and refine the centralized GetFailureReasonFromStatusCode so all HTTP integrations benefit automatically. Also fix the discord and webex integrations, which previously dropped the failure reason entirely.

Note: this changes the `reason` label values on
alertmanager_notifications_failed_total; dashboards or alerts matching reason="clientError" for 401/403/429 must be updated.

<!--
    - Please give your PR a title in the form "area: short description".  For example "dispatcher: improve performance"

    - Please sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Pull Request Checklist
Please check all the applicable boxes.

- Please list all open issue(s) discussed with maintainers related to this change
    - Fixes #<issue number>
    <!--
    If it applies.
    Automatically closes linked issue when PR is merged.
    Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
    More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
    -->
- Is this a new Receiver integration?
    - [ ] I have already tried to use the [Webhook Receiver Integration](https://prometheus.io/docs/alerting/latest/configuration/#webhook_config) and [3rd party integrations](https://prometheus.io/docs/operating/integrations/#alertmanager-webhook-receiver) before adding this new Receiver Integration
- Is this a bugfix?
    - [ ] I have added tests that can reproduce the bug which pass with this bugfix applied
- Is this a new feature?
    - [ ] I have added tests that test the new feature's functionality
- Does this change affect performance?
    - [ ] I have provided benchmarks comparison that shows performance is improved or is not degraded
        - You can use [`benchstat`](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat) to compare benchmarks
    - [ ] I have added new benchmarks if required or requested by maintainers
- Is this a breaking change?
    - [ ] My changes do not break the existing cluster messages
    - [ ] My changes do not break the existing api
- [ ] I have added/updated the required documentation
- [x] I have signed-off my commits
- [x] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/alertmanager/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[CHANGE] notify: The `reason` label on `alertmanager_notifications_failed_total` now distinguishes `authError` (HTTP 401/403) and `rateLimited` (HTTP 429) from the generic `clientError`. Dashboards/alerts matching `reason="clientError"` for these codes must be updated.
[ENHANCEMENT] notify: The discord and webex integrations now report a failure `reason` on `alertmanager_notifications_failed_total`.
```
