### PR TITLE
docs: add reusable HTML email template example

### DIFF
--- a/docs/notification_examples.md
+++ b/docs/notification_examples.md
@@ -102,3 +102,57 @@ templates:
 ```
 
 This example is explained in further detail in this [blogpost](https://prometheus.io/blog/2016/03/03/custom-alertmanager-templates/).
+
+## Defining a reusable HTML email template
+
+The HTML body of an email notification can use a named template from an external file.
+Create `/etc/alertmanager/templates/email.tmpl` with the following content:
+
+```
+{{ define "email.myorg.html" }}
+<!DOCTYPE html>
+<html>
+  <body>
+    <h1>{{ .Status | toUpper }}</h1>
+    <table>
+      <thead>
+        <tr>
+          <th>Alert</th>
+          <th>Summary</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{ range .Alerts }}
+        <tr>
+          <td>{{ index .Labels "alertname" }}</td>
+          <td>{{ index .Annotations "summary" }}</td>
+        </tr>
+        {{ end }}
+      </tbody>
+    </table>
+  </body>
+</html>
+{{ end }}
+```
+
+Load the template file and reference its name from the email receiver's `html` field:
+
+```
+global:
+  smtp_smarthost: 'smtp.example.org:587'
+  smtp_from: 'alertmanager@example.org'
+
+route:
+  receiver: 'email-notifications'
+
+receivers:
+- name: 'email-notifications'
+  email_configs:
+  - to: 'oncall@example.org'
+    html: '{{ template "email.myorg.html" . }}'
+
+templates:
+- '/etc/alertmanager/templates/*.tmpl'
+```
+
+See the [`<email_config>` reference](configuration.md#email_config) for SMTP authentication and TLS options.

--- a/docs/notification_examples.md
+++ b/docs/notification_examples.md
@@ -108,7 +108,7 @@ This example is explained in further detail in this [blogpost](https://prometheu
 The HTML body of an email notification can use a named template from an external file.
 Create `/etc/alertmanager/templates/email.tmpl` with the following content:
 
-```
+```html
 {{ define "email.myorg.html" }}
 <!DOCTYPE html>
 <html>
@@ -137,7 +137,7 @@ Create `/etc/alertmanager/templates/email.tmpl` with the following content:
 
 Load the template file and reference its name from the email receiver's `html` field:
 
-```
+```yaml
 global:
   smtp_smarthost: 'smtp.example.org:587'
   smtp_from: 'alertmanager@example.org'


### PR DESCRIPTION
#### Summary

Add a complete example showing how to define an external HTML email template, load it with the top-level `templates` glob, and reference it from an email receiver. The example stays intentionally small while covering the configuration gap described in #1602.

cc @mxinden

#### Pull Request Checklist

- Please list all open issue(s) discussed with maintainers related to this change
    - Fixes #1602
- Is this a new Receiver integration?
    - [ ] I have already tried to use the Webhook Receiver Integration and 3rd party integrations before adding this new Receiver Integration
- Is this a bugfix?
    - [ ] I have added tests that can reproduce the bug which pass with this bugfix applied
- Is this a new feature?
    - [ ] I have added tests that test the new feature functionality
- Does this change affect performance?
    - [ ] I have provided benchmarks comparison that shows performance is improved or is not degraded
    - [ ] I have added new benchmarks if required or requested by maintainers
- Is this a breaking change?
    - [ ] My changes do not break the existing cluster messages
    - [ ] My changes do not break the existing api
- [x] I have added/updated the required documentation
- [x] I have signed-off my commits
- [x] I will follow best practices for contributing to this project

#### Validation

- `git diff --check`
- parsed the YAML example with Ruby/Psych
- checked the template fields and `toUpper` function against the current template data model and function map
- checked the email fields against the current configuration schema

This is a documentation-only change; no product code tests were run.

#### Which user-facing changes does this PR introduce?

```release-notes
NONE
```