### PR TITLE
perf(silence): count silences without materialising them

### DIFF
--- a/silence/silence.go
+++ b/silence/silence.go
@@ -1142,12 +1142,19 @@ func (s *Silences) CountState(ctx context.Context, states ...SilenceState) (int,
 		trace.WithSpanKind(trace.SpanKindInternal),
 	)
 	defer span.End()
-	// This could probably be optimized.
-	sils, _, err := s.Query(ctx, QState(states...))
-	if err != nil {
-		return -1, err
+
+	now := s.nowUTC()
+	count := 0
+
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+
+	for _, sv := range s.vi {
+		if slices.Contains(states, getState(s.st[sv.id].Silence, now)) {
+			count++
+		}
 	}
-	return len(sils), nil
+	return count, nil
 }
 
 // query executes the given query and returns the resulting silences.

--- a/silence/silence_bench_test.go
+++ b/silence/silence_bench_test.go
@@ -630,3 +630,46 @@ func benchmarkGC(b *testing.B, numSilences int, expiredRatio float64) {
 		b.StartTimer()
 	}
 }
+
+// BenchmarkCountState benchmarks counting silences by state, which is what the
+// alertmanager_silences gauges do on every scrape.
+func BenchmarkCountState(b *testing.B) {
+	b.Run("100 silences", func(b *testing.B) {
+		benchmarkCountState(b, 100)
+	})
+	b.Run("1000 silences", func(b *testing.B) {
+		benchmarkCountState(b, 1000)
+	})
+	b.Run("10000 silences", func(b *testing.B) {
+		benchmarkCountState(b, 10000)
+	})
+}
+
+func benchmarkCountState(b *testing.B, numSilences int) {
+	s, err := New(Options{Metrics: prometheus.NewRegistry()})
+	require.NoError(b, err)
+
+	now := time.Now()
+
+	for i := range numSilences {
+		sil := &silencepb.Silence{
+			Matchers: []*silencepb.Matcher{
+				{Type: silencepb.Matcher_EQUAL, Name: "aaaa", Pattern: strconv.Itoa(i)},
+			},
+			StartsAt:  timestamppb.New(now.Add(-time.Minute)),
+			EndsAt:    timestamppb.New(now.Add(time.Hour)),
+			UpdatedAt: timestamppb.New(now.Add(-time.Hour)),
+		}
+		require.NoError(b, s.Set(b.Context(), sil))
+	}
+
+	ctx := b.Context()
+
+	count, err := s.CountState(ctx, SilenceStateActive)
+	require.NoError(b, err)
+	require.Equal(b, numSilences, count)
+
+	for b.Loop() {
+		_, _ = s.CountState(ctx, SilenceStateActive)
+	}
+}


### PR DESCRIPTION
CountState went through Query, which clones every matching silence with proto.Clone into a slice. The `alertmanager_silences` gauges are GaugeFuncs, so this ran three times per scrape, once per state, each time scanning the full state under the read lock.

Counting is no longer routed through Query, so it stops contributing to alertmanager_silences_queries_total, _query_duration_seconds and _query_silences_scanned_total. Those now describe actual queries rather than being dominated by the scrape-driven counting.

#### Pull Request Checklist
Please check all the applicable boxes.

- Please list all open issue(s) discussed with maintainers related to this change
    - Fixes: #4358
- Does this change affect performance?
    - [x] I have provided benchmarks comparison that shows performance is improved or is not degraded
        - You can use [`benchstat`](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat) to compare benchmarks
    - [x] I have added new benchmarks if required or requested by maintainers
- [ ] I have added/updated the required documentation
- [x] I have signed-off my commits
- [ x] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Benchmark

`BenchmarkCountState` is added by this PR, so the baseline is built by compiling
this branch's test binary against the base `silence.go`:

```sh
go test -c -o after.test ./silence
git show HEAD~1:silence/silence.go > silence/silence.go
go test -c -o before.test ./silence
git checkout silence/silence.go

cd silence
for i in $(seq 1 10); do
  for side in before after; do
    taskset -c 2 ../$side.test -test.run=XXX -test.bench=BenchmarkCountState \
      -test.benchmem -test.count=1 >> ../bench-$side.txt
  done
done
cd .. && benchstat bench-before.txt bench-after.txt
```

Runs are interleaved and pinned to one core to keep the two sides comparable.

```
goos: linux
goarch: amd64
pkg: github.com/prometheus/alertmanager/silence
cpu: Intel(R) Core(TM) Ultra 7 268V
                          │ bench-before.txt │           bench-after.txt           │
                          │      sec/op      │   sec/op     vs base                │
CountState/100_silences         37.087µ ± 1%   1.484µ ± 4%  -96.00% (p=0.000 n=10)
CountState/1000_silences        440.04µ ± 0%   16.76µ ± 1%  -96.19% (p=0.000 n=10)
CountState/10000_silences       5472.3µ ± 1%   242.6µ ± 1%  -95.57% (p=0.000 n=10)
geomean                          447.0µ        18.20µ       -95.93%

                          │ bench-before.txt │           bench-after.txt           │
                          │       B/op       │    B/op     vs base                 │
CountState/100_silences         59608.0 ± 0%   112.0 ± 0%   -99.81% (p=0.000 n=10)
CountState/1000_silences       593368.0 ± 0%   112.0 ± 0%   -99.98% (p=0.000 n=10)
CountState/10000_silences     6070239.0 ± 0%   112.0 ± 0%  -100.00% (p=0.000 n=10)
geomean                         584.8Ki        112.0        -99.98%

                          │ bench-before.txt │           bench-after.txt           │
                          │    allocs/op     │ allocs/op   vs base                 │
CountState/100_silences         812.000 ± 0%   3.000 ± 0%   -99.63% (p=0.000 n=10)
CountState/1000_silences       8015.000 ± 0%   3.000 ± 0%   -99.96% (p=0.000 n=10)
CountState/10000_silences     80022.000 ± 0%   3.000 ± 0%  -100.00% (p=0.000 n=10)
geomean                          8.046k        3.000        -99.96%
```

#### Which user-facing changes does this PR introduce?

```release-notes
[ENHANCEMENT] silences: Count silences for the `alertmanager_silences` metric without cloning them, removing per-scrape allocations.
```