### PR TITLE
api: add active/expired/pending filter params to GET /silences

### DIFF
--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -702,6 +702,25 @@ func (api *API) getSilencesHandler(params silence_ops.GetSilencesParams) middlew
 		sils = append(sils, &silence)
 	}
 
+	// Filter by silence state. params.Active/Expired/Pending are always non-nil
+	// because NewGetSilencesParams() initialises them to true; the filter is a
+	// no-op unless the caller explicitly passes false.
+	var filtered open_api_models.GettableSilences
+	for _, sil := range sils {
+		state := string(*sil.Status.State)
+		if !*params.Active && state == "active" {
+			continue
+		}
+		if !*params.Expired && state == "expired" {
+			continue
+		}
+		if !*params.Pending && state == "pending" {
+			continue
+		}
+		filtered = append(filtered, sil)
+	}
+	sils = filtered
+
 	SortSilences(sils)
 
 	return silence_ops.NewGetSilencesOK().WithPayload(sils)

--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -683,7 +683,20 @@ func (api *API) getSilencesHandler(params silence_ops.GetSilencesParams) middlew
 		return silence_ops.NewGetSilencesBadRequest().WithPayload(err.Error())
 	}
 
-	psils, _, err := api.silences.Query(ctx)
+	// Build the state filter. Params are always non-nil (defaults to true) so
+	// we only add a state to the query when the caller has not excluded it.
+	var states []silence.SilenceState
+	if *params.Active {
+		states = append(states, silence.SilenceStateActive)
+	}
+	if *params.Expired {
+		states = append(states, silence.SilenceStateExpired)
+	}
+	if *params.Pending {
+		states = append(states, silence.SilenceStatePending)
+	}
+
+	psils, _, err := api.silences.Query(ctx, silence.QState(states...))
 	if err != nil {
 		logger.Error("Failed to get silences", "err", err)
 		return silence_ops.NewGetSilencesInternalServerError().WithPayload(err.Error())
@@ -694,32 +707,13 @@ func (api *API) getSilencesHandler(params silence_ops.GetSilencesParams) middlew
 		if !CheckSilenceMatchesFilterLabels(ps, matchers) {
 			continue
 		}
-		silence, err := GettableSilenceFromProto(ps)
+		sil, err := GettableSilenceFromProto(ps)
 		if err != nil {
 			logger.Error("Failed to unmarshal silence from proto", "err", err)
 			return silence_ops.NewGetSilencesInternalServerError().WithPayload(err.Error())
 		}
-		sils = append(sils, &silence)
+		sils = append(sils, &sil)
 	}
-
-	// Filter by silence state. params.Active/Expired/Pending are always non-nil
-	// because NewGetSilencesParams() initialises them to true; the filter is a
-	// no-op unless the caller explicitly passes false.
-	var filtered open_api_models.GettableSilences
-	for _, sil := range sils {
-		state := string(*sil.Status.State)
-		if !*params.Active && state == "active" {
-			continue
-		}
-		if !*params.Expired && state == "expired" {
-			continue
-		}
-		if !*params.Pending && state == "pending" {
-			continue
-		}
-		filtered = append(filtered, sil)
-	}
-	sils = filtered
 
 	SortSilences(sils)
 

--- a/api/v2/api_test.go
+++ b/api/v2/api_test.go
@@ -160,6 +160,93 @@ func TestGetSilencesHandler(t *testing.T) {
 	}
 }
 
