### PR TITLE
notify/opsgenie: use the caller's context for the update-message request

### DIFF
--- a/notify/opsgenie/opsgenie.go
+++ b/notify/opsgenie/opsgenie.go
@@ -249,7 +249,7 @@ func (n *Notifier) createRequests(ctx context.Context, as ...*types.Alert) ([]*h
 			if err != nil {
 				return nil, true, err
 			}
-			requests = append(requests, req)
+			requests = append(requests, req.WithContext(ctx))
 
 			updateDescriptionEndpointURL := n.conf.APIURL.Copy()
 			updateDescriptionEndpointURL.Path += fmt.Sprintf("v2/alerts/%s/description", alias)

--- a/notify/opsgenie/opsgenie_test.go
+++ b/notify/opsgenie/opsgenie_test.go
@@ -320,6 +320,45 @@ func TestOpsGenieWithUpdate(t *testing.T) {
 	require.JSONEq(t, `{"description":"new description"}`, body2)
 }
 
+func TestOpsGenieWithUpdateRequestContext(t *testing.T) {
+	u, err := url.Parse("https://test-opsgenie-url")
+	require.NoError(t, err)
+	opsGenieConfigWithUpdate := OpsGenieConfig{
+		Message:      `{{ .CommonLabels.Message }}`,
+		Description:  `{{ .CommonLabels.Description }}`,
+		UpdateAlerts: true,
+		APIKey:       "test-api-key",
+		APIURL:       &amcommoncfg.URL{URL: u},
+		HTTPConfig:   &commoncfg.HTTPClientConfig{},
+	}
+	notifierWithUpdate, err := New(&opsGenieConfigWithUpdate, test.CreateTmpl(t), promslog.NewNopLogger())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx = notify.WithGroupKey(ctx, "1")
+	alert := &types.Alert{
+		Alert: model.Alert{
+			StartsAt: time.Now(),
+			EndsAt:   time.Now().Add(time.Hour),
+			Labels: model.LabelSet{
+				"Message":     "new message",
+				"Description": "new description",
+			},
+		},
+	}
+
+	requests, _, err := notifierWithUpdate.createRequests(ctx, alert)
+	require.NoError(t, err)
+	require.Len(t, requests, 3)
+
+	// Every request must carry the caller's context, so that cancelling the
+	// notification also cancels the requests it created.
+	cancel()
+	for i, req := range requests {
+		require.ErrorIs(t, req.Context().Err(), context.Canceled, "request %d does not use the caller's context", i)
+	}
+}
+
 func TestOpsGenieApiKeyFile(t *testing.T) {
 	u, err := url.Parse("https://test-opsgenie-url")
 	require.NoError(t, err)

--- a/notify/opsgenie/opsgenie_test.go
+++ b/notify/opsgenie/opsgenie_test.go
@@ -278,7 +278,7 @@ func TestOpsGenieWithUpdate(t *testing.T) {
 	u, err := url.Parse("https://test-opsgenie-url")
 	require.NoError(t, err)
 	tmpl := test.CreateTmpl(t)
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
 	ctx = notify.WithGroupKey(ctx, "1")
 	opsGenieConfigWithUpdate := OpsGenieConfig{
 		Message:      `{{ .CommonLabels.Message }}`,
@@ -318,41 +318,8 @@ func TestOpsGenieWithUpdate(t *testing.T) {
 	require.JSONEq(t, `{"message":"new message"}`, body1)
 	require.Equal(t, requests[2].URL.String(), fmt.Sprintf("https://test-opsgenie-url/v2/alerts/%s/description?identifierType=alias", alias))
 	require.JSONEq(t, `{"description":"new description"}`, body2)
-}
 
-func TestOpsGenieWithUpdateRequestContext(t *testing.T) {
-	u, err := url.Parse("https://test-opsgenie-url")
-	require.NoError(t, err)
-	opsGenieConfigWithUpdate := OpsGenieConfig{
-		Message:      `{{ .CommonLabels.Message }}`,
-		Description:  `{{ .CommonLabels.Description }}`,
-		UpdateAlerts: true,
-		APIKey:       "test-api-key",
-		APIURL:       &amcommoncfg.URL{URL: u},
-		HTTPConfig:   &commoncfg.HTTPClientConfig{},
-	}
-	notifierWithUpdate, err := New(&opsGenieConfigWithUpdate, test.CreateTmpl(t), promslog.NewNopLogger())
-	require.NoError(t, err)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	ctx = notify.WithGroupKey(ctx, "1")
-	alert := &types.Alert{
-		Alert: model.Alert{
-			StartsAt: time.Now(),
-			EndsAt:   time.Now().Add(time.Hour),
-			Labels: model.LabelSet{
-				"Message":     "new message",
-				"Description": "new description",
-			},
-		},
-	}
-
-	requests, _, err := notifierWithUpdate.createRequests(ctx, alert)
-	require.NoError(t, err)
-	require.Len(t, requests, 3)
-
-	// Every request must carry the caller's context, so that cancelling the
-	// notification also cancels the requests it created.
+	// Cancelling the caller's context must cancel every request it created.
 	cancel()
 	for i, req := range requests {
 		require.ErrorIs(t, req.Context().Err(), context.Canceled, "request %d does not use the caller's context", i)


### PR DESCRIPTION
`createRequests` in `notify/opsgenie/opsgenie.go` builds up to three HTTP requests when `update_alerts` is enabled: create the alert, update its message, update its description. The create, close and update-description requests are all built with `req.WithContext(ctx)`. The update-message request is appended without it, so it runs with the background context instead of the notification pipeline's context.

Two things follow from that. The request is not cancelled when the pipeline context is cancelled or its deadline passes, and it carries no trace context, so its span has no parent. The OpsGenie notifier sets no client timeout of its own, so a hung endpoint on `PUT /v2/alerts/{alias}/message` can hold the retry loop for that aggregation group open after the flush has already been cancelled.

This looks like an oversight rather than a decision. The line was added in the commit that introduced `update_message` (later renamed to `update_alerts`) and the three sibling requests around it all attach the context.

## What changed

One line in `createRequests` attaches the caller's context to the update-message request, and one test covers all three requests.

## How tested

I added `TestOpsGenieWithUpdateRequestContext`. It builds the three requests with a cancellable context, cancels it, and requires every request to report `context.Canceled`.

With the fix reverted, the new test fails on the update-message request:

```
=== RUN   TestOpsGenieWithUpdateRequestContext
    opsgenie_test.go:358:
        	Error:      	Expected error with "context canceled" in chain but got nil.
        	Messages:   	request 1 does not use the caller's context
--- FAIL: TestOpsGenieWithUpdateRequestContext (0.00s)
```

With the fix applied:

```
go test ./notify/opsgenie/...     ok
go test ./notify/...              ok (all 20 packages)
go vet ./notify/opsgenie/...      clean
golangci-lint run ./notify/opsgenie/...   0 issues (v2.12.2, the version pinned in Makefile.common)
```

I built `./notify/...` rather than `./...`, because `./...` needs the generated UI assets that a fresh clone does not have.

#### Pull Request Checklist

- Please list all open issue(s) discussed with maintainers related to this change
    - None. I found this by reading the code, so there is no issue to link.
- Is this a new Receiver integration?
    - [ ] I have already tried to use the [Webhook Receiver Integration](https://prometheus.io/docs/alerting/latest/configuration/#webhook_config) and [3rd party integrations](https://prometheus.io/docs/operating/integrations/#alertmanager-webhook-receiver) before adding this new Receiver Integration
- Is this a bugfix?
    - [x] I have added tests that can reproduce the bug which pass with this bugfix applied
- Is this a new feature?
    - [ ] I have added tests that test the new feature's functionality
- Does this change affect performance?
    - [ ] I have provided benchmarks comparison that shows performance is improved or is not degraded
    - [ ] I have added new benchmarks if required or requested by maintainers
- Is this a breaking change?
    - [x] My changes do not break the existing cluster messages
    - [x] My changes do not break the existing api
- [ ] I have added/updated the required documentation (no user-facing configuration or behaviour is documented differently by this change)
- [x] I have signed-off my commits
- [x] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?

```release-notes
[BUGFIX] opsgenie: Attach the notification context to the update-message request sent when `update_alerts` is enabled, so it is cancelled with the notification and is traced under the same span.
```

Happy to add the CHANGELOG entry once this has a PR number, if you would rather it went in here than in the release notes block.
