### PR TITLE
CHANGELOG.md: Avoid merge conflicts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,7 +117,6 @@ Do not hand‑edit generated files under `api/v2/models`, `api/v2/restapi`, `api
 - Register the notifier in `cmd/alertmanager/main.go` where receivers are built.
 - Add unit tests in the notifier package; reuse helpers from `notify/test/`.
 - Update `template/default.tmpl` only if you are introducing new default templates.
-- Note the change in `CHANGELOG.md` under the unreleased section.
 
 ## When touching configuration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## main / (unreleased)
 
-* [CHANGE] eventrecorder: The output data format now uses the new `events/v2` schema. This is a breaking change: alert labels, alert annotations, group labels, silence annotations, and muted-alert labels are JSON maps, and protobuf consumers must use the new schema.
-* [FEATURE] api: Add an experimental ConnectRPC API served alongside `/api/v2/` under the version-neutral `/api/` prefix, exposing the Connect, gRPC, and gRPC-Web protocols plus the gRPC Health Checking Protocol and server reflection. The first service is `status.v3alpha.StatusService`.
-* [ENHANCEMENT] ui: The silence form no longer requires a creator and a comment, matching the API. #5471
+Please do **not** add any entries in this section. If your change affects
+behaviour, describe it in the pull request description. Those entries are added
+here, when the release is prepared.
 
 ## 0.34.0 / 2026-08-16
 


### PR DESCRIPTION
The changelog was never intended to be modified on every PR, which introduces user-facing behaviour. That just makes git unhappy.

#### Pull Request Checklist

- [x] I have signed-off my commits
- [x] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?

```release-notes
NONE
```
