### PR TITLE
feat(ui): serve the Mantine application

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ lint: ui-elm ui-mantine-lint common-lint
 assets: $(FRONTEND_DIR)/src/Data ui-elm ui-mantine template/email.tmpl
 
 .PHONY: assets-tarball
-assets-tarball: ui-elm
+assets-tarball: ui-elm ui-mantine
 	mkdir -p .tarballs
 	tar czf ".tarballs/alertmanager-web-ui-$(file <VERSION).tar.gz" -C ui/app dist
 

--- a/ui/app/vite.config.mjs
+++ b/ui/app/vite.config.mjs
@@ -4,6 +4,9 @@ import { compression, defineAlgorithm } from "vite-plugin-compression2";
 
 export default defineConfig({
   base: "./",  // ensure that `--web.route.prefix` works correctly.
+  build: {
+    outDir: "dist/elm",
+  },
   plugins: [
     elm(),
     compression({

--- a/ui/mantine-ui/Makefile
+++ b/ui/mantine-ui/Makefile
@@ -17,4 +17,4 @@ lint: node_modules
 
 .PHONY: clean
 clean:
-	- @rm -rf dist node_modules
+	- @rm -rf ../app/dist/mantine node_modules

--- a/ui/mantine-ui/src/App.test.tsx
+++ b/ui/mantine-ui/src/App.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+
+import App from './App';
+
+afterEach(() => {
+  window.location.hash = '';
+});
+
+describe('App routing', () => {
+  it('renders routes from the URL hash', () => {
+    window.location.hash = '#/alerts';
+
+    render(<App />);
+
+    expect(screen.getByText('Alerts List')).toBeInTheDocument();
+  });
+});

--- a/ui/mantine-ui/src/App.tsx
+++ b/ui/mantine-ui/src/App.tsx
@@ -7,7 +7,7 @@ import { CodeHighlightAdapterProvider, createHighlightJsAdapter } from '@mantine
 import { AppShell, Box, MantineProvider, Skeleton } from '@mantine/core';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import hljs from 'highlight.js/lib/core';
-import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
+import { HashRouter, Navigate, Route, Routes } from 'react-router-dom';
 
 import ErrorBoundary from './components/ErrorBoundary';
 import { Header } from './components/Header';
@@ -28,7 +28,7 @@ const queryClient = new QueryClient();
 
 export default function App() {
   return (
-    <BrowserRouter>
+    <HashRouter>
       <MantineProvider theme={theme}>
         <CodeHighlightAdapterProvider adapter={highlightJsAdapter}>
           <QueryClientProvider client={queryClient}>
@@ -62,6 +62,6 @@ export default function App() {
           </QueryClientProvider>
         </CodeHighlightAdapterProvider>
       </MantineProvider>
-    </BrowserRouter>
+    </HashRouter>
   );
 }

--- a/ui/mantine-ui/vite.config.mjs
+++ b/ui/mantine-ui/vite.config.mjs
@@ -25,9 +25,7 @@ export default defineConfig({
       },
     }),
     compression({
-      include: [
-        /(^|\/)assets\/.*\.(avif|css|eot|gif|ico|jpe?g|js|json|mjs|otf|png|svg|ttf|txt|webp|woff2?)$/,
-      ],
+      include: [/\.(css|html|js|txt)$/],
       artifacts: () => [
         {
           src: licenseFile,

--- a/ui/mantine-ui/vite.config.mjs
+++ b/ui/mantine-ui/vite.config.mjs
@@ -13,6 +13,10 @@ const licenseFile = path.resolve(
 
 export default defineConfig({
   base: './',
+  build: {
+    outDir: '../app/dist/mantine',
+    emptyOutDir: true,
+  },
   plugins: [
     react(),
     tsconfigPaths(),

--- a/ui/web.go
+++ b/ui/web.go
@@ -42,6 +42,7 @@ var fileTypes = map[string]struct {
 	".js":    {"text/javascript; charset=utf-8", true},
 	".svg":   {"image/svg+xml", true},
 	".ttf":   {"font/ttf", true},
+	".txt":   {"text/plain; charset=utf-8", true},
 	".woff":  {"font/woff", false},
 	".woff2": {"font/woff2", false},
 }

--- a/ui/web.go
+++ b/ui/web.go
@@ -31,6 +31,24 @@ import (
 //go:embed app/dist
 var asset embed.FS
 
+const (
+	elmRoot     = "app/dist/elm"
+	mantineRoot = "app/dist/mantine"
+)
+
+var (
+	elmFS     = mustSub(elmRoot)
+	mantineFS = mustSub(mantineRoot)
+)
+
+func mustSub(root string) fs.FS {
+	sub, err := fs.Sub(asset, root)
+	if err != nil {
+		panic(err)
+	}
+	return sub
+}
+
 var fileTypes = map[string]struct {
 	contentType  string // https://www.iana.org/assignments/media-types/
 	varyEncoding bool   // Must match build configuration in vite.config.mjs.
@@ -117,11 +135,7 @@ func decompressToReader(f fs.File) (*bytes.Reader, error) {
 
 // Register registers handlers to serve files for the web interface.
 func Register(r *route.Router) {
-	appFS, err := fs.Sub(asset, "app/dist")
-	if err != nil {
-		panic(err) // During build step, we did not embed a directory named `app/dist`.
-	}
-	serve := func(w http.ResponseWriter, req *http.Request, filePath string, immutable bool) {
+	serve := func(w http.ResponseWriter, req *http.Request, appFS fs.FS, filePath string, immutable bool) {
 		ext := strings.ToLower(path.Ext(filePath))
 		fileType, ok := fileTypes[ext]
 		if !ok {
@@ -178,16 +192,37 @@ func Register(r *route.Router) {
 		http.NotFound(w, req)
 	}
 
+	serveAssets := func(w http.ResponseWriter, req *http.Request, appFS fs.FS) {
+		filePath := strings.TrimPrefix(route.Param(req.Context(), "path"), "/")
+		if filePath == "" || !fs.ValidPath(filePath) {
+			http.NotFound(w, req)
+			return
+		}
+		serve(w, req, appFS, path.Join("assets", filePath), true)
+	}
+
 	r.Get("/", func(w http.ResponseWriter, req *http.Request) {
-		serve(w, req, "index.html", false)
+		serve(w, req, elmFS, "index.html", false)
 	})
 
 	r.Get("/favicon.ico", func(w http.ResponseWriter, req *http.Request) {
-		serve(w, req, "favicon.ico", false)
+		serve(w, req, elmFS, "favicon.ico", false)
 	})
 
 	r.Get("/assets/*path", func(w http.ResponseWriter, req *http.Request) {
-		serve(w, req, path.Join("assets", route.Param(req.Context(), "path")), true)
+		serveAssets(w, req, elmFS)
+	})
+
+	r.Get("/ui", func(w http.ResponseWriter, req *http.Request) {
+		http.Redirect(w, req, req.URL.Path+"/", http.StatusFound)
+	})
+
+	r.Get("/ui/", func(w http.ResponseWriter, req *http.Request) {
+		serve(w, req, mantineFS, "index.html", false)
+	})
+
+	r.Get("/ui/assets/*path", func(w http.ResponseWriter, req *http.Request) {
+		serveAssets(w, req, mantineFS)
 	})
 }
 

--- a/ui/web_test.go
+++ b/ui/web_test.go
@@ -17,6 +17,7 @@ import (
 	"io/fs"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path"
 	"regexp"
 	"strings"
@@ -90,16 +91,10 @@ func TestIndexAssetsAreServedPrefix(t *testing.T) {
 	fetchIndexAndAssets(t, router, "/alertmanager/")
 }
 
-// walkEmbeddedFiles returns a map of URL to encodings for every file in
-// app/dist.
-func walkEmbeddedFiles(t *testing.T) map[string][]encoding {
+func walkFiles(t *testing.T, appFS fs.FS, urlRoot string) map[string][]encoding {
 	t.Helper()
-	appFS, err := fs.Sub(asset, "app/dist")
-	require.NoError(t, err)
-
 	count := make(map[string]int)
-
-	err = fs.WalkDir(appFS, ".", func(filePath string, d fs.DirEntry, err error) error {
+	err := fs.WalkDir(appFS, ".", func(filePath string, d fs.DirEntry, err error) error {
 		if err != nil || d.IsDir() {
 			return err
 		}
@@ -111,9 +106,9 @@ func walkEmbeddedFiles(t *testing.T) map[string][]encoding {
 
 	files := make(map[string][]encoding)
 	for base, n := range count {
-		url := "/" + base
+		url := path.Join(urlRoot, base)
 		if base == "index.html" {
-			url = "/"
+			url = urlRoot
 		}
 		ext := path.Ext(base)
 		fileType, known := fileTypes[ext]
@@ -126,8 +121,27 @@ func walkEmbeddedFiles(t *testing.T) map[string][]encoding {
 			files[url] = []encoding{encNone}
 		}
 	}
-
 	return files
+}
+
+func TestMantineBuildOutput(t *testing.T) {
+	mantineFS := os.DirFS("mantine-ui/dist")
+	if _, err := fs.Stat(mantineFS, "."); os.IsNotExist(err) {
+		t.Skip("Mantine UI assets are not built")
+	} else {
+		require.NoError(t, err)
+	}
+	files := walkFiles(t, mantineFS, "/ui/")
+	require.Contains(t, files, "/ui/")
+}
+
+// walkEmbeddedFiles returns a map of URL to encodings for every file in
+// app/dist.
+func walkEmbeddedFiles(t *testing.T) map[string][]encoding {
+	t.Helper()
+	appFS, err := fs.Sub(asset, "app/dist")
+	require.NoError(t, err)
+	return walkFiles(t, appFS, "/")
 }
 
 func fetchWithEncoding(router *route.Router, urlPath string, encoding encoding) *httptest.ResponseRecorder {

--- a/ui/web_test.go
+++ b/ui/web_test.go
@@ -17,7 +17,6 @@ import (
 	"io/fs"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"path"
 	"regexp"
 	"strings"
@@ -91,6 +90,43 @@ func TestIndexAssetsAreServedPrefix(t *testing.T) {
 	fetchIndexAndAssets(t, router, "/alertmanager/")
 }
 
+func TestMantineIndexAssetsAreServed(t *testing.T) {
+	router := route.New()
+	Register(router)
+	fetchIndexAndAssets(t, router, "/ui/")
+}
+
+func TestMantineIndexAssetsAreServedPrefix(t *testing.T) {
+	router := route.New().WithPrefix("/alertmanager")
+	Register(router)
+	fetchIndexAndAssets(t, router, "/alertmanager/ui/")
+}
+
+func TestMantineRedirect(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		router     *route.Router
+		requestURL string
+	}{
+		{"root", route.New(), "/ui"},
+		{"prefix", route.New().WithPrefix("/alertmanager"), "/alertmanager/ui"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			Register(tt.router)
+			res := fetchWithEncoding(tt.router, tt.requestURL, encNone)
+			require.Equal(t, http.StatusFound, res.Code)
+			require.Equal(t, tt.requestURL+"/", res.Header().Get("Location"))
+		})
+	}
+}
+
+func TestMantineHashRoutesStayClientSide(t *testing.T) {
+	router := route.New()
+	Register(router)
+	res := fetchWithEncoding(router, "/ui/alerts", encNone)
+	require.Equal(t, http.StatusNotFound, res.Code)
+}
+
 func walkFiles(t *testing.T, appFS fs.FS, urlRoot string) map[string][]encoding {
 	t.Helper()
 	count := make(map[string]int)
@@ -124,24 +160,14 @@ func walkFiles(t *testing.T, appFS fs.FS, urlRoot string) map[string][]encoding 
 	return files
 }
 
-func TestMantineBuildOutput(t *testing.T) {
-	mantineFS := os.DirFS("mantine-ui/dist")
-	if _, err := fs.Stat(mantineFS, "."); os.IsNotExist(err) {
-		t.Skip("Mantine UI assets are not built")
-	} else {
-		require.NoError(t, err)
-	}
-	files := walkFiles(t, mantineFS, "/ui/")
-	require.Contains(t, files, "/ui/")
-}
-
-// walkEmbeddedFiles returns a map of URL to encodings for every file in
-// app/dist.
 func walkEmbeddedFiles(t *testing.T) map[string][]encoding {
 	t.Helper()
-	appFS, err := fs.Sub(asset, "app/dist")
-	require.NoError(t, err)
-	return walkFiles(t, appFS, "/")
+	return walkFiles(t, elmFS, "/")
+}
+
+func walkMantineFiles(t *testing.T) map[string][]encoding {
+	t.Helper()
+	return walkFiles(t, mantineFS, "/ui/")
 }
 
 func fetchWithEncoding(router *route.Router, urlPath string, encoding encoding) *httptest.ResponseRecorder {
@@ -187,10 +213,13 @@ func TestAssetsNotFoundCacheHeader(t *testing.T) {
 	router := route.New()
 	Register(router)
 
-	res := fetchWithEncoding(router, "/assets/nonexistent.js", encNone)
-
-	require.Equal(t, http.StatusNotFound, res.Code)
-	require.Empty(t, res.Header().Get("Cache-Control"))
+	for _, urlPath := range []string{"/assets/nonexistent.js", "/ui/assets/nonexistent.js", "/ui/assets/../index.html"} {
+		t.Run(urlPath, func(t *testing.T) {
+			res := fetchWithEncoding(router, urlPath, encNone)
+			require.Equal(t, http.StatusNotFound, res.Code)
+			require.Empty(t, res.Header().Get("Cache-Control"))
+		})
+	}
 }
 
 // TestWebRoutes walks the embedded FS and issues an HTTP request for every
@@ -200,10 +229,17 @@ func TestWebRoutes(t *testing.T) {
 	Register(router)
 
 	files := walkEmbeddedFiles(t)
-
 	require.Contains(t, files, "/")
 	require.Contains(t, files, "/favicon.ico")
+	checkWebRoutes(t, router, files)
 
+	mantineFiles := walkMantineFiles(t)
+	require.Contains(t, mantineFiles, "/ui/")
+	checkWebRoutes(t, router, mantineFiles)
+}
+
+func checkWebRoutes(t *testing.T, router *route.Router, files map[string][]encoding) {
+	t.Helper()
 	for url, encodings := range files {
 		t.Run(url, func(t *testing.T) {
 			for _, encoding := range encodings {


### PR DESCRIPTION
## Summary

- build the Elm and Mantine distributions as sibling trees under `ui/app/dist/{elm,mantine}`
- embed both distributions in the Alertmanager binary and include both in the existing UI archive
- serve the Mantine application at `/ui/` with its assets isolated under `/ui/assets/`
- use hash-based client routing so root and route-prefixed deployments need no SPA fallback or runtime path injection
- preserve the existing explicit Go compression contract and add only the `.txt` type required by the Mantine license artifact
- leave WOFF/WOFF2 raw while requiring both gzip and Brotli for compressible formats
- verify the real embedded outputs rather than synthetic asset fixtures
- reject invalid asset paths before joining them into either embedded filesystem

The local workflow is:

```bash
make ui-elm ui-mantine
go run ./cmd/alertmanager --config.file=doc/examples/simple.yml
```

Clean BrowserRouter paths and runtime public-prefix handling will follow separately.

Part of #5486