### PR TITLE
perf(ui): lazily render the alert list with Html.Lazy and Html.Keyed

### DIFF
--- a/ui/app/src/Views/AlertList/Views.elm
+++ b/ui/app/src/Views/AlertList/Views.elm
@@ -7,6 +7,8 @@ import Dict
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
+import Html.Keyed
+import Html.Lazy exposing (lazy4)
 import Set exposing (Set)
 import Types exposing (Msg(..))
 import Utils.Filter exposing (Filter)
@@ -83,8 +85,13 @@ view { alertGroups, groupBar, filterBar, receiverBar, tab, activeId, activeGroup
                     [ i [ class "fa fa-plus mr-3" ] [], text "Expand all groups" ]
                 )
             ]
-        , Utils.Views.apiData (defaultAlertGroups activeId activeGroups expandAll) alertGroups
+        , lazy4 alertGroupsView activeId activeGroups expandAll alertGroups
         ]
+
+
+alertGroupsView : Maybe String -> Set Int -> Bool -> ApiData (List AlertGroup) -> Html Msg
+alertGroupsView activeId activeGroups expandAll alertGroups =
+    Utils.Views.apiData (defaultAlertGroups activeId activeGroups expandAll) alertGroups
 
 
 defaultAlertGroups : Maybe String -> Set Int -> Bool -> List AlertGroup -> Html Msg
@@ -101,13 +108,23 @@ defaultAlertGroups activeId activeGroups expandAll groups =
             alertGroup activeId (Set.singleton 0) receiver labels_ (Dict.toList routeLabels) alerts 0 expandAll
 
         _ ->
-            div [ class "pl-5" ]
+            Html.Keyed.node "div"
+                [ class "pl-5" ]
                 (List.indexedMap
                     (\index group ->
-                        alertGroup activeId activeGroups group.receiver (Dict.toList group.labels) (Dict.toList group.routeLabels) group.alerts index expandAll
+                        ( groupKey group
+                        , alertGroup activeId activeGroups group.receiver (Dict.toList group.labels) (Dict.toList group.routeLabels) group.alerts index expandAll
+                        )
                     )
                     groups
                 )
+
+
+groupKey : AlertGroup -> String
+groupKey group =
+    group.receiver.name
+        ++ ":"
+        ++ String.join "," (List.map (\( key, value ) -> key ++ "=" ++ value) (Dict.toList group.labels))
 
 
 alertGroup : Maybe String -> Set Int -> ReceiverReference -> Labels -> Labels -> List GettableAlert -> Int -> Bool -> Html Msg
@@ -178,7 +195,8 @@ alertGroup activeId activeGroups receiver labels routeLabels alerts groupId expa
     div []
         [ div [ class "mb-3" ] (expandButton :: labels_ ++ routeLabels_ ++ alertEl)
         , if groupActive then
-            ul [ class "list-group mb-0" ] (List.map (AlertView.view labels activeId) alerts)
+            Html.Keyed.ul [ class "list-group mb-0" ]
+                (List.map (\alert -> ( alert.fingerprint, AlertView.view labels activeId alert )) alerts)
 
           else
             text ""

--- a/ui/app/src/Views/AlertList/Views.elm
+++ b/ui/app/src/Views/AlertList/Views.elm
@@ -108,23 +108,13 @@ defaultAlertGroups activeId activeGroups expandAll groups =
             alertGroup activeId (Set.singleton 0) receiver labels_ (Dict.toList routeLabels) alerts 0 expandAll
 
         _ ->
-            Html.Keyed.node "div"
-                [ class "pl-5" ]
+            div [ class "pl-5" ]
                 (List.indexedMap
                     (\index group ->
-                        ( groupKey group
-                        , alertGroup activeId activeGroups group.receiver (Dict.toList group.labels) (Dict.toList group.routeLabels) group.alerts index expandAll
-                        )
+                        alertGroup activeId activeGroups group.receiver (Dict.toList group.labels) (Dict.toList group.routeLabels) group.alerts index expandAll
                     )
                     groups
                 )
-
-
-groupKey : AlertGroup -> String
-groupKey group =
-    group.receiver.name
-        ++ ":"
-        ++ String.join "," (List.map (\( key, value ) -> key ++ "=" ++ value) (Dict.toList group.labels))
 
 
 alertGroup : Maybe String -> Set Int -> ReceiverReference -> Labels -> Labels -> List GettableAlert -> Int -> Bool -> Html Msg


### PR DESCRIPTION
The /alerts view rebuilt and re-diffed the entire alert-group tree on every model update, so interactions such as typing in the filter bar were sluggish when many alerts (10K+) were loaded.

This wraps the alert-group rendering in lazy4 so it is skipped while its inputs are unchanged, and render the group and alert lists with Html.Keyed keyed by group identity and alert fingerprint so list diffs are matched by identity rather than position.

It's similar to what is done for listing silences [here](https://github.com/prometheus/alertmanager/blob/1dee97b337fbd7af7d2bcd0f154b1a4da2b62e41/ui/app/src/Views/SilenceList/Views.elm).

Now, even though loading a 30MB+ response of all alerts is still slow on first load, typing in the filter box is at least responsive.

<!--
    - Please give your PR a title in the form "area: short description".  For example "dispatcher: improve performance"

    - Please sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->

#### Pull Request Checklist
Please check all the applicable boxes.

- Please list all open issue(s) discussed with maintainers related to this change
    - Related to https://github.com/prometheus/alertmanager/issues/924 #<issue number>
- Is this a new Receiver integration?
    - No
- Is this a bugfix?
    - No
- Is this a new feature?
    - No
- Does this change affect performance?
    - [ ] I have provided benchmarks comparison that shows performance is improved or is not degraded
        - I'm not sure how to benchmark the frontend?
    - [ ] I have added new benchmarks if required or requested by maintainers
- Is this a breaking change?
    - [x] My changes do not break the existing cluster messages
    - [x] My changes do not break the existing api
- [x] I have added/updated the required documentation
- [x] I have signed-off my commits
- [x] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/alertmanager/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
[PERF] Improve responsiveness of UI when loading thousands of alerts
```
