### PR TITLE
eventrecorder: add optional webhook batching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [CHANGE] notify: The `reason` label on `alertmanager_notifications_failed_total` now distinguishes `authError` (HTTP 401/403) and `rateLimited` (HTTP 429) from the generic `clientError`. Dashboards/alerts matching `reason="clientError"` for these codes must be updated.
 * [ENHANCEMENT] notify: The discord and webex integrations now report a failure `reason` on `alertmanager_notifications_failed_total`.
+* [ENHANCEMENT] eventrecorder: Add optional webhook batching.
 * [BUGFIX] webhook: Keep custom `payload` string values verbatim instead of reinterpreting JSON leaves that look like YAML (e.g. values ending with a colon). #5302
 
 ## 0.33.1 / 2026-07-04

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -45,6 +45,30 @@ func TestLoadEmptyString(t *testing.T) {
 	}
 }
 
+func TestEventRecorderWebhookBatchingConfig(t *testing.T) {
+	cfg, err := Load(`
+route:
+  receiver: default
+receivers:
+- name: default
+event_recorder:
+  webhook_outputs:
+  - url: https://stream-id.ingest.cloudflare.com
+    batch: true
+    http_config:
+      authorization:
+        credentials_file: pipeline-token
+`)
+	require.NoError(t, err)
+	require.Len(t, cfg.EventRecorder.WebhookOutputs, 1)
+	require.True(t, cfg.EventRecorder.WebhookOutputs[0].Batch)
+
+	resolveFilepaths("/etc/alertmanager", cfg)
+	auth := cfg.EventRecorder.WebhookOutputs[0].HTTPConfig.Authorization
+	require.NotNil(t, auth)
+	require.Equal(t, "/etc/alertmanager/pipeline-token", auth.CredentialsFile)
+}
+
 func TestDefaultReceiverExists(t *testing.T) {
 	in := `
 route:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -170,7 +170,8 @@ time_intervals:
 # Optional event recorder configuration.  Captures significant
 # Alertmanager events (startup/shutdown, alert lifecycle, silences,
 # notifications) and ships them to one or more outputs (file, webhook,
-# kafka).  Recording is gated behind the `event-recorder` feature flag;
+# Kafka, stdout). Recording is gated behind the
+# `event-recorder` feature flag;
 # pass `--enable-feature=event-recorder` on the command line to
 # activate it.  See the Event Recorder section below.
 [ event_recorder: <event_recorder_config> ]
@@ -2174,6 +2175,10 @@ POSTs each event as a JSON body to an HTTP endpoint.  Delivery is
 performed by a bounded worker pool with bounded retries and exponential
 backoff.
 
+Retries resend the entire event or batch, so receivers should tolerate
+duplicate events after ambiguous failures. With multiple workers, requests
+may complete out of order; set `workers: 1` when request ordering matters.
+
 ```yaml
 # URL to POST events to.
 url: <secret>
@@ -2187,12 +2192,43 @@ url: <secret>
 # Number of concurrent delivery workers.
 [ workers: <int> | default = 4 ]
 
-# Maximum number of delivery attempts per event.
+# Maximum number of delivery attempts per event or batch.
 [ max_retries: <int> | default = 3 ]
 
 # Base backoff between retries; subsequent attempts use exponential
 # backoff (base * 2^attempt) capped at 30s.
 [ retry_backoff: <duration> | default = 500ms ]
+
+# Send events in JSON arrays instead of posting each event as an individual
+# JSON object. This changes the webhook payload contract and must only be
+# enabled when the receiving endpoint accepts arrays.
+[ batch: <boolean> | default = false ]
+
+# Maximum number of events in one request when batching is enabled.
+[ batch_max_events: <int> | default = 100 ]
+
+# Soft maximum encoded request size in bytes when batching is enabled. A
+# single event larger than the limit is sent alone.
+[ batch_max_bytes: <int> | default = 1048576 ]
+
+# Maximum time an incomplete batch waits before delivery.
+[ batch_flush_interval: <duration> | default = 100ms ]
+```
+
+For example, [Cloudflare Pipelines streams](https://developers.cloudflare.com/pipelines/streams/writing-to-streams/)
+accept JSON arrays through their HTTP ingestion endpoints and can be configured
+as a batched webhook output:
+
+```yaml
+event_recorder:
+  webhook_outputs:
+  - url: https://<stream-id>.ingest.cloudflare.com
+    batch: true
+    http_config:
+      # The token must have the "Workers Pipeline Send" permission when
+      # authentication is enabled for the stream.
+      authorization:
+        credentials: <api_token>
 ```
 
 #### `<kafka_output>`

--- a/eventrecorder/recorder.go
+++ b/eventrecorder/recorder.go
@@ -183,7 +183,7 @@ func buildOutputs(cfg Config, instance string, m *metrics, logger *slog.Logger) 
 	for _, wc := range cfg.WebhookOutputs {
 		wo, err := NewWebhookOutput(wc, m.outputDrops, logger)
 		if err != nil {
-			logger.Error("Failed to create webhook event recorder output", "url", wc.URL, "err", err)
+			logger.Error("Failed to create webhook event recorder output", "url", sanitizeSecretURL(wc.URL), "err", err)
 			continue
 		}
 		outputs = append(outputs, wo)

--- a/eventrecorder/webhook.go
+++ b/eventrecorder/webhook.go
@@ -51,6 +51,14 @@ type WebhookOutputConfig struct {
 	// 500ms).  Successive attempts use exponential backoff (base *
 	// 2^attempt).
 	RetryBackoff model.Duration `yaml:"retry_backoff,omitempty" json:"retry_backoff,omitempty"`
+	// Batch enables sending events as JSON arrays instead of individual objects.
+	Batch bool `yaml:"batch,omitempty" json:"batch,omitempty"`
+	// BatchMaxEvents is the maximum number of events in one request (default 100).
+	BatchMaxEvents int `yaml:"batch_max_events,omitempty" json:"batch_max_events,omitempty"`
+	// BatchMaxBytes is the soft maximum encoded request size (default 1 MiB).
+	BatchMaxBytes int `yaml:"batch_max_bytes,omitempty" json:"batch_max_bytes,omitempty"`
+	// BatchFlushInterval is the maximum time an incomplete batch waits (default 100ms).
+	BatchFlushInterval model.Duration `yaml:"batch_flush_interval,omitempty" json:"batch_flush_interval,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface, validating
@@ -71,6 +79,12 @@ func (c *WebhookOutputConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	}
 	if c.URL.Scheme == "" || c.URL.Host == "" {
 		return errors.New("event_recorder webhook output requires an absolute http(s) url")
+	}
+	if c.BatchMaxEvents < 0 || c.BatchMaxBytes < 0 || c.BatchFlushInterval < 0 {
+		return errors.New("event_recorder webhook batch settings cannot be negative")
+	}
+	if !c.Batch && (c.BatchMaxEvents != 0 || c.BatchMaxBytes != 0 || c.BatchFlushInterval != 0) {
+		return errors.New("event_recorder webhook batch settings require batch: true")
 	}
 	return nil
 }
