### PR TITLE
config: keep local SMTP auth secret overrides

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -408,8 +408,10 @@ func (c *Config) UnmarshalYAML(unmarshal func(any) error) error {
 				ec.AuthPassword = c.Global.SMTPAuthPassword
 				ec.AuthPasswordFile = c.Global.SMTPAuthPasswordFile
 			}
-			ec.AuthSecret = cmp.Or(ec.AuthSecret, c.Global.SMTPAuthSecret)
-			ec.AuthSecretFile = cmp.Or(ec.AuthSecretFile, c.Global.SMTPAuthSecretFile)
+			if ec.AuthSecret == "" && ec.AuthSecretFile == "" {
+				ec.AuthSecret = c.Global.SMTPAuthSecret
+				ec.AuthSecretFile = c.Global.SMTPAuthSecretFile
+			}
 			ec.AuthIdentity = cmp.Or(ec.AuthIdentity, c.Global.SMTPAuthIdentity)
 			if ec.RequireTLS == nil {
 				ec.RequireTLS = new(bool)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1021,6 +1021,8 @@ func TestGlobalAndLocalSMTPPassword(t *testing.T) {
 
 	require.Equal(t, "/tmp/globaluserpassword", config.Receivers[0].EmailConfigs[0].AuthPasswordFile, "first email should use password file /tmp/globaluserpassword")
 	require.Emptyf(t, config.Receivers[0].EmailConfigs[0].AuthPassword, "password field should be empty when file provided")
+	require.Equal(t, "/tmp/globalusersecret", config.Receivers[0].EmailConfigs[0].AuthSecretFile, "first email should use secret file /tmp/globalusersecret")
+	require.Emptyf(t, config.Receivers[0].EmailConfigs[0].AuthSecret, "secret field should be empty when file provided")
 
 	require.Equal(t, "/tmp/localuser1password", config.Receivers[0].EmailConfigs[1].AuthPasswordFile, "second email should use password file /tmp/localuser1password")
 	require.Emptyf(t, config.Receivers[0].EmailConfigs[1].AuthPassword, "password field should be empty when file provided")
@@ -1029,8 +1031,10 @@ func TestGlobalAndLocalSMTPPassword(t *testing.T) {
 	require.Emptyf(t, config.Receivers[0].EmailConfigs[2].AuthPasswordFile, "file field should be empty when password provided")
 
 	require.Equal(t, commoncfg.Secret("myprecious"), config.Receivers[0].EmailConfigs[3].AuthSecret, "fourth email should use secret myprecious")
+	require.Emptyf(t, config.Receivers[0].EmailConfigs[3].AuthSecretFile, "fourth email should not inherit the global secret file when a secret is provided")
 
 	require.Equal(t, "/tmp/localuser4secret", config.Receivers[0].EmailConfigs[4].AuthSecretFile, "fifth email should use secret file /tmp/localuser4secret")
+	require.Emptyf(t, config.Receivers[0].EmailConfigs[4].AuthSecret, "fifth email should not inherit the global secret when a secret file is provided")
 }
 
 func TestGroupByAll(t *testing.T) {

--- a/config/testdata/conf.smtp-password-global-and-local.yml
+++ b/config/testdata/conf.smtp-password-global-and-local.yml
@@ -3,6 +3,7 @@ global:
   smtp_from: 'alertmanager@example.org'
   smtp_auth_username: 'globaluser'
   smtp_auth_password_file: '/tmp/globaluserpassword'
+  smtp_auth_secret_file: '/tmp/globalusersecret'
   smtp_hello: "host.example.org"
 route:
   receiver: 'email-notifications'


### PR DESCRIPTION
A receiver-level `auth_secret` should override the global SMTP auth secret defaults. The loader currently merges `auth_secret` and `auth_secret_file` independently, though, so a receiver with a local inline secret also inherits `global.smtp_auth_secret_file`.

That leaves both fields set. `getAuthSecret` checks the file first, so the receiver's inline secret is not used. If the global path is unavailable, the notification fails while trying to read it; if it is available, CRAM-MD5 uses the global file contents instead of the receiver override.

This restores paired inheritance: copy the global secret fields only when neither receiver field is set, matching the existing password/password-file handling. The global/local SMTP fixture now covers a global secret file with both local inline-secret and local secret-file overrides.

Tested with:

- `go test ./config/ -run '^TestGlobalAndLocalSMTPPassword$' -count=1`
- `go test ./config/... ./notify/email/... -count=1`
- `go test -race ./config/... ./notify/email/... -count=1`
- `go vet ./config/... ./notify/email/...`
- `go build ./config/... ./notify/email/... ./cmd/amtool`

#### Pull Request Checklist

- Please list all open issue(s) discussed with maintainers related to this change
    - None
- Is this a new Receiver integration?
    - [ ] I have already tried to use the Webhook Receiver Integration and third-party integrations before adding this new Receiver Integration
- Is this a bugfix?
    - [x] I have added tests that can reproduce the bug which pass with this bugfix applied
- Is this a new feature?
    - [ ] I have added tests that test the new feature's functionality
- Does this change affect performance?
    - [ ] I have provided benchmarks comparison that shows performance is improved or is not degraded
    - [ ] I have added new benchmarks if required or requested by maintainers
- Is this a breaking change?
    - [ ] My changes do not break the existing cluster messages
    - [ ] My changes do not break the existing api
- [ ] I have added/updated the required documentation
    - Not needed: the current docs already say `auth_secret` and `auth_secret_file` are mutually exclusive.
- [x] I have signed-off my commits
- [x] I will follow best practices for contributing to this project

#### Which user-facing changes does this PR introduce?

```release-notes
[BUGFIX] Email: Honor a receiver's inline `auth_secret` when a global `smtp_auth_secret_file` is configured.
```
