### PR TITLE
template: add base64encode and base64decode template functions

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -87,6 +87,8 @@ templating.
 | Name             | Arguments                  | Description |
 | ---------------- | -------------------------- | ----------- |
 | append           | slice []any, args ...any   | Returns a new slice with the provided arguments appended to the provided slice. |
+| base64decode     | text string                | [base64.URLEncoding.DecodeString](https://pkg.go.dev/encoding/base64#Encoding.DecodeString), decodes a URL-safe base64 encoded string, and the error if it happened. |
+| base64encode     | text string                | [base64.URLEncoding.EncodeToString](https://pkg.go.dev/encoding/base64#Encoding.EncodeToString), returns the URL-safe base64 encoding of a string, e.g. for use in a query parameter. |
 | date             | string, time.Time          | Returns the text representation of the time in the specified format. For documentation on formats refer to [pkg.go.dev/time](https://pkg.go.dev/time#pkg-constants). |
 | dict             | values ...any              | Returns a map of string to any, constructed from the variadic list of key-value pairs. The number of arguments must be even, and the keys must be strings. |
 | humanizeDuration | number or string           | Returns a human-readable string representing the duration, and the error if it happened. |

--- a/template/template.go
+++ b/template/template.go
@@ -16,6 +16,7 @@ package template
 import (
 	"bytes"
 	"embed"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	tmplhtml "html/template"
@@ -344,6 +345,19 @@ var DefaultFuncs = FuncMap{
 			return "", err
 		}
 		return string(bytes), nil
+	},
+	// base64encode and base64decode use the URL-safe alphabet so the result
+	// can be embedded directly in a URL query parameter, e.g. to build a
+	// silence link for an external dashboard.
+	"base64encode": func(text string) string {
+		return base64.URLEncoding.EncodeToString([]byte(text))
+	},
+	"base64decode": func(text string) (string, error) {
+		decoded, err := base64.URLEncoding.DecodeString(text)
+		if err != nil {
+			return "", err
+		}
+		return string(decoded), nil
 	},
 	"list": func(args ...any) ([]any, error) {
 		if args == nil {

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -495,6 +495,26 @@ func TestTemplateExpansion(t *testing.T) {
 			exp: `[{"status":"firing","labels":null,"annotations":null,"startsAt":"0001-01-01T00:00:00Z","endsAt":"0001-01-01T00:00:00Z","generatorURL":"","fingerprint":""}]`,
 		},
 		{
+			title: "Template using base64encode",
+			in:    `{{ "test" | base64encode }}`,
+			exp:   "dGVzdA==",
+		},
+		{
+			title: "Template using base64encode produces a URL-safe alphabet",
+			in:    `{{ "flush>>" | base64encode }}`,
+			exp:   "Zmx1c2g-Pg==",
+		},
+		{
+			title: "Template using base64decode",
+			in:    `{{ "dGVzdA==" | base64decode }}`,
+			exp:   "test",
+		},
+		{
+			title: "Template using base64decode with invalid input",
+			in:    `{{ "not-valid-base64!" | base64decode }}`,
+			fail:  true,
+		},
+		{
 			title: "Template creates empty dict when using dict on nil",
 			in:    `{{- $test := dict -}}{{ $test }}`,
 			exp:   "map[]",


### PR DESCRIPTION
Motivation:
Notification templates have no way to base64-encode a string. Issue #3127
needs this to build a link into Karma, which expects its silence-search
query parameter to be a base64-encoded JSON payload
(`?m=<base64(json)>`), e.g. as an action button URL in a Slack message.

Approach:
Add `base64encode` and `base64decode` to the DefaultFuncs map in
template/template.go, alongside the existing `toJson`/`reReplaceAll`/
`urlUnescape` helpers. Both use base64.URLEncoding (the URL/filename-safe
alphabet) rather than StdEncoding, since the output is meant to be
embedded directly in a URL query parameter: StdEncoding's `+` and `/`
characters can be misinterpreted by URL/form parsers (`+` is commonly
decoded as a space), silently corrupting the payload, which URLEncoding
avoids. The existing `dict`/`list`/`toJson` functions can already build
the JSON structure Karma expects; base64encode is the missing piece to
turn it into a link.

This only adds new template functions; no existing behavior changes.

Validation:
  go build ./template/...
  go test ./template/...
both pass, including new test cases in template/template_test.go for
base64encode, base64encode's URL-safe alphabet (verified against an
input whose encoding differs between Std and URL alphabets), base64decode,
and the base64decode error path for invalid input.

docs/notifications.md's function reference table is updated with both
new entries.

Fixes #3127

```release-notes
[ENHANCEMENT] Templates: Add `base64encode` and `base64decode` template functions
```

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>