### PR TITLE
telegram: exclude link targets from message length

### DIFF
--- a/notify/telegram/telegram.go
+++ b/notify/telegram/telegram.go
@@ -162,6 +162,8 @@ func htmlTextRuneCount(message string) int {
 				return utf8.RuneCountInString(message)
 			}
 			return count
+		case html.CommentToken, html.DoctypeToken:
+			return utf8.RuneCountInString(message)
 		case html.TextToken:
 			count += utf8.RuneCount(tokenizer.Text())
 		}

--- a/notify/telegram/telegram.go
+++ b/notify/telegram/telegram.go
@@ -158,6 +158,9 @@ func htmlTextRuneCount(message string) int {
 	for {
 		switch tokenizer.Next() {
 		case html.ErrorToken:
+			if len(tokenizer.Raw()) > 0 {
+				return utf8.RuneCountInString(message)
+			}
 			return count
 		case html.TextToken:
 			count += utf8.RuneCount(tokenizer.Text())

--- a/notify/telegram/telegram.go
+++ b/notify/telegram/telegram.go
@@ -22,8 +22,10 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	commoncfg "github.com/prometheus/common/config"
+	"golang.org/x/net/html"
 	"gopkg.in/telebot.v3"
 
 	"github.com/prometheus/alertmanager/notify"
@@ -31,7 +33,8 @@ import (
 	"github.com/prometheus/alertmanager/types"
 )
 
-// Telegram supports 4096 chars max - from https://limits.tginfo.me/en.
+// Telegram supports up to 4096 characters after entity parsing.
+// See https://core.telegram.org/bots/api#sendmessage.
 const maxMessageLenRunes = 4096
 
 // Notifier implements a Notifier for telegram notifications.
@@ -92,7 +95,7 @@ func (n *Notifier) Notify(ctx context.Context, alert ...*types.Alert) (bool, err
 		if err != nil {
 			return false, err
 		}
-		if len([]rune(messageText)) > maxMessageLenRunes {
+		if htmlTextRuneCount(messageText) > maxMessageLenRunes {
 			messageText = `Alertmanager notification could not be sent: message length exceeds Telegram limits.
 			Please check the template used for producing the message content.`
 		}
@@ -145,6 +148,21 @@ func wrapWithFailureReason(err error) error {
 		return notify.NewErrorWithReason(notify.GetFailureReasonFromStatusCode(apiErr.Code), err)
 	}
 	return err
+}
+
+// htmlTextRuneCount excludes HTML markup and attribute values such as link targets.
+func htmlTextRuneCount(message string) int {
+	tokenizer := html.NewTokenizer(strings.NewReader(message))
+	count := 0
+
+	for {
+		switch tokenizer.Next() {
+		case html.ErrorToken:
+			return count
+		case html.TextToken:
+			count += utf8.RuneCount(tokenizer.Text())
+		}
+	}
 }
 
 func createTelegramClient(apiURL, parseMode string, httpClient *http.Client) (*telebot.Bot, error) {

--- a/notify/telegram/telegram.go
+++ b/notify/telegram/telegram.go
@@ -169,9 +169,73 @@ func htmlTextRuneCount(message string) int {
 		case html.CommentToken, html.DoctypeToken:
 			return utf8.RuneCountInString(message)
 		case html.TextToken:
-			count += utf8.RuneCount(tokenizer.Text())
+			count += telegramHTMLTextRuneCount(tokenizer.Raw())
 		}
 	}
+}
+
+func telegramHTMLTextRuneCount(text []byte) int {
+	count := 0
+	for len(text) > 0 {
+		if text[0] == '&' {
+			if entityLen := telegramHTMLEntityLen(text); entityLen > 0 {
+				count++
+				text = text[entityLen:]
+				continue
+			}
+		}
+
+		_, size := utf8.DecodeRune(text)
+		count++
+		text = text[size:]
+	}
+	return count
+}
+
+func telegramHTMLEntityLen(text []byte) int {
+	if len(text) < 2 || text[0] != '&' {
+		return 0
+	}
+
+	end := 1
+	if text[end] != '#' {
+		for end < len(text) && (text[end] >= 'a' && text[end] <= 'z' || text[end] >= 'A' && text[end] <= 'Z') {
+			end++
+		}
+		switch string(text[1:end]) {
+		case "lt", "gt", "amp", "quot":
+			if end < len(text) && text[end] == ';' {
+				end++
+			}
+			return end
+		default:
+			return 0
+		}
+	}
+
+	end++
+	base := 10
+	if end < len(text) && text[end] == 'x' {
+		base = 16
+		end++
+	}
+	digitsStart := end
+	for end < len(text) {
+		c := text[end]
+		if c >= '0' && c <= '9' || base == 16 && (c >= 'a' && c <= 'f' || c >= 'A' && c <= 'F') {
+			end++
+			continue
+		}
+		break
+	}
+	code, err := strconv.ParseUint(string(text[digitsStart:end]), base, 32)
+	if err != nil || code == 0 || code >= utf8.MaxRune || end >= 10 {
+		return 0
+	}
+	if end < len(text) && text[end] == ';' {
+		end++
+	}
+	return end
 }
 
 func createTelegramClient(apiURL, parseMode string, httpClient *http.Client) (*telebot.Bot, error) {

--- a/notify/telegram/telegram.go
+++ b/notify/telegram/telegram.go
@@ -169,11 +169,16 @@ func htmlTextRuneCount(message string) int {
 		case html.CommentToken, html.DoctypeToken:
 			return utf8.RuneCountInString(message)
 		case html.TextToken:
+			// tokenizer.Text applies HTML5 entity decoding, while Telegram
+			// supports a smaller set. Use raw text so unsupported entities
+			// remain literal.
 			count += telegramHTMLTextRuneCount(tokenizer.Raw())
 		}
 	}
 }
 
+// telegramHTMLTextRuneCount counts visible runes in a raw HTML text token.
+// Telegram-supported entities count as one rune; other input remains literal.
 func telegramHTMLTextRuneCount(text []byte) int {
 	count := 0
 	for len(text) > 0 {
@@ -192,6 +197,10 @@ func telegramHTMLTextRuneCount(text []byte) int {
 	return count
 }
 
+// telegramHTMLEntityLen returns the byte length of an entity Telegram would
+// decode at the start of text, or zero if Telegram would render it literally.
+// Telegram accepts four named entities and valid decimal or hexadecimal numeric
+// entities, with or without a trailing semicolon.
 func telegramHTMLEntityLen(text []byte) int {
 	if len(text) < 2 || text[0] != '&' {
 		return 0

--- a/notify/telegram/telegram.go
+++ b/notify/telegram/telegram.go
@@ -201,6 +201,8 @@ func telegramHTMLTextRuneCount(text []byte) int {
 // decode at the start of text, or zero if Telegram would render it literally.
 // Telegram accepts four named entities and valid decimal or hexadecimal numeric
 // entities, with or without a trailing semicolon.
+// This mirrors TDLib's decode_html_entity implementation:
+// https://github.com/tdlib/td/blob/d1085f9cebc5a62379991ae1652673954f229c1f/td/telegram/MessageEntity.cpp#L3240-L3286
 func telegramHTMLEntityLen(text []byte) int {
 	if len(text) < 2 || text[0] != '&' {
 		return 0

--- a/notify/telegram/telegram.go
+++ b/notify/telegram/telegram.go
@@ -33,9 +33,13 @@ import (
 	"github.com/prometheus/alertmanager/types"
 )
 
-// Telegram supports up to 4096 characters after entity parsing.
-// See https://core.telegram.org/bots/api#sendmessage.
-const maxMessageLenRunes = 4096
+const (
+	// Telegram rejects formatted input over 1 << 15 bytes before entity parsing.
+	maxMessageLenBytes = 1 << 15
+	// Telegram supports up to 4096 characters after entity parsing.
+	// See https://core.telegram.org/bots/api#sendmessage.
+	maxMessageLenRunes = 4096
+)
 
 // Notifier implements a Notifier for telegram notifications.
 type Notifier struct {
@@ -95,7 +99,7 @@ func (n *Notifier) Notify(ctx context.Context, alert ...*types.Alert) (bool, err
 		if err != nil {
 			return false, err
 		}
-		if htmlTextRuneCount(messageText) > maxMessageLenRunes {
+		if len(messageText) > maxMessageLenBytes || htmlTextRuneCount(messageText) > maxMessageLenRunes {
 			messageText = `Alertmanager notification could not be sent: message length exceeds Telegram limits.
 			Please check the template used for producing the message content.`
 		}

--- a/notify/telegram/telegram_test.go
+++ b/notify/telegram/telegram_test.go
@@ -83,6 +83,7 @@ func TestTelegramRetry(t *testing.T) {
 
 func TestTelegramNotify(t *testing.T) {
 	token := "secret"
+	longHTMLLink := `<a href="https://example.com/` + strings.Repeat("x", maxMessageLenRunes) + `">Open</a>`
 
 	fileWithToken, err := os.CreateTemp(t.TempDir(), "telegram-bot-token")
 	require.NoError(t, err, "creating temp file failed")
@@ -132,6 +133,16 @@ func TestTelegramNotify(t *testing.T) {
 			},
 			expText: `Alertmanager notification could not be sent: message length exceeds Telegram limits.
 			Please check the template used for producing the message content.`,
+		},
+		{
+			name: "HTML mode ignores link targets when enforcing length limit",
+			cfg: TelegramConfig{
+				ParseMode:  "HTML",
+				Message:    longHTMLLink,
+				HTTPConfig: &commoncfg.HTTPClientConfig{},
+				BotToken:   commoncfg.Secret(token),
+			},
+			expText: longHTMLLink,
 		},
 		{
 			name: "Default mode with too-large message",

--- a/notify/telegram/telegram_test.go
+++ b/notify/telegram/telegram_test.go
@@ -86,6 +86,10 @@ func TestTelegramNotify(t *testing.T) {
 	longHTMLLink := `<a href="https://example.com/` + strings.Repeat("x", maxMessageLenRunes) + `">Open</a>`
 	longMalformedHTML := `<a href="` + strings.Repeat("x", maxMessageLenRunes)
 	longMalformedHTMLTemplate := fmt.Sprintf(`{{ %q | safeHtml }}`, longMalformedHTML)
+	longMalformedComment := `<!--` + strings.Repeat("x", maxMessageLenRunes)
+	longMalformedCommentTemplate := fmt.Sprintf(`{{ %q | safeHtml }}`, longMalformedComment)
+	longMalformedDoctype := `<!DOCTYPE ` + strings.Repeat("x", maxMessageLenRunes)
+	longMalformedDoctypeTemplate := fmt.Sprintf(`{{ %q | safeHtml }}`, longMalformedDoctype)
 
 	fileWithToken, err := os.CreateTemp(t.TempDir(), "telegram-bot-token")
 	require.NoError(t, err, "creating temp file failed")
@@ -151,6 +155,28 @@ func TestTelegramNotify(t *testing.T) {
 			cfg: TelegramConfig{
 				ParseMode:  "HTML",
 				Message:    longMalformedHTMLTemplate,
+				HTTPConfig: &commoncfg.HTTPClientConfig{},
+				BotToken:   commoncfg.Secret(token),
+			},
+			expText: `Alertmanager notification could not be sent: message length exceeds Telegram limits.
+			Please check the template used for producing the message content.`,
+		},
+		{
+			name: "HTML mode falls back for too-large malformed comment",
+			cfg: TelegramConfig{
+				ParseMode:  "HTML",
+				Message:    longMalformedCommentTemplate,
+				HTTPConfig: &commoncfg.HTTPClientConfig{},
+				BotToken:   commoncfg.Secret(token),
+			},
+			expText: `Alertmanager notification could not be sent: message length exceeds Telegram limits.
+			Please check the template used for producing the message content.`,
+		},
+		{
+			name: "HTML mode falls back for too-large malformed doctype",
+			cfg: TelegramConfig{
+				ParseMode:  "HTML",
+				Message:    longMalformedDoctypeTemplate,
 				HTTPConfig: &commoncfg.HTTPClientConfig{},
 				BotToken:   commoncfg.Secret(token),
 			},

--- a/notify/telegram/telegram_test.go
+++ b/notify/telegram/telegram_test.go
@@ -84,6 +84,8 @@ func TestTelegramRetry(t *testing.T) {
 func TestTelegramNotify(t *testing.T) {
 	token := "secret"
 	longHTMLLink := `<a href="https://example.com/` + strings.Repeat("x", maxMessageLenRunes) + `">Open</a>`
+	longMalformedHTML := `<a href="` + strings.Repeat("x", maxMessageLenRunes)
+	longMalformedHTMLTemplate := fmt.Sprintf(`{{ %q | safeHtml }}`, longMalformedHTML)
 
 	fileWithToken, err := os.CreateTemp(t.TempDir(), "telegram-bot-token")
 	require.NoError(t, err, "creating temp file failed")
@@ -143,6 +145,17 @@ func TestTelegramNotify(t *testing.T) {
 				BotToken:   commoncfg.Secret(token),
 			},
 			expText: longHTMLLink,
+		},
+		{
+			name: "HTML mode falls back for too-large malformed tag",
+			cfg: TelegramConfig{
+				ParseMode:  "HTML",
+				Message:    longMalformedHTMLTemplate,
+				HTTPConfig: &commoncfg.HTTPClientConfig{},
+				BotToken:   commoncfg.Secret(token),
+			},
+			expText: `Alertmanager notification could not be sent: message length exceeds Telegram limits.
+			Please check the template used for producing the message content.`,
 		},
 		{
 			name: "Default mode with too-large message",

--- a/notify/telegram/telegram_test.go
+++ b/notify/telegram/telegram_test.go
@@ -83,7 +83,15 @@ func TestTelegramRetry(t *testing.T) {
 
 func TestTelegramNotify(t *testing.T) {
 	token := "secret"
+	htmlLinkWithSize := func(size int) string {
+		const prefix = `<a href="https://example.com/`
+		const suffix = `">Open</a>`
+
+		return prefix + strings.Repeat("x", size-len(prefix)-len(suffix)) + suffix
+	}
 	longHTMLLink := `<a href="https://example.com/` + strings.Repeat("x", maxMessageLenRunes) + `">Open</a>`
+	htmlAtInputLimit := htmlLinkWithSize(1 << 15)
+	htmlOverInputLimit := htmlLinkWithSize(1<<15 + 1)
 	longMalformedHTML := `<a href="` + strings.Repeat("x", maxMessageLenRunes)
 	longMalformedHTMLTemplate := fmt.Sprintf(`{{ %q | safeHtml }}`, longMalformedHTML)
 	longMalformedComment := `<!--` + strings.Repeat("x", maxMessageLenRunes)
@@ -149,6 +157,27 @@ func TestTelegramNotify(t *testing.T) {
 				BotToken:   commoncfg.Secret(token),
 			},
 			expText: longHTMLLink,
+		},
+		{
+			name: "HTML mode accepts raw input at Telegram limit",
+			cfg: TelegramConfig{
+				ParseMode:  "HTML",
+				Message:    htmlAtInputLimit,
+				HTTPConfig: &commoncfg.HTTPClientConfig{},
+				BotToken:   commoncfg.Secret(token),
+			},
+			expText: htmlAtInputLimit,
+		},
+		{
+			name: "HTML mode falls back for raw input over Telegram limit",
+			cfg: TelegramConfig{
+				ParseMode:  "HTML",
+				Message:    htmlOverInputLimit,
+				HTTPConfig: &commoncfg.HTTPClientConfig{},
+				BotToken:   commoncfg.Secret(token),
+			},
+			expText: `Alertmanager notification could not be sent: message length exceeds Telegram limits.
+			Please check the template used for producing the message content.`,
 		},
 		{
 			name: "HTML mode falls back for too-large malformed tag",

--- a/notify/telegram/telegram_test.go
+++ b/notify/telegram/telegram_test.go
@@ -286,6 +286,38 @@ func TestTelegramNotify(t *testing.T) {
 	}
 }
 
+func TestHTMLTextRuneCount(t *testing.T) {
+	for _, tc := range []struct {
+		input string
+		want  int
+	}{
+		{input: `&lt;`, want: 1},
+		{input: `&gt;`, want: 1},
+		{input: `&amp;`, want: 1},
+		{input: `&quot;`, want: 1},
+		{input: `&#39;`, want: 1},
+		{input: `&#x27;`, want: 1},
+		{input: `&#128293;`, want: 1},
+		{input: `&#x1F525;`, want: 1},
+		{input: `&nbsp;`, want: 6},
+		{input: `&mdash;`, want: 7},
+		{input: `&apos;`, want: 6},
+		{input: `&copy;`, want: 6},
+		{input: `&hellip;`, want: 8},
+		{input: `&nbspa`, want: 6},
+		{input: `&nbsp `, want: 6},
+		{input: `&ampa`, want: 5},
+		{input: `&amp `, want: 2},
+		{input: `&#0;`, want: 4},
+		{input: `&#1114112;`, want: 10},
+		{input: `a & b`, want: 5},
+	} {
+		t.Run(tc.input, func(t *testing.T) {
+			require.Equal(t, tc.want, htmlTextRuneCount(tc.input))
+		})
+	}
+}
+
 func TestTelegramNotifyFailureReason(t *testing.T) {
 	token := "secret"
 


### PR DESCRIPTION
## Summary

- Count decoded visible HTML text toward Telegram's 4096-character limit.
- Exclude markup and attribute values such as embedded `href` URLs.
- Preserve fallback for genuinely over-limit visible messages.
- Add regression coverage for long hidden link targets.

## Testing

- `go test ./notify/... -count=1`
- `golangci-lint run ./notify/telegram/...`

#### Pull Request Checklist

- Open issues discussed with maintainers: none.
- Is this a bugfix?
  - [x] I have added tests that can reproduce the bug which pass with this bugfix applied
- [x] I have signed-off my commits
- [x] I will follow best practices for contributing to this project

#### Which user-facing changes does this PR introduce?

```release-notes
[BUGFIX] Telegram: Count only visible HTML text toward the message limit, excluding embedded link URLs.
```
