### PR TITLE
ci: avoid duplicate checkouts in build jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       matrix:
         thread: [0, 1, 2]
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -51,6 +51,7 @@ jobs:
           path: ui/app/dist
       - uses: prometheus/promci/build@370e8c15dcec50043cbe66f2f34633d9efc0a190 # v0.9.0
         with:
+          checkout: "false"
           promu_opts: "-p linux/amd64 -p windows/amd64 -p linux/arm64 -p darwin/amd64 -p darwin/arm64 -p linux/386"
           parallelism: 3
           thread: ${{ matrix.thread }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
           path: ui/app/dist
       - uses: prometheus/promci/build@370e8c15dcec50043cbe66f2f34633d9efc0a190 # v0.9.0
         with:
+          checkout: "false"
           parallelism: 12
           thread: ${{ matrix.thread }}
   publish_release:


### PR DESCRIPTION
The promci build action checks out the repository by default, but the CI and release build jobs already perform a checkout before downloading the UI artifact.

Disable the action's internal checkout to avoid redundant work and prevent the downloaded UI distribution from being removed by checkout cleanup. Also correct the stale actions/checkout version annotation.
