### PR TITLE
docs: describe Alertmanager architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,15 @@ To contribute to the user interface, refer to [ui/app/CONTRIBUTING.md](ui/app/CO
 
 ![](doc/arch.svg)
 
+Alert generators send alerts to the API, which stores them in the alert
+provider. The dispatcher subscribes to the provider, routes and groups alerts,
+and sends each group through the notification pipeline. The pipeline waits for
+the configured timing, filters silenced and inhibited alerts, deduplicates
+notifications, retries delivery to receivers, and records successful sends in
+the notification log. In high availability mode, peers use gossip to replicate
+silences and the notification log. Alerts themselves are not gossiped, so each
+alert generator must send alerts to every Alertmanager instance.
+
 ## License
 
 Apache License 2.0, see [LICENSE](https://github.com/prometheus/alertmanager/blob/main/LICENSE).

--- a/README.md
+++ b/README.md
@@ -405,14 +405,10 @@ To contribute to the user interface, refer to [ui/app/CONTRIBUTING.md](ui/app/CO
 
 ![](doc/arch.svg)
 
-Alert generators send alerts to the API, which stores them in the alert
-provider. The dispatcher subscribes to the provider, routes and groups alerts,
-and sends each group through the notification pipeline. The pipeline waits for
-the configured timing, filters silenced and inhibited alerts, deduplicates
-notifications, retries delivery to receivers, and records successful sends in
-the notification log. In high availability mode, peers use gossip to replicate
-silences and the notification log. Alerts themselves are not gossiped, so each
-alert generator must send alerts to every Alertmanager instance.
+This diagram shows how incoming alerts are grouped, routed, and delivered to
+configured receivers. See the
+[Alertmanager architecture overview](docs/alertmanager.md#architecture) for
+details.
 
 ## License
 

--- a/docs/alertmanager.md
+++ b/docs/alertmanager.md
@@ -14,6 +14,16 @@ The following describes the core concepts the Alertmanager implements. Consult
 the [configuration documentation](configuration.md) to learn how to use them
 in more detail.
 
+## Architecture
+
+Alert generators send alerts to Alertmanager's API. Alertmanager stores active
+alerts, groups and routes them according to its configuration, applies
+inhibition and silences, and sends notifications through configured receivers.
+
+In a high-availability deployment, every Alertmanager instance receives alerts
+independently, while silences and notification state are replicated between
+peers. See [High Availability](high_availability.md) for details.
+
 ## Grouping
 
 Grouping categorizes alerts of similar nature into a single notification. This


### PR DESCRIPTION
#### Summary

Keep a short, stable summary and documentation link below the architecture diagram. Add an architecture overview to `docs/alertmanager.md` covering the alert flow, while linking to the existing high-availability documentation for cluster-specific behavior.

This keeps implementation details out of the README so they are less likely to become stale.

cc @simonpasquier

#### Pull Request Checklist

- Please list all open issue(s) discussed with maintainers related to this change
    - Fixes #2424
- Is this a new Receiver integration?
    - [ ] I have already tried to use the Webhook Receiver Integration and 3rd party integrations before adding this new Receiver Integration
- Is this a bugfix?
    - [ ] I have added tests that can reproduce the bug which pass with this bugfix applied
- Is this a new feature?
    - [ ] I have added tests that test the new feature functionality
- Does this change affect performance?
    - [ ] I have provided benchmarks comparison that shows performance is improved or is not degraded
    - [ ] I have added new benchmarks if required or requested by maintainers
- Is this a breaking change?
    - [ ] My changes do not break the existing cluster messages
    - [ ] My changes do not break the existing api
- [x] I have added/updated the required documentation
- [x] I have signed-off my commits
- [x] I will follow best practices for contributing to this project

#### Validation

- `git diff --check`
- Verified the README architecture link resolves to `docs/alertmanager.md#architecture`
- Verified the architecture overview links to `docs/high_availability.md`

#### Which user-facing changes does this PR introduce?

```release-notes
NONE
```