### PR TITLE
jira: allow disabling label updates via labels.enable_update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main / (unreleased)
 
+* [ENHANCEMENT] jira: Allow disabling label updates on existing issues via `labels.enable_update` (legacy `labels:` list form unchanged).
 * [CHANGE] notify: The `reason` label on `alertmanager_notifications_failed_total` now distinguishes `authError` (HTTP 401/403) and `rateLimited` (HTTP 429) from the generic `clientError`. Dashboards/alerts matching `reason="clientError"` for these codes must be updated.
 * [ENHANCEMENT] notify: The discord and webex integrations now report a failure `reason` on `alertmanager_notifications_failed_total`.
 * [ENHANCEMENT] eventrecorder: Add optional webhook batching.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1921,3 +1921,15 @@ receivers:
 		t.Errorf("expected local proxy_url %q, got %q", "http://local-proxy.example.com:8080", got)
 	}
 }
+
+func TestLoadJiraLegacyLabelsList(t *testing.T) {
+	cfg, err := LoadFile("testdata/conf.jira-legacy-labels.yml")
+	require.NoError(t, err)
+	require.Len(t, cfg.Receivers, 1)
+	require.Len(t, cfg.Receivers[0].JiraConfigs, 1)
+
+	jc := cfg.Receivers[0].JiraConfigs[0]
+	require.Equal(t, []string{"alertmanager", "{{ .CommonLabels.severity }}"}, jc.Labels.Values)
+	require.True(t, jc.Labels.EnableUpdateValue())
+	require.Nil(t, jc.Labels.EnableUpdate)
+}

--- a/config/testdata/conf.jira-legacy-labels.yml
+++ b/config/testdata/conf.jira-legacy-labels.yml
@@ -1,0 +1,15 @@
+global:
+  resolve_timeout: 5m
+  jira_api_url: 'https://jira.example.com'
+
+route:
+  receiver: default
+
+receivers:
+  - name: default
+    jira_configs:
+      - project: OPS
+        issue_type: Bug
+        labels:
+          - alertmanager
+          - '{{ .CommonLabels.severity }}'

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1330,8 +1330,18 @@ project: <string>
 ]
 
 # Labels to be added to the issue.
+# Legacy list form (fully supported; updates replace all labels on existing issues):
 labels:
   [ - <tmpl_string> ... ]
+
+# Or object form (required to set enable_update):
+[ labels:
+    # If set to false, labels are not written when updating an existing issue (create still sets labels).
+    [ enable_update: <boolean> | default = true ]
+    # Label templates (same as the legacy list items).
+    values:
+      [ - <tmpl_string> ... ]
+]
 
 # Priority of the issue.
 [ priority: <tmpl_string> | default = '{{ template "jira.default.priority" . }}' ]
