### PR TITLE
featurecontrol: log auto-gomemlimit activation at INFO

### DIFF
--- a/featurecontrol/featurecontrol.go
+++ b/featurecontrol/featurecontrol.go
@@ -160,7 +160,7 @@ func NewFlags(logger *slog.Logger, features string) (Flagger, error) {
 			logger.Warn("UTF-8 strict mode enabled")
 		case FeatureAutoGOMEMLIMIT:
 			opts = append(opts, enableAutoGOMEMLIMIT())
-			logger.Warn("Automatically set GOMEMLIMIT to match the Linux container or system memory limit.")
+			logger.Info("Automatically set GOMEMLIMIT to match the Linux container or system memory limit.")
 		case FeatureEventRecorder:
 			opts = append(opts, enableEventRecorder())
 			logger.Warn("Experimental event recorder enabled")


### PR DESCRIPTION
Narrowing #5412 to the one part that isn't a matter of taste.

@TheMeier's point in the issue is fair: whether a warning-heavy start-up log is a problem at all
depends on how you read logs, and I'm not going to argue anyone out of their preference. But the
agreement in that reply — that `auto-gomemlimit` should be promoted — doesn't depend on taste, so
here it is as a one-line change instead of a longer discussion.

`auto-gomemlimit` is how the Go heap learns about a container memory limit. In a memory-limited
container, running *without* it is the worse of the two configurations. Logging its activation at
`WARN` therefore announces the safer choice as a caution, which is backwards regardless of how
loudly you think a log should speak.

#### What this changes

One `switch` branch in `featurecontrol/featurecontrol.go`:

```go
case FeatureAutoGOMEMLIMIT:
	opts = append(opts, enableAutoGOMEMLIMIT())
-	logger.Warn("Automatically set GOMEMLIMIT to match the Linux container or system memory limit.")
+	logger.Info("Automatically set GOMEMLIMIT to match the Linux container or system memory limit.")
```

The message text is unchanged. Each feature has its own branch with its own log call, so this
reaches nothing else — in particular the unbounded-cardinality metrics flags
(`alert-names-in-metrics`, `group-key-in-metrics`) keep `WARN`, which I think is right: their
message carries a real operational cost, so a caution is the correct level for them. The
`Experimental …` messages also keep `WARN`. I've deliberately left the wider question in #5412
alone; if a maintainer wants the same treatment for `utf8-strict-mode`, that's a separate call and
I'm happy to follow up.

#### Verification

`go build`, `go test` and `go vet` on `./featurecontrol/` pass with the change applied (Go 1.25,
matching `go.mod`). `featurecontrol_test.go` asserts the resulting flag state and makes no
assertion about log level, so it neither needed nor received a change — the behaviour under test is
identical.

#### Pull Request Checklist

- Fixes #5412
- Is this a new Receiver integration? No.
- Is this a bugfix? No — a log-level change, no behaviour change to test.
- Is this a new feature? No.
- Does this change affect performance? No.
- Is this a breaking change? No. No cluster message or API surface is touched.
- [x] I have signed-off my commits

#### Which user-facing changes does this PR introduce?

```release-notes
[CHANGE] Log activation of the `auto-gomemlimit` feature flag at INFO instead of WARN. #5412
```
