### PR TITLE
docs: fix traciing typo in tracing config key

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -181,7 +181,7 @@ time_intervals:
 [ event_recorder: <event_recorder_config> ]
 
 # Optional tracing configuration.  Configures distributed tracing for Alertmanager.
-[ traciing: <tracing_config> ]
+[ tracing: <tracing_config> ]
 ```
 
 ## Route-related settings


### PR DESCRIPTION
The top-level tracing configuration key in the config reference is misspelled `traciing` (double i):

```
# Optional tracing configuration.  Configures distributed tracing for Alertmanager.
[ traciing: <tracing_config> ]
```

The actual key is `tracing` — see `config/config.go` (`TracingConfig ... yaml:"tracing,omitempty"`), and the surrounding comment and the `<tracing_config>` type anchor both use `tracing`. A config copied from the docs currently fails to load with an unknown-field error. Fixed the key to `tracing`.

Signed-off-by: latent-9 <296084221+latent-9@users.noreply.github.com>