@@ -1365,13 +1375,27 @@ fields:
 [ http_config: <http_config> | default = global.http_config ]
 ```
 
-The `labels` field is a list of labels added to the issue. Template expressions are supported. For example:
+The `labels` field configures labels added to the issue. Template expressions are supported.
+
+Legacy list form (default behavior: create and update both set `fields.labels`, replacing any existing labels on update):
 
 ```yaml
 labels:
   - 'alertmanager'
   - '{{ .CommonLabels.severity }}'
 ```
+
+Object form, for example to leave labels unchanged on update (similar to jiralert):
+
+```yaml
+labels:
+  enable_update: false
+  values:
+    - 'alertmanager'
+    - '{{ .CommonLabels.severity }}'
+```
+
+`enable_update: false` only affects updates (HTTP PUT); create still writes labels including the `ALERT{…}` group-key label. Flags such as `enable_update` require the object form; the legacy list cannot express them.
 
 #### `<jira_field>`
 

--- a/notify/jira/config.go
+++ b/notify/jira/config.go
@@ -43,6 +43,13 @@ type JiraFieldConfig struct {
 	EnableUpdate *bool `yaml:"enable_update,omitempty" json:"enable_update,omitempty"`
 }
 
+// JiraLabelsConfig configures issue labels. Supports legacy YAML list form
+// or an object with enable_update (same pattern as JiraFieldConfig).
+type JiraLabelsConfig struct {
+	Values       []string `yaml:"values,omitempty" json:"values,omitempty"`
+	EnableUpdate *bool    `yaml:"enable_update,omitempty" json:"enable_update,omitempty"`
+}
+
 type JiraConfig struct {
 	amcommoncfg.NotifierConfig `yaml:",inline" json:",inline"`
 	HTTPConfig                 *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
@@ -50,12 +57,12 @@ type JiraConfig struct {
 	APIURL  *amcommoncfg.URL `yaml:"api_url,omitempty" json:"api_url,omitempty"`
 	APIType string           `yaml:"api_type,omitempty" json:"api_type,omitempty"`
 
-	Project     string          `yaml:"project,omitempty" json:"project,omitempty"`
-	Summary     JiraFieldConfig `yaml:"summary,omitempty" json:"summary,omitempty"`
-	Description JiraFieldConfig `yaml:"description,omitempty" json:"description,omitempty"`
-	Labels      []string        `yaml:"labels,omitempty" json:"labels,omitempty"`
-	Priority    string          `yaml:"priority,omitempty" json:"priority,omitempty"`
-	IssueType   string          `yaml:"issue_type,omitempty" json:"issue_type,omitempty"`
+	Project     string           `yaml:"project,omitempty" json:"project,omitempty"`
+	Summary     JiraFieldConfig  `yaml:"summary,omitempty" json:"summary,omitempty"`
+	Description JiraFieldConfig  `yaml:"description,omitempty" json:"description,omitempty"`
+	Labels      JiraLabelsConfig `yaml:"labels,omitempty" json:"labels,omitempty"`
+	Priority    string           `yaml:"priority,omitempty" json:"priority,omitempty"`
+	IssueType   string           `yaml:"issue_type,omitempty" json:"issue_type,omitempty"`
 
 	ReopenTransition  string         `yaml:"reopen_transition,omitempty" json:"reopen_transition,omitempty"`
 	ResolveTransition string         `yaml:"resolve_transition,omitempty" json:"resolve_transition,omitempty"`
@@ -70,6 +77,26 @@ func (f *JiraFieldConfig) EnableUpdateValue() bool {
 		return true
 	}
 	return *f.EnableUpdate
+}
+
+func (l *JiraLabelsConfig) EnableUpdateValue() bool {
+	if l.EnableUpdate == nil {
+		return true
+	}
+	return *l.EnableUpdate
+}
+
+// Supports both the legacy list and the new object form.
+func (l *JiraLabelsConfig) UnmarshalYAML(unmarshal func(any) error) error {
+	// Legacy: labels: [ "a", "b" ] → Values (full backward compatibility).
+	var legacy []string
+	if err := unmarshal(&legacy); err == nil {
+		l.Values = legacy
+		return nil
+	}
+	// Object: labels: { enable_update, values: [...] }
+	type plain JiraLabelsConfig
+	return unmarshal((*plain)(l))
 }
 
 // Supports both the legacy string and the new object form.

--- a/notify/jira/jira.go
+++ b/notify/jira/jira.go
@@ -101,7 +101,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	} else {
 		path = "issue/" + existingIssue.Key
 		method = http.MethodPut
-		logger.Debug("updating existing issue", "issue_key", existingIssue.Key, "summary_update_enabled", n.conf.Summary.EnableUpdateValue(), "description_update_enabled", n.conf.Description.EnableUpdateValue())
+		logger.Debug("updating existing issue", "issue_key", existingIssue.Key, "summary_update_enabled", n.conf.Summary.EnableUpdateValue(), "description_update_enabled", n.conf.Description.EnableUpdateValue(), "labels_update_enabled", n.conf.Labels.EnableUpdateValue())
 	}
 
 	requestBody, err := n.prepareIssueRequestBody(ctx, logger, key.Hash(), tmplTextFunc)
@@ -115,6 +115,9 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		}
 		if !n.conf.Summary.EnableUpdateValue() {
 			requestBody.Fields.Summary = nil
+		}
+		if !n.conf.Labels.EnableUpdateValue() {
+			requestBody.Fields.Labels = nil
 		}
 	}
 
@@ -158,7 +161,7 @@ func (n *Notifier) prepareIssueRequestBody(_ context.Context, logger *slog.Logge
 		Project:   &issueProject{Key: project},
 		Issuetype: &idNameValue{Name: issueType},
 		Summary:   &summary,
-		Labels:    make([]string, 0, len(n.conf.Labels)+1),
+		Labels:    make([]string, 0, len(n.conf.Labels.Values)+1),
 		Fields:    fieldsWithStringKeys,
 	}}
 
@@ -192,7 +195,7 @@ func (n *Notifier) prepareIssueRequestBody(_ context.Context, logger *slog.Logge
 
 	requestBody.Fields.Description = description
 
-	for i, label := range n.conf.Labels {
+	for i, label := range n.conf.Labels.Values {
 		label, err = tmplTextFunc(label)
 		if err != nil {
 			return issue{}, fmt.Errorf("labels[%d] template: %w", i, err)

--- a/notify/jira/jira_test.go
+++ b/notify/jira/jira_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
 
 	amcommoncfg "github.com/prometheus/alertmanager/config/common"
 
@@ -497,7 +498,7 @@ func TestJiraNotify(t *testing.T) {
 				IssueType:         "Incident",
 				Project:           "OPS",
 				Priority:          `{{ template "jira.default.priority" . }}`,
-				Labels:            []string{"alertmanager", "{{ .GroupLabels.alertname }}"},
+				Labels:            JiraLabelsConfig{Values: []string{"alertmanager", "{{ .GroupLabels.alertname }}"}},
 				ReopenDuration:    model.Duration(1 * time.Hour),
 				ReopenTransition:  "REOPEN",
 				ResolveTransition: "CLOSE",
@@ -532,6 +533,54 @@ func TestJiraNotify(t *testing.T) {
 			errMsg:             "",
 		},
 		{
+			title: "create new issue with disabled labels still sets labels",
+			cfg: &JiraConfig{
+				Summary:     JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
+				Description: JiraFieldConfig{Template: `{{ template "jira.default.description" . }}`},
+				IssueType:   "Incident",
+				Project:     "OPS",
+				Priority:    `{{ template "jira.default.priority" . }}`,
+				Labels: JiraLabelsConfig{
+					Values:       []string{"alertmanager", "{{ .GroupLabels.alertname }}"},
+					EnableUpdate: boolPtr(false),
+				},
+				ReopenDuration:    model.Duration(1 * time.Hour),
+				ReopenTransition:  "REOPEN",
+				ResolveTransition: "CLOSE",
+				WontFixResolution: "WONTFIX",
+			},
+			alert: &types.Alert{
+				Alert: model.Alert{
+					Labels: model.LabelSet{
+						"alertname": "test",
+						"instance":  "vm1",
+						"severity":  "critical",
+					},
+					StartsAt: time.Now(),
+					EndsAt:   time.Now().Add(time.Hour),
+				},
+			},
+			searchResponse: issueSearchResult{
+				Issues: []issue{},
+			},
+			issue: issue{
+				Key: "",
+				Fields: &issueFields{
+					Summary:     stringPtr("[FIRING:1] test (vm1 critical)"),
+					Description: jiraStringDescription("\n\n# Alerts Firing:\n\nLabels:\n  - alertname = test\n  - instance = vm1\n  - severity = critical\n\nAnnotations:\n\nSource: \n\n\n\n\n"),
+					Issuetype:   &idNameValue{Name: "Incident"},
+					Labels:      []string{"ALERT{6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b}", "alertmanager", "test"},
+					Project:     &issueProject{Key: "OPS"},
+					Priority:    &idNameValue{Name: "High"},
+				},
+			},
+			customFieldAssetFn: func(t *testing.T, issue map[string]any) {
+				_, hasLabels := issue["labels"]
+				require.True(t, hasLabels, "labels must be present on create even when enable_update is false")
+			},
+			errMsg: "",
+		},
+		{
 			title: "update existing issue with disabled summary and description",
 			cfg: &JiraConfig{
 				Summary: JiraFieldConfig{
@@ -545,7 +594,7 @@ func TestJiraNotify(t *testing.T) {
 				IssueType:         "{{ .CommonLabels.issue_type }}",
 				Project:           "{{ .CommonLabels.project }}",
 				Priority:          `{{ template "jira.default.priority" . }}`,
-				Labels:            []string{"alertmanager", "{{ .GroupLabels.alertname }}"},
+				Labels:            JiraLabelsConfig{Values: []string{"alertmanager", "{{ .GroupLabels.alertname }}"}},
 				ReopenDuration:    model.Duration(1 * time.Hour),
 				ReopenTransition:  "REOPEN",
 				ResolveTransition: "CLOSE",
@@ -603,6 +652,72 @@ func TestJiraNotify(t *testing.T) {
 			errMsg: "",
 		},
 		{
+			title: "update existing issue with disabled labels",
+			cfg: &JiraConfig{
+				Summary:     JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
+				Description: JiraFieldConfig{Template: `{{ template "jira.default.description" . }}`},
+				IssueType:   "{{ .CommonLabels.issue_type }}",
+				Project:     "{{ .CommonLabels.project }}",
+				Priority:    `{{ template "jira.default.priority" . }}`,
+				Labels: JiraLabelsConfig{
+					Values:       []string{"alertmanager", "{{ .GroupLabels.alertname }}"},
+					EnableUpdate: boolPtr(false),
+				},
+				ReopenDuration:    model.Duration(1 * time.Hour),
+				ReopenTransition:  "REOPEN",
+				ResolveTransition: "CLOSE",
+				WontFixResolution: "WONTFIX",
+			},
+			alert: &types.Alert{
+				Alert: model.Alert{
+					Labels: model.LabelSet{
+						"alertname":  "test",
+						"instance":   "vm1",
+						"severity":   "critical",
+						"project":    "MONITORING",
+						"issue_type": "MINOR",
+					},
+					StartsAt: time.Now(),
+					EndsAt:   time.Now().Add(time.Hour),
+				},
+			},
+			searchResponse: issueSearchResult{
+				Issues: []issue{
+					{
+						Key: "MONITORING-1",
+						Fields: &issueFields{
+							Summary:     stringPtr("Original Summary"),
+							Description: jiraStringDescription("Original Description"),
+							Status: &issueStatus{
+								Name: "Open",
+								StatusCategory: struct {
+									Key string `json:"key"`
+								}{
+									Key: "open",
+								},
+							},
+						},
+					},
+				},
+			},
+			issue: issue{
+				Key: "MONITORING-1",
+				Fields: &issueFields{
+					Summary:     stringPtr("[FIRING:1] test (vm1 critical MONITORING MINOR)"),
+					Description: jiraStringDescription("\n\n# Alerts Firing:\n\nLabels:\n  - alertname = test\n  - instance = vm1\n  - issue_type = MINOR\n  - project = MONITORING\n  - severity = critical\n\nAnnotations:\n\nSource: \n\n\n\n\n"),
+					Issuetype:   &idNameValue{Name: "MINOR"},
+					Labels:      nil,
+					Project:     &issueProject{Key: "MONITORING"},
+					Priority:    &idNameValue{Name: "High"},
+				},
+			},
+			customFieldAssetFn: func(t *testing.T, issue map[string]any) {
+				_, hasLabels := issue["labels"]
+				require.False(t, hasLabels, "labels should not be present in update request")
+			},
+			errMsg: "",
+		},
+		{
 			title: "create new issue with template project and issue type",
 			cfg: &JiraConfig{
 				Summary:           JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
@@ -610,7 +725,7 @@ func TestJiraNotify(t *testing.T) {
 				IssueType:         "{{ .CommonLabels.issue_type }}",
 				Project:           "{{ .CommonLabels.project }}",
 				Priority:          `{{ template "jira.default.priority" . }}`,
-				Labels:            []string{"alertmanager", "{{ .GroupLabels.alertname }}"},
+				Labels:            JiraLabelsConfig{Values: []string{"alertmanager", "{{ .GroupLabels.alertname }}"}},
 				ReopenDuration:    model.Duration(1 * time.Hour),
 				ReopenTransition:  "REOPEN",
 				ResolveTransition: "CLOSE",
@@ -654,7 +769,7 @@ func TestJiraNotify(t *testing.T) {
 				IssueType:   "Incident",
 				Project:     "OPS",
 				Priority:    `{{ template "jira.default.priority" . }}`,
-				Labels:      []string{"alertmanager", "{{ .GroupLabels.alertname }}"},
+				Labels:      JiraLabelsConfig{Values: []string{"alertmanager", "{{ .GroupLabels.alertname }}"}},
 				Fields: map[string]any{
 					"components":        map[any]any{"name": "Monitoring"},
 					"customfield_10001": "value",
@@ -719,7 +834,7 @@ func TestJiraNotify(t *testing.T) {
 				IssueType:         "Incident",
 				Project:           "OPS",
 				Priority:          `{{ template "jira.default.priority" . }}`,
-				Labels:            []string{"alertmanager", "{{ .GroupLabels.alertname }}"},
+				Labels:            JiraLabelsConfig{Values: []string{"alertmanager", "{{ .GroupLabels.alertname }}"}},
 				ReopenDuration:    model.Duration(1 * time.Hour),
 				ReopenTransition:  "REOPEN",
 				ResolveTransition: "CLOSE",
@@ -774,7 +889,7 @@ func TestJiraNotify(t *testing.T) {
 				IssueType:         "Incident",
 				Project:           "OPS",
 				Priority:          `{{ template "jira.default.priority" . }}`,
-				Labels:            []string{"alertmanager", "{{ .GroupLabels.alertname }}"},
+				Labels:            JiraLabelsConfig{Values: []string{"alertmanager", "{{ .GroupLabels.alertname }}"}},
 				ReopenDuration:    model.Duration(1 * time.Hour),
 				ReopenTransition:  "REOPEN",
 				ResolveTransition: "CLOSE",
@@ -828,7 +943,7 @@ func TestJiraNotify(t *testing.T) {
 				IssueType:         "Incident",
 				Project:           "OPS",
 				Priority:          `{{ template "jira.default.priority" . }}`,
-				Labels:            []string{"alertmanager", "{{ .GroupLabels.alertname }}"},
+				Labels:            JiraLabelsConfig{Values: []string{"alertmanager", "{{ .GroupLabels.alertname }}"}},
 				ReopenDuration:    model.Duration(1 * time.Hour),
 				ReopenTransition:  "REOPEN",
 				ResolveTransition: "CLOSE",
@@ -1281,7 +1396,7 @@ func TestPrepareIssueRequestBodyAPIv3DescriptionValidation(t *testing.T) {
 				Description: JiraFieldConfig{Template: tc.descriptionTemplate},
 				IssueType:   "Incident",
 				Project:     "OPS",
-				Labels:      []string{"alertmanager"},
+				Labels:      JiraLabelsConfig{Values: []string{"alertmanager"}},
 				Priority:    `{{ template "jira.default.priority" . }}`,
 				APIURL: &amcommoncfg.URL{
 					URL: &url.URL{
@@ -1337,4 +1452,68 @@ func TestPrepareIssueRequestBodyAPIv3DescriptionValidation(t *testing.T) {
 			require.JSONEq(t, tc.descriptionTemplate, string(issue.Fields.Description.RawJSONDescription))
 		})
 	}
+}
+
+func TestJiraLabelsConfigUnmarshalYAML(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name                string
+		yaml                string
+		wantValues          []string
+		wantEnableUpdate    bool
+		wantEnableUpdateNil bool
+	}{
+		{
+			name:             "legacy list",
+			yaml:             "labels: [a, b]\n",
+			wantValues:       []string{"a", "b"},
+			wantEnableUpdate: true,
+		},
+		{
+			name:             "legacy flow list",
+			yaml:             "labels: ['x']\n",
+			wantValues:       []string{"x"},
+			wantEnableUpdate: true,
+		},
+		{
+			name:             "object values only",
+			yaml:             "labels:\n  values: [a]\n",
+			wantValues:       []string{"a"},
+			wantEnableUpdate: true,
+		},
+		{
+			name:             "object enable_update false",
+			yaml:             "labels:\n  enable_update: false\n  values: [a]\n",
+			wantValues:       []string{"a"},
+			wantEnableUpdate: false,
+		},
+		{
+			name:             "object enable_update true",
+			yaml:             "labels:\n  enable_update: true\n  values: [a]\n",
+			wantValues:       []string{"a"},
+			wantEnableUpdate: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var cfg struct {
+				Labels JiraLabelsConfig `yaml:"labels"`
+			}
+			err := yaml.Unmarshal([]byte(tc.yaml), &cfg)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantValues, cfg.Labels.Values)
+			require.Equal(t, tc.wantEnableUpdate, cfg.Labels.EnableUpdateValue())
+			if tc.wantEnableUpdateNil {
+				require.Nil(t, cfg.Labels.EnableUpdate)
+			}
+		})
+	}
+
+	t.Run("omit labels key", func(t *testing.T) {
+		var cfg JiraConfig
+		err := yaml.Unmarshal([]byte("project: OPS\nissue_type: Bug\n"), &cfg)
+		require.NoError(t, err)
+		require.Empty(t, cfg.Labels.Values)
+		require.True(t, cfg.Labels.EnableUpdateValue())
+		require.Nil(t, cfg.Labels.EnableUpdate)
+	})
 }


### PR DESCRIPTION
## What changed
- notify/jira/config.go: JiraLabelsConfig gains EnableUpdate *bool and Values []string;
  a custom UnmarshalYAML accepts both the legacy labels: [a, b] list and a new object
  form labels: { enable_update: false, values: [...] }. EnableUpdateValue() defaults
  to true when unset (matches the enable_update pattern already used for
  summary/description in #4621).
- notify/jira/jira.go: on issue update (HTTP PUT), if enable_update resolves to false,
  Fields.Labels is set to nil (not an empty slice) so the JSON labels key is omitted
  entirely - manually added / automation-added Jira labels are left untouched. Issue
  creation (POST) is unaffected and always sets labels.
- Docs (docs/configuration.md) and CHANGELOG.md updated.

## Why
Every notifier PUT today fully replaces fields.labels, silently wiping labels added by
a human or by Jira automation after issue creation - a known migration issue coming
from jiralert (which never updated labels post-create). This mirrors the existing
enable_update pattern for summary/description (#4621) rather than inventing a new
mechanism.

## Backward compatibility
The legacy labels: [a, b] YAML list keeps working unchanged - enable_update defaults
to true, so existing configs see identical behavior (labels are still replaced on
every update, as before). Only configs that opt into the new object form and
explicitly set enable_update: false see a behavior change.

## Testing
- Unit tests: go test ./notify/jira/ ./config/ -count=1 - new/updated cases cover:
  legacy list unmarshal, object-form unmarshal (both flag values), create always sets
  labels, update with enable_update true (labels replaced) and false (labels omitted
  from the request body).
- Config loading: amtool check-config against a new fixture using the legacy labels
  list form - confirms no regression in config parsing for existing users.
- Manual end-to-end testing against a private Jira Data Center instance: created an
  issue, manually added a label unrelated to the Alertmanager config, then triggered
  an update. With enable_update unset (legacy default), the manually added label was
  removed (expected baseline, matches current released behavior). With
  enable_update: false, the manually added label survived the update.

#### Pull Request Checklist
Please check all the applicable boxes.

- Please list all open issue(s) discussed with maintainers related to this change
    - Related to #4621, #4297
- Is this a new Receiver integration?
    - [ ] N/A - existing jira_configs receiver, not a new receiver type
- Is this a bugfix?
    - [ ] N/A - this is not a bugfix
- Is this a new feature?
    - [x] I have added tests that test the new feature's functionality
- Does this change affect performance?
    - [ ] N/A - no performance-sensitive path touched
- Is this a breaking change?
    - [x] My changes do not break the existing cluster messages
    - [x] My changes do not break the existing api
- [x] I have added/updated the required documentation
- [x] I have signed-off my commits
- [x] I will follow best practices for contributing to this project

#### Which user-facing changes does this PR introduce?
```release-notes
[ENHANCEMENT] jira: Allow disabling label updates on existing issues via labels.enable_update (legacy labels list unchanged).
```
