### PR TITLE
template: export GroupKey on template.Data

### DIFF
--- a/notify/util.go
+++ b/notify/util.go
@@ -213,6 +213,11 @@ func GetTemplateData(ctx context.Context, tmpl *template.Template, alerts []*typ
 		notificationReason = ReasonUnknown
 	}
 	data := tmpl.Data(recv, groupLabels, routeLabels, notificationReason.String(), alerts...)
+	// Group key is optional for some callers (e.g. tests); populate when present
+	// so templates and webhook-style consumers can access .GroupKey.
+	if groupKey, ok := GroupKey(ctx); ok {
+		data.GroupKey = groupKey
+	}
 	// Route labels are pre-rendered by the dispatcher; don't execute them again.
 	template.MarkRouteLabelsRendered(data)
 	return data

--- a/notify/util_test.go
+++ b/notify/util_test.go
@@ -244,6 +244,7 @@ func TestGetTemplateDataWithRouteLabels(t *testing.T) {
 
 	data := GetTemplateData(ctx, tmpl, nil, promslog.NewNopLogger())
 
+	require.Equal(t, "test-key", data.GroupKey)
 	require.Equal(t, "ops", data.RouteLabels["team"])
 	require.Equal(t, "value is {{ $value }}", data.RouteLabels["desc"])
 
@@ -251,6 +252,34 @@ func TestGetTemplateDataWithRouteLabels(t *testing.T) {
 	got, err := tmpl.ExecuteTextString(`{{ routeLabels "team" }}|{{ routeLabels "desc" }}`, data)
 	require.NoError(t, err)
 	require.Equal(t, "ops|value is {{ $value }}", got)
+}
+
+func TestGetTemplateDataGroupKey(t *testing.T) {
+	tmpl, err := template.New()
+	require.NoError(t, err)
+	tmpl.ExternalURL = &url.URL{Scheme: "http", Host: "example.com"}
+
+	groupKey := `{}:{alertname="HighErrorRate"}`
+	ctx := context.Background()
+	ctx = WithReceiverName(ctx, "webhook")
+	ctx = WithGroupKey(ctx, groupKey)
+	ctx = WithGroupLabels(ctx, model.LabelSet{"alertname": "HighErrorRate"})
+	ctx = WithNotificationReason(ctx, ReasonFirstNotification)
+
+	data := GetTemplateData(ctx, tmpl, nil, promslog.NewNopLogger())
+	require.Equal(t, groupKey, data.GroupKey)
+
+	// Templates can reference .GroupKey like other Data fields.
+	got, err := tmpl.ExecuteTextString(`{{ .GroupKey }}`, data)
+	require.NoError(t, err)
+	require.Equal(t, groupKey, got)
+
+	// Missing group key leaves GroupKey empty without failing.
+	ctxNoKey := WithReceiverName(context.Background(), "webhook")
+	ctxNoKey = WithGroupLabels(ctxNoKey, model.LabelSet{"alertname": "HighErrorRate"})
+	ctxNoKey = WithNotificationReason(ctxNoKey, ReasonFirstNotification)
+	dataNoKey := GetTemplateData(ctxNoKey, tmpl, nil, promslog.NewNopLogger())
+	require.Empty(t, dataNoKey.GroupKey)
 }
 
 func TestGetFailureReasonFromStatusCode(t *testing.T) {

--- a/template/template.go
+++ b/template/template.go
@@ -485,6 +485,10 @@ type Data struct {
 	Status   string `json:"status"`
 	Alerts   Alerts `json:"alerts"`
 
+	// GroupKey is the grouping key of the alert group, matching the webhook
+	// payload field of the same name.
+	GroupKey string `json:"groupKey"`
+
 	NotificationReason string `json:"notification_reason"`
 
 	GroupLabels       KV `json:"groupLabels"`


### PR DESCRIPTION
#### Pull Request Checklist

- Please list all open issue(s) discussed with maintainers related to this change
    - Fixes #2526
- Is this a new Receiver integration?
    - [ ] N/A
- Is this a bug fix?
    - [x] I have added tests that can reproduce the bug which pass with this bug fix applied
- Is this a new feature?
    - [ ] N/A (small API completeness fix)
- Does this change affect performance?
    - [ ] N/A
- Is this a breaking change?
    - [x] My changes do not break the existing cluster messages
    - [x] My changes do not break the existing api
- [ ] I have added/updated the required documentation
- [x] I have signed-off my commits
- [x] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Summary

`template.Data` did not export `GroupKey`, even though the webhook JSON payload has always included `groupKey`. Webhook receivers that reuse `template.Data` (or custom templates that need the grouping key) had no way to access it without defining their own struct.

This change:

1. Adds `GroupKey` to `template.Data` with JSON tag `groupKey` (matching the documented webhook field).
2. Populates it from the notify context in `GetTemplateData` when a group key is present.
3. Adds unit tests for population and template access via `{{ .GroupKey }}`.

The webhook `Message` type still sets its own `GroupKey` field for the wire format; Go's encoding/json prefers the outer field, so the payload is unchanged.

#### Which user-facing changes does this PR introduce?

```release-notes
[ENHANCEMENT] template: Export GroupKey on template.Data for templates and webhook-style consumers. #2526
```

#### Notes from review discussion

- Custom **webhook payload** templates still will not see `GroupKey` until something like https://github.com/prometheus/alertmanager/issues/5012 (or `renderPayload` wiring) lands; this PR only exposes it on `template.Data` for the existing Go template path.
- `groupKey` is not globally unique (https://github.com/prometheus/alertmanager/issues/3817); this change surfaces the dispatcher value as-is and does not claim uniqueness.
