### PR TITLE
jira: add labels.update_mode replace|merge for label updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main / (unreleased)
 
 * [ENHANCEMENT] jira: Allow disabling label updates on existing issues via `labels.enable_update` (legacy `labels:` list form unchanged).
+* [ENHANCEMENT] jira: Add `labels.update_mode` (`replace`|`merge`) so label updates on existing issues can add configured labels without removing manually or automation-added ones.
 * [CHANGE] notify: The `reason` label on `alertmanager_notifications_failed_total` now distinguishes `authError` (HTTP 401/403) and `rateLimited` (HTTP 429) from the generic `clientError`. Dashboards/alerts matching `reason="clientError"` for these codes must be updated.
 * [ENHANCEMENT] notify: The discord and webex integrations now report a failure `reason` on `alertmanager_notifications_failed_total`.
 * [ENHANCEMENT] eventrecorder: Add optional webhook batching.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## main / (unreleased)
 
+* [ENHANCEMENT] jira: Allow disabling label updates on existing issues via `labels.enable_update` (legacy `labels:` list form unchanged).
 * [CHANGE] notify: The `reason` label on `alertmanager_notifications_failed_total` now distinguishes `authError` (HTTP 401/403) and `rateLimited` (HTTP 429) from the generic `clientError`. Dashboards/alerts matching `reason="clientError"` for these codes must be updated.
 * [ENHANCEMENT] notify: The discord and webex integrations now report a failure `reason` on `alertmanager_notifications_failed_total`.
 * [ENHANCEMENT] eventrecorder: Add optional webhook batching.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1921,3 +1921,15 @@ receivers:
 		t.Errorf("expected local proxy_url %q, got %q", "http://local-proxy.example.com:8080", got)
 	}
 }
+
+func TestLoadJiraLegacyLabelsList(t *testing.T) {
+	cfg, err := LoadFile("testdata/conf.jira-legacy-labels.yml")
+	require.NoError(t, err)
+	require.Len(t, cfg.Receivers, 1)
+	require.Len(t, cfg.Receivers[0].JiraConfigs, 1)
+
+	jc := cfg.Receivers[0].JiraConfigs[0]
+	require.Equal(t, []string{"alertmanager", "{{ .CommonLabels.severity }}"}, jc.Labels.Values)
+	require.True(t, jc.Labels.EnableUpdateValue())
+	require.Nil(t, jc.Labels.EnableUpdate)
+}

