### PR TITLE
notify/discord: retry on HTTP 429 like the Slack integration

### DIFF
--- a/notify/discord/discord.go
+++ b/notify/discord/discord.go
@@ -70,7 +70,7 @@ func New(c *DiscordConfig, t *template.Template, l *slog.Logger, httpOpts ...com
 		tmpl:       t,
 		logger:     l,
 		client:     client,
-		retrier:    &notify.Retrier{},
+		retrier:    &notify.Retrier{RetryCodes: []int{http.StatusTooManyRequests}},
 		webhookURL: c.WebhookURL,
 	}
 	return n, nil

--- a/notify/discord/discord_test.go
+++ b/notify/discord/discord_test.go
@@ -50,7 +50,8 @@ func TestDiscordRetry(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	for statusCode, expected := range test.RetryTests(test.DefaultRetryCodes()) {
+	retryCodes := append(test.DefaultRetryCodes(), http.StatusTooManyRequests)
+	for statusCode, expected := range test.RetryTests(retryCodes) {
 		actual, _ := notifier.retrier.Check(statusCode, nil)
 		require.Equal(t, expected, actual, "retry - error on status %d", statusCode)
 	}

--- a/notify/discord/discord_test.go
+++ b/notify/discord/discord_test.go
@@ -39,6 +39,8 @@ import (
 // This is a test URL that has been modified to not be valid.
 var testWebhookURL, _ = url.Parse("https://discord.com/api/webhooks/971139602272503183/78ZWZ4V3xwZUBKRFF-G9m1nRtDtNTChl_WzW6Q4kxShjSB02oLSiPTPa8TS2tTGO9EYf")
 
+// TestDiscordRetry checks that the notifier retries on 5xx and on HTTP 429, and
+// treats every other status code as a permanent failure.
 func TestDiscordRetry(t *testing.T) {
 	notifier, err := New(
 		&DiscordConfig{


### PR DESCRIPTION
Discord answers a burst of webhook POSTs with HTTP 429 and a sub-second `retry_after` (observed `0.376`). The Discord notifier builds its `Retrier` with no `RetryCodes`, so `Retrier.Check` treats 429 as unrecoverable and drops the notification after one attempt:

```text
discord/discord[0]: notify retry canceled due to unrecoverable error after 1 attempts: unexpected status code 429: {"message": "You are being rate limited.", "retry_after": 0.376, "global": false}
```

A group that fires and resolves inside a run of 429s is never delivered. Slack has retried 429 since #3189; this mirrors it for Discord, using the same `Retrier` back-off the other integrations use (no new retry strategy — honouring `retry_after` across integrations is the larger scope tracked in #2205). Observed on v0.33.1 and v0.34.0; still present on `main`.

Refs #2205 (umbrella; this PR ticks its Discord item but does not complete it).

#### Pull Request Checklist
Please check all the applicable boxes.

- Please list all open issue(s) discussed with maintainers related to this change
    - Refs #2205
- Is this a new Receiver integration?
    - [ ] I have already tried to use the [Webhook Receiver Integration](https://prometheus.io/docs/alerting/latest/configuration/#webhook_config) and [3rd party integrations](https://prometheus.io/docs/operating/integrations/#alertmanager-webhook-receiver) before adding this new Receiver Integration
- Is this a bugfix?
    - [x] I have added tests that can reproduce the bug which pass with this bugfix applied
- Is this a new feature?
    - [ ] I have added tests that test the new feature's functionality
- Does this change affect performance?
    - [ ] I have provided benchmarks comparison that shows performance is improved or is not degraded
        - You can use [`benchstat`](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat) to compare benchmarks
    - [ ] I have added new benchmarks if required or requested by maintainers
- Is this a breaking change?
    - [x] My changes do not break the existing cluster messages
    - [x] My changes do not break the existing api
- [ ] I have added/updated the required documentation (none needed: no config surface changes)
- [x] I have signed-off my commits
- [x] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?
```release-notes
[BUGFIX] notify/discord: Retry webhook notifications on HTTP 429 (rate limited) instead of dropping them after one attempt, matching the Slack integration.
```