@@ -100,6 +114,15 @@ func (c WebhookOutputConfig) equal(o WebhookOutputConfig) bool {
 	if c.RetryBackoff != o.RetryBackoff {
 		return false
 	}
+	if c.Batch != o.Batch {
+		return false
+	}
+	if c.Batch && !httpBatchConfigsEqual(
+		newHTTPBatchConfig(c.BatchMaxEvents, c.BatchMaxBytes, c.BatchFlushInterval),
+		newHTTPBatchConfig(o.BatchMaxEvents, o.BatchMaxBytes, o.BatchFlushInterval),
+	) {
+		return false
+	}
 	return reflect.DeepEqual(c.HTTPConfig, o.HTTPConfig)
 }
 
@@ -109,6 +132,9 @@ const (
 	defaultWebhookMaxRetries   = 3
 	defaultWebhookRetryBackoff = 500 * time.Millisecond
 	defaultWebhookMaxBackoff   = 30 * time.Second
+	defaultHTTPBatchMaxEvents  = 100
+	defaultHTTPBatchMaxBytes   = 1 << 20
+	defaultHTTPBatchInterval   = 100 * time.Millisecond
 	webhookQueueSize           = 1024
 )
 
@@ -121,19 +147,58 @@ type WebhookOutput struct {
 	client       *http.Client
 	url          string
 	name         string
+	kind         string
+	batch        *httpBatchConfig
 	maxRetries   int
 	retryBackoff time.Duration
 	maxBackoff   time.Duration
 	logger       *slog.Logger
 	drops        prometheus.Counter
 	work         chan []byte
+	batches      chan []byte
 	done         chan struct{}
 	cancel       chan struct{} // closed after drain to abort remaining retries
 	wg           sync.WaitGroup
 }
 
