### PR TITLE
add workflow for building release branches

### DIFF
--- a/.github/workflows/build-release-branch.yml
+++ b/.github/workflows/build-release-branch.yml
@@ -4,6 +4,7 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - release-*
+  workflow_dispatch:
 permissions:
   contents: read
 

--- a/.github/workflows/build-release-branch.yml
+++ b/.github/workflows/build-release-branch.yml
@@ -1,0 +1,26 @@
+---
+name: Build release branch
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - release-*
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    name: Run ci
+    uses: ./.github/workflows/ci.yml
+
+  build:
+    name: Build Alertmanager for all architectures
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        thread: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+    needs: ci
+    steps:
+      - uses: prometheus/promci/build@13941414d409d227afd67544e5d306827db5a1a2 # v0.8.5
+        with:
+          parallelism: 12
+          thread: ${{ matrix.thread }}


### PR DESCRIPTION
Adds a new `build-release-branch` workflow which builds alertmanager for _all_ architectures and runs CI. This mirrors the behavior of the main branch's `publish` workflow, but it does not publish artifacts (because that uses some main-branch scheme that I don't think is portable).

Right now, there's no CI at all for release branches, so this should give us some signal about build status before pushing tags to release a patch. 

#### Which user-facing changes does this PR introduce?

```release-notes
NONE
```
