### PR TITLE
notify/pushover: trim whitespace from token and user key files

### DIFF
--- a/notify/pushover/pushover.go
+++ b/notify/pushover/pushover.go
@@ -95,7 +95,8 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		if err != nil {
 			return false, fmt.Errorf("read token_file: %w", err)
 		}
-		token = string(content)
+		// Trim trailing newlines from editors like vim that append them by default.
+		token = strings.TrimSpace(string(content))
 	}
 	if n.conf.UserKey != "" {
 		userKey = string(n.conf.UserKey)
@@ -104,7 +105,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		if err != nil {
 			return false, fmt.Errorf("read user_key_file: %w", err)
 		}
-		userKey = string(content)
+		userKey = strings.TrimSpace(string(content))
 	}
 
 	parameters := url.Values{}

--- a/notify/pushover/pushover_test.go
+++ b/notify/pushover/pushover_test.go
@@ -70,8 +70,10 @@ func TestPushoverReadingUserKeyFromFile(t *testing.T) {
 	const userKey = "user key"
 	f, err := os.CreateTemp(t.TempDir(), "pushover_user_key")
 	require.NoError(t, err, "creating temp file failed")
-	_, err = f.WriteString(userKey)
+	// Editors like vim append a trailing newline; that must not be sent to Pushover.
+	_, err = f.WriteString(userKey + "\n")
 	require.NoError(t, err, "writing to temp file failed")
+	require.NoError(t, f.Close(), "closing temp file failed")
 
 	notifier, err := New(
 		&config.PushoverConfig{
@@ -95,8 +97,9 @@ func TestPushoverReadingTokenFromFile(t *testing.T) {
 	const token = "token"
 	f, err := os.CreateTemp(t.TempDir(), "pushover_token")
 	require.NoError(t, err, "creating temp file failed")
-	_, err = f.WriteString(token)
+	_, err = f.WriteString(token + "\n")
 	require.NoError(t, err, "writing to temp file failed")
+	require.NoError(t, f.Close(), "closing temp file failed")
 
 	notifier, err := New(
 		&config.PushoverConfig{


### PR DESCRIPTION
## Summary
- Trim trailing whitespace/newlines when reading `token_file` and `user_key_file` (same pattern as pagerduty/slack/etc.).
- Editors like vim append a newline by default; Pushover then rejects the credentials with HTTP 400.

Related to https://github.com/prometheus/alertmanager/issues/3641

## Test plan
- [x] `go test ./notify/pushover/ -count=1`
- [x] Existing file-backed secret tests now write secrets with a trailing `\n` and still succeed