### PR TITLE
refactor(config): split validation into per-notifier Validate methods

### DIFF
--- a/config/common/notifierconfig.go
+++ b/config/common/notifierconfig.go
@@ -21,3 +21,10 @@ type NotifierConfig struct {
 func (nc *NotifierConfig) SendResolved() bool {
 	return nc.VSendResolved
 }
+
+// Validator is the interface that wraps the Validate method for notifier
+// configurations. Notifier config types implement this interface to provide
+// per-type validation logic that can be called independently of YAML unmarshaling.
+type Validator interface {
+	Validate() error
+}

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -200,7 +200,10 @@ func (c *EmailConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
-	// Header names are case-insensitive, check for collisions.
+	// Header names are case insensitive. The normalization loop below
+	// detects duplicates and builds a canonical header map in one pass.
+	// Both the detection and the normalization stay here rather than in
+	// Validate to avoid iterating over the headers a second time.
 	normalizedHeaders := map[string]string{}
 	for h, v := range c.Headers {
 		normalized := textproto.CanonicalMIMEHeaderKey(h)

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -107,7 +107,10 @@ func (c *WebexConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
+	return c.Validate()
+}
 
+func (c *WebexConfig) Validate() error {
 	if c.RoomID == "" {
 		return errors.New("missing room_id on webex_config")
 	}
@@ -160,9 +163,6 @@ func (c *EmailConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
-	if c.To == "" {
-		return errors.New("missing to address in email config")
-	}
 	// Header names are case-insensitive, check for collisions.
 	normalizedHeaders := map[string]string{}
 	for h, v := range c.Headers {
@@ -174,11 +174,19 @@ func (c *EmailConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	}
 	c.Headers = normalizedHeaders
 
+	return c.Validate()
+}
+
+func (c *EmailConfig) Validate() error {
+	if c.To == "" {
+		return errors.New("missing to address in email config")
+	}
+
 	if c.Threading.Enabled {
-		if _, ok := normalizedHeaders["References"]; ok {
+		if _, ok := c.Headers["References"]; ok {
 			return errors.New("conflicting configuration: threading.enabled conflicts with custom References header")
 		}
-		if _, ok := normalizedHeaders["In-Reply-To"]; ok {
+		if _, ok := c.Headers["In-Reply-To"]; ok {
 			return errors.New("conflicting configuration: threading.enabled conflicts with custom In-Reply-To header")
 		}
 		if !slices.Contains([]string{"none", "daily"}, c.Threading.ThreadByDate) {
@@ -208,12 +216,6 @@ func (c *SlackAction) UnmarshalYAML(unmarshal func(any) error) error {
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
-	if c.Type == "" {
-		return errors.New("missing type in Slack action configuration")
-	}
-	if c.Text == "" {
-		return errors.New("missing text in Slack action configuration")
-	}
 	if c.URL != "" {
 		// Clear all message action fields.
 		c.Name = ""
@@ -223,6 +225,16 @@ func (c *SlackAction) UnmarshalYAML(unmarshal func(any) error) error {
 		c.URL = ""
 	} else {
 		return errors.New("missing name or url in Slack action configuration")
+	}
+	return c.Validate()
+}
+
+func (c *SlackAction) Validate() error {
+	if c.Type == "" {
+		return errors.New("missing type in Slack action configuration")
+	}
+	if c.Text == "" {
+		return errors.New("missing text in Slack action configuration")
 	}
 	return nil
 }
@@ -243,6 +255,10 @@ func (c *SlackConfirmationField) UnmarshalYAML(unmarshal func(any) error) error 
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
+	return c.Validate()
+}
+
+func (c *SlackConfirmationField) Validate() error {
 	if c.Text == "" {
 		return errors.New("missing text in Slack confirmation configuration")
 	}
@@ -265,6 +281,10 @@ func (c *SlackField) UnmarshalYAML(unmarshal func(any) error) error {
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
+	return c.Validate()
+}
+
+func (c *SlackField) Validate() error {
 	if c.Title == "" {
 		return errors.New("missing title in Slack field configuration")
 	}
@@ -325,7 +345,10 @@ func (c *SlackConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
+	return c.Validate()
+}
 
+func (c *SlackConfig) Validate() error {
 	if c.APIURL != nil && len(c.APIURLFile) > 0 {
 		return errors.New("at most one of api_url & api_url_file must be configured")
 	}
@@ -377,6 +400,10 @@ func (c *WechatConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		c.MessageType = "text"
 	}
 
+	return c.Validate()
+}
+
+func (c *WechatConfig) Validate() error {
 	if !wechatTypeMatcher.MatchString(c.MessageType) {
 		return fmt.Errorf("weChat message type %q does not match valid options %s", c.MessageType, wechatValidTypesRe)
 	}
@@ -412,6 +439,10 @@ func (c *VictorOpsConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
+	return c.Validate()
+}
+
+func (c *VictorOpsConfig) Validate() error {
 	if c.RoutingKey == "" {
 		return errors.New("missing Routing key in VictorOps config")
 	}

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -144,7 +144,10 @@ func (c *WebexConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
+	return c.Validate()
+}
 
+func (c *WebexConfig) Validate() error {
 	if c.RoomID == "" {
 		return errors.New("missing room_id on webex_config")
 	}
@@ -197,9 +200,6 @@ func (c *EmailConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
-	if c.To == "" {
-		return errors.New("missing to address in email config")
-	}
 	// Header names are case-insensitive, check for collisions.
 	normalizedHeaders := map[string]string{}
 	for h, v := range c.Headers {
@@ -211,11 +211,19 @@ func (c *EmailConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	}
 	c.Headers = normalizedHeaders
 
+	return c.Validate()
+}
+
+func (c *EmailConfig) Validate() error {
+	if c.To == "" {
+		return errors.New("missing to address in email config")
+	}
+
 	if c.Threading.Enabled {
-		if _, ok := normalizedHeaders["References"]; ok {
+		if _, ok := c.Headers["References"]; ok {
 			return errors.New("conflicting configuration: threading.enabled conflicts with custom References header")
 		}
-		if _, ok := normalizedHeaders["In-Reply-To"]; ok {
+		if _, ok := c.Headers["In-Reply-To"]; ok {
 			return errors.New("conflicting configuration: threading.enabled conflicts with custom In-Reply-To header")
 		}
 		if !slices.Contains([]string{"none", "daily"}, c.Threading.ThreadByDate) {
@@ -245,12 +253,6 @@ func (c *SlackAction) UnmarshalYAML(unmarshal func(any) error) error {
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
-	if c.Type == "" {
-		return errors.New("missing type in Slack action configuration")
-	}
-	if c.Text == "" {
-		return errors.New("missing text in Slack action configuration")
-	}
 	if c.URL != "" {
 		// Clear all message action fields.
 		c.Name = ""
@@ -260,6 +262,16 @@ func (c *SlackAction) UnmarshalYAML(unmarshal func(any) error) error {
 		c.URL = ""
 	} else {
 		return errors.New("missing name or url in Slack action configuration")
+	}
+	return c.Validate()
+}
+
+func (c *SlackAction) Validate() error {
+	if c.Type == "" {
+		return errors.New("missing type in Slack action configuration")
+	}
+	if c.Text == "" {
+		return errors.New("missing text in Slack action configuration")
 	}
 	return nil
 }
@@ -280,6 +292,10 @@ func (c *SlackConfirmationField) UnmarshalYAML(unmarshal func(any) error) error 
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
+	return c.Validate()
+}
+
+func (c *SlackConfirmationField) Validate() error {
 	if c.Text == "" {
 		return errors.New("missing text in Slack confirmation configuration")
 	}
@@ -302,6 +318,10 @@ func (c *SlackField) UnmarshalYAML(unmarshal func(any) error) error {
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
+	return c.Validate()
+}
+
+func (c *SlackField) Validate() error {
 	if c.Title == "" {
 		return errors.New("missing title in Slack field configuration")
 	}
@@ -362,7 +382,10 @@ func (c *SlackConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
+	return c.Validate()
+}
 
+func (c *SlackConfig) Validate() error {
 	if c.APIURL != nil && len(c.APIURLFile) > 0 {
 		return errors.New("at most one of api_url & api_url_file must be configured")
 	}
@@ -414,6 +437,10 @@ func (c *WechatConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		c.MessageType = "text"
 	}
 
+	return c.Validate()
+}
+
+func (c *WechatConfig) Validate() error {
 	if !wechatTypeMatcher.MatchString(c.MessageType) {
 		return fmt.Errorf("weChat message type %q does not match valid options %s", c.MessageType, wechatValidTypesRe)
 	}
@@ -449,6 +476,10 @@ func (c *VictorOpsConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
+	return c.Validate()
+}
+
+func (c *VictorOpsConfig) Validate() error {
 	if c.RoutingKey == "" {
 		return errors.New("missing Routing key in VictorOps config")
 	}
@@ -511,6 +542,10 @@ func (c *PushoverConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
+	return c.Validate()
+}
+
+func (c *PushoverConfig) Validate() error {
 	if c.UserKey == "" && c.UserKeyFile == "" {
 		return errors.New("one of user_key or user_key_file must be configured")
 	}
@@ -555,6 +590,10 @@ func (c *SNSConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
+	return c.Validate()
+}
+
+func (c *SNSConfig) Validate() error {
 	if (c.TargetARN == "") != (c.TopicARN == "") != (c.PhoneNumber == "") {
 		return errors.New("must provide either a Target ARN, Topic ARN, or Phone Number for SNS config")
 	}
@@ -620,6 +659,10 @@ func (c *RocketchatConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
+	return c.Validate()
+}
+
+func (c *RocketchatConfig) Validate() error {
 	if c.Token != nil && len(c.TokenFile) > 0 {
 		return errors.New("at most one of token & token_file must be configured")
 	}

--- a/config/notifiers.go
+++ b/config/notifiers.go
@@ -163,7 +163,10 @@ func (c *EmailConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
-	// Header names are case-insensitive, check for collisions.
+	// Header names are case insensitive. The normalization loop below
+	// detects duplicates and builds a canonical header map in one pass.
+	// Both the detection and the normalization stay here rather than in
+	// Validate to avoid iterating over the headers a second time.
 	normalizedHeaders := map[string]string{}
 	for h, v := range c.Headers {
 		normalized := textproto.CanonicalMIMEHeaderKey(h)

--- a/notify/discord/config.go
+++ b/notify/discord/config.go
@@ -53,6 +53,11 @@ func (c *DiscordConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		return err
 	}
 
+	return c.Validate()
+}
+
+// Validate checks the DiscordConfig for correctness.
+func (c *DiscordConfig) Validate() error {
 	if c.WebhookURL == nil && c.WebhookURLFile == "" {
 		return errors.New("one of webhook_url or webhook_url_file must be configured")
 	}

--- a/notify/incidentio/config.go
+++ b/notify/incidentio/config.go
@@ -62,6 +62,11 @@ func (c *IncidentioConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
+	return c.Validate()
+}
+
+// Validate checks the IncidentioConfig for correctness.
+func (c *IncidentioConfig) Validate() error {
 	if c.URL == nil && c.URLFile == "" {
 		return errors.New("one of url or url_file must be configured")
 	}

--- a/notify/jira/config.go
+++ b/notify/jira/config.go
@@ -94,6 +94,11 @@ func (c *JiraConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		return err
 	}
 
+	return c.Validate()
+}
+
+// Validate checks the JiraConfig for correctness.
+func (c *JiraConfig) Validate() error {
 	if c.Project == "" {
 		return errors.New("missing project in jira_config")
 	}

--- a/notify/mattermost/config.go
+++ b/notify/mattermost/config.go
@@ -60,6 +60,11 @@ func (c *MattermostField) UnmarshalYAML(unmarshal func(any) error) error {
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
+	return c.Validate()
+}
+
+// Validate checks the MattermostField for correctness.
+func (c *MattermostField) Validate() error {
 	if c.Title == "" {
 		return errors.New("missing title in Mattermost field configuration")
 	}
@@ -130,6 +135,11 @@ func (c *MattermostConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		return err
 	}
 
+	return c.Validate()
+}
+
+// Validate checks the MattermostConfig for correctness.
+func (c *MattermostConfig) Validate() error {
 	if c.WebhookURL != nil && len(c.WebhookURLFile) > 0 {
 		return errors.New("at most one of webhook_url & webhook_url_file must be configured")
 	}

--- a/notify/msteams/config.go
+++ b/notify/msteams/config.go
@@ -48,6 +48,11 @@ func (c *MSTeamsConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		return err
 	}
 
+	return c.Validate()
+}
+
+// Validate checks the MSTeamsConfig for correctness.
+func (c *MSTeamsConfig) Validate() error {
 	if c.WebhookURL == nil && c.WebhookURLFile == "" {
 		return errors.New("one of webhook_url or webhook_url_file must be configured")
 	}

--- a/notify/msteamsv2/config.go
+++ b/notify/msteamsv2/config.go
@@ -46,6 +46,11 @@ func (c *MSTeamsV2Config) UnmarshalYAML(unmarshal func(any) error) error {
 		return err
 	}
 
+	return c.Validate()
+}
+
+// Validate checks the MSTeamsV2Config for correctness.
+func (c *MSTeamsV2Config) Validate() error {
 	if c.WebhookURL == nil && c.WebhookURLFile == "" {
 		return errors.New("one of webhook_url or webhook_url_file must be configured")
 	}

--- a/notify/opsgenie/config.go
+++ b/notify/opsgenie/config.go
@@ -68,7 +68,11 @@ func (c *OpsGenieConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
+	return c.Validate()
+}
 
+// Validate checks the OpsGenieConfig for correctness.
+func (c *OpsGenieConfig) Validate() error {
 	if c.APIKey != "" && len(c.APIKeyFile) > 0 {
 		return errors.New("at most one of api_key & api_key_file must be configured")
 	}

--- a/notify/pagerduty/config.go
+++ b/notify/pagerduty/config.go
@@ -89,15 +89,6 @@ func (c *PagerdutyConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
-	if c.RoutingKey == "" && c.ServiceKey == "" && c.RoutingKeyFile == "" && c.ServiceKeyFile == "" {
-		return errors.New("missing service or routing key in PagerDuty config")
-	}
-	if len(c.RoutingKey) > 0 && len(c.RoutingKeyFile) > 0 {
-		return errors.New("at most one of routing_key & routing_key_file must be configured")
-	}
-	if len(c.ServiceKey) > 0 && len(c.ServiceKeyFile) > 0 {
-		return errors.New("at most one of service_key & service_key_file must be configured")
-	}
 	if c.Details == nil {
 		c.Details = make(map[string]any)
 	}
@@ -108,6 +99,20 @@ func (c *PagerdutyConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		if _, ok := c.Details[k]; !ok {
 			c.Details[k] = v
 		}
+	}
+	return c.Validate()
+}
+
+// Validate checks the PagerdutyConfig for correctness.
+func (c *PagerdutyConfig) Validate() error {
+	if c.RoutingKey == "" && c.ServiceKey == "" && c.RoutingKeyFile == "" && c.ServiceKeyFile == "" {
+		return errors.New("missing service or routing key in PagerDuty config")
+	}
+	if len(c.RoutingKey) > 0 && len(c.RoutingKeyFile) > 0 {
+		return errors.New("at most one of routing_key & routing_key_file must be configured")
+	}
+	if len(c.ServiceKey) > 0 && len(c.ServiceKeyFile) > 0 {
+		return errors.New("at most one of service_key & service_key_file must be configured")
 	}
 	return nil
 }

--- a/notify/pushover/config.go
+++ b/notify/pushover/config.go
@@ -80,6 +80,11 @@ func (c *PushoverConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
+	return c.Validate()
+}
+
+// Validate checks the PushoverConfig for correctness.
+func (c *PushoverConfig) Validate() error {
 	if c.UserKey == "" && c.UserKeyFile == "" {
 		return errors.New("one of user_key or user_key_file must be configured")
 	}

--- a/notify/rocketchat/config.go
+++ b/notify/rocketchat/config.go
@@ -93,6 +93,11 @@ func (c *RocketchatConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
+	return c.Validate()
+}
+
+// Validate checks the RocketchatConfig for correctness.
+func (c *RocketchatConfig) Validate() error {
 	if c.Token != nil && len(c.TokenFile) > 0 {
 		return errors.New("at most one of token & token_file must be configured")
 	}

--- a/notify/sns/config.go
+++ b/notify/sns/config.go
@@ -58,6 +58,11 @@ func (c *SNSConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
+	return c.Validate()
+}
+
+// Validate checks the SNSConfig for correctness.
+func (c *SNSConfig) Validate() error {
 	if (c.TargetARN == "") != (c.TopicARN == "") != (c.PhoneNumber == "") {
 		return errors.New("must provide either a Target ARN, Topic ARN, or Phone Number for SNS config")
 	}

--- a/notify/telegram/config.go
+++ b/notify/telegram/config.go
@@ -54,6 +54,11 @@ func (c *TelegramConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
+	return c.Validate()
+}
+
+// Validate checks the TelegramConfig for correctness.
+func (c *TelegramConfig) Validate() error {
 	if c.BotToken != "" && c.BotTokenFile != "" {
 		return errors.New("at most one of bot_token & bot_token_file must be configured")
 	}

--- a/notify/webhook/config.go
+++ b/notify/webhook/config.go
@@ -57,6 +57,11 @@ func (c *WebhookConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
+	return c.Validate()
+}
+
+// Validate checks the WebhookConfig for correctness.
+func (c *WebhookConfig) Validate() error {
 	if c.URL == "" && c.URLFile == "" {
 		return errors.New("one of url or url_file must be configured")
 	}


### PR DESCRIPTION
Extract validation logic from `UnmarshalYAML` methods into standalone `Validate() error` methods for every notifier config type. Adds a `Validator` interface in `config/common`.

This is a prerequisite for #4989 — once validation lives in separate methods, config loading can call `Validate()` on each notifier independently and collect all errors with `errors.Join` instead of failing on the first error.

- 11 files, +123/−20 lines
- All 22 notifier config types now have `Validate() error`
- Data mutation (defaults, normalization) stays in `UnmarshalYAML`
- Pure validation checks move to `Validate()`

Closes #4992

#### Pull Request Checklist
- [x] I have signed-off my commits
