### PR TITLE
docs: document wildcard CORS default and security considerations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## main / (unreleased)
 
+* [ENHANCEMENT] doc: Document wildcard CORS default and security considerations for API v2. #5455
+
 ## 0.34.0 / 2026-08-16
 
 * [CHANGE] notify: The `reason` label on `alertmanager_notifications_failed_total` now distinguishes `authError` (HTTP 401/403) and `rateLimited` (HTTP 429) from the generic `clientError`. Dashboards/alerts matching `reason="clientError"` for these codes must be updated. #5332

--- a/docs/https.md
+++ b/docs/https.md
@@ -12,6 +12,28 @@ Currently TLS is supported for the HTTP traffic and gossip traffic.
 
 To specify which web configuration file to load, use the `--web.config.file` flag.
 
+### CORS (Cross-Origin Resource Sharing)
+
+By default, Alertmanager's API v2 responds with `Access-Control-Allow-Origin: *` on all endpoints.
+This allows any origin to make cross-origin requests to the Alertmanager API. While convenient for development,
+this default may not be suitable for production environments where you want to restrict access to specific origins.
+
+The current CORS behavior is configured using the `github.com/rs/cors` library with default settings,
+which allows all origins and common HTTP methods.
+
+**Security Considerations**: The wildcard CORS policy allows any website to make requests to your Alertmanager API.
+If your Alertmanager is exposed to the internet or to untrusted networks, you should consider restricting CORS
+by fronting Alertmanager with a reverse proxy (such as nginx or Apache) that can enforce stricter CORS policies
+based on your security requirements.
+
+For production deployments, it is recommended to:
+1. Use a reverse proxy to enforce CORS policies
+2. Implement authentication to protect API endpoints
+3. Restrict network access to Alertmanager using firewalls or VPC rules
+
+**Note**: The wildcard CORS default is a legacy configuration from the initial CORS implementation in PR #1667.
+Future API versions (such as v3) may adopt a more restrictive default as part of security hardening efforts.
+
 The file is written in [YAML format](https://en.wikipedia.org/wiki/YAML),
 defined by the scheme described below.
 Brackets indicate that a parameter is optional. For non-list parameters the

--- a/docs/https.md
+++ b/docs/https.md
@@ -21,13 +21,18 @@ this default may not be suitable for production environments where you want to r
 The current CORS behavior is configured using the `github.com/rs/cors` library with default settings,
 which allows all origins and common HTTP methods.
 
-**Security Considerations**: The wildcard CORS policy allows any website to make requests to your Alertmanager API.
-If your Alertmanager is exposed to the internet or to untrusted networks, you should consider restricting CORS
+**Important Security Notes**:
+
+- The wildcard CORS policy allows non-credentialed browser reads from any origin, but it does not bypass authentication or act as access control. Alertmanager's existing authentication and authorization mechanisms still apply.
+- Browsers reject credentialed requests (requests with cookies, HTTP authentication, or client certificates) when the response includes `Access-Control-Allow-Origin: *`. For credentialed requests, the origin must be explicitly specified.
+- If you use a reverse proxy to implement custom CORS policies, the proxy must remove or replace Alertmanager's existing `Access-Control-Allow-Origin` header. Simply appending additional headers will result in invalid CORS responses (browsers reject responses with multiple Access-Control-Allow-Origin headers).
+
+**Security Considerations**: If your Alertmanager is exposed to the internet or to untrusted networks, you should consider restricting CORS
 by fronting Alertmanager with a reverse proxy (such as nginx or Apache) that can enforce stricter CORS policies
 based on your security requirements.
 
 For production deployments, it is recommended to:
-1. Use a reverse proxy to enforce CORS policies
+1. Use a reverse proxy to enforce CORS policies by removing/replacing Alertmanager's wildcard header
 2. Implement authentication to protect API endpoints
 3. Restrict network access to Alertmanager using firewalls or VPC rules
 

--- a/docs/https.md
+++ b/docs/https.md
@@ -23,10 +23,13 @@ origin. It does not bypass Alertmanager authentication or authorization. Browser
 reject credentialed CORS responses using `Access-Control-Allow-Origin: *`.
 CORS is not CSRF protection.
 
-To apply a restricted origin to mutating endpoints with a reverse proxy, remove or
-replace Alertmanager's `Access-Control-Allow-Origin` header before setting the custom
-value. See Prometheus's [security model](https://prometheus.io/docs/operating/security/)
-for API security considerations.
+To set a restricted origin with a reverse proxy, remove or replace Alertmanager's
+`Access-Control-Allow-Origin` header before setting the custom value. This only
+restricts browser reads; it does not block cross-origin mutating requests. The proxy
+must reject unauthorized cross-origin mutating requests, or an explicit CSRF
+protection policy must be used. See Prometheus's
+[security model](https://prometheus.io/docs/operating/security/) for API security
+considerations.
 The file is written in [YAML format](https://en.wikipedia.org/wiki/YAML),
 defined by the scheme described below.
 Brackets indicate that a parameter is optional. For non-list parameters the

--- a/docs/https.md
+++ b/docs/https.md
@@ -14,27 +14,18 @@ To specify which web configuration file to load, use the `--web.config.file` fla
 
 ### CORS (Cross-Origin Resource Sharing)
 
-By default, Alertmanager's API v2 responds with `Access-Control-Allow-Origin: *` on all endpoints.
-This allows any origin to make cross-origin requests to the Alertmanager API. While convenient for development,
+By default, Alertmanager's API v2 responds with `Access-Control-Allow-Origin: *`.
+This allows any origin to make cross-origin requests to the API v2 endpoints. While convenient for development,
 this default may not be suitable for production environments where you want to restrict access to specific origins.
 
 The current CORS behavior is configured using the `github.com/rs/cors` library with default settings,
-which allows all origins and common HTTP methods.
+which allows all origins and the `GET`, `POST`, and `HEAD` methods.
 
 **Important Security Notes**:
 
-- The wildcard CORS policy allows non-credentialed browser reads from any origin, but it does not bypass authentication or act as access control. Alertmanager's existing authentication and authorization mechanisms still apply.
+- Alertmanager's API [security and trust model](https://prometheus.io/docs/operating/security/) is documented by Prometheus.
 - Browsers reject credentialed requests (requests with cookies, HTTP authentication, or client certificates) when the response includes `Access-Control-Allow-Origin: *`. For credentialed requests, the origin must be explicitly specified.
 - If you use a reverse proxy to implement custom CORS policies, the proxy must remove or replace Alertmanager's existing `Access-Control-Allow-Origin` header. Simply appending additional headers will result in invalid CORS responses (browsers reject responses with multiple Access-Control-Allow-Origin headers).
-
-**Security Considerations**: If your Alertmanager is exposed to the internet or to untrusted networks, you should consider restricting CORS
-by fronting Alertmanager with a reverse proxy (such as nginx or Apache) that can enforce stricter CORS policies
-based on your security requirements.
-
-For production deployments, it is recommended to:
-1. Use a reverse proxy to enforce CORS policies by removing/replacing Alertmanager's wildcard header
-2. Implement authentication to protect API endpoints
-3. Restrict network access to Alertmanager using firewalls or VPC rules
 
 **Note**: The wildcard CORS default is a legacy configuration from the initial CORS implementation in PR #1667.
 Future API versions (such as v3) may adopt a more restrictive default as part of security hardening efforts.

--- a/docs/https.md
+++ b/docs/https.md
@@ -14,22 +14,14 @@ To specify which web configuration file to load, use the `--web.config.file` fla
 
 ### CORS (Cross-Origin Resource Sharing)
 
-By default, Alertmanager's API v2 responds with `Access-Control-Allow-Origin: *`.
-This allows any origin to make cross-origin requests to the API v2 endpoints. While convenient for development,
-this default may not be suitable for production environments where you want to restrict access to specific origins.
+Alertmanager's API v2 responds with `Access-Control-Allow-Origin: *` and allows the
+`GET`, `POST`, and `HEAD` methods.
 
-The current CORS behavior is configured using the `github.com/rs/cors` library with default settings,
-which allows all origins and the `GET`, `POST`, and `HEAD` methods.
+See Prometheus's [security model](https://prometheus.io/docs/operating/security/)
+for API security considerations.
 
-**Important Security Notes**:
-
-- Alertmanager's API [security and trust model](https://prometheus.io/docs/operating/security/) is documented by Prometheus.
-- Browsers reject credentialed requests (requests with cookies, HTTP authentication, or client certificates) when the response includes `Access-Control-Allow-Origin: *`. For credentialed requests, the origin must be explicitly specified.
-- If you use a reverse proxy to implement custom CORS policies, the proxy must remove or replace Alertmanager's existing `Access-Control-Allow-Origin` header. Simply appending additional headers will result in invalid CORS responses (browsers reject responses with multiple Access-Control-Allow-Origin headers).
-
-**Note**: The wildcard CORS default is a legacy configuration from the initial CORS implementation in PR #1667.
-Future API versions (such as v3) may adopt a more restrictive default as part of security hardening efforts.
-
+To apply a custom CORS policy with a reverse proxy, remove or replace Alertmanager's
+`Access-Control-Allow-Origin` header before setting a custom value.
 The file is written in [YAML format](https://en.wikipedia.org/wiki/YAML),
 defined by the scheme described below.
 Brackets indicate that a parameter is optional. For non-list parameters the

--- a/docs/https.md
+++ b/docs/https.md
@@ -14,14 +14,19 @@ To specify which web configuration file to load, use the `--web.config.file` fla
 
 ### CORS (Cross-Origin Resource Sharing)
 
-Alertmanager's API v2 responds with `Access-Control-Allow-Origin: *` and allows the
-`GET`, `POST`, and `HEAD` methods.
+Alertmanager applies CORS middleware to requests routed to `/api/v2/`. For requests
+with an `Origin` header, it responds with `Access-Control-Allow-Origin: *`. The
+default CORS configuration permits the `GET`, `POST`, and `HEAD` methods.
 
-See Prometheus's [security model](https://prometheus.io/docs/operating/security/)
+The wildcard origin allows browsers without credentials to read responses from any
+origin. It does not bypass Alertmanager authentication or authorization. Browsers
+reject credentialed CORS responses using `Access-Control-Allow-Origin: *`.
+CORS is not CSRF protection.
+
+To apply a restricted origin to mutating endpoints with a reverse proxy, remove or
+replace Alertmanager's `Access-Control-Allow-Origin` header before setting the custom
+value. See Prometheus's [security model](https://prometheus.io/docs/operating/security/)
 for API security considerations.
-
-To apply a custom CORS policy with a reverse proxy, remove or replace Alertmanager's
-`Access-Control-Allow-Origin` header before setting a custom value.
 The file is written in [YAML format](https://en.wikipedia.org/wiki/YAML),
 defined by the scheme described below.
 Brackets indicate that a parameter is optional. For non-list parameters the


### PR DESCRIPTION
Clarify that wildcard CORS allows non-credentialed browser reads but does not
bypass authentication or act as access control. Note that browsers reject
credentialed requests with wildcard origin, and that reverse proxies must
remove/replace (not append) Alertmanager's existing CORS header.

Addresses CodeRabbit feedback on PR #5466.

Partially addresses #5455.

#### Pull Request Checklist
Please check all the applicable boxes.

- Please list all open issue(s) discussed with maintainers related to this change
    - Partially addresses #5455
- Is this a new Receiver integration?
    - [ ] I have already tried to use the [Webhook Receiver Integration](https://prometheus.io/docs/alerting/latest/configuration/#webhook_config) and [3rd party integrations](https://prometheus.io/docs/operating/integrations/#alertmanager-webhook-receiver) before adding this new Receiver Integration
- Is this a bugfix?
    - [ ] I have added tests that can reproduce the bug which pass with this bugfix applied
- Is this a new feature?
    - [ ] I have added tests that test the new feature's functionality
- Does this change affect performance?
    - [ ] I have provided benchmarks comparison that shows performance is improved or is not degraded
        - You can use [`benchstat`](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat) to compare benchmarks
    - [ ] I have added new benchmarks if required or requested by maintainers
- Is this a breaking change?
    - [ ] My changes do not break the existing cluster messages
    - [ ] My changes do not break the existing api
- [x] I have added/updated the required documentation
- [x] I have signed-off my commits
- [x] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?
```release-notes
[ENHANCEMENT] doc: Clarify CORS security details in https.md, noting that wildcard CORS allows non-credentialed browser reads but does not bypass authentication, browsers reject credentialed requests with wildcard origin, and reverse proxies must remove/replace (not append) Alertmanager's existing CORS header.