### PR TITLE
api: centralize Connect service metadata

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -186,10 +186,10 @@ func (api *API) Register(r *route.Router, routePrefix string) *http.ServeMux {
 	// ConnectRPC procedure paths are the only bounded label values on the
 	// Connect/gRPC surface; any other path yields a 404 and must not be
 	// recorded verbatim, or a client could inflate metric/trace cardinality.
-	servicePrefixes := api.connect.ServicePrefixes()
+	procedures := api.connect.Procedures()
 	// Native gRPC is served at the server root, so match against the raw
 	// request path (no mount prefix).
-	grpcHandler := api.instrumentConnectHandler("", servicePrefixes, connectHandler)
+	grpcHandler := api.instrumentConnectHandler("", procedures, connectHandler)
 	webHandler := api.limitHandler(r)
 	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if isGRPCRequest(r) {
@@ -231,7 +231,7 @@ func (api *API) Register(r *route.Router, routePrefix string) *http.ServeMux {
 		apiPrefix+"/api/",
 		api.instrumentConnectHandler(
 			apiPrefix+"/api",
-			servicePrefixes,
+			procedures,
 			http.StripPrefix(apiPrefix+"/api", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if isGRPCRequest(r) {
 					http.NotFound(w, r)
@@ -318,17 +318,15 @@ const unmatchedRPCLabel = "unmatched"
 
 // instrumentConnectHandler is like instrumentHandler but bounds label and
 // span cardinality for the Connect/gRPC surface. Requests whose path (after
-// stripping mountPrefix) matches a registered service are recorded under that
-// service's prefix; the trailing method segment is intentionally dropped so a
-// client cannot inflate cardinality by appending arbitrary (and 404-ing)
-// method names. Everything else collapses to unmatchedRPCLabel.
-func (api *API) instrumentConnectHandler(mountPrefix string, servicePrefixes []string, h http.Handler) http.Handler {
+// stripping mountPrefix) exactly matches a registered procedure are recorded
+// under that procedure. Everything else collapses to unmatchedRPCLabel.
+func (api *API) instrumentConnectHandler(mountPrefix string, procedures []string, h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		procedure, _ := strings.CutPrefix(r.URL.Path, mountPrefix)
 		label := unmatchedRPCLabel
-		for _, p := range servicePrefixes {
-			if strings.HasPrefix(procedure, p) {
-				label = p
+		for _, known := range procedures {
+			if procedure == known {
+				label = known
 				break
 			}
 		}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -16,12 +16,18 @@ package api
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"testing/synctest"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/promslog"
+	"github.com/prometheus/common/route"
 	"github.com/stretchr/testify/require"
+
+	apiconnect "github.com/prometheus/alertmanager/api/connect"
+	apiv2 "github.com/prometheus/alertmanager/api/v2"
 )
 
 func TestConcurrencyLimitHandler(t *testing.T) {
@@ -76,12 +82,48 @@ func TestConcurrencyLimitHandler(t *testing.T) {
 	})
 }
 
+func TestConnectProceduresRegistered(t *testing.T) {
+	for _, routePrefix := range []string{"/", "/alertmanager"} {
+		t.Run(routePrefix, func(t *testing.T) {
+			connectAPI := apiconnect.NewAPI(apiconnect.Options{})
+			requestDuration := prometheus.NewHistogramVec(
+				prometheus.HistogramOpts{Name: "test_registered_http_request_duration_seconds"},
+				[]string{"handler", "method", "code"},
+			)
+			api := &API{
+				v2:                &apiv2.API{Handler: http.NotFoundHandler()},
+				connect:           connectAPI,
+				deprecationRouter: NewV1DeprecationRouter(promslog.NewNopLogger()),
+				requestDuration:   requestDuration,
+				requestsInFlight: prometheus.NewGauge(prometheus.GaugeOpts{
+					Name: "test_registered_requests_in_flight",
+				}),
+				concurrencyLimitExceeded: prometheus.NewCounter(prometheus.CounterOpts{
+					Name: "test_registered_concurrency_limit_exceeded_total",
+				}),
+				inFlightSem: make(chan struct{}, 1),
+			}
+			mux := api.Register(route.New(), routePrefix)
+			mountPrefix := strings.TrimSuffix(routePrefix, "/") + "/api"
+
+			for _, procedure := range connectAPI.Procedures() {
+				t.Run(procedure, func(t *testing.T) {
+					recorder := httptest.NewRecorder()
+					request := httptest.NewRequest(http.MethodOptions, mountPrefix+procedure, nil)
+					mux.ServeHTTP(recorder, request)
+					require.NotEqual(t, http.StatusNotFound, recorder.Code)
+				})
+			}
+		})
+	}
+}
+
 // TestInstrumentConnectHandlerBoundsCardinality ensures that Connect/gRPC
 // requests to unregistered paths collapse to a single placeholder handler
 // label instead of being recorded verbatim, which would let a client inflate
 // metric cardinality by hitting arbitrary paths.
 func TestInstrumentConnectHandlerBoundsCardinality(t *testing.T) {
-	const servicePrefix = "/status.v3alpha.StatusService/"
+	const registeredProcedure = "/status.v3alpha.StatusService/GetStatus"
 
 	for _, mountPrefix := range []string{"", "/alertmanager/api"} {
 		t.Run(mountPrefix, func(t *testing.T) {
@@ -98,7 +140,7 @@ func TestInstrumentConnectHandlerBoundsCardinality(t *testing.T) {
 			// procedure, 404 for everything else (including unknown methods on a
 			// known service).
 			inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path == servicePrefix+"GetStatus" {
+				if r.URL.Path == registeredProcedure {
 					w.WriteHeader(http.StatusOK)
 					return
 				}
@@ -106,22 +148,22 @@ func TestInstrumentConnectHandlerBoundsCardinality(t *testing.T) {
 			})
 			h := api.instrumentConnectHandler(
 				mountPrefix,
-				[]string{servicePrefix},
+				[]string{registeredProcedure},
 				http.StripPrefix(mountPrefix, inner),
 			)
 
-			for _, procedure := range []string{
-				servicePrefix + "GetStatus",
+			for _, path := range []string{
+				registeredProcedure,
 				// Unknown methods on a known service must not each get their own
-				// label; they collapse onto the service prefix.
-				servicePrefix + "Evil1",
-				servicePrefix + "Evil2",
+				// label; they collapse onto the unmatched placeholder.
+				"/status.v3alpha.StatusService/Evil1",
+				"/status.v3alpha.StatusService/Evil2",
 				// Entirely unregistered paths collapse onto the placeholder.
 				"/attacker/controlled/1",
 				"/attacker/controlled/2",
 			} {
 				recorder := httptest.NewRecorder()
-				h.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, mountPrefix+procedure, nil))
+				h.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, mountPrefix+path, nil))
 			}
 
 			families, err := reg.Gather()
@@ -142,8 +184,8 @@ func TestInstrumentConnectHandlerBoundsCardinality(t *testing.T) {
 			}
 
 			require.Equal(t, map[string]struct{}{
-				servicePrefix:     {},
-				unmatchedRPCLabel: {},
+				registeredProcedure: {},
+				unmatchedRPCLabel:   {},
 			}, handlers)
 		})
 	}

--- a/api/connect/connect.go
+++ b/api/connect/connect.go
@@ -43,12 +43,24 @@ type Options struct {
 	UnaryTimeout      time.Duration
 }
 
+type procedureDescriptor struct {
+	path string
+}
+
+type serviceDescriptor struct {
+	name       string
+	procedures []procedureDescriptor
+	handler    func(...connect.HandlerOption) (string, http.Handler)
+}
+
 // API implements the ConnectRPC service handlers for the Connect API.
 type API struct {
 	peer            cluster.ClusterPeer
 	uptime          time.Time
 	admission       *admissionInterceptor
 	peerSnapshotSem chan struct{}
+	services        []serviceDescriptor
+	procedures      map[string]procedureDescriptor
 
 	configSnapshot atomic.Pointer[string]
 }
@@ -58,16 +70,24 @@ type API struct {
 func NewAPI(opts Options) *API {
 	unaryConcurrency := defaultConcurrency(opts.UnaryConcurrency)
 	streamConcurrency := defaultConcurrency(opts.StreamConcurrency)
-	return &API{
+	api := &API{
 		peer:            opts.Peer,
 		uptime:          time.Now(),
 		peerSnapshotSem: make(chan struct{}, 1),
+		procedures:      make(map[string]procedureDescriptor),
 		admission: &admissionInterceptor{
 			unary:        make(chan struct{}, unaryConcurrency),
 			streams:      make(chan struct{}, streamConcurrency),
 			unaryTimeout: opts.UnaryTimeout,
 		},
 	}
+	api.services = api.serviceDescriptors()
+	for _, service := range api.services {
+		for _, procedure := range service.procedures {
+			api.procedures[procedure.path] = procedure
+		}
+	}
+	return api
 }
 
 func defaultConcurrency(concurrency int) int {
@@ -75,6 +95,56 @@ func defaultConcurrency(concurrency int) int {
 		return max(runtime.GOMAXPROCS(0), 8)
 	}
 	return concurrency
+}
+
+func procedure(service, name string) procedureDescriptor {
+	return procedureDescriptor{path: "/" + service + "/" + name}
+}
+
+func (api *API) serviceDescriptors() []serviceDescriptor {
+	status := serviceDescriptor{
+		name: statusv3alphaconnect.StatusServiceName,
+		procedures: []procedureDescriptor{
+			procedure(statusv3alphaconnect.StatusServiceName, "GetStatus"),
+		},
+		handler: func(opts ...connect.HandlerOption) (string, http.Handler) {
+			return statusv3alphaconnect.NewStatusServiceHandler(api, opts...)
+		},
+	}
+	advertised := []string{status.name}
+	checker := grpchealth.NewStaticChecker(advertised...)
+	reflector := grpcreflect.NewStaticReflector(advertised...)
+	return []serviceDescriptor{
+		status,
+		{
+			name: grpchealth.HealthV1ServiceName,
+			procedures: []procedureDescriptor{
+				procedure(grpchealth.HealthV1ServiceName, "Check"),
+				procedure(grpchealth.HealthV1ServiceName, "Watch"),
+			},
+			handler: func(opts ...connect.HandlerOption) (string, http.Handler) {
+				return grpchealth.NewHandler(checker, opts...)
+			},
+		},
+		{
+			name: grpcreflect.ReflectV1ServiceName,
+			procedures: []procedureDescriptor{
+				procedure(grpcreflect.ReflectV1ServiceName, "ServerReflectionInfo"),
+			},
+			handler: func(opts ...connect.HandlerOption) (string, http.Handler) {
+				return grpcreflect.NewHandlerV1(reflector, opts...)
+			},
+		},
+		{
+			name: grpcreflect.ReflectV1AlphaServiceName,
+			procedures: []procedureDescriptor{
+				procedure(grpcreflect.ReflectV1AlphaServiceName, "ServerReflectionInfo"),
+			},
+			handler: func(opts ...connect.HandlerOption) (string, http.Handler) {
+				return grpcreflect.NewHandlerV1Alpha(reflector, opts...)
+			},
+		},
+	}
 }
 
 // admissionInterceptor gives unary RPCs and streams independent capacity so
@@ -149,37 +219,31 @@ func (api *API) Handler(opts ...connect.HandlerOption) http.Handler {
 	return api.buildHandler(opts...)
 }
 
-// ServicePrefixes returns the URL path prefixes ("/<fully-qualified-service>/")
-// for every service registered by Handler. Callers use it to bound the
-// cardinality of metric and trace labels: any request path that does not
-// match one of these prefixes yields a 404 and should not be recorded
-// verbatim.
-func (*API) ServicePrefixes() []string {
-	return []string{
-		"/status.v3alpha.StatusService/",
-		"/grpc.health.v1.Health/",
-		"/grpc.reflection.v1.ServerReflection/",
-		"/grpc.reflection.v1alpha.ServerReflection/",
+// Procedures returns the fully-qualified URL paths for every procedure
+// registered by Handler. Callers use it to bound metric and trace labels:
+// any request path that does not exactly match one of these paths yields a
+// 404 and should not be recorded verbatim.
+func (api *API) Procedures() []string {
+	procedures := make([]string, 0, len(api.procedures))
+	for _, service := range api.services {
+		for _, procedure := range service.procedures {
+			procedures = append(procedures, procedure.path)
+		}
 	}
+	return procedures
 }
 
 // buildHandler registers every ConnectRPC service on a fresh mux.
 func (api *API) buildHandler(opts ...connect.HandlerOption) http.Handler {
 	opts = append([]connect.HandlerOption{connect.WithInterceptors(api.admission)}, opts...)
 
-	// serviceNames lists the fully-qualified service names advertised via
-	// health checking and reflection.
-	serviceNames := []string{
-		statusv3alphaconnect.StatusServiceName,
-	}
-
 	mux := http.NewServeMux()
-	mux.Handle(statusv3alphaconnect.NewStatusServiceHandler(api, opts...))
-	mux.Handle(grpchealth.NewHandler(grpchealth.NewStaticChecker(serviceNames...), opts...))
-
-	reflector := grpcreflect.NewStaticReflector(serviceNames...)
-	mux.Handle(grpcreflect.NewHandlerV1(reflector, opts...))
-	mux.Handle(grpcreflect.NewHandlerV1Alpha(reflector, opts...))
-
+	for _, service := range api.services {
+		path, handler := service.handler(opts...)
+		if path != "/"+service.name+"/" {
+			panic("Connect service descriptor and handler path disagree")
+		}
+		mux.Handle(path, handler)
+	}
 	return mux
 }

--- a/api/connect/status_test.go
+++ b/api/connect/status_test.go
@@ -231,12 +231,13 @@ var _ = Describe("StatusService", func() {
 })
 
 var _ = Describe("Connect API", func() {
-	It("pins registered service prefixes", func() {
-		Expect(NewAPI(Options{}).ServicePrefixes()).To(Equal([]string{
-			"/status.v3alpha.StatusService/",
-			"/grpc.health.v1.Health/",
-			"/grpc.reflection.v1.ServerReflection/",
-			"/grpc.reflection.v1alpha.ServerReflection/",
+	It("pins registered procedures", func() {
+		Expect(NewAPI(Options{}).Procedures()).To(Equal([]string{
+			"/status.v3alpha.StatusService/GetStatus",
+			"/grpc.health.v1.Health/Check",
+			"/grpc.health.v1.Health/Watch",
+			"/grpc.reflection.v1.ServerReflection/ServerReflectionInfo",
+			"/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",
 		}))
 	})
 })


### PR DESCRIPTION
Keep handler registration, health and reflection names, and bounded procedure instrumentation derived from one catalog, and verify every advertised procedure resolves through the registered API mux.

Part of #5478