### PR TITLE
pagerduty: classify v1 HTTP failures

### DIFF
--- a/notify/pagerduty/pagerduty.go
+++ b/notify/pagerduty/pagerduty.go
@@ -199,7 +199,11 @@ func (n *Notifier) notifyV1(
 	}
 	defer notify.Drain(resp)
 
-	return n.retrier.Check(resp.StatusCode, resp.Body)
+	retry, err := n.retrier.Check(resp.StatusCode, resp.Body)
+	if err != nil {
+		return retry, notify.NewErrorWithReason(notify.GetFailureReasonFromStatusCode(resp.StatusCode), err)
+	}
+	return retry, err
 }
 
 func (n *Notifier) notifyV2(

--- a/notify/pagerduty/pagerduty_test.go
+++ b/notify/pagerduty/pagerduty_test.go
@@ -75,6 +75,79 @@ func TestPagerDutyRetryV2(t *testing.T) {
 	}
 }
 
+func TestPagerDutyFailureReason(t *testing.T) {
+	for _, version := range []string{"v1", "v2"} {
+		for _, tc := range []struct {
+			name           string
+			statusCode     int
+			expectedReason notify.Reason
+		}{
+			{
+				name:           "client error",
+				statusCode:     http.StatusBadRequest,
+				expectedReason: notify.ClientErrorReason,
+			},
+			{
+				name:           "authentication error",
+				statusCode:     http.StatusUnauthorized,
+				expectedReason: notify.AuthErrorReason,
+			},
+			{
+				name:           "authorization error",
+				statusCode:     http.StatusForbidden,
+				expectedReason: notify.AuthErrorReason,
+			},
+			{
+				name:           "rate limited",
+				statusCode:     http.StatusTooManyRequests,
+				expectedReason: notify.RateLimitedReason,
+			},
+			{
+				name:           "server error",
+				statusCode:     http.StatusInternalServerError,
+				expectedReason: notify.ServerErrorReason,
+			},
+		} {
+			t.Run(version+"/"+tc.name, func(t *testing.T) {
+				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(tc.statusCode)
+				}))
+				defer srv.Close()
+
+				cfg := &PagerdutyConfig{HTTPConfig: &commoncfg.HTTPClientConfig{}}
+				if version == "v1" {
+					cfg.ServiceKey = commoncfg.Secret("01234567890123456789012345678901")
+				} else {
+					u, err := url.Parse(srv.URL)
+					require.NoError(t, err)
+					cfg.RoutingKey = commoncfg.Secret("01234567890123456789012345678901")
+					cfg.URL = &amcommoncfg.URL{URL: u}
+				}
+
+				notifier, err := New(cfg, test.CreateTmpl(t), promslog.NewNopLogger())
+				require.NoError(t, err)
+				if version == "v1" {
+					notifier.apiV1 = srv.URL
+				}
+
+				ctx := notify.WithGroupKey(context.Background(), "1")
+				alert := &types.Alert{
+					Alert: model.Alert{
+						Labels:   model.LabelSet{"lbl1": "val1"},
+						StartsAt: time.Now(),
+						EndsAt:   time.Now().Add(time.Hour),
+					},
+				}
+
+				_, err = notifier.Notify(ctx, alert)
+				var reasonError *notify.ErrorWithReason
+				require.ErrorAs(t, err, &reasonError)
+				require.Equal(t, tc.expectedReason, reasonError.Reason)
+			})
+		}
+	}
+}
+
 func TestPagerDutyRedactedURLV1(t *testing.T) {
 	ctx, u, fn := test.GetContextWithCancelingURL()
 	defer fn()


### PR DESCRIPTION
## Summary

- classify PagerDuty Events API v1 HTTP failures with the same structured failure reasons already used by the v2 notifier
- preserve the existing PagerDuty v1 retry decisions and error text
- add end-to-end coverage for both PagerDuty API versions across client, authentication, authorization, rate-limit, and server failures

Part of #3231.

## Problem

`notifyV1` returned the raw error from `Retrier.Check`. Because that error was not wrapped in `notify.ErrorWithReason`, `alertmanager_notifications_failed_total` recorded PagerDuty v1 HTTP failures with the fallback `reason="other"` label.

The v2 path already wraps the same retry-check error using `GetFailureReasonFromStatusCode`, so the two PagerDuty API versions reported identical HTTP failures differently.

## Implementation

The v1 path now:

1. preserves the retry decision returned by `Retrier.Check`
2. wraps non-success errors with `notify.NewErrorWithReason`
3. derives the metric reason through the existing centralized `notify.GetFailureReasonFromStatusCode` mapping

No exported API, request payload, retry code, timeout, or notifier configuration changes.

## Behavior and compatibility

- Retry behavior is unchanged. PagerDuty v1 still retries HTTP 403 and 5xx responses according to its existing retrier configuration.
- Error messages are unchanged because `ErrorWithReason.Error` delegates to the original error.
- The observable change is limited to the failure metric label for PagerDuty v1 HTTP responses: failures previously categorized as `other` are now categorized as `clientError`, `authError`, `rateLimited`, or `serverError`.
- PagerDuty v2 is not changed; it is included in the regression table to prevent the two implementations from diverging again.

## Validation

- `go test ./notify/pagerduty/...` — passed
- `go test ./notify/...` — passed
- `go test -race ./notify/pagerduty/...` — passed
- `go test -count=10 ./notify/pagerduty/...` — passed
- `go vet ./notify/pagerduty/...` — passed
- `git diff --check` — passed
- formatted with Go 1.26.0 `gofmt`

The new test exercises PagerDuty v1 and v2 for HTTP 400, 401, 403, 429, and 500 and asserts the resulting `notify.ErrorWithReason.Reason` value.

## Pull Request Checklist

- Is this a bugfix?
  - [x] I have added tests that reproduce the missing classification and pass with the fix applied.
- Does this change affect performance?
  - [x] No meaningful performance impact; it adds one error wrapper only on failed PagerDuty v1 requests.
- Is this a breaking change?
  - [x] This does not change cluster messages.
  - [x] This does not change the API.
- [x] No documentation files require changes; the unreleased changelog instructs contributors to put behavior notes in the PR description.
- [x] I have signed off the commit.
- [x] I will follow the project's contribution practices.

## Release note

```release-notes
[BUGFIX] pagerduty: Classify Events API v1 HTTP failures in `alertmanager_notifications_failed_total` instead of reporting the fallback `reason="other"`.
```

## AI assistance disclosure

This contribution was implemented, tested, and described by OpenAI Codex operating autonomously on behalf of the contributor account. No human code review or manual validation is being claimed.