--- a/config/testdata/conf.jira-legacy-labels.yml
+++ b/config/testdata/conf.jira-legacy-labels.yml
@@ -1,0 +1,15 @@
+global:
+  resolve_timeout: 5m
+  jira_api_url: 'https://jira.example.com'
+
+route:
+  receiver: default
+
+receivers:
+  - name: default
+    jira_configs:
+      - project: OPS
+        issue_type: Bug
+        labels:
+          - alertmanager
+          - '{{ .CommonLabels.severity }}'

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1338,6 +1338,11 @@ labels:
 [ labels:
     # If set to false, labels are not written when updating an existing issue (create still sets labels).
     [ enable_update: <boolean> | default = true ]
+    # Controls how labels are written when updating an existing issue: "replace"
+    # overwrites all labels (default, matches legacy behavior); "merge" only adds
+    # the configured labels via Jira's update.labels operations, never removing
+    # existing labels. Ignored (labels are skipped) if enable_update is false.
+    [ update_mode: <string> | default = "replace" ]
     # Label templates (same as the legacy list items).
     values:
       [ - <tmpl_string> ... ]
@@ -1395,7 +1400,19 @@ labels:
     - '{{ .CommonLabels.severity }}'
 ```
 
-`enable_update: false` only affects updates (HTTP PUT); create still writes labels including the `ALERT{…}` group-key label. Flags such as `enable_update` require the object form; the legacy list cannot express them.
+`enable_update: false` only affects updates (HTTP PUT); create still writes labels including the `ALERT{…}` group-key label. Flags such as `enable_update` and `update_mode` require the object form; the legacy list cannot express them.
+
+Object form with `update_mode: merge`, to add the configured labels to an existing issue without removing any labels added manually or by Jira automation:
+
+```yaml
+labels:
+  update_mode: merge
+  values:
+    - 'alertmanager'
+    - '{{ .CommonLabels.severity }}'
+```
+
+`update_mode: merge` sends the configured labels as `update.labels` add operations instead of replacing `fields.labels`, so labels never present in the Alertmanager config are preserved across updates. `update_mode: replace` (the default) keeps the existing overwrite behavior. `update_mode` only affects updates; create always sets `fields.labels` directly regardless of `update_mode`. If both `enable_update: false` and `update_mode: merge` are set, `enable_update: false` wins: labels are skipped entirely on update, not merged.
 
 #### `<jira_field>`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1330,8 +1330,18 @@ project: <string>
 ]
 
 # Labels to be added to the issue.
+# Legacy list form (fully supported; updates replace all labels on existing issues):
 labels:
   [ - <tmpl_string> ... ]
+
+# Or object form (required to set enable_update):
+[ labels:
+    # If set to false, labels are not written when updating an existing issue (create still sets labels).
+    [ enable_update: <boolean> | default = true ]
+    # Label templates (same as the legacy list items).
+    values:
+      [ - <tmpl_string> ... ]
+]
 
 # Priority of the issue.
 [ priority: <tmpl_string> | default = '{{ template "jira.default.priority" . }}' ]
@@ -1365,13 +1375,27 @@ fields:
 [ http_config: <http_config> | default = global.http_config ]
 ```
 
-The `labels` field is a list of labels added to the issue. Template expressions are supported. For example:
+The `labels` field configures labels added to the issue. Template expressions are supported.
+
+Legacy list form (default behavior: create and update both set `fields.labels`, replacing any existing labels on update):
 
 ```yaml
 labels:
   - 'alertmanager'
   - '{{ .CommonLabels.severity }}'
 ```
+
+Object form, for example to leave labels unchanged on update (similar to jiralert):
+
+```yaml
+labels:
+  enable_update: false
+  values:
+    - 'alertmanager'
+    - '{{ .CommonLabels.severity }}'
+```
+
+`enable_update: false` only affects updates (HTTP PUT); create still writes labels including the `ALERT{…}` group-key label. Flags such as `enable_update` require the object form; the legacy list cannot express them.
 
 #### `<jira_field>`
 

--- a/notify/jira/config.go
+++ b/notify/jira/config.go
@@ -43,11 +43,28 @@ type JiraFieldConfig struct {
 	EnableUpdate *bool `yaml:"enable_update,omitempty" json:"enable_update,omitempty"`
 }
 
+// JiraLabelUpdateMode controls how labels are written when updating an
+// existing issue.
+type JiraLabelUpdateMode string
+
+const (
+	// JiraLabelUpdateReplace overwrites fields.labels with the configured
+	// values (default, matches historic behavior).
+	JiraLabelUpdateReplace JiraLabelUpdateMode = "replace"
+	// JiraLabelUpdateMerge appends the configured values via Jira's
+	// update.labels add operations, never removing existing labels.
+	JiraLabelUpdateMerge JiraLabelUpdateMode = "merge"
+)
+
 // JiraLabelsConfig configures issue labels. Supports legacy YAML list form
 // or an object with enable_update (same pattern as JiraFieldConfig).
 type JiraLabelsConfig struct {
 	Values       []string `yaml:"values,omitempty" json:"values,omitempty"`
 	EnableUpdate *bool    `yaml:"enable_update,omitempty" json:"enable_update,omitempty"`
+	// UpdateMode controls how labels are updated on an existing issue: replace
+	// (default, overwrites fields.labels) or merge (add-only, never removes
+	// labels). Ignored when EnableUpdate is false.
+	UpdateMode JiraLabelUpdateMode `yaml:"update_mode,omitempty" json:"update_mode,omitempty"`
 }
 
 type JiraConfig struct {
@@ -86,6 +103,15 @@ func (l *JiraLabelsConfig) EnableUpdateValue() bool {
 	return *l.EnableUpdate
 }
 
+// UpdateModeValue returns the effective label update mode, defaulting to
+// replace when unset.
+func (l *JiraLabelsConfig) UpdateModeValue() JiraLabelUpdateMode {
+	if l.UpdateMode == "" {
+		return JiraLabelUpdateReplace
+	}
+	return l.UpdateMode
+}
+
 // Supports both the legacy list and the new object form.
 func (l *JiraLabelsConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	// Legacy: labels: [ "a", "b" ] → Values (full backward compatibility).
@@ -94,9 +120,15 @@ func (l *JiraLabelsConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		l.Values = legacy
 		return nil
 	}
-	// Object: labels: { enable_update, values: [...] }
+	// Object: labels: { enable_update, update_mode, values: [...] }
 	type plain JiraLabelsConfig
-	return unmarshal((*plain)(l))
+	if err := unmarshal((*plain)(l)); err != nil {
+		return err
+	}
+	if l.UpdateMode != "" && l.UpdateMode != JiraLabelUpdateReplace && l.UpdateMode != JiraLabelUpdateMerge {
+		return errors.New("unknown labels.update_mode, must be replace or merge")
+	}
+	return nil
 }
 
 // Supports both the legacy string and the new object form.

--- a/notify/jira/config.go
+++ b/notify/jira/config.go
@@ -43,6 +43,13 @@ type JiraFieldConfig struct {
 	EnableUpdate *bool `yaml:"enable_update,omitempty" json:"enable_update,omitempty"`
 }
 
+// JiraLabelsConfig configures issue labels. Supports legacy YAML list form
+// or an object with enable_update (same pattern as JiraFieldConfig).
+type JiraLabelsConfig struct {
+	Values       []string `yaml:"values,omitempty" json:"values,omitempty"`
+	EnableUpdate *bool    `yaml:"enable_update,omitempty" json:"enable_update,omitempty"`
+}
+
 type JiraConfig struct {
 	amcommoncfg.NotifierConfig `yaml:",inline" json:",inline"`
 	HTTPConfig                 *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
@@ -50,12 +57,12 @@ type JiraConfig struct {
 	APIURL  *amcommoncfg.URL `yaml:"api_url,omitempty" json:"api_url,omitempty"`
 	APIType string           `yaml:"api_type,omitempty" json:"api_type,omitempty"`
 
-	Project     string          `yaml:"project,omitempty" json:"project,omitempty"`
-	Summary     JiraFieldConfig `yaml:"summary,omitempty" json:"summary,omitempty"`
-	Description JiraFieldConfig `yaml:"description,omitempty" json:"description,omitempty"`
-	Labels      []string        `yaml:"labels,omitempty" json:"labels,omitempty"`
-	Priority    string          `yaml:"priority,omitempty" json:"priority,omitempty"`
-	IssueType   string          `yaml:"issue_type,omitempty" json:"issue_type,omitempty"`
+	Project     string           `yaml:"project,omitempty" json:"project,omitempty"`
+	Summary     JiraFieldConfig  `yaml:"summary,omitempty" json:"summary,omitempty"`
+	Description JiraFieldConfig  `yaml:"description,omitempty" json:"description,omitempty"`
+	Labels      JiraLabelsConfig `yaml:"labels,omitempty" json:"labels,omitempty"`
+	Priority    string           `yaml:"priority,omitempty" json:"priority,omitempty"`
+	IssueType   string           `yaml:"issue_type,omitempty" json:"issue_type,omitempty"`
 
 	ReopenTransition  string         `yaml:"reopen_transition,omitempty" json:"reopen_transition,omitempty"`
 	ResolveTransition string         `yaml:"resolve_transition,omitempty" json:"resolve_transition,omitempty"`
@@ -70,6 +77,26 @@ func (f *JiraFieldConfig) EnableUpdateValue() bool {
 		return true
 	}
 	return *f.EnableUpdate
+}
+
+func (l *JiraLabelsConfig) EnableUpdateValue() bool {
+	if l.EnableUpdate == nil {
+		return true
+	}
+	return *l.EnableUpdate
+}
+
+// Supports both the legacy list and the new object form.
+func (l *JiraLabelsConfig) UnmarshalYAML(unmarshal func(any) error) error {
+	// Legacy: labels: [ "a", "b" ] → Values (full backward compatibility).
+	var legacy []string
+	if err := unmarshal(&legacy); err == nil {
+		l.Values = legacy
+		return nil
+	}
+	// Object: labels: { enable_update, values: [...] }
+	type plain JiraLabelsConfig
+	return unmarshal((*plain)(l))
 }
 
 // Supports both the legacy string and the new object form.

--- a/notify/jira/config.go
+++ b/notify/jira/config.go
@@ -112,7 +112,7 @@ func (l *JiraLabelsConfig) UpdateModeValue() JiraLabelUpdateMode {
 	return l.UpdateMode
 }
 
-// Supports both the legacy list and the new object form.
+// UnmarshalYAML supports both the legacy list form and the new object form.
 func (l *JiraLabelsConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	// Legacy: labels: [ "a", "b" ] → Values (full backward compatibility).
 	var legacy []string

--- a/notify/jira/jira.go
+++ b/notify/jira/jira.go
@@ -101,7 +101,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	} else {
 		path = "issue/" + existingIssue.Key
 		method = http.MethodPut
-		logger.Debug("updating existing issue", "issue_key", existingIssue.Key, "summary_update_enabled", n.conf.Summary.EnableUpdateValue(), "description_update_enabled", n.conf.Description.EnableUpdateValue(), "labels_update_enabled", n.conf.Labels.EnableUpdateValue())
+		logger.Debug("updating existing issue", "issue_key", existingIssue.Key, "summary_update_enabled", n.conf.Summary.EnableUpdateValue(), "description_update_enabled", n.conf.Description.EnableUpdateValue(), "labels_update_enabled", n.conf.Labels.EnableUpdateValue(), "labels_update_mode", string(n.conf.Labels.UpdateModeValue()))
 	}
 
 	requestBody, err := n.prepareIssueRequestBody(ctx, logger, key.Hash(), tmplTextFunc)
@@ -117,7 +117,20 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 			requestBody.Fields.Summary = nil
 		}
 		if !n.conf.Labels.EnableUpdateValue() {
+			// enable_update: false always wins over update_mode: labels are
+			// skipped entirely, never merged.
 			requestBody.Fields.Labels = nil
+		} else if n.conf.Labels.UpdateModeValue() == JiraLabelUpdateMerge {
+			// Move labels out of fields.labels (which would replace them)
+			// into update.labels add-operations, so existing labels
+			// (manually or automation-added) are preserved.
+			labels := requestBody.Fields.Labels
+			requestBody.Fields.Labels = nil
+			ops := make([]labelOp, 0, len(labels))
+			for _, l := range labels {
+				ops = append(ops, labelOp{Add: l})
+			}
+			requestBody.Update = &issueUpdate{Labels: ops}
 		}
 	}
 

--- a/notify/jira/jira.go
+++ b/notify/jira/jira.go
@@ -101,7 +101,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	} else {
 		path = "issue/" + existingIssue.Key
 		method = http.MethodPut
-		logger.Debug("updating existing issue", "issue_key", existingIssue.Key, "summary_update_enabled", n.conf.Summary.EnableUpdateValue(), "description_update_enabled", n.conf.Description.EnableUpdateValue())
+		logger.Debug("updating existing issue", "issue_key", existingIssue.Key, "summary_update_enabled", n.conf.Summary.EnableUpdateValue(), "description_update_enabled", n.conf.Description.EnableUpdateValue(), "labels_update_enabled", n.conf.Labels.EnableUpdateValue())
 	}
 
 	requestBody, err := n.prepareIssueRequestBody(ctx, logger, key.Hash(), tmplTextFunc)
@@ -115,6 +115,9 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 		}
 		if !n.conf.Summary.EnableUpdateValue() {
 			requestBody.Fields.Summary = nil
+		}
+		if !n.conf.Labels.EnableUpdateValue() {
+			requestBody.Fields.Labels = nil
 		}
 	}
 
@@ -158,7 +161,7 @@ func (n *Notifier) prepareIssueRequestBody(_ context.Context, logger *slog.Logge
 		Project:   &issueProject{Key: project},
 		Issuetype: &idNameValue{Name: issueType},
 		Summary:   &summary,
-		Labels:    make([]string, 0, len(n.conf.Labels)+1),
+		Labels:    make([]string, 0, len(n.conf.Labels.Values)+1),
 		Fields:    fieldsWithStringKeys,
 	}}
 
@@ -192,7 +195,7 @@ func (n *Notifier) prepareIssueRequestBody(_ context.Context, logger *slog.Logge
 
 	requestBody.Fields.Description = description
 
-	for i, label := range n.conf.Labels {
+	for i, label := range n.conf.Labels.Values {
 		label, err = tmplTextFunc(label)
 		if err != nil {
 			return issue{}, fmt.Errorf("labels[%d] template: %w", i, err)

--- a/notify/jira/jira_test.go
+++ b/notify/jira/jira_test.go
@@ -1714,13 +1714,12 @@ func TestPrepareIssueRequestBodyAPIv3DescriptionValidation(t *testing.T) {
 func TestJiraLabelsConfigUnmarshalYAML(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
-		name                string
-		yaml                string
-		wantValues          []string
-		wantEnableUpdate    bool
-		wantEnableUpdateNil bool
-		wantUpdateMode      JiraLabelUpdateMode
-		wantErr             string
+		name             string
+		yaml             string
+		wantValues       []string
+		wantEnableUpdate bool
+		wantUpdateMode   JiraLabelUpdateMode
+		wantErr          string
 	}{
 		{
 			name:             "legacy list",
@@ -1793,9 +1792,6 @@ func TestJiraLabelsConfigUnmarshalYAML(t *testing.T) {
 			require.Equal(t, tc.wantValues, cfg.Labels.Values)
 			require.Equal(t, tc.wantEnableUpdate, cfg.Labels.EnableUpdateValue())
 			require.Equal(t, tc.wantUpdateMode, cfg.Labels.UpdateModeValue())
-			if tc.wantEnableUpdateNil {
-				require.Nil(t, cfg.Labels.EnableUpdate)
-			}
 		})
 	}
 

--- a/notify/jira/jira_test.go
+++ b/notify/jira/jira_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
 
 	amcommoncfg "github.com/prometheus/alertmanager/config/common"
 
@@ -497,7 +498,7 @@ func TestJiraNotify(t *testing.T) {
 				IssueType:         "Incident",
 				Project:           "OPS",
 				Priority:          `{{ template "jira.default.priority" . }}`,
-				Labels:            []string{"alertmanager", "{{ .GroupLabels.alertname }}"},
+				Labels:            JiraLabelsConfig{Values: []string{"alertmanager", "{{ .GroupLabels.alertname }}"}},
 				ReopenDuration:    model.Duration(1 * time.Hour),
 				ReopenTransition:  "REOPEN",
 				ResolveTransition: "CLOSE",
@@ -532,6 +533,54 @@ func TestJiraNotify(t *testing.T) {
 			errMsg:             "",
 		},
 		{
+			title: "create new issue with disabled labels still sets labels",
+			cfg: &JiraConfig{
+				Summary:     JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
+				Description: JiraFieldConfig{Template: `{{ template "jira.default.description" . }}`},
+				IssueType:   "Incident",
+				Project:     "OPS",
+				Priority:    `{{ template "jira.default.priority" . }}`,
+				Labels: JiraLabelsConfig{
+					Values:       []string{"alertmanager", "{{ .GroupLabels.alertname }}"},
+					EnableUpdate: boolPtr(false),
+				},
+				ReopenDuration:    model.Duration(1 * time.Hour),
+				ReopenTransition:  "REOPEN",
+				ResolveTransition: "CLOSE",
+				WontFixResolution: "WONTFIX",
+			},
+			alert: &types.Alert{
+				Alert: model.Alert{
+					Labels: model.LabelSet{
+						"alertname": "test",
+						"instance":  "vm1",
+						"severity":  "critical",
+					},
+					StartsAt: time.Now(),
+					EndsAt:   time.Now().Add(time.Hour),
+				},
+			},
+			searchResponse: issueSearchResult{
+				Issues: []issue{},
+			},
+			issue: issue{
+				Key: "",
+				Fields: &issueFields{
+					Summary:     stringPtr("[FIRING:1] test (vm1 critical)"),
+					Description: jiraStringDescription("\n\n# Alerts Firing:\n\nLabels:\n  - alertname = test\n  - instance = vm1\n  - severity = critical\n\nAnnotations:\n\nSource: \n\n\n\n\n"),
+					Issuetype:   &idNameValue{Name: "Incident"},
+					Labels:      []string{"ALERT{6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b}", "alertmanager", "test"},
+					Project:     &issueProject{Key: "OPS"},
+					Priority:    &idNameValue{Name: "High"},
+				},
+			},
+			customFieldAssetFn: func(t *testing.T, issue map[string]any) {
+				_, hasLabels := issue["labels"]
+				require.True(t, hasLabels, "labels must be present on create even when enable_update is false")
+			},
+			errMsg: "",
+		},
+		{
 			title: "update existing issue with disabled summary and description",
 			cfg: &JiraConfig{
 				Summary: JiraFieldConfig{
@@ -545,7 +594,7 @@ func TestJiraNotify(t *testing.T) {
 				IssueType:         "{{ .CommonLabels.issue_type }}",
 				Project:           "{{ .CommonLabels.project }}",
 				Priority:          `{{ template "jira.default.priority" . }}`,
-				Labels:            []string{"alertmanager", "{{ .GroupLabels.alertname }}"},
+				Labels:            JiraLabelsConfig{Values: []string{"alertmanager", "{{ .GroupLabels.alertname }}"}},
 				ReopenDuration:    model.Duration(1 * time.Hour),
 				ReopenTransition:  "REOPEN",
 				ResolveTransition: "CLOSE",
@@ -603,6 +652,72 @@ func TestJiraNotify(t *testing.T) {
 			errMsg: "",
 		},
 		{
+			title: "update existing issue with disabled labels",
+			cfg: &JiraConfig{
+				Summary:     JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
+				Description: JiraFieldConfig{Template: `{{ template "jira.default.description" . }}`},
+				IssueType:   "{{ .CommonLabels.issue_type }}",
+				Project:     "{{ .CommonLabels.project }}",
+				Priority:    `{{ template "jira.default.priority" . }}`,
+				Labels: JiraLabelsConfig{
+					Values:       []string{"alertmanager", "{{ .GroupLabels.alertname }}"},
+					EnableUpdate: boolPtr(false),
+				},
+				ReopenDuration:    model.Duration(1 * time.Hour),
+				ReopenTransition:  "REOPEN",
+				ResolveTransition: "CLOSE",
+				WontFixResolution: "WONTFIX",
+			},
+			alert: &types.Alert{
+				Alert: model.Alert{
+					Labels: model.LabelSet{
+						"alertname":  "test",
+						"instance":   "vm1",
+						"severity":   "critical",
+						"project":    "MONITORING",
+						"issue_type": "MINOR",
+					},
+					StartsAt: time.Now(),
+					EndsAt:   time.Now().Add(time.Hour),
+				},
+			},
+			searchResponse: issueSearchResult{
+				Issues: []issue{
+					{
+						Key: "MONITORING-1",
+						Fields: &issueFields{
+							Summary:     stringPtr("Original Summary"),
+							Description: jiraStringDescription("Original Description"),
+							Status: &issueStatus{
+								Name: "Open",
+								StatusCategory: struct {
+									Key string `json:"key"`
+								}{
+									Key: "open",
+								},
+							},
+						},
+					},
+				},
+			},
+			issue: issue{
+				Key: "MONITORING-1",
+				Fields: &issueFields{
+					Summary:     stringPtr("[FIRING:1] test (vm1 critical MONITORING MINOR)"),
+					Description: jiraStringDescription("\n\n# Alerts Firing:\n\nLabels:\n  - alertname = test\n  - instance = vm1\n  - issue_type = MINOR\n  - project = MONITORING\n  - severity = critical\n\nAnnotations:\n\nSource: \n\n\n\n\n"),
+					Issuetype:   &idNameValue{Name: "MINOR"},
+					Labels:      nil,
+					Project:     &issueProject{Key: "MONITORING"},
+					Priority:    &idNameValue{Name: "High"},
+				},
+			},
+			customFieldAssetFn: func(t *testing.T, issue map[string]any) {
+				_, hasLabels := issue["labels"]
+				require.False(t, hasLabels, "labels should not be present in update request")
+			},
+			errMsg: "",
+		},
+		{
 			title: "create new issue with template project and issue type",
 			cfg: &JiraConfig{
 				Summary:           JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
@@ -610,7 +725,7 @@ func TestJiraNotify(t *testing.T) {
 				IssueType:         "{{ .CommonLabels.issue_type }}",
 				Project:           "{{ .CommonLabels.project }}",
 				Priority:          `{{ template "jira.default.priority" . }}`,
-				Labels:            []string{"alertmanager", "{{ .GroupLabels.alertname }}"},
+				Labels:            JiraLabelsConfig{Values: []string{"alertmanager", "{{ .GroupLabels.alertname }}"}},
 				ReopenDuration:    model.Duration(1 * time.Hour),
 				ReopenTransition:  "REOPEN",
 				ResolveTransition: "CLOSE",
@@ -654,7 +769,7 @@ func TestJiraNotify(t *testing.T) {
 				IssueType:   "Incident",
 				Project:     "OPS",
 				Priority:    `{{ template "jira.default.priority" . }}`,
-				Labels:      []string{"alertmanager", "{{ .GroupLabels.alertname }}"},
+				Labels:      JiraLabelsConfig{Values: []string{"alertmanager", "{{ .GroupLabels.alertname }}"}},
 				Fields: map[string]any{
 					"components":        map[any]any{"name": "Monitoring"},
 					"customfield_10001": "value",
@@ -719,7 +834,7 @@ func TestJiraNotify(t *testing.T) {
 				IssueType:         "Incident",
 				Project:           "OPS",
 				Priority:          `{{ template "jira.default.priority" . }}`,
-				Labels:            []string{"alertmanager", "{{ .GroupLabels.alertname }}"},
+				Labels:            JiraLabelsConfig{Values: []string{"alertmanager", "{{ .GroupLabels.alertname }}"}},
 				ReopenDuration:    model.Duration(1 * time.Hour),
 				ReopenTransition:  "REOPEN",
 				ResolveTransition: "CLOSE",
@@ -774,7 +889,7 @@ func TestJiraNotify(t *testing.T) {
 				IssueType:         "Incident",
 				Project:           "OPS",
 				Priority:          `{{ template "jira.default.priority" . }}`,
-				Labels:            []string{"alertmanager", "{{ .GroupLabels.alertname }}"},
+				Labels:            JiraLabelsConfig{Values: []string{"alertmanager", "{{ .GroupLabels.alertname }}"}},
 				ReopenDuration:    model.Duration(1 * time.Hour),
 				ReopenTransition:  "REOPEN",
 				ResolveTransition: "CLOSE",
@@ -828,7 +943,7 @@ func TestJiraNotify(t *testing.T) {
 				IssueType:         "Incident",
 				Project:           "OPS",
 				Priority:          `{{ template "jira.default.priority" . }}`,
-				Labels:            []string{"alertmanager", "{{ .GroupLabels.alertname }}"},
+				Labels:            JiraLabelsConfig{Values: []string{"alertmanager", "{{ .GroupLabels.alertname }}"}},
 				ReopenDuration:    model.Duration(1 * time.Hour),
 				ReopenTransition:  "REOPEN",
 				ResolveTransition: "CLOSE",
@@ -1281,7 +1396,7 @@ func TestPrepareIssueRequestBodyAPIv3DescriptionValidation(t *testing.T) {
 				Description: JiraFieldConfig{Template: tc.descriptionTemplate},
 				IssueType:   "Incident",
 				Project:     "OPS",
-				Labels:      []string{"alertmanager"},
+				Labels:      JiraLabelsConfig{Values: []string{"alertmanager"}},
 				Priority:    `{{ template "jira.default.priority" . }}`,
 				APIURL: &amcommoncfg.URL{
 					URL: &url.URL{
@@ -1337,4 +1452,68 @@ func TestPrepareIssueRequestBodyAPIv3DescriptionValidation(t *testing.T) {
 			require.JSONEq(t, tc.descriptionTemplate, string(issue.Fields.Description.RawJSONDescription))
 		})
 	}
+}
+
+func TestJiraLabelsConfigUnmarshalYAML(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name                string
+		yaml                string
+		wantValues          []string
+		wantEnableUpdate    bool
+		wantEnableUpdateNil bool
+	}{
+		{
+			name:             "legacy list",
+			yaml:             "labels: [a, b]\n",
+			wantValues:       []string{"a", "b"},
+			wantEnableUpdate: true,
+		},
+		{
+			name:             "legacy flow list",
+			yaml:             "labels: ['x']\n",
+			wantValues:       []string{"x"},
+			wantEnableUpdate: true,
+		},
+		{
+			name:             "object values only",
+			yaml:             "labels:\n  values: [a]\n",
+			wantValues:       []string{"a"},
+			wantEnableUpdate: true,
+		},
+		{
+			name:             "object enable_update false",
+			yaml:             "labels:\n  enable_update: false\n  values: [a]\n",
+			wantValues:       []string{"a"},
+			wantEnableUpdate: false,
+		},
+		{
+			name:             "object enable_update true",
+			yaml:             "labels:\n  enable_update: true\n  values: [a]\n",
+			wantValues:       []string{"a"},
+			wantEnableUpdate: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var cfg struct {
+				Labels JiraLabelsConfig `yaml:"labels"`
+			}
+			err := yaml.Unmarshal([]byte(tc.yaml), &cfg)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantValues, cfg.Labels.Values)
+			require.Equal(t, tc.wantEnableUpdate, cfg.Labels.EnableUpdateValue())
+			if tc.wantEnableUpdateNil {
+				require.Nil(t, cfg.Labels.EnableUpdate)
+			}
+		})
+	}
+
+	t.Run("omit labels key", func(t *testing.T) {
+		var cfg JiraConfig
+		err := yaml.Unmarshal([]byte("project: OPS\nissue_type: Bug\n"), &cfg)
+		require.NoError(t, err)
+		require.Empty(t, cfg.Labels.Values)
+		require.True(t, cfg.Labels.EnableUpdateValue())
+		require.Nil(t, cfg.Labels.EnableUpdate)
+	})
 }

--- a/notify/jira/jira_test.go
+++ b/notify/jira/jira_test.go
@@ -488,7 +488,10 @@ func TestJiraNotify(t *testing.T) {
 		customFieldAssetFn func(t *testing.T, issue map[string]any)
 		searchResponse     issueSearchResult
 		issue              issue
-		errMsg             string
+		// issueUpdate is the expected update.labels block on an update (PUT)
+		// request; nil for all cases except update_mode: merge scenarios.
+		issueUpdate *issueUpdate
+		errMsg      string
 	}{
 		{
 			title: "create new issue",
@@ -714,6 +717,251 @@ func TestJiraNotify(t *testing.T) {
 			customFieldAssetFn: func(t *testing.T, issue map[string]any) {
 				_, hasLabels := issue["labels"]
 				require.False(t, hasLabels, "labels should not be present in update request")
+			},
+			errMsg: "",
+		},
+		{
+			// B5: update existing issue with update_mode: merge sends
+			// update.labels add-operations instead of replacing fields.labels.
+			title: "update existing issue with update_mode merge",
+			cfg: &JiraConfig{
+				Summary:     JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
+				Description: JiraFieldConfig{Template: `{{ template "jira.default.description" . }}`},
+				IssueType:   "{{ .CommonLabels.issue_type }}",
+				Project:     "{{ .CommonLabels.project }}",
+				Priority:    `{{ template "jira.default.priority" . }}`,
+				Labels: JiraLabelsConfig{
+					Values:     []string{"alertmanager", "{{ .GroupLabels.alertname }}"},
+					UpdateMode: JiraLabelUpdateMerge,
+				},
+				ReopenDuration:    model.Duration(1 * time.Hour),
+				ReopenTransition:  "REOPEN",
+				ResolveTransition: "CLOSE",
+				WontFixResolution: "WONTFIX",
+			},
+			alert: &types.Alert{
+				Alert: model.Alert{
+					Labels: model.LabelSet{
+						"alertname":  "test",
+						"instance":   "vm1",
+						"severity":   "critical",
+						"project":    "MONITORING",
+						"issue_type": "MINOR",
+					},
+					StartsAt: time.Now(),
+					EndsAt:   time.Now().Add(time.Hour),
+				},
+			},
+			searchResponse: issueSearchResult{
+				Issues: []issue{
+					{
+						Key: "MONITORING-1",
+						Fields: &issueFields{
+							Summary:     stringPtr("Original Summary"),
+							Description: jiraStringDescription("Original Description"),
+							Status: &issueStatus{
+								Name: "Open",
+								StatusCategory: struct {
+									Key string `json:"key"`
+								}{
+									Key: "open",
+								},
+							},
+						},
+					},
+				},
+			},
+			issue: issue{
+				Key: "MONITORING-1",
+			},
+			issueUpdate: &issueUpdate{
+				Labels: []labelOp{
+					{Add: "ALERT{6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b}"},
+					{Add: "alertmanager"},
+					{Add: "test"},
+				},
+			},
+			customFieldAssetFn: func(t *testing.T, issue map[string]any) {
+				// C1: labels must NOT be present in fields when merging.
+				_, hasLabels := issue["labels"]
+				require.False(t, hasLabels, "labels should not be present in fields when update_mode is merge")
+			},
+			errMsg: "",
+		},
+		{
+			// B6: enable_update: false wins over update_mode: merge - labels
+			// are skipped entirely, not merged.
+			title: "update existing issue with disabled labels wins over update_mode merge",
+			cfg: &JiraConfig{
+				Summary:     JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
+				Description: JiraFieldConfig{Template: `{{ template "jira.default.description" . }}`},
+				IssueType:   "{{ .CommonLabels.issue_type }}",
+				Project:     "{{ .CommonLabels.project }}",
+				Priority:    `{{ template "jira.default.priority" . }}`,
+				Labels: JiraLabelsConfig{
+					Values:       []string{"alertmanager", "{{ .GroupLabels.alertname }}"},
+					EnableUpdate: boolPtr(false),
+					UpdateMode:   JiraLabelUpdateMerge,
+				},
+				ReopenDuration:    model.Duration(1 * time.Hour),
+				ReopenTransition:  "REOPEN",
+				ResolveTransition: "CLOSE",
+				WontFixResolution: "WONTFIX",
+			},
+			alert: &types.Alert{
+				Alert: model.Alert{
+					Labels: model.LabelSet{
+						"alertname":  "test",
+						"instance":   "vm1",
+						"severity":   "critical",
+						"project":    "MONITORING",
+						"issue_type": "MINOR",
+					},
+					StartsAt: time.Now(),
+					EndsAt:   time.Now().Add(time.Hour),
+				},
+			},
+			searchResponse: issueSearchResult{
+				Issues: []issue{
+					{
+						Key: "MONITORING-1",
+						Fields: &issueFields{
+							Summary:     stringPtr("Original Summary"),
+							Description: jiraStringDescription("Original Description"),
+							Status: &issueStatus{
+								Name: "Open",
+								StatusCategory: struct {
+									Key string `json:"key"`
+								}{
+									Key: "open",
+								},
+							},
+						},
+					},
+				},
+			},
+			issue: issue{
+				Key: "MONITORING-1",
+			},
+			issueUpdate: nil,
+			customFieldAssetFn: func(t *testing.T, issue map[string]any) {
+				// C2: labels must not be present when enable_update is false,
+				// regardless of update_mode.
+				_, hasLabels := issue["labels"]
+				require.False(t, hasLabels, "labels should not be present in fields when enable_update is false")
+			},
+			errMsg: "",
+		},
+		{
+			// B7: update existing issue with update_mode: replace (explicit,
+			// same effective behavior as the default/unset case).
+			title: "update existing issue with update_mode replace",
+			cfg: &JiraConfig{
+				Summary:     JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
+				Description: JiraFieldConfig{Template: `{{ template "jira.default.description" . }}`},
+				IssueType:   "{{ .CommonLabels.issue_type }}",
+				Project:     "{{ .CommonLabels.project }}",
+				Priority:    `{{ template "jira.default.priority" . }}`,
+				Labels: JiraLabelsConfig{
+					Values:     []string{"alertmanager", "{{ .GroupLabels.alertname }}"},
+					UpdateMode: JiraLabelUpdateReplace,
+				},
+				ReopenDuration:    model.Duration(1 * time.Hour),
+				ReopenTransition:  "REOPEN",
+				ResolveTransition: "CLOSE",
+				WontFixResolution: "WONTFIX",
+			},
+			alert: &types.Alert{
+				Alert: model.Alert{
+					Labels: model.LabelSet{
+						"alertname":  "test",
+						"instance":   "vm1",
+						"severity":   "critical",
+						"project":    "MONITORING",
+						"issue_type": "MINOR",
+					},
+					StartsAt: time.Now(),
+					EndsAt:   time.Now().Add(time.Hour),
+				},
+			},
+			searchResponse: issueSearchResult{
+				Issues: []issue{
+					{
+						Key: "MONITORING-1",
+						Fields: &issueFields{
+							Summary:     stringPtr("Original Summary"),
+							Description: jiraStringDescription("Original Description"),
+							Status: &issueStatus{
+								Name: "Open",
+								StatusCategory: struct {
+									Key string `json:"key"`
+								}{
+									Key: "open",
+								},
+							},
+						},
+					},
+				},
+			},
+			issue: issue{
+				Key: "MONITORING-1",
+			},
+			issueUpdate: nil,
+			customFieldAssetFn: func(t *testing.T, issue map[string]any) {
+				// C3: labels ARE present (replaced) when update_mode is
+				// replace, and update.labels is absent.
+				_, hasLabels := issue["labels"]
+				require.True(t, hasLabels, "labels should be present in fields when update_mode is replace")
+			},
+			errMsg: "",
+		},
+		{
+			// B8: create-path is unaffected by update_mode - fields.labels is
+			// always set on create, and update is always nil (no PUT).
+			title: "create new issue with update_mode merge config",
+			cfg: &JiraConfig{
+				Summary:     JiraFieldConfig{Template: `{{ template "jira.default.summary" . }}`},
+				Description: JiraFieldConfig{Template: `{{ template "jira.default.description" . }}`},
+				IssueType:   "Incident",
+				Project:     "OPS",
+				Priority:    `{{ template "jira.default.priority" . }}`,
+				Labels: JiraLabelsConfig{
+					Values:     []string{"alertmanager", "{{ .GroupLabels.alertname }}"},
+					UpdateMode: JiraLabelUpdateMerge,
+				},
+				ReopenDuration:    model.Duration(1 * time.Hour),
+				ReopenTransition:  "REOPEN",
+				ResolveTransition: "CLOSE",
+				WontFixResolution: "WONTFIX",
+			},
+			alert: &types.Alert{
+				Alert: model.Alert{
+					Labels: model.LabelSet{
+						"alertname": "test",
+						"instance":  "vm1",
+						"severity":  "critical",
+					},
+					StartsAt: time.Now(),
+					EndsAt:   time.Now().Add(time.Hour),
+				},
+			},
+			searchResponse: issueSearchResult{
+				Issues: []issue{},
+			},
+			issue: issue{
+				Key: "",
+				Fields: &issueFields{
+					Summary:     stringPtr("[FIRING:1] test (vm1 critical)"),
+					Description: jiraStringDescription("\n\n# Alerts Firing:\n\nLabels:\n  - alertname = test\n  - instance = vm1\n  - severity = critical\n\nAnnotations:\n\nSource: \n\n\n\n\n"),
+					Issuetype:   &idNameValue{Name: "Incident"},
+					Labels:      []string{"ALERT{6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b}", "alertmanager", "test"},
+					Project:     &issueProject{Key: "OPS"},
+					Priority:    &idNameValue{Name: "High"},
+				},
+			},
+			customFieldAssetFn: func(t *testing.T, issue map[string]any) {
+				_, hasLabels := issue["labels"]
+				require.True(t, hasLabels, "labels must be present on create regardless of update_mode")
 			},
 			errMsg: "",
 		},
@@ -1083,6 +1331,15 @@ func TestJiraNotify(t *testing.T) {
 					if err != nil {
 						panic(err)
 					}
+
+					var decoded issue
+					if err := json.Unmarshal(body, &decoded); err != nil {
+						panic(err)
+					}
+					// Only assert the new update.labels block here; existing
+					// per-field checks (labels present/absent, etc.) already
+					// run via customFieldAssetFn below on the raw JSON.
+					require.Equal(t, tc.issueUpdate, decoded.Update)
 
 					var raw map[string]any
 					if err := json.Unmarshal(body, &raw); err != nil {
@@ -1462,36 +1719,65 @@ func TestJiraLabelsConfigUnmarshalYAML(t *testing.T) {
 		wantValues          []string
 		wantEnableUpdate    bool
 		wantEnableUpdateNil bool
+		wantUpdateMode      JiraLabelUpdateMode
+		wantErr             string
 	}{
 		{
 			name:             "legacy list",
 			yaml:             "labels: [a, b]\n",
 			wantValues:       []string{"a", "b"},
 			wantEnableUpdate: true,
+			wantUpdateMode:   JiraLabelUpdateReplace,
 		},
 		{
 			name:             "legacy flow list",
 			yaml:             "labels: ['x']\n",
 			wantValues:       []string{"x"},
 			wantEnableUpdate: true,
+			wantUpdateMode:   JiraLabelUpdateReplace,
 		},
 		{
 			name:             "object values only",
 			yaml:             "labels:\n  values: [a]\n",
 			wantValues:       []string{"a"},
 			wantEnableUpdate: true,
+			wantUpdateMode:   JiraLabelUpdateReplace,
 		},
 		{
 			name:             "object enable_update false",
 			yaml:             "labels:\n  enable_update: false\n  values: [a]\n",
 			wantValues:       []string{"a"},
 			wantEnableUpdate: false,
+			wantUpdateMode:   JiraLabelUpdateReplace,
 		},
 		{
 			name:             "object enable_update true",
 			yaml:             "labels:\n  enable_update: true\n  values: [a]\n",
 			wantValues:       []string{"a"},
 			wantEnableUpdate: true,
+			wantUpdateMode:   JiraLabelUpdateReplace,
+		},
+		{
+			// A7: update_mode: merge is accepted.
+			name:             "object update_mode merge",
+			yaml:             "labels:\n  update_mode: merge\n  values: [a]\n",
+			wantValues:       []string{"a"},
+			wantEnableUpdate: true,
+			wantUpdateMode:   JiraLabelUpdateMerge,
+		},
+		{
+			// A8: update_mode: replace is accepted (same as default).
+			name:             "object update_mode replace",
+			yaml:             "labels:\n  update_mode: replace\n  values: [a]\n",
+			wantValues:       []string{"a"},
+			wantEnableUpdate: true,
+			wantUpdateMode:   JiraLabelUpdateReplace,
+		},
+		{
+			// A9: unknown update_mode is rejected.
+			name:    "object update_mode invalid",
+			yaml:    "labels:\n  update_mode: bogus\n  values: [a]\n",
+			wantErr: "unknown labels.update_mode, must be replace or merge",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1499,9 +1785,14 @@ func TestJiraLabelsConfigUnmarshalYAML(t *testing.T) {
 				Labels JiraLabelsConfig `yaml:"labels"`
 			}
 			err := yaml.Unmarshal([]byte(tc.yaml), &cfg)
+			if tc.wantErr != "" {
+				require.EqualError(t, err, tc.wantErr)
+				return
+			}
 			require.NoError(t, err)
 			require.Equal(t, tc.wantValues, cfg.Labels.Values)
 			require.Equal(t, tc.wantEnableUpdate, cfg.Labels.EnableUpdateValue())
+			require.Equal(t, tc.wantUpdateMode, cfg.Labels.UpdateModeValue())
 			if tc.wantEnableUpdateNil {
 				require.Nil(t, cfg.Labels.EnableUpdate)
 			}
@@ -1515,5 +1806,6 @@ func TestJiraLabelsConfigUnmarshalYAML(t *testing.T) {
 		require.Empty(t, cfg.Labels.Values)
 		require.True(t, cfg.Labels.EnableUpdateValue())
 		require.Nil(t, cfg.Labels.EnableUpdate)
+		require.Equal(t, JiraLabelUpdateReplace, cfg.Labels.UpdateModeValue())
 	})
 }

--- a/notify/jira/types.go
+++ b/notify/jira/types.go
@@ -24,6 +24,18 @@ type issue struct {
 	Key        string       `json:"key,omitempty"`
 	Fields     *issueFields `json:"fields,omitempty"`
 	Transition *idNameValue `json:"transition,omitempty"`
+	Update     *issueUpdate `json:"update,omitempty"`
+}
+
+// issueUpdate represents Jira's "update" operations block, used to append to
+// (rather than overwrite) a field such as labels.
+type issueUpdate struct {
+	Labels []labelOp `json:"labels,omitempty"`
+}
+
+// labelOp represents a single Jira label update operation, e.g. {"add": "foo"}.
+type labelOp struct {
+	Add string `json:"add,omitempty"`
 }
 
 type issueFields struct {

--- a/notify/jira/types.go
+++ b/notify/jira/types.go
@@ -35,7 +35,7 @@ type issueUpdate struct {
 
 // labelOp represents a single Jira label update operation, e.g. {"add": "foo"}.
 type labelOp struct {
-	Add string `json:"add,omitempty"`
+	Add string `json:"add"`
 }
 
 type issueFields struct {


### PR DESCRIPTION
Depends on #5442

## What changed
- notify/jira/config.go: adds JiraLabelUpdateMode (replace default, merge),
  UpdateModeValue(), and validation rejecting any other value.
- notify/jira/types.go: adds issue.Update *issueUpdate, issueUpdate{Labels []labelOp},
  labelOp{Add string} to represent Jira's update.labels: [{add: ...}] operation.
- notify/jira/jira.go: on PUT, when enable_update is true and update_mode is merge,
  labels are sent as update.labels add-operations instead of a fields.labels SET, and
  fields.labels is omitted from that request. replace (default) behavior is unchanged
  from today. enable_update: false still wins over update_mode (skip takes priority
  over merge).
- Test harness fix: the existing /issue/MONITORING-1 PUT test handler only inspected a
  raw JSON map; reworked it to unmarshal into the typed issue{} struct so
  Fields/Update are structurally asserted, not just spot-checked.
- New test cases for config unmarshal (valid/invalid update_mode), notifier
  merge/replace/skip interactions, and raw-JSON checks that fields.labels and
  update.labels are never both present in one request body.
- Docs and CHANGELOG updated.

## Why
enable_update: false (this PR's predecessor) fully stops label updates, which is
sometimes too blunt - users may still want Alertmanager's templated labels applied on
update, while preserving labels added by humans/automation. update_mode: merge
achieves this using Jira's native incremental label API instead of a destructive
replace.

## Design notes / limitations
- Merge is additive only: it never removes a label that disappears from the
  Alertmanager template between updates. This is called out explicitly in the docs -
  a "smart sync" (diffing old vs new label sets) was considered and rejected as
  unnecessary complexity for this use case.
- enable_update: false always wins over update_mode: merge - if both are set, labels
  are skipped entirely, not merged.
- The legacy YAML list form cannot express update_mode (or enable_update); users need
  the object form to opt in.

## Testing
- Unit tests: go test ./notify/jira/ ./config/ -count=1, including the MONITORING-1
  harness rework asserting typed Fields/Update equality, plus new cases for
  merge/replace/skip combinations and unmarshal validation of update_mode.
- Manual end-to-end testing against a private Jira Data Center instance: created an
  issue with update_mode: merge, manually added a foreign label, triggered an update,
  and confirmed both the Alertmanager-managed labels were present and the manually
  added label survived (add-only semantics behaved as intended against a real Jira
  API, not just a test double). Also re-verified the enable_update: false path from
  the predecessor PR still works unchanged with this code present, and exercised
  several edge cases (empty label list, idempotent repeated updates, a label value
  rejected by Jira's own validation) to confirm no partial/corrupted writes occur in
  any case.

#### Pull Request Checklist
Please check all the applicable boxes.

- Please list all open issue(s) discussed with maintainers related to this change
    - Related to #4621, #4297
- Is this a new Receiver integration?
    - [ ] N/A - existing jira_configs receiver, not a new receiver type
- Is this a bugfix?
    - [ ] N/A - this is not a bugfix
- Is this a new feature?
    - [x] I have added tests that test the new feature's functionality
- Does this change affect performance?
    - [ ] N/A - no performance-sensitive path touched
- Is this a breaking change?
    - [x] My changes do not break the existing cluster messages
    - [x] My changes do not break the existing api
- [x] I have added/updated the required documentation
- [x] I have signed-off my commits
- [x] I will follow best practices for contributing to this project

#### Which user-facing changes does this PR introduce?
```release-notes
[ENHANCEMENT] jira: Add labels.update_mode (replace|merge) for non-destructive label updates.
```
