### PR TITLE
docs: document VictorOps custom fields

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1928,6 +1928,11 @@ routing_key: <tmpl_string>
 # The monitoring tool the state message is from.
 [ monitoring_tool: <tmpl_string> | default = '{{ template "victorops.default.monitoring_tool" . }}' ]
 
+# Optional custom fields sent with the notification. The names `routing_key`,
+# `message_type`, `state_message`, `entity_display_name`, `monitoring_tool`,
+# `entity_id`, and `entity_state` are reserved and cannot be used as keys.
+[ custom_fields: { <string>: <tmpl_string>, ... } ]
+
 # The HTTP client's configuration.
 [ http_config: <http_config> | default = global.http_config ]
 ```


### PR DESCRIPTION
Fixes prometheus/docs#2014

Documents the existing `custom_fields` option for VictorOps receivers and lists the field names rejected by configuration validation. This keeps the change scoped to the missing option and describes the names as reserved without implying that every reserved name is part of the JSON body.

Testing:
- `git diff --check`

#### Pull Request Checklist

- Is this a bugfix?
    - [ ] I have added tests that can reproduce the bug which pass with this bugfix applied
- Is this a new feature?
    - [ ] I have added tests that test the new feature's functionality
- Does this change affect performance?
    - [ ] I have provided benchmarks comparison that shows performance is improved or is not degraded
    - [ ] I have added new benchmarks if required or requested by maintainers
- Is this a breaking change?
    - [x] My changes do not break the existing cluster messages
    - [x] My changes do not break the existing api
- [x] I have added/updated the required documentation
- [x] I have signed-off my commits
- [x] I will follow best practices for contributing to this project

#### Which user-facing changes does this PR introduce?

```release-notes
NONE
```