### PR TITLE
timeinterval: fix negative days_of_month across DST transitions

### DIFF
--- a/timeinterval/timeinterval.go
+++ b/timeinterval/timeinterval.go
@@ -474,13 +474,7 @@ var (
 
 // Given a time, determines the number of days in the month that time occurs in.
 func daysInMonth(t time.Time) int {
-	// Day 0 of the following month normalizes to the last day of t's month,
-	// so its day-of-month is the number of days in the month. This is
-	// calendar arithmetic and stays correct across daylight-saving
-	// transitions. Deriving the count from an elapsed duration instead
-	// (monthEnd.Sub(monthStart).Hours()/24) undercounts by one in a
-	// spring-forward month, which spans 743 wall-clock hours rather than 744.
-	return time.Date(t.Year(), t.Month()+1, 0, 0, 0, 0, 0, t.Location()).Day()
+	return time.Date(t.Year(), t.Month()+1, 0, 12, 0, 0, 0, t.Location()).Day()
 }
 
 func clamp(n, min, max int) int {

--- a/timeinterval/timeinterval.go
+++ b/timeinterval/timeinterval.go
@@ -474,10 +474,13 @@ var (
 
 // Given a time, determines the number of days in the month that time occurs in.
 func daysInMonth(t time.Time) int {
-	monthStart := time.Date(t.Year(), t.Month(), 1, 0, 0, 0, 0, t.Location())
-	monthEnd := monthStart.AddDate(0, 1, 0)
-	diff := monthEnd.Sub(monthStart)
-	return int(diff.Hours() / 24)
+	// Day 0 of the following month normalizes to the last day of t's month,
+	// so its day-of-month is the number of days in the month. This is
+	// calendar arithmetic and stays correct across daylight-saving
+	// transitions. Deriving the count from an elapsed duration instead
+	// (monthEnd.Sub(monthStart).Hours()/24) undercounts by one in a
+	// spring-forward month, which spans 743 wall-clock hours rather than 744.
+	return time.Date(t.Year(), t.Month()+1, 0, 0, 0, 0, 0, t.Location()).Day()
 }
 
 func clamp(n, min, max int) int {

--- a/timeinterval/timeinterval_test.go
+++ b/timeinterval/timeinterval_test.go
@@ -144,11 +144,7 @@ var timeIntervalTestCases = []struct {
 		},
 	},
 	{
-		// Negative days of month must resolve against the true month length,
-		// even in a location whose month contains a daylight-saving transition.
-		// March 2021 in America/New_York springs forward on the 14th, so the
-		// month spans 743 wall-clock hours; the last day is still the 31st, and
-		// a last-day mute (-1) must fire on the 31st, not the 30th.
+		// Last-day mutes should not shift during spring-forward months.
 		timeInterval: TimeInterval{
 			DaysOfMonth: []DayOfMonthRange{{InclusiveRange{Begin: -1, End: -1}}},
 			Location:    &Location{mustLoadLocation("America/New_York")},

--- a/timeinterval/timeinterval_test.go
+++ b/timeinterval/timeinterval_test.go
@@ -143,6 +143,23 @@ var timeIntervalTestCases = []struct {
 			"31 Oct 21 21:00 +0000",
 		},
 	},
+	{
+		// Negative days of month must resolve against the true month length,
+		// even in a location whose month contains a daylight-saving transition.
+		// March 2021 in America/New_York springs forward on the 14th, so the
+		// month spans 743 wall-clock hours; the last day is still the 31st, and
+		// a last-day mute (-1) must fire on the 31st, not the 30th.
+		timeInterval: TimeInterval{
+			DaysOfMonth: []DayOfMonthRange{{InclusiveRange{Begin: -1, End: -1}}},
+			Location:    &Location{mustLoadLocation("America/New_York")},
+		},
+		validTimeStrings: []string{
+			"31 Mar 21 12:00 -0400",
+		},
+		invalidTimeStrings: []string{
+			"30 Mar 21 12:00 -0400",
+		},
+	},
 }
 
 var timeStringTestCases = []struct {


### PR DESCRIPTION
`daysInMonth` computes a month's length by dividing the elapsed duration between the first of the month and the first of the next month by 24 hours. When a `location` is set and that month contains a spring-forward DST transition, the span is 743 wall-clock hours rather than 744, so the truncating division returns 30 for a 31-day month.

`ContainsTime` uses that count to resolve negative `days_of_month` entries such as `-1` (the last day of the month). So a "last day of the month" mute with a non-UTC location resolves to the 30th during a spring-forward month: it does not fire on the actual last day (the 31st) and fires a day early on the 30th.

Reproduced with `days_of_month: ['-1']` and `location: America/New_York` for March 2021 (spring-forward on the 14th): before the change `ContainsTime(Mar 31)` is false and `ContainsTime(Mar 30)` is true; after, it is the reverse. A non-DST month (May) is unaffected either way.

The fix computes the count with calendar arithmetic — day 0 of the following month is the last day of the current month — which does not depend on DST. I added a regression case to `timeIntervalTestCases` covering `-1` in `America/New_York` across the March transition; it fails before and passes after.

Tested with `go test ./timeinterval/...` plus the dependent `notify`, `config`, and `dispatch` packages.

```release-notes
[BUGFIX] Time intervals: fix negative `days_of_month` indices resolving one day early in a `location` whose month contains a spring-forward DST transition.
```