+func boolPtr(b bool) *bool { return &b }
+
+func TestGetSilencesHandlerStateFilter(t *testing.T) {
+	now := timestamppb.Now()
+	silences := newSilences(t)
+	m := &silencepb.Matcher{Type: silencepb.Matcher_EQUAL, Name: "a", Pattern: "b"}
+
+	// active silence: starts in the past, ends in the future.
+	activeSil := &silencepb.Silence{
+		MatcherSets: []*silencepb.MatcherSet{{Matchers: []*silencepb.Matcher{m}}},
+		StartsAt:    timestamppb.New(now.AsTime().Add(-time.Hour)),
+		EndsAt:      timestamppb.New(now.AsTime().Add(time.Hour)),
+		UpdatedAt:   now,
+	}
+	require.NoError(t, silences.Set(t.Context(), activeSil))
+
+	// pending silence: starts in the future.
+	pendingSil := &silencepb.Silence{
+		MatcherSets: []*silencepb.MatcherSet{{Matchers: []*silencepb.Matcher{m}}},
+		StartsAt:    timestamppb.New(now.AsTime().Add(time.Hour)),
+		EndsAt:      timestamppb.New(now.AsTime().Add(2 * time.Hour)),
+		UpdatedAt:   now,
+	}
+	require.NoError(t, silences.Set(t.Context(), pendingSil))
+
+	// expired silence: explicitly expired via Expire().
+	expiredSil := &silencepb.Silence{
+		MatcherSets: []*silencepb.MatcherSet{{Matchers: []*silencepb.Matcher{m}}},
+		StartsAt:    timestamppb.New(now.AsTime().Add(-time.Hour)),
+		EndsAt:      timestamppb.New(now.AsTime().Add(time.Hour)),
+		UpdatedAt:   now,
+	}
+	require.NoError(t, silences.Set(t.Context(), expiredSil))
+	require.NoError(t, silences.Expire(t.Context(), expiredSil.Id))
+
+	api := API{
+		uptime:   time.Now(),
+		silences: silences,
+		logger:   promslog.NewNopLogger(),
+	}
+
+	callHandler := func(active, expired, pending *bool) []*open_api_models.GettableSilence {
+		r, err := http.NewRequest("GET", "/api/v2/silences", nil)
+		require.NoError(t, err)
+		w := httptest.NewRecorder()
+		p := runtime.TextProducer()
+		responder := api.getSilencesHandler(silence_ops.GetSilencesParams{
+			HTTPRequest: r,
+			Active:      active,
+			Expired:     expired,
+			Pending:     pending,
+		})
+		responder.WriteResponse(w, p)
+		require.Equal(t, http.StatusOK, w.Code)
+		var resp []*open_api_models.GettableSilence
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+		return resp
+	}
+
+	stateSet := func(sils []*open_api_models.GettableSilence) map[string]bool {
+		states := make(map[string]bool, len(sils))
+		for _, s := range sils {
+			states[string(*s.Status.State)] = true
+		}
+		return states
+	}
+
+	// No filter params (all true) - all three states returned.
+	require.Len(t, callHandler(boolPtr(true), boolPtr(true), boolPtr(true)), 3)
+
+	// active=false - active silences excluded.
+	got := stateSet(callHandler(boolPtr(false), boolPtr(true), boolPtr(true)))
+	require.False(t, got["active"])
+	require.True(t, got["expired"] || got["pending"])
+
+	// expired=false - expired silences excluded.
+	got = stateSet(callHandler(boolPtr(true), boolPtr(false), boolPtr(true)))
+	require.False(t, got["expired"])
+
+	// pending=false - pending silences excluded.
+	got = stateSet(callHandler(boolPtr(true), boolPtr(true), boolPtr(false)))
+	require.False(t, got["pending"])
+
+	// all false - empty result.
+	require.Empty(t, callHandler(boolPtr(false), boolPtr(false), boolPtr(false)))
+}
+
 func TestDeleteSilenceHandler(t *testing.T) {
 	now := timestamppb.Now()
 	silences := newSilences(t)
@@ -364,11 +451,11 @@ func getSilences(
 	r, err := http.NewRequest("GET", "/api/v2/silences", nil)
 	require.NoError(t, err)
 
+	params := silence_ops.NewGetSilencesParams()
+	params.HTTPRequest = r
+
 	p := runtime.TextProducer()
-	responder := handlerFunc(silence_ops.GetSilencesParams{
-		HTTPRequest: r,
-		Filter:      nil,
-	})
+	responder := handlerFunc(params)
 	responder.WriteResponse(w, p)
 }
 

--- a/api/v2/client/silence/get_silences_parameters.go
+++ b/api/v2/client/silence/get_silences_parameters.go
@@ -76,11 +76,35 @@ GetSilencesParams contains all the parameters to send to the API endpoint
 */
 type GetSilencesParams struct {
 
+	/* Active.
+
+	   Include active silences in results. If false, excludes active silences.
+
+	   Default: true
+	*/
+	Active *bool
+
+	/* Expired.
+
+	   Include expired silences in results. If false, excludes expired silences.
+
+	   Default: true
+	*/
+	Expired *bool
+
 	/* Filter.
 
 	   A matcher expression to filter silences. For example `alertname="MyAlert"`. It can be repeated to apply multiple matchers.
 	*/
 	Filter []string
+
+	/* Pending.
+
+	   Include pending silences in results. If false, excludes pending silences.
+
+	   Default: true
+	*/
+	Pending *bool
 
 	timeout    time.Duration
 	Context    context.Context
@@ -99,7 +123,24 @@ func (o *GetSilencesParams) WithDefaults() *GetSilencesParams {
 //
 // All values with no default are reset to their zero value.
 func (o *GetSilencesParams) SetDefaults() {
-	// no default values defined for this parameter
+	var (
+		activeDefault = bool(true)
+
+		expiredDefault = bool(true)
+
+		pendingDefault = bool(true)
+	)
+
+	val := GetSilencesParams{
+		Active:  &activeDefault,
+		Expired: &expiredDefault,
+		Pending: &pendingDefault,
+	}
+
+	val.timeout = o.timeout
+	val.Context = o.Context
+	val.HTTPClient = o.HTTPClient
+	*o = val
 }
 
 // WithTimeout adds the timeout to the get silences params
@@ -135,6 +176,28 @@ func (o *GetSilencesParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
+// WithActive adds the active to the get silences params
+func (o *GetSilencesParams) WithActive(active *bool) *GetSilencesParams {
+	o.SetActive(active)
+	return o
+}
+
+// SetActive adds the active to the get silences params
+func (o *GetSilencesParams) SetActive(active *bool) {
+	o.Active = active
+}
+
+// WithExpired adds the expired to the get silences params
+func (o *GetSilencesParams) WithExpired(expired *bool) *GetSilencesParams {
+	o.SetExpired(expired)
+	return o
+}
+
+// SetExpired adds the expired to the get silences params
+func (o *GetSilencesParams) SetExpired(expired *bool) {
+	o.Expired = expired
+}
+
 // WithFilter adds the filter to the get silences params
 func (o *GetSilencesParams) WithFilter(filter []string) *GetSilencesParams {
 	o.SetFilter(filter)
@@ -146,6 +209,17 @@ func (o *GetSilencesParams) SetFilter(filter []string) {
 	o.Filter = filter
 }
 
+// WithPending adds the pending to the get silences params
+func (o *GetSilencesParams) WithPending(pending *bool) *GetSilencesParams {
+	o.SetPending(pending)
+	return o
+}
+
+// SetPending adds the pending to the get silences params
+func (o *GetSilencesParams) SetPending(pending *bool) {
+	o.Pending = pending
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *GetSilencesParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -153,6 +227,40 @@ func (o *GetSilencesParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.R
 		return err
 	}
 	var res []error
+
+	if o.Active != nil {
+
+		// query param active
+		var qrActive bool
+
+		if o.Active != nil {
+			qrActive = *o.Active
+		}
+		qActive := swag.FormatBool(qrActive)
+		if qActive != "" {
+
+			if err := r.SetQueryParam("active", qActive); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.Expired != nil {
+
+		// query param expired
+		var qrExpired bool
+
+		if o.Expired != nil {
+			qrExpired = *o.Expired
+		}
+		qExpired := swag.FormatBool(qrExpired)
+		if qExpired != "" {
+
+			if err := r.SetQueryParam("expired", qExpired); err != nil {
+				return err
+			}
+		}
+	}
 
 	if o.Filter != nil {
 
@@ -162,6 +270,23 @@ func (o *GetSilencesParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.R
 		// query array param filter
 		if err := r.SetQueryParam("filter", joinedFilter...); err != nil {
 			return err
+		}
+	}
+
+	if o.Pending != nil {
+
+		// query param pending
+		var qrPending bool
+
+		if o.Pending != nil {
+			qrPending = *o.Pending
+		}
+		qPending := swag.FormatBool(qrPending)
+		if qPending != "" {
+
+			if err := r.SetQueryParam("pending", qPending); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/api/v2/openapi.yaml
+++ b/api/v2/openapi.yaml
@@ -70,6 +70,21 @@ paths:
           collectionFormat: multi
           items:
             type: string
+        - in: query
+          name: active
+          type: boolean
+          description: Include active silences in results. If false, excludes active silences.
+          default: true
+        - in: query
+          name: expired
+          type: boolean
+          description: Include expired silences in results. If false, excludes expired silences.
+          default: true
+        - in: query
+          name: pending
+          type: boolean
+          description: Include pending silences in results. If false, excludes pending silences.
+          default: true
     post:
       tags:
         - silence

--- a/api/v2/restapi/embedded_spec.go
+++ b/api/v2/restapi/embedded_spec.go
@@ -329,6 +329,27 @@ func init() {
             "description": "A matcher expression to filter silences. For example ` + "`" + `alertname=\"MyAlert\"` + "`" + `. It can be repeated to apply multiple matchers.",
             "name": "filter",
             "in": "query"
+          },
+          {
+            "type": "boolean",
+            "default": true,
+            "description": "Include active silences in results. If false, excludes active silences.",
+            "name": "active",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "default": true,
+            "description": "Include expired silences in results. If false, excludes expired silences.",
+            "name": "expired",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "default": true,
+            "description": "Include pending silences in results. If false, excludes pending silences.",
+            "name": "pending",
+            "in": "query"
           }
         ],
         "responses": {
@@ -1228,6 +1249,27 @@ func init() {
             "collectionFormat": "multi",
             "description": "A matcher expression to filter silences. For example ` + "`" + `alertname=\"MyAlert\"` + "`" + `. It can be repeated to apply multiple matchers.",
             "name": "filter",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "default": true,
+            "description": "Include active silences in results. If false, excludes active silences.",
+            "name": "active",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "default": true,
+            "description": "Include expired silences in results. If false, excludes expired silences.",
+            "name": "expired",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "default": true,
+            "description": "Include pending silences in results. If false, excludes pending silences.",
+            "name": "pending",
             "in": "query"
           }
         ],

--- a/api/v2/restapi/operations/silence/get_silences_parameters.go
+++ b/api/v2/restapi/operations/silence/get_silences_parameters.go
@@ -26,14 +26,29 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 )
 
 // NewGetSilencesParams creates a new GetSilencesParams object
-//
-// There are no default values defined in the spec.
+// with the default values initialized.
 func NewGetSilencesParams() GetSilencesParams {
 
-	return GetSilencesParams{}
+	var (
+		// initialize parameters with default values
+
+		activeDefault  = bool(true)
+		expiredDefault = bool(true)
+
+		pendingDefault = bool(true)
+	)
+
+	return GetSilencesParams{
+		Active: &activeDefault,
+
+		Expired: &expiredDefault,
+
+		Pending: &pendingDefault,
+	}
 }
 
 // GetSilencesParams contains all the bound params for the get silences operation
@@ -44,11 +59,29 @@ type GetSilencesParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
+	/*Include active silences in results. If false, excludes active silences.
+	  In: query
+	  Default: true
+	*/
+	Active *bool
+
+	/*Include expired silences in results. If false, excludes expired silences.
+	  In: query
+	  Default: true
+	*/
+	Expired *bool
+
 	/*A matcher expression to filter silences. For example `alertname="MyAlert"`. It can be repeated to apply multiple matchers.
 	  In: query
 	  Collection Format: multi
 	*/
 	Filter []string
+
+	/*Include pending silences in results. If false, excludes pending silences.
+	  In: query
+	  Default: true
+	*/
+	Pending *bool
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -61,13 +94,76 @@ func (o *GetSilencesParams) BindRequest(r *http.Request, route *middleware.Match
 	o.HTTPRequest = r
 	qs := runtime.Values(r.URL.Query())
 
+	qActive, qhkActive, _ := qs.GetOK("active")
+	if err := o.bindActive(qActive, qhkActive, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qExpired, qhkExpired, _ := qs.GetOK("expired")
+	if err := o.bindExpired(qExpired, qhkExpired, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
 	qFilter, qhkFilter, _ := qs.GetOK("filter")
 	if err := o.bindFilter(qFilter, qhkFilter, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qPending, qhkPending, _ := qs.GetOK("pending")
+	if err := o.bindPending(qPending, qhkPending, route.Formats); err != nil {
 		res = append(res, err)
 	}
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+// bindActive binds and validates parameter Active from query.
+func (o *GetSilencesParams) bindActive(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		// Default values have been previously initialized by NewGetSilencesParams()
+		return nil
+	}
+
+	value, err := swag.ConvertBool(raw)
+	if err != nil {
+		return errors.InvalidType("active", "query", "bool", raw)
+	}
+	o.Active = &value
+
+	return nil
+}
+
+// bindExpired binds and validates parameter Expired from query.
+func (o *GetSilencesParams) bindExpired(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		// Default values have been previously initialized by NewGetSilencesParams()
+		return nil
+	}
+
+	value, err := swag.ConvertBool(raw)
+	if err != nil {
+		return errors.InvalidType("expired", "query", "bool", raw)
+	}
+	o.Expired = &value
+
 	return nil
 }
 
@@ -89,6 +185,30 @@ func (o *GetSilencesParams) bindFilter(rawData []string, hasKey bool, formats st
 	}
 
 	o.Filter = filterIR
+
+	return nil
+}
+
+// bindPending binds and validates parameter Pending from query.
+func (o *GetSilencesParams) bindPending(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		// Default values have been previously initialized by NewGetSilencesParams()
+		return nil
+	}
+
+	value, err := swag.ConvertBool(raw)
+	if err != nil {
+		return errors.InvalidType("pending", "query", "bool", raw)
+	}
+	o.Pending = &value
 
 	return nil
 }

--- a/api/v2/restapi/operations/silence/get_silences_urlbuilder.go
+++ b/api/v2/restapi/operations/silence/get_silences_urlbuilder.go
@@ -29,7 +29,10 @@ import (
 
 // GetSilencesURL generates an URL for the get silences operation
 type GetSilencesURL struct {
-	Filter []string
+	Active  *bool
+	Expired *bool
+	Filter  []string
+	Pending *bool
 
 	_basePath string
 	// avoid unkeyed usage
@@ -65,6 +68,22 @@ func (o *GetSilencesURL) Build() (*url.URL, error) {
 
 	qs := make(url.Values)
 
+	var activeQ string
+	if o.Active != nil {
+		activeQ = swag.FormatBool(*o.Active)
+	}
+	if activeQ != "" {
+		qs.Set("active", activeQ)
+	}
+
+	var expiredQ string
+	if o.Expired != nil {
+		expiredQ = swag.FormatBool(*o.Expired)
+	}
+	if expiredQ != "" {
+		qs.Set("expired", expiredQ)
+	}
+
 	var filterIR []string
 	for _, filterI := range o.Filter {
 		filterIS := filterI
@@ -77,6 +96,14 @@ func (o *GetSilencesURL) Build() (*url.URL, error) {
 
 	for _, qsv := range filter {
 		qs.Add("filter", qsv)
+	}
+
+	var pendingQ string
+	if o.Pending != nil {
+		pendingQ = swag.FormatBool(*o.Pending)
+	}
+	if pendingQ != "" {
+		qs.Set("pending", pendingQ)
 	}
 
 	_result.RawQuery = qs.Encode()


### PR DESCRIPTION
Fixes #5404

`GET /api/v2/silences` returns all silences with no way to filter by state. This means callers who only care about active silences have to fetch everything and filter client-side, which is the same problem that was solved for alerts with the existing `active`, `silenced`, `inhibited`, and `unprocessed` params on `GET /alerts`.

This PR adds three optional boolean query params that are  `active`, `expired`, `pending`  to `GET /api/v2/silences`. Omitting a param includes that state (default behaviour is unchanged). Passing `false` excludes it.

The filter is applied server-side after the existing label-matcher filter, before sorting.

[FEATURE] API: Add active, expired, and pending boolean filter parameters to GET /api/v2/silences to allow filtering silences by state server-side.