+type httpBatchConfig struct {
+	maxEvents     int
+	maxBytes      int
+	flushInterval time.Duration
+}
+
 // NewWebhookOutput creates a new webhook-based event recorder output.
 func NewWebhookOutput(cfg WebhookOutputConfig, dropsCounter *prometheus.CounterVec, logger *slog.Logger) (*WebhookOutput, error) {
+	var batch *httpBatchConfig
+	if cfg.Batch {
+		batch = newHTTPBatchConfig(cfg.BatchMaxEvents, cfg.BatchMaxBytes, cfg.BatchFlushInterval)
+	}
+	return newWebhookOutput(cfg, "webhook", batch, dropsCounter, logger)
+}
+
+func newHTTPBatchConfig(maxEvents, maxBytes int, flushInterval model.Duration) *httpBatchConfig {
+	batch := &httpBatchConfig{
+		maxEvents:     defaultHTTPBatchMaxEvents,
+		maxBytes:      defaultHTTPBatchMaxBytes,
+		flushInterval: defaultHTTPBatchInterval,
+	}
+	if maxEvents > 0 {
+		batch.maxEvents = maxEvents
+	}
+	if maxBytes > 0 {
+		batch.maxBytes = maxBytes
+	}
+	if flushInterval > 0 {
+		batch.flushInterval = time.Duration(flushInterval)
+	}
+	return batch
+}
+
+func httpBatchConfigsEqual(a, b *httpBatchConfig) bool {
+	return *a == *b
+}
+
+func newWebhookOutput(cfg WebhookOutputConfig, kind string, batch *httpBatchConfig, dropsCounter *prometheus.CounterVec, logger *slog.Logger) (*WebhookOutput, error) {
 	httpCfg := commoncfg.DefaultHTTPClientConfig
 	if cfg.HTTPConfig != nil {
 		httpCfg = *cfg.HTTPConfig
@@ -141,7 +206,7 @@ func NewWebhookOutput(cfg WebhookOutputConfig, dropsCounter *prometheus.CounterV
 
 	client, err := commoncfg.NewClientFromConfig(httpCfg, "eventrecorder")
 	if err != nil {
-		return nil, fmt.Errorf("creating HTTP client for event recorder webhook: %w", err)
+		return nil, fmt.Errorf("creating HTTP client for event recorder %s: %w", kind, err)
 	}
 
 	timeout := defaultWebhookTimeout
@@ -166,23 +231,36 @@ func NewWebhookOutput(cfg WebhookOutputConfig, dropsCounter *prometheus.CounterV
 	}
 
 	urlStr := cfg.URL.String()
+	name := fmt.Sprintf("%s:%s", kind, sanitizeURL(urlStr))
 	wo := &WebhookOutput{
 		client:       client,
 		url:          urlStr,
-		name:         fmt.Sprintf("webhook:%s", sanitizeURL(urlStr)),
+		name:         name,
+		kind:         kind,
+		batch:        batch,
 		maxRetries:   maxRetries,
 		retryBackoff: retryBackoff,
 		maxBackoff:   defaultWebhookMaxBackoff,
 		logger:       logger,
-		drops:        dropsCounter.WithLabelValues(fmt.Sprintf("webhook:%s", sanitizeURL(urlStr))),
+		drops:        dropsCounter.WithLabelValues(name),
 		work:         make(chan []byte, webhookQueueSize),
 		done:         make(chan struct{}),
 		cancel:       make(chan struct{}),
 	}
 
-	for range workers {
+	if batch != nil {
 		wo.wg.Add(1)
-		go wo.worker()
+		wo.batches = make(chan []byte, workers)
+		go wo.batchLoop()
+		for range workers {
+			wo.wg.Add(1)
+			go wo.batchDeliveryWorker()
+		}
+	} else {
+		for range workers {
+			wo.wg.Add(1)
+			go wo.worker()
+		}
 	}
 
 	return wo, nil
@@ -200,6 +278,13 @@ func sanitizeURL(raw string) string {
 	u.RawQuery = ""
 	u.Fragment = ""
 	return u.String()
+}
+
+func sanitizeSecretURL(u *amcommoncfg.SecretURL) string {
+	if u == nil || u.URL == nil {
+		return "<missing>"
+	}
+	return sanitizeURL(u.String())
 }
 
 // Name returns a stable identifier for this output.  The URL is
@@ -221,7 +306,7 @@ func (wo *WebhookOutput) SendEvent(event *eventrecorderpb.Event) (int, error) {
 	case wo.work <- data:
 	default:
 		wo.drops.Inc()
-		wo.logger.Warn("Event recorder webhook queue full, dropping event", "output", wo.name)
+		wo.logger.Warn("Event recorder HTTP output queue full, dropping event", "output", wo.name)
 	}
 	return len(data), nil
 }
@@ -246,13 +331,97 @@ func (wo *WebhookOutput) worker() {
 	}
 }
 
+func (wo *WebhookOutput) batchLoop() {
+	defer wo.wg.Done()
+	defer close(wo.batches)
+
+	batch := make([][]byte, 0, min(wo.batch.maxEvents, webhookQueueSize))
+	batchSize := 2 // Opening and closing brackets.
+	var timer *time.Timer
+	var timerC <-chan time.Time
+
+	stopTimer := func() {
+		if timer != nil {
+			timer.Stop()
+			timer = nil
+			timerC = nil
+		}
+	}
+	flush := func() {
+		stopTimer()
+		if len(batch) == 0 {
+			return
+		}
+		wo.batches <- jsonArray(batch, batchSize)
+		batch = batch[:0]
+		batchSize = 2
+	}
+	add := func(data []byte) {
+		additionalSize := len(data)
+		if len(batch) > 0 {
+			additionalSize++ // Comma separator.
+		}
+		if len(batch) > 0 && (len(batch) >= wo.batch.maxEvents || batchSize+additionalSize > wo.batch.maxBytes) {
+			flush()
+			additionalSize = len(data)
+		}
+		batch = append(batch, data)
+		batchSize += additionalSize
+		if len(batch) == 1 {
+			timer = time.NewTimer(wo.batch.flushInterval)
+			timerC = timer.C
+		}
+		if len(batch) >= wo.batch.maxEvents || batchSize >= wo.batch.maxBytes {
+			flush()
+		}
+	}
+
+	for {
+		select {
+		case data := <-wo.work:
+			add(data)
+		case <-timerC:
+			flush()
+		case <-wo.done:
+			for {
+				select {
+				case data := <-wo.work:
+					add(data)
+				default:
+					flush()
+					return
+				}
+			}
+		}
+	}
+}
+
+func (wo *WebhookOutput) batchDeliveryWorker() {
+	defer wo.wg.Done()
+	for data := range wo.batches {
+		wo.postWithRetry(data)
+	}
+}
+
+func jsonArray(events [][]byte, size int) []byte {
+	data := make([]byte, 0, size)
+	data = append(data, '[')
+	for i, event := range events {
+		if i > 0 {
+			data = append(data, ',')
+		}
+		data = append(data, event...)
+	}
+	return append(data, ']')
+}
+
 func (wo *WebhookOutput) postWithRetry(data []byte) {
 	for attempt := range wo.maxRetries {
 		err := wo.post(data)
 		if err == nil {
 			return
 		}
-		wo.logger.Warn("Event recorder webhook POST failed", "output", wo.name, "attempt", attempt+1, "err", err)
+		wo.logger.Warn("Event recorder HTTP output POST failed", "output", wo.name, "attempt", attempt+1, "err", err)
 		if attempt < wo.maxRetries-1 {
 			backoff := min(wo.retryBackoff<<attempt, wo.maxBackoff)
 			select {
@@ -263,13 +432,13 @@ func (wo *WebhookOutput) postWithRetry(data []byte) {
 			}
 		}
 	}
-	wo.logger.Error("Event recorder webhook POST failed after retries, dropping event", "output", wo.name, "retries", wo.maxRetries)
+	wo.logger.Error("Event recorder HTTP output POST failed after retries, dropping event", "output", wo.name, "retries", wo.maxRetries)
 }
 
 func (wo *WebhookOutput) post(data []byte) error {
 	resp, err := wo.client.Post(wo.url, "application/json", bytes.NewReader(data))
 	if err != nil {
-		return fmt.Errorf("event recorder webhook POST failed: %w", err)
+		return fmt.Errorf("event recorder %s POST failed: %w", wo.kind, err)
 	}
 	defer func() {
 		io.Copy(io.Discard, resp.Body)
@@ -277,7 +446,7 @@ func (wo *WebhookOutput) post(data []byte) error {
 	}()
 
 	if resp.StatusCode/100 != 2 {
-		return fmt.Errorf("event recorder webhook returned HTTP %d", resp.StatusCode)
+		return fmt.Errorf("event recorder %s returned HTTP %d", wo.kind, resp.StatusCode)
 	}
 	return nil
 }

--- a/eventrecorder/webhook_test.go
+++ b/eventrecorder/webhook_test.go
@@ -14,6 +14,7 @@
 package eventrecorder
 
 import (
+	"encoding/json"
 	"io"
 	"log/slog"
 	"net/http"
@@ -27,6 +28,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
 	"gopkg.in/yaml.v2"
 
 	amcommoncfg "github.com/prometheus/alertmanager/config/common"
@@ -43,6 +45,15 @@ func mustParseURL(t *testing.T, raw string) *amcommoncfg.SecretURL {
 	u, err := url.Parse(raw)
 	require.NoError(t, err)
 	return &amcommoncfg.SecretURL{URL: u}
+}
+
+func readRequestBody(t *testing.T, r *http.Request) []byte {
+	t.Helper()
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Errorf("failed to read request body: %v", err)
+	}
+	return body
 }
 
 func TestWebhookOutput_SendEvent(t *testing.T) {
@@ -78,6 +89,8 @@ func TestWebhookOutput_SendEvent(t *testing.T) {
 
 	mu.Lock()
 	// The POST body is the protojson encoding of the event.
+	var event map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(received[0], &event))
 	require.Contains(t, string(received[0]), "alertmanagerStartupEvent")
 	mu.Unlock()
 }
@@ -108,6 +121,171 @@ func TestWebhookOutput_MultipleWorkers(t *testing.T) {
 
 	require.NoError(t, wo.Close())
 	require.Equal(t, int64(n), count.Load())
+}
+
+func TestWebhookOutput_Batching(t *testing.T) {
+	requests := make(chan []byte, 3)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- readRequestBody(t, r)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	out, err := NewWebhookOutput(WebhookOutputConfig{
+		URL:                mustParseURL(t, srv.URL),
+		Workers:            4,
+		Batch:              true,
+		BatchMaxEvents:     3,
+		BatchFlushInterval: model.Duration(time.Hour),
+	}, testWebhookDrops(), slog.Default())
+	require.NoError(t, err)
+
+	for range 3 {
+		_, err := out.SendEvent(sampleEvent())
+		require.NoError(t, err)
+	}
+	require.NoError(t, out.Close())
+
+	var events []json.RawMessage
+	require.NoError(t, json.Unmarshal(<-requests, &events))
+	require.Len(t, events, 3)
+	require.Empty(t, requests)
+}
+
+func TestWebhookOutput_BatchingFlushesOnInterval(t *testing.T) {
+	requests := make(chan []byte, 2)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- readRequestBody(t, r)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	out, err := NewWebhookOutput(WebhookOutputConfig{
+		URL:                mustParseURL(t, srv.URL),
+		Workers:            1,
+		Batch:              true,
+		BatchMaxEvents:     10,
+		BatchFlushInterval: model.Duration(10 * time.Millisecond),
+	}, testWebhookDrops(), slog.Default())
+	require.NoError(t, err)
+	defer out.Close()
+
+	for range 2 {
+		_, err := out.SendEvent(sampleEvent())
+		require.NoError(t, err)
+	}
+
+	select {
+	case body := <-requests:
+		var events []json.RawMessage
+		require.NoError(t, json.Unmarshal(body, &events))
+		require.Len(t, events, 2)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for batch interval flush")
+	}
+}
+
+func TestWebhookOutput_BatchingByEncodedSize(t *testing.T) {
+	requests := make(chan []byte, 3)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- readRequestBody(t, r)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	event := sampleEvent()
+	encoded, err := protojson.Marshal(event)
+	require.NoError(t, err)
+	out, err := NewWebhookOutput(WebhookOutputConfig{
+		URL:                mustParseURL(t, srv.URL),
+		Workers:            1,
+		Batch:              true,
+		BatchMaxEvents:     10,
+		BatchMaxBytes:      2*len(encoded) + 2, // One byte below two events plus JSON framing.
+		BatchFlushInterval: model.Duration(time.Hour),
+	}, testWebhookDrops(), slog.Default())
+	require.NoError(t, err)
+
+	for range 2 {
+		_, err := out.SendEvent(event)
+		require.NoError(t, err)
+	}
+	require.NoError(t, out.Close())
+
+	for range 2 {
+		var events []json.RawMessage
+		require.NoError(t, json.Unmarshal(<-requests, &events))
+		require.Len(t, events, 1)
+	}
+	require.Empty(t, requests)
+}
+
+func TestWebhookOutput_BatchingCloseFlushesPartialBatch(t *testing.T) {
+	requests := make(chan []byte, 2)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- readRequestBody(t, r)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	out, err := NewWebhookOutput(WebhookOutputConfig{
+		URL:                mustParseURL(t, srv.URL),
+		Workers:            1,
+		Batch:              true,
+		BatchMaxEvents:     10,
+		BatchFlushInterval: model.Duration(time.Hour),
+	}, testWebhookDrops(), slog.Default())
+	require.NoError(t, err)
+
+	for range 2 {
+		_, err := out.SendEvent(sampleEvent())
+		require.NoError(t, err)
+	}
+	require.NoError(t, out.Close())
+
+	var events []json.RawMessage
+	require.NoError(t, json.Unmarshal(<-requests, &events))
+	require.Len(t, events, 2)
+}
+
+func TestWebhookOutput_BatchingRetriesWholeBatch(t *testing.T) {
+	requests := make(chan []byte, 3)
+	attempt := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- readRequestBody(t, r)
+		attempt++
+		if attempt == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	out, err := NewWebhookOutput(WebhookOutputConfig{
+		URL:                mustParseURL(t, srv.URL),
+		Workers:            1,
+		MaxRetries:         2,
+		RetryBackoff:       model.Duration(time.Millisecond),
+		Batch:              true,
+		BatchMaxEvents:     2,
+		BatchFlushInterval: model.Duration(time.Hour),
+	}, testWebhookDrops(), slog.Default())
+	require.NoError(t, err)
+
+	for range 2 {
+		_, err := out.SendEvent(sampleEvent())
+		require.NoError(t, err)
+	}
+	require.NoError(t, out.Close())
+
+	first := <-requests
+	second := <-requests
+	require.JSONEq(t, string(first), string(second))
+	var events []json.RawMessage
+	require.NoError(t, json.Unmarshal(second, &events))
+	require.Len(t, events, 2)
+	require.Empty(t, requests)
 }
 
 func TestWebhookOutput_RetryOnFailure(t *testing.T) {
@@ -221,6 +399,21 @@ func TestWebhookOutputConfig_UnmarshalYAML(t *testing.T) {
 			},
 		},
 		{
+			name: "valid with batching",
+			yaml: "url: https://example.com/h\nbatch: true\nbatch_max_events: 200\nbatch_max_bytes: 2097152\nbatch_flush_interval: 500ms\n",
+			check: func(t *testing.T, c WebhookOutputConfig) {
+				require.True(t, c.Batch)
+				require.Equal(t, 200, c.BatchMaxEvents)
+				require.Equal(t, 2097152, c.BatchMaxBytes)
+				require.Equal(t, model.Duration(500*time.Millisecond), c.BatchFlushInterval)
+			},
+		},
+		{
+			name:    "batch settings without batching",
+			yaml:    "url: https://example.com/h\nbatch_max_events: 200\n",
+			wantErr: true,
+		},
+		{
 			name:    "missing url",
 			yaml:    "{}\n",
 			wantErr: true,
@@ -283,4 +476,13 @@ func TestEventRecorderConfigEqual_Webhook(t *testing.T) {
 	// Differing workers.
 	b.WebhookOutputs[0].Workers = 8
 	require.False(t, configEqual(a, b))
+	b.WebhookOutputs[0].Workers = a.WebhookOutputs[0].Workers
+	b.WebhookOutputs[0].Batch = true
+	require.False(t, configEqual(a, b))
+
+	a.WebhookOutputs[0].Batch = true
+	b.WebhookOutputs[0].BatchMaxEvents = defaultHTTPBatchMaxEvents
+	b.WebhookOutputs[0].BatchMaxBytes = defaultHTTPBatchMaxBytes
+	b.WebhookOutputs[0].BatchFlushInterval = model.Duration(defaultHTTPBatchInterval)
+	require.True(t, configEqual(a, b))
 }


### PR DESCRIPTION
Allow webhook outputs to send events as JSON arrays, reducing HTTP request
overhead for endpoints that support batched ingestion.

Add a single batching coordinator per output that flushes events when the
configured count, encoded size, or interval limit is reached. Completed
batches are dispatched across the existing HTTP worker pool, while partial
batches are flushed during shutdown and retries resend the complete payload.

Preserve the existing single-object webhook contract by requiring batching
to be explicitly enabled with `batch: true`.

Document batching controls, duplicate and ordering semantics, and using a
batched webhook output with Cloudflare Pipelines:

https://developers.cloudflare.com/pipelines/streams/writing-to-streams/

Cover count-, size-, interval-, retry-, and shutdown-triggered delivery.

#### Which user-facing changes does this PR introduce?
```release-notes
[ENHANCEMENT] eventrecorder: Add optional webhook batching.
```