### PR TITLE
api: bound Connect admission and message resources

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -67,15 +67,33 @@ type Options struct {
 	GroupMutedFunc func(routeID, groupKey string) ([]string, bool)
 	// Peer from the gossip cluster. If nil, no clustering will be used.
 	Peer cluster.ClusterPeer
-	// Timeout for HTTP requests and Connect unary RPCs. The zero value (and
-	// negative values) result in no timeout.
+	// Timeout for HTTP requests and Connect unary RPCs. The zero value and
+	// negative values result in no timeout.
 	Timeout time.Duration
-	// Concurrency limit for GET requests and, independently, Connect unary
-	// RPCs and streams. The zero value (and negative values) result in a
-	// limit of GOMAXPROCS or 8, whichever is larger. Status code 503 is served
-	// for GET requests that would exceed the concurrency limit; Connect calls
-	// receive ResourceExhausted.
+	// Concurrency is the limit for GET requests. The zero value and negative
+	// values result in a limit of GOMAXPROCS or 8, whichever is larger. Status
+	// code 503 is served for requests that would exceed the limit.
 	Concurrency int
+	// ConnectUnaryConcurrency is the independent limit for Connect unary RPCs.
+	// Non-positive values inherit Concurrency. Calls that exceed the limit
+	// receive ResourceExhausted.
+	ConnectUnaryConcurrency int
+	// ConnectStreamConcurrency is the independent limit for Connect streams.
+	// Non-positive values inherit Concurrency. Calls that exceed the limit
+	// receive ResourceExhausted.
+	ConnectStreamConcurrency int
+	// ConnectUnaryTimeout is the timeout for Connect unary RPCs. Zero inherits
+	// Timeout. A negative value disables the Connect unary timeout.
+	ConnectUnaryTimeout time.Duration
+	// ConnectReadMaxBytes limits each incoming Connect protobuf message.
+	// Non-positive values do not set a limit.
+	ConnectReadMaxBytes int
+	// ConnectSendMaxBytes limits each outgoing Connect protobuf message.
+	// Non-positive values do not set a limit.
+	ConnectSendMaxBytes int
+	// ConnectMaxRequestBodyBytes limits the wire size of a Connect unary request
+	// body before decoding. Non-positive values do not set a limit.
+	ConnectMaxRequestBodyBytes int64
 	// Logger is used for logging, if nil, no logging will happen.
 	Logger *slog.Logger
 	// Registry is used to register Prometheus metrics. If nil, no metrics
@@ -87,6 +105,55 @@ type Options struct {
 	// according to the current active configuration. Alerts returned are
 	// filtered by the arguments provided to the function.
 	GroupFunc func(context.Context, func(*dispatch.Route) bool, func(*types.Alert, time.Time) bool) (dispatch.AlertGroups, map[model.Fingerprint][]string, error)
+}
+
+type effectiveOptions struct {
+	logger      *slog.Logger
+	timeout     time.Duration
+	concurrency int
+	connect     apiconnect.Options
+}
+
+func (o Options) resolve() effectiveOptions {
+	logger := o.Logger
+	if logger == nil {
+		logger = promslog.NewNopLogger()
+	}
+	timeout := max(o.Timeout, 0)
+	concurrency := o.Concurrency
+	if concurrency < 1 {
+		concurrency = max(runtime.GOMAXPROCS(0), 8)
+	}
+	unaryConcurrency := o.ConnectUnaryConcurrency
+	if unaryConcurrency < 1 {
+		unaryConcurrency = concurrency
+	}
+	streamConcurrency := o.ConnectStreamConcurrency
+	if streamConcurrency < 1 {
+		streamConcurrency = concurrency
+	}
+	unaryTimeout := o.ConnectUnaryTimeout
+	switch {
+	case unaryTimeout == 0:
+		unaryTimeout = timeout
+	case unaryTimeout < 0:
+		unaryTimeout = 0
+	}
+	return effectiveOptions{
+		logger:      logger,
+		timeout:     timeout,
+		concurrency: concurrency,
+		connect: apiconnect.Options{
+			Peer:                o.Peer,
+			Registerer:          o.Registry,
+			UnaryConcurrency:    unaryConcurrency,
+			StreamConcurrency:   streamConcurrency,
+			UnaryTimeout:        unaryTimeout,
+			ReadMaxBytes:        max(o.ConnectReadMaxBytes, 0),
+			SendMaxBytes:        max(o.ConnectSendMaxBytes, 0),
+			MaxRequestBodyBytes: max(o.ConnectMaxRequestBodyBytes, 0),
+		},
+	}
 }
 
 func (o Options) validate() error {
@@ -111,14 +178,7 @@ func New(opts Options) (*API, error) {
 	if err := opts.validate(); err != nil {
 		return nil, fmt.Errorf("invalid API options: %w", err)
 	}
-	l := opts.Logger
-	if l == nil {
-		l = promslog.NewNopLogger()
-	}
-	concurrency := opts.Concurrency
-	if concurrency < 1 {
-		concurrency = max(runtime.GOMAXPROCS(0), 8)
-	}
+	effective := opts.resolve()
 
 	// The Connect API is always mounted alongside API v2.
 	v2, err := apiv2.NewAPI(
@@ -127,18 +187,13 @@ func New(opts Options) (*API, error) {
 		opts.GroupMutedFunc,
 		opts.Silences,
 		opts.Peer,
-		l.With("version", "v2"),
+		effective.logger.With("version", "v2"),
 		opts.Registry,
 	)
 	if err != nil {
 		return nil, err
 	}
-	connect := apiconnect.NewAPI(apiconnect.Options{
-		Peer:              opts.Peer,
-		UnaryConcurrency:  concurrency,
-		StreamConcurrency: concurrency,
-		UnaryTimeout:      opts.Timeout,
-	})
+	connect := apiconnect.NewAPI(effective.connect)
 
 	requestsInFlight := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name:        "alertmanager_http_requests_in_flight",
@@ -160,14 +215,14 @@ func New(opts Options) (*API, error) {
 	}
 
 	return &API{
-		deprecationRouter:        NewV1DeprecationRouter(l.With("version", "v1")),
+		deprecationRouter:        NewV1DeprecationRouter(effective.logger.With("version", "v1")),
 		v2:                       v2,
 		connect:                  connect,
 		requestDuration:          opts.RequestDuration,
 		requestsInFlight:         requestsInFlight,
 		concurrencyLimitExceeded: concurrencyLimitExceeded,
-		timeout:                  opts.Timeout,
-		inFlightSem:              make(chan struct{}, concurrency),
+		timeout:                  effective.timeout,
+		inFlightSem:              make(chan struct{}, effective.concurrency),
 	}, nil
 }
 
@@ -184,8 +239,9 @@ func (api *API) Register(r *route.Router, routePrefix string) *http.ServeMux {
 	mux := http.NewServeMux()
 	connectHandler := api.connect.Handler()
 	// ConnectRPC procedure paths are the only bounded label values on the
-	// Connect/gRPC surface; any other path yields a 404 and must not be
-	// recorded verbatim, or a client could inflate metric/trace cardinality.
+	// Connect/gRPC surface. The Connect handler rejects every other path. Do not
+	// record unmatched paths verbatim because a client could inflate metric and
+	// trace cardinality.
 	procedures := api.connect.Procedures()
 	// Native gRPC is served at the server root, so match against the raw
 	// request path (no mount prefix).

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"testing"
 	"testing/synctest"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/promslog"
@@ -82,6 +83,35 @@ func TestConcurrencyLimitHandler(t *testing.T) {
 	})
 }
 
+func TestOptionsResolve(t *testing.T) {
+	effective := (Options{
+		Concurrency:                3,
+		Timeout:                    time.Minute,
+		ConnectReadMaxBytes:        -1,
+		ConnectSendMaxBytes:        -1,
+		ConnectMaxRequestBodyBytes: -1,
+	}).resolve()
+	require.Equal(t, 3, effective.concurrency)
+	require.Equal(t, time.Minute, effective.timeout)
+	require.Equal(t, 3, effective.connect.UnaryConcurrency)
+	require.Equal(t, 3, effective.connect.StreamConcurrency)
+	require.Equal(t, time.Minute, effective.connect.UnaryTimeout)
+	require.Zero(t, effective.connect.ReadMaxBytes)
+	require.Zero(t, effective.connect.SendMaxBytes)
+	require.Zero(t, effective.connect.MaxRequestBodyBytes)
+
+	effective = (Options{
+		Concurrency:              3,
+		Timeout:                  time.Minute,
+		ConnectUnaryConcurrency:  4,
+		ConnectStreamConcurrency: 5,
+		ConnectUnaryTimeout:      -time.Second,
+	}).resolve()
+	require.Equal(t, 4, effective.connect.UnaryConcurrency)
+	require.Equal(t, 5, effective.connect.StreamConcurrency)
+	require.Zero(t, effective.connect.UnaryTimeout)
+}
+
 func TestConnectProceduresRegistered(t *testing.T) {
 	for _, routePrefix := range []string{"/", "/alertmanager"} {
 		t.Run(routePrefix, func(t *testing.T) {
@@ -136,9 +166,8 @@ func TestInstrumentConnectHandlerBoundsCardinality(t *testing.T) {
 
 			api := &API{requestDuration: requestDuration}
 
-			// The inner handler mimics the ConnectRPC mux: 200 for the registered
-			// procedure, 404 for everything else (including unknown methods on a
-			// known service).
+			// The inner handler isolates instrumentation behavior: 200 for the
+			// registered procedure and 404 for every other path.
 			inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path == registeredProcedure {
 					w.WriteHeader(http.StatusOK)

--- a/api/connect/connect.go
+++ b/api/connect/connect.go
@@ -29,6 +29,7 @@ import (
 	"connectrpc.com/connect"
 	"connectrpc.com/grpchealth"
 	"connectrpc.com/grpcreflect"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/prometheus/alertmanager/api/status/v3alpha/statusv3alphaconnect"
 	"github.com/prometheus/alertmanager/cluster"
@@ -37,20 +38,127 @@ import (
 
 // Options configures the Connect API.
 type Options struct {
-	Peer              cluster.ClusterPeer
-	UnaryConcurrency  int
+	// Peer provides cluster status. A nil value disables clustering.
+	Peer cluster.ClusterPeer
+	// Registerer registers API metrics. A nil value keeps usable metrics without
+	// registering them.
+	Registerer prometheus.Registerer
+	// UnaryConcurrency limits Connect unary RPCs independently. Non-positive
+	// values use GOMAXPROCS or 8, whichever is larger.
+	UnaryConcurrency int
+	// StreamConcurrency limits Connect streams independently. Non-positive
+	// values use GOMAXPROCS or 8, whichever is larger.
 	StreamConcurrency int
-	UnaryTimeout      time.Duration
+	// UnaryTimeout limits Connect unary RPCs, including request reads.
+	// Non-positive values disable the timeout.
+	UnaryTimeout time.Duration
+	// ReadMaxBytes limits each incoming protobuf message. Non-positive values do
+	// not set a limit.
+	ReadMaxBytes int
+	// SendMaxBytes limits each outgoing protobuf message. Non-positive values do
+	// not set a limit.
+	SendMaxBytes int
+	// MaxRequestBodyBytes limits a unary request body before decoding.
+	// Non-positive values do not set a limit.
+	MaxRequestBodyBytes int64
+}
+
+type effectiveOptions struct {
+	peer                cluster.ClusterPeer
+	registerer          prometheus.Registerer
+	unaryConcurrency    int
+	streamConcurrency   int
+	unaryTimeout        time.Duration
+	readMaxBytes        int
+	sendMaxBytes        int
+	maxRequestBodyBytes int64
+}
+
+func (o Options) resolve() effectiveOptions {
+	defaultConcurrency := max(runtime.GOMAXPROCS(0), 8)
+	unaryConcurrency := o.UnaryConcurrency
+	if unaryConcurrency < 1 {
+		unaryConcurrency = defaultConcurrency
+	}
+	streamConcurrency := o.StreamConcurrency
+	if streamConcurrency < 1 {
+		streamConcurrency = defaultConcurrency
+	}
+	return effectiveOptions{
+		peer:                o.Peer,
+		registerer:          o.Registerer,
+		unaryConcurrency:    unaryConcurrency,
+		streamConcurrency:   streamConcurrency,
+		unaryTimeout:        max(o.UnaryTimeout, 0),
+		readMaxBytes:        max(o.ReadMaxBytes, 0),
+		sendMaxBytes:        max(o.SendMaxBytes, 0),
+		maxRequestBodyBytes: max(o.MaxRequestBodyBytes, 0),
+	}
 }
 
 type procedureDescriptor struct {
-	path string
+	path       string
+	service    string
+	procedure  string
+	streamType connect.StreamType
 }
 
 type serviceDescriptor struct {
 	name       string
 	procedures []procedureDescriptor
 	handler    func(...connect.HandlerOption) (string, http.Handler)
+}
+
+type rpcMetrics struct {
+	unaryInFlight       *prometheus.GaugeVec
+	unaryLimitExceeded  *prometheus.CounterVec
+	unaryDuration       *prometheus.HistogramVec
+	unaryDeadlines      *prometheus.CounterVec
+	streamInFlight      *prometheus.GaugeVec
+	streamLimitExceeded *prometheus.CounterVec
+}
+
+func newRPCMetrics(reg prometheus.Registerer) *rpcMetrics {
+	labels := []string{"service", "procedure"}
+	outcomeLabels := []string{"service", "procedure", "outcome"}
+	metrics := &rpcMetrics{
+		unaryInFlight: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "alertmanager_api_connect_unary_requests_in_flight",
+			Help: "Current number of admitted Connect API unary RPCs.",
+		}, labels),
+		unaryLimitExceeded: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "alertmanager_api_connect_unary_concurrency_limit_exceeded_total",
+			Help: "Total number of Connect API unary RPCs rejected because the concurrency limit was reached.",
+		}, labels),
+		unaryDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "alertmanager_api_connect_unary_request_duration_seconds",
+			Help:    "Duration of Connect API unary RPCs.",
+			Buckets: prometheus.DefBuckets,
+		}, outcomeLabels),
+		unaryDeadlines: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "alertmanager_api_connect_unary_deadline_exceeded_total",
+			Help: "Total number of Connect API unary RPCs whose configured server timeout expired, independent of the final RPC outcome.",
+		}, labels),
+		streamInFlight: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "alertmanager_api_connect_stream_requests_in_flight",
+			Help: "Current number of admitted Connect API streams.",
+		}, labels),
+		streamLimitExceeded: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "alertmanager_api_connect_stream_concurrency_limit_exceeded_total",
+			Help: "Total number of Connect API streams rejected because the concurrency limit was reached.",
+		}, labels),
+	}
+	if reg != nil {
+		reg.MustRegister(
+			metrics.unaryInFlight,
+			metrics.unaryLimitExceeded,
+			metrics.unaryDuration,
+			metrics.unaryDeadlines,
+			metrics.streamInFlight,
+			metrics.streamLimitExceeded,
+		)
+	}
+	return metrics
 }
 
 // API implements the ConnectRPC service handlers for the Connect API.
@@ -61,6 +169,9 @@ type API struct {
 	peerSnapshotSem chan struct{}
 	services        []serviceDescriptor
 	procedures      map[string]procedureDescriptor
+	readMaxBytes    int
+	sendMaxBytes    int
+	maxRequestBytes int64
 
 	configSnapshot atomic.Pointer[string]
 }
@@ -68,44 +179,56 @@ type API struct {
 // NewAPI returns a new Connect API handler. Peer may be nil when clustering
 // is disabled.
 func NewAPI(opts Options) *API {
-	unaryConcurrency := defaultConcurrency(opts.UnaryConcurrency)
-	streamConcurrency := defaultConcurrency(opts.StreamConcurrency)
+	effective := opts.resolve()
+	metrics := newRPCMetrics(effective.registerer)
 	api := &API{
-		peer:            opts.Peer,
+		peer:            effective.peer,
 		uptime:          time.Now(),
 		peerSnapshotSem: make(chan struct{}, 1),
 		procedures:      make(map[string]procedureDescriptor),
-		admission: &admissionInterceptor{
-			unary:        make(chan struct{}, unaryConcurrency),
-			streams:      make(chan struct{}, streamConcurrency),
-			unaryTimeout: opts.UnaryTimeout,
-		},
+		readMaxBytes:    effective.readMaxBytes,
+		sendMaxBytes:    effective.sendMaxBytes,
+		maxRequestBytes: effective.maxRequestBodyBytes,
 	}
 	api.services = api.serviceDescriptors()
 	for _, service := range api.services {
 		for _, procedure := range service.procedures {
 			api.procedures[procedure.path] = procedure
+			labels := prometheus.Labels{"service": procedure.service, "procedure": procedure.procedure}
+			if procedure.streamType == connect.StreamTypeUnary {
+				metrics.unaryInFlight.With(labels)
+				metrics.unaryLimitExceeded.With(labels)
+				metrics.unaryDeadlines.With(labels)
+			} else {
+				metrics.streamInFlight.With(labels)
+				metrics.streamLimitExceeded.With(labels)
+			}
 		}
+	}
+	api.admission = &admissionInterceptor{
+		unary:        make(chan struct{}, effective.unaryConcurrency),
+		streams:      make(chan struct{}, effective.streamConcurrency),
+		unaryTimeout: effective.unaryTimeout,
+		procedures:   api.procedures,
+		metrics:      metrics,
 	}
 	return api
 }
 
-func defaultConcurrency(concurrency int) int {
-	if concurrency < 1 {
-		return max(runtime.GOMAXPROCS(0), 8)
+func procedure(service, name string, streamType connect.StreamType) procedureDescriptor {
+	return procedureDescriptor{
+		path:       "/" + service + "/" + name,
+		service:    service,
+		procedure:  name,
+		streamType: streamType,
 	}
-	return concurrency
-}
-
-func procedure(service, name string) procedureDescriptor {
-	return procedureDescriptor{path: "/" + service + "/" + name}
 }
 
 func (api *API) serviceDescriptors() []serviceDescriptor {
 	status := serviceDescriptor{
 		name: statusv3alphaconnect.StatusServiceName,
 		procedures: []procedureDescriptor{
-			procedure(statusv3alphaconnect.StatusServiceName, "GetStatus"),
+			procedure(statusv3alphaconnect.StatusServiceName, "GetStatus", connect.StreamTypeUnary),
 		},
 		handler: func(opts ...connect.HandlerOption) (string, http.Handler) {
 			return statusv3alphaconnect.NewStatusServiceHandler(api, opts...)
@@ -119,8 +242,8 @@ func (api *API) serviceDescriptors() []serviceDescriptor {
 		{
 			name: grpchealth.HealthV1ServiceName,
 			procedures: []procedureDescriptor{
-				procedure(grpchealth.HealthV1ServiceName, "Check"),
-				procedure(grpchealth.HealthV1ServiceName, "Watch"),
+				procedure(grpchealth.HealthV1ServiceName, "Check", connect.StreamTypeUnary),
+				procedure(grpchealth.HealthV1ServiceName, "Watch", connect.StreamTypeServer),
 			},
 			handler: func(opts ...connect.HandlerOption) (string, http.Handler) {
 				return grpchealth.NewHandler(checker, opts...)
@@ -129,7 +252,7 @@ func (api *API) serviceDescriptors() []serviceDescriptor {
 		{
 			name: grpcreflect.ReflectV1ServiceName,
 			procedures: []procedureDescriptor{
-				procedure(grpcreflect.ReflectV1ServiceName, "ServerReflectionInfo"),
+				procedure(grpcreflect.ReflectV1ServiceName, "ServerReflectionInfo", connect.StreamTypeBidi),
 			},
 			handler: func(opts ...connect.HandlerOption) (string, http.Handler) {
 				return grpcreflect.NewHandlerV1(reflector, opts...)
@@ -138,7 +261,7 @@ func (api *API) serviceDescriptors() []serviceDescriptor {
 		{
 			name: grpcreflect.ReflectV1AlphaServiceName,
 			procedures: []procedureDescriptor{
-				procedure(grpcreflect.ReflectV1AlphaServiceName, "ServerReflectionInfo"),
+				procedure(grpcreflect.ReflectV1AlphaServiceName, "ServerReflectionInfo", connect.StreamTypeBidi),
 			},
 			handler: func(opts ...connect.HandlerOption) (string, http.Handler) {
 				return grpcreflect.NewHandlerV1Alpha(reflector, opts...)
@@ -147,39 +270,112 @@ func (api *API) serviceDescriptors() []serviceDescriptor {
 	}
 }
 
+type unaryRequestStateContextKey struct{}
+
+type unaryTimeoutError struct{}
+
+func (unaryTimeoutError) Error() string {
+	return "configured Connect unary timeout expired"
+}
+
+type unaryRequestState struct {
+	started    time.Time
+	controller *http.ResponseController
+	observed   atomic.Bool
+}
+
+func withUnaryRequestState(ctx context.Context, state *unaryRequestState) context.Context {
+	return context.WithValue(ctx, unaryRequestStateContextKey{}, state)
+}
+
+func unaryRequestStateFromContext(ctx context.Context) *unaryRequestState {
+	state, ok := ctx.Value(unaryRequestStateContextKey{}).(*unaryRequestState)
+	if !ok || state == nil {
+		panic("missing Connect unary request state")
+	}
+	return state
+}
+
 // admissionInterceptor gives unary RPCs and streams independent capacity so
 // slow Connect clients cannot consume the API v2 GET request allowance.
 type admissionInterceptor struct {
 	unary        chan struct{}
 	streams      chan struct{}
 	unaryTimeout time.Duration
+	procedures   map[string]procedureDescriptor
+	metrics      *rpcMetrics
+}
+
+func (i *admissionInterceptor) descriptor(path string) procedureDescriptor {
+	if procedure, ok := i.procedures[path]; ok {
+		return procedure
+	}
+	panic("missing Connect procedure descriptor for " + path)
+}
+
+func (i *admissionInterceptor) enter(desc procedureDescriptor) (func(), error) {
+	labels := prometheus.Labels{"service": desc.service, "procedure": desc.procedure}
+	if desc.streamType == connect.StreamTypeUnary {
+		select {
+		case i.unary <- struct{}{}:
+			i.metrics.unaryInFlight.With(labels).Inc()
+			return func() {
+				<-i.unary
+				i.metrics.unaryInFlight.With(labels).Dec()
+			}, nil
+		default:
+			i.metrics.unaryLimitExceeded.With(labels).Inc()
+			return nil, connect.NewError(connect.CodeResourceExhausted, errors.New("maximum concurrent unary RPCs reached"))
+		}
+	}
+	select {
+	case i.streams <- struct{}{}:
+		i.metrics.streamInFlight.With(labels).Inc()
+		return func() {
+			<-i.streams
+			i.metrics.streamInFlight.With(labels).Dec()
+		}, nil
+	default:
+		i.metrics.streamLimitExceeded.With(labels).Inc()
+		return nil, connect.NewError(connect.CodeResourceExhausted, errors.New("maximum concurrent streams reached"))
+	}
+}
+
+func (i *admissionInterceptor) observe(desc procedureDescriptor, started time.Time, err error) {
+	outcome := "ok"
+	if err != nil {
+		outcome = connect.CodeOf(err).String()
+	}
+	labels := prometheus.Labels{"service": desc.service, "procedure": desc.procedure, "outcome": outcome}
+	i.metrics.unaryDuration.With(labels).Observe(time.Since(started).Seconds())
+}
+
+func normalizeContextError(err error) error {
+	if connect.CodeOf(err) != connect.CodeUnknown {
+		return err
+	}
+	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		return connect.NewError(connect.CodeDeadlineExceeded, context.DeadlineExceeded)
+	case errors.Is(err, context.Canceled):
+		return connect.NewError(connect.CodeCanceled, context.Canceled)
+	default:
+		return err
+	}
 }
 
 func (i *admissionInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
-		select {
-		case i.unary <- struct{}{}:
-			defer func() { <-i.unary }()
-		default:
-			return nil, connect.NewError(connect.CodeResourceExhausted, errors.New("maximum concurrent unary RPCs reached"))
-		}
-		if i.unaryTimeout > 0 {
-			var cancel context.CancelFunc
-			ctx, cancel = context.WithTimeout(ctx, i.unaryTimeout)
-			defer cancel()
+		desc := i.descriptor(req.Spec().Procedure)
+		state := unaryRequestStateFromContext(ctx)
+		if state.controller != nil {
+			_ = state.controller.SetReadDeadline(time.Time{})
 		}
 		response, err := next(ctx, req)
-		if err == nil || connect.CodeOf(err) != connect.CodeUnknown {
-			return response, err
-		}
-		switch {
-		case errors.Is(err, context.DeadlineExceeded):
-			return nil, connect.NewError(connect.CodeDeadlineExceeded, err)
-		case errors.Is(err, context.Canceled):
-			return nil, connect.NewError(connect.CodeCanceled, err)
-		default:
-			return response, err
-		}
+		err = normalizeContextError(err)
+		i.observe(desc, state.started, err)
+		state.observed.Store(true)
+		return response, err
 	}
 }
 
@@ -189,13 +385,8 @@ func (i *admissionInterceptor) WrapStreamingClient(next connect.StreamingClientF
 
 func (i *admissionInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
 	return func(ctx context.Context, conn connect.StreamingHandlerConn) error {
-		select {
-		case i.streams <- struct{}{}:
-			defer func() { <-i.streams }()
-		default:
-			return connect.NewError(connect.CodeResourceExhausted, errors.New("maximum concurrent streams reached"))
-		}
-		return next(ctx, conn)
+		_ = i.descriptor(conn.Spec().Procedure)
+		return normalizeContextError(next(ctx, conn))
 	}
 }
 
@@ -220,9 +411,8 @@ func (api *API) Handler(opts ...connect.HandlerOption) http.Handler {
 }
 
 // Procedures returns the fully-qualified URL paths for every procedure
-// registered by Handler. Callers use it to bound metric and trace labels:
-// any request path that does not exactly match one of these paths yields a
-// 404 and should not be recorded verbatim.
+// registered by Handler. Callers use it to bound metric and trace labels.
+// Handler rejects every request path that is not in this list.
 func (api *API) Procedures() []string {
 	procedures := make([]string, 0, len(api.procedures))
 	for _, service := range api.services {
@@ -233,9 +423,84 @@ func (api *API) Procedures() []string {
 	return procedures
 }
 
+func writeConnectError(w http.ResponseWriter, r *http.Request, errorWriter *connect.ErrorWriter, err error) {
+	controller := http.NewResponseController(w)
+	if err := controller.EnableFullDuplex(); err != nil && r.ProtoMajor < 2 {
+		w.Header().Set("Connection", "close")
+	}
+	_ = errorWriter.Write(w, r, err)
+	_ = controller.Flush()
+}
+
+func (api *API) controlHandler(next http.Handler, errorWriter *connect.ErrorWriter) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		desc, ok := api.procedures[r.URL.Path]
+		if !ok {
+			writeConnectError(w, r, errorWriter, connect.NewError(connect.CodeUnimplemented, errors.New("unknown Connect procedure")))
+			return
+		}
+		release, err := api.admission.enter(desc)
+		if err != nil {
+			writeConnectError(w, r, errorWriter, err)
+			return
+		}
+		defer release()
+
+		if desc.streamType != connect.StreamTypeUnary {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		state := &unaryRequestState{started: time.Now()}
+		ctx := withUnaryRequestState(r.Context(), state)
+		if api.admission.unaryTimeout > 0 {
+			state.controller = http.NewResponseController(w)
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeoutCause(ctx, api.admission.unaryTimeout, unaryTimeoutError{})
+			defer cancel()
+			if deadline, ok := ctx.Deadline(); ok {
+				_ = state.controller.SetReadDeadline(deadline)
+			}
+		}
+		defer func() {
+			if !state.observed.Load() {
+				var err error
+				err = errors.New("rpc ended before handler execution")
+				switch cause := context.Cause(ctx); {
+				case errors.Is(cause, unaryTimeoutError{}):
+					err = connect.NewError(connect.CodeDeadlineExceeded, context.DeadlineExceeded)
+				case errors.Is(cause, context.Canceled):
+					err = connect.NewError(connect.CodeCanceled, context.Canceled)
+				}
+				api.admission.observe(desc, state.started, err)
+			}
+		}()
+		defer func() {
+			if errors.Is(context.Cause(ctx), unaryTimeoutError{}) {
+				api.admission.metrics.unaryDeadlines.With(prometheus.Labels{"service": desc.service, "procedure": desc.procedure}).Inc()
+			}
+		}()
+		defer func() {
+			if state.controller != nil && ctx.Err() == nil {
+				_ = state.controller.SetReadDeadline(time.Time{})
+			}
+		}()
+
+		handler := next
+		if api.maxRequestBytes > 0 {
+			handler = http.MaxBytesHandler(handler, api.maxRequestBytes)
+		}
+		handler.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
 // buildHandler registers every ConnectRPC service on a fresh mux.
 func (api *API) buildHandler(opts ...connect.HandlerOption) http.Handler {
-	opts = append([]connect.HandlerOption{connect.WithInterceptors(api.admission)}, opts...)
+	opts = append([]connect.HandlerOption{
+		connect.WithReadMaxBytes(api.readMaxBytes),
+		connect.WithSendMaxBytes(api.sendMaxBytes),
+		connect.WithInterceptors(api.admission),
+	}, opts...)
 
 	mux := http.NewServeMux()
 	for _, service := range api.services {
@@ -245,5 +510,5 @@ func (api *API) buildHandler(opts ...connect.HandlerOption) http.Handler {
 		}
 		mux.Handle(path, handler)
 	}
-	return mux
+	return api.controlHandler(mux, connect.NewErrorWriter(opts...))
 }

--- a/api/connect/connect_suite_test.go
+++ b/api/connect/connect_suite_test.go
@@ -24,3 +24,8 @@ func TestConnectAPI(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Connect API Suite")
 }
+
+func newTestAPI(opts Options) *API {
+	GinkgoHelper()
+	return NewAPI(opts)
+}

--- a/api/connect/health_test.go
+++ b/api/connect/health_test.go
@@ -33,7 +33,7 @@ import (
 // protocol with JSON, which needs only an HTTP/1.1 client.
 var _ = Describe("gRPC health", func() {
 	It("reports serving for the server and StatusService", func() {
-		api := NewAPI(Options{})
+		api := newTestAPI(Options{})
 		api.Update(&config.Config{})
 
 		srv := httptest.NewServer(api.Handler())

--- a/api/connect/status_test.go
+++ b/api/connect/status_test.go
@@ -15,15 +15,22 @@ package apiconnect
 
 import (
 	"context"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"connectrpc.com/connect"
+	"connectrpc.com/grpchealth"
+	"connectrpc.com/grpcreflect"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/version"
 
 	statusv3alpha "github.com/prometheus/alertmanager/api/status/v3alpha"
@@ -70,9 +77,17 @@ func (p *blockingPeer) Peers() []cluster.ClusterMember {
 }
 func (p *blockingPeer) unblock() { p.releaseOnce.Do(func() { close(p.release) }) }
 
+type flushOnlyResponseWriter struct {
+	http.ResponseWriter
+}
+
+func (w flushOnlyResponseWriter) Flush() {
+	_ = http.NewResponseController(w.ResponseWriter).Flush()
+}
+
 var _ = Describe("StatusService", func() {
 	It("returns status when clustering is disabled", func() {
-		api := NewAPI(Options{})
+		api := newTestAPI(Options{})
 		api.Update(&config.Config{})
 
 		resp, err := api.GetStatus(context.Background(), connect.NewRequest(&statusv3alpha.GetStatusRequest{}))
@@ -102,7 +117,7 @@ var _ = Describe("StatusService", func() {
 			},
 		}
 
-		api := NewAPI(Options{Peer: peer})
+		api := newTestAPI(Options{Peer: peer})
 		api.Update(&config.Config{})
 
 		resp, err := api.GetStatus(context.Background(), connect.NewRequest(&statusv3alpha.GetStatusRequest{}))
@@ -126,7 +141,7 @@ var _ = Describe("StatusService", func() {
 		}
 		DeferCleanup(peer.unblock)
 
-		api := NewAPI(Options{Peer: peer})
+		api := newTestAPI(Options{Peer: peer})
 		api.Update(&config.Config{})
 
 		statusDone := make(chan error, 1)
@@ -154,7 +169,7 @@ var _ = Describe("StatusService", func() {
 			entered: make(chan struct{}),
 			release: make(chan struct{}),
 		}
-		api := NewAPI(Options{Peer: peer, UnaryTimeout: 20 * time.Millisecond})
+		api := newTestAPI(Options{Peer: peer, Registerer: prometheus.NewRegistry(), UnaryConcurrency: 1, UnaryTimeout: 20 * time.Millisecond})
 		api.Update(&config.Config{})
 
 		srv := httptest.NewServer(api.Handler())
@@ -168,6 +183,8 @@ var _ = Describe("StatusService", func() {
 			Expect(connect.CodeOf(err)).To(Equal(connect.CodeDeadlineExceeded))
 			Expect(time.Since(started)).To(BeNumerically("<", 500*time.Millisecond))
 		}
+		labels := prometheus.Labels{"service": statusv3alphaconnect.StatusServiceName, "procedure": "GetStatus"}
+		Expect(testutil.ToFloat64(api.admission.metrics.unaryDeadlines.With(labels))).To(Equal(float64(2)))
 		Eventually(peer.calls.Load, time.Second).Should(Equal(int64(1)))
 	})
 
@@ -188,7 +205,7 @@ var _ = Describe("StatusService", func() {
 	// standard library's http.Protocols.
 	DescribeTable("serves status over HTTP",
 		func(wantMethod string, opts []connect.ClientOption) {
-			api := NewAPI(Options{})
+			api := newTestAPI(Options{})
 			api.Update(&config.Config{})
 
 			methods := make(chan string, 1)
@@ -228,11 +245,152 @@ var _ = Describe("StatusService", func() {
 		Entry("gRPC-Web", http.MethodPost, []connect.ClientOption{connect.WithGRPCWeb()}),
 		Entry("gRPC", http.MethodPost, []connect.ClientOption{connect.WithGRPC()}),
 	)
+
+	It("rejects oversized incoming messages before handler execution", func() {
+		peer := &blockingPeer{entered: make(chan struct{}), release: make(chan struct{})}
+		api := newTestAPI(Options{Peer: peer, ReadMaxBytes: 1, MaxRequestBodyBytes: 1024})
+		api.Update(&config.Config{})
+		srv := httptest.NewServer(api.Handler())
+		DeferCleanup(srv.Close)
+		DeferCleanup(peer.unblock)
+
+		request := &statusv3alpha.GetStatusRequest{}
+		request.ProtoReflect().SetUnknown([]byte{0x08, 0x01})
+		client := statusv3alphaconnect.NewStatusServiceClient(srv.Client(), srv.URL)
+		_, err := client.GetStatus(context.Background(), connect.NewRequest(request))
+		Expect(connect.CodeOf(err)).To(Equal(connect.CodeResourceExhausted))
+		Consistently(peer.entered, 50*time.Millisecond).ShouldNot(BeClosed())
+	})
+
+	It("allows handler options to override message limits", func() {
+		api := newTestAPI(Options{ReadMaxBytes: 1, SendMaxBytes: 1})
+		api.Update(&config.Config{})
+		srv := httptest.NewServer(api.Handler(connect.WithReadMaxBytes(1024), connect.WithSendMaxBytes(1024*1024)))
+		DeferCleanup(srv.Close)
+
+		request := &statusv3alpha.GetStatusRequest{}
+		request.ProtoReflect().SetUnknown([]byte{0x08, 0x01})
+		client := statusv3alphaconnect.NewStatusServiceClient(srv.Client(), srv.URL)
+		_, err := client.GetStatus(context.Background(), connect.NewRequest(request))
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("rejects oversized unary request bodies", func() {
+		api := newTestAPI(Options{ReadMaxBytes: 1024, MaxRequestBodyBytes: 1})
+		api.Update(&config.Config{})
+		srv := httptest.NewServer(api.Handler())
+		DeferCleanup(srv.Close)
+
+		request := &statusv3alpha.GetStatusRequest{}
+		request.ProtoReflect().SetUnknown([]byte{0x08, 0x01})
+		client := statusv3alphaconnect.NewStatusServiceClient(srv.Client(), srv.URL)
+		_, err := client.GetStatus(context.Background(), connect.NewRequest(request))
+		Expect(connect.CodeOf(err)).To(Equal(connect.CodeResourceExhausted))
+	})
+
+	It("rejects oversized outgoing messages", func() {
+		api := newTestAPI(Options{SendMaxBytes: 1})
+		api.Update(&config.Config{})
+		srv := httptest.NewServer(api.Handler())
+		DeferCleanup(srv.Close)
+		client := statusv3alphaconnect.NewStatusServiceClient(srv.Client(), srv.URL)
+
+		_, err := client.GetStatus(context.Background(), connect.NewRequest(&statusv3alpha.GetStatusRequest{}))
+		Expect(connect.CodeOf(err)).To(Equal(connect.CodeResourceExhausted))
+	})
+
+	It("bounds slow unary uploads before handler execution", func() {
+		peer := &blockingPeer{entered: make(chan struct{}), release: make(chan struct{})}
+		api := newTestAPI(Options{Peer: peer, UnaryConcurrency: 1, UnaryTimeout: 500 * time.Millisecond})
+		api.Update(&config.Config{})
+		srv := httptest.NewServer(api.Handler())
+		DeferCleanup(srv.Close)
+		DeferCleanup(peer.unblock)
+
+		reader, writer := io.Pipe()
+		DeferCleanup(writer.Close)
+		req, err := http.NewRequest(http.MethodPost, srv.URL+statusv3alphaconnect.StatusServiceGetStatusProcedure, reader)
+		Expect(err).NotTo(HaveOccurred())
+		req.Header.Set("Content-Type", "application/proto")
+		req.ContentLength = 1
+		done := make(chan *http.Response, 1)
+		go func() {
+			resp, _ := srv.Client().Do(req)
+			done <- resp
+		}()
+		Eventually(func() int { return len(api.admission.unary) }).Should(Equal(1))
+
+		client := statusv3alphaconnect.NewStatusServiceClient(srv.Client(), srv.URL)
+		_, err = client.GetStatus(context.Background(), connect.NewRequest(&statusv3alpha.GetStatusRequest{}))
+		Expect(connect.CodeOf(err)).To(Equal(connect.CodeResourceExhausted))
+
+		var resp *http.Response
+		Eventually(done, time.Second).Should(Receive(&resp))
+		Expect(resp).NotTo(BeNil())
+		Expect(resp.Body.Close()).To(Succeed())
+		Expect(peer.calls.Load()).To(BeZero())
+
+		peer.unblock()
+		_, err = client.GetStatus(context.Background(), connect.NewRequest(&statusv3alpha.GetStatusRequest{}))
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("rejects unread request bodies without blocking", func() {
+		peer := &blockingPeer{entered: make(chan struct{}), release: make(chan struct{})}
+		api := newTestAPI(Options{Peer: peer, UnaryConcurrency: 1})
+		api.Update(&config.Config{})
+		handler := api.Handler()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			handler.ServeHTTP(flushOnlyResponseWriter{ResponseWriter: w}, r)
+		}))
+		DeferCleanup(srv.Close)
+		DeferCleanup(peer.unblock)
+		client := statusv3alphaconnect.NewStatusServiceClient(srv.Client(), srv.URL)
+
+		firstDone := make(chan error, 1)
+		go func() {
+			_, err := client.GetStatus(context.Background(), connect.NewRequest(&statusv3alpha.GetStatusRequest{}))
+			firstDone <- err
+		}()
+		Eventually(peer.entered, 5*time.Second).Should(BeClosed())
+
+		for _, tc := range []struct {
+			path       string
+			statusCode int
+		}{
+			{path: "/unknown.Service/Unknown", statusCode: http.StatusNotImplemented},
+			{path: statusv3alphaconnect.StatusServiceGetStatusProcedure, statusCode: http.StatusTooManyRequests},
+		} {
+			reader, writer := io.Pipe()
+			DeferCleanup(func() { _ = writer.Close() })
+			req, err := http.NewRequest(http.MethodPost, srv.URL+tc.path, reader)
+			Expect(err).NotTo(HaveOccurred())
+			req.Header.Set("Content-Type", "application/proto")
+			req.ContentLength = 1
+			done := make(chan *http.Response, 1)
+			go func() {
+				resp, _ := srv.Client().Do(req)
+				done <- resp
+			}()
+
+			var resp *http.Response
+			Eventually(done, time.Second).Should(Receive(&resp))
+			Expect(resp).NotTo(BeNil())
+			Expect(resp.StatusCode).To(Equal(tc.statusCode))
+			Expect(resp.Body.Close()).To(Succeed())
+			Expect(writer.Close()).To(Succeed())
+		}
+
+		peer.unblock()
+		var firstErr error
+		Eventually(firstDone, 5*time.Second).Should(Receive(&firstErr))
+		Expect(firstErr).NotTo(HaveOccurred())
+	})
 })
 
 var _ = Describe("Connect API", func() {
 	It("pins registered procedures", func() {
-		Expect(NewAPI(Options{}).Procedures()).To(Equal([]string{
+		Expect(newTestAPI(Options{}).Procedures()).To(Equal([]string{
 			"/status.v3alpha.StatusService/GetStatus",
 			"/grpc.health.v1.Health/Check",
 			"/grpc.health.v1.Health/Watch",
@@ -240,101 +398,257 @@ var _ = Describe("Connect API", func() {
 			"/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",
 		}))
 	})
+
+	It("rejects unregistered reflection procedures", func() {
+		api := newTestAPI(Options{StreamConcurrency: 1})
+		srv := httptest.NewUnstartedServer(api.Handler())
+		serverProtocols := new(http.Protocols)
+		serverProtocols.SetUnencryptedHTTP2(true)
+		srv.Config.Protocols = serverProtocols
+		srv.Start()
+		DeferCleanup(srv.Close)
+
+		clientProtocols := new(http.Protocols)
+		clientProtocols.SetUnencryptedHTTP2(true)
+		transport := &http.Transport{Protocols: clientProtocols}
+		client := &http.Client{Transport: transport}
+		DeferCleanup(transport.CloseIdleConnections)
+
+		for _, service := range []string{grpcreflect.ReflectV1ServiceName, grpcreflect.ReflectV1AlphaServiceName} {
+			req, err := http.NewRequest(http.MethodPost, srv.URL+"/"+service+"/Unknown", http.NoBody)
+			Expect(err).NotTo(HaveOccurred())
+			req.Header.Set("Content-Type", "application/grpc")
+			req.Header.Set("TE", "trailers")
+			resp, err := client.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.ProtoMajor).To(Equal(2))
+			_, err = io.Copy(io.Discard, resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.Body.Close()).To(Succeed())
+			Expect(resp.Trailer.Get("Grpc-Status")).To(Equal(strconv.Itoa(int(connect.CodeUnimplemented))))
+			Expect(api.admission.streams).To(HaveLen(0))
+		}
+	})
+
+	It("allows unlimited message and request body sizes for non-positive values", func() {
+		for _, opts := range []Options{
+			{},
+			{ReadMaxBytes: -1, SendMaxBytes: -1, MaxRequestBodyBytes: -1, UnaryTimeout: -time.Second},
+		} {
+			api := newTestAPI(opts)
+			Expect(api.readMaxBytes).To(BeZero())
+			Expect(api.sendMaxBytes).To(BeZero())
+			Expect(api.maxRequestBytes).To(BeZero())
+			Expect(api.admission.unaryTimeout).To(BeZero())
+		}
+	})
+
+	It("panics on duplicate metric registration", func() {
+		reg := prometheus.NewRegistry()
+		newTestAPI(Options{Registerer: reg})
+		Expect(func() { NewAPI(Options{Registerer: reg}) }).To(Panic())
+	})
+
+	It("initializes admission metrics", func() {
+		reg := prometheus.NewRegistry()
+		newTestAPI(Options{Registerer: reg})
+
+		families, err := reg.Gather()
+		Expect(err).NotTo(HaveOccurred())
+		expected := map[string]int{
+			"alertmanager_api_connect_unary_requests_in_flight":                2,
+			"alertmanager_api_connect_unary_concurrency_limit_exceeded_total":  2,
+			"alertmanager_api_connect_unary_deadline_exceeded_total":           2,
+			"alertmanager_api_connect_stream_requests_in_flight":               3,
+			"alertmanager_api_connect_stream_concurrency_limit_exceeded_total": 3,
+		}
+		counts := map[string]int{}
+		for _, family := range families {
+			if _, ok := expected[family.GetName()]; !ok {
+				continue
+			}
+			counts[family.GetName()] = len(family.GetMetric())
+			for _, metric := range family.GetMetric() {
+				if metric.GetGauge() != nil {
+					Expect(metric.GetGauge().GetValue()).To(BeZero())
+				} else {
+					Expect(metric.GetCounter().GetValue()).To(BeZero())
+				}
+			}
+		}
+		Expect(counts).To(Equal(expected))
+	})
+
+	It("registers bounded unary lifecycle metrics", func() {
+		reg := prometheus.NewRegistry()
+		api := newTestAPI(Options{Registerer: reg})
+		api.Update(&config.Config{})
+		srv := httptest.NewServer(api.Handler())
+		DeferCleanup(srv.Close)
+		client := statusv3alphaconnect.NewStatusServiceClient(srv.Client(), srv.URL)
+
+		_, err := client.GetStatus(context.Background(), connect.NewRequest(&statusv3alpha.GetStatusRequest{}))
+		Expect(err).NotTo(HaveOccurred())
+		families, err := reg.Gather()
+		Expect(err).NotTo(HaveOccurred())
+
+		var labels map[string]string
+		for _, family := range families {
+			if family.GetName() != "alertmanager_api_connect_unary_request_duration_seconds" {
+				continue
+			}
+			labels = map[string]string{}
+			for _, pair := range family.GetMetric()[0].GetLabel() {
+				labels[pair.GetName()] = pair.GetValue()
+			}
+		}
+		Expect(labels).To(Equal(map[string]string{
+			"outcome":   "ok",
+			"procedure": "GetStatus",
+			"service":   statusv3alphaconnect.StatusServiceName,
+		}))
+	})
+
+	It("observes errors from caller interceptors", func() {
+		reg := prometheus.NewRegistry()
+		api := newTestAPI(Options{Registerer: reg})
+		api.Update(&config.Config{})
+		interceptor := connect.UnaryInterceptorFunc(func(connect.UnaryFunc) connect.UnaryFunc {
+			return func(context.Context, connect.AnyRequest) (connect.AnyResponse, error) {
+				return nil, connect.NewError(connect.CodePermissionDenied, errors.New("denied"))
+			}
+		})
+		srv := httptest.NewServer(api.Handler(connect.WithInterceptors(interceptor)))
+		DeferCleanup(srv.Close)
+		client := statusv3alphaconnect.NewStatusServiceClient(srv.Client(), srv.URL)
+
+		_, err := client.GetStatus(context.Background(), connect.NewRequest(&statusv3alpha.GetStatusRequest{}))
+		Expect(connect.CodeOf(err)).To(Equal(connect.CodePermissionDenied))
+		families, err := reg.Gather()
+		Expect(err).NotTo(HaveOccurred())
+
+		var outcome string
+		for _, family := range families {
+			if family.GetName() != "alertmanager_api_connect_unary_request_duration_seconds" {
+				continue
+			}
+			for _, pair := range family.GetMetric()[0].GetLabel() {
+				if pair.GetName() == "outcome" {
+					outcome = pair.GetValue()
+				}
+			}
+		}
+		Expect(outcome).To(Equal(connect.CodePermissionDenied.String()))
+	})
 })
 
 var _ = Describe("RPC admission", func() {
 	It("defaults unary and stream concurrency independently", func() {
-		api := NewAPI(Options{UnaryConcurrency: 1})
+		api := newTestAPI(Options{UnaryConcurrency: 1})
 		Expect(cap(api.admission.unary)).To(Equal(1))
 		Expect(cap(api.admission.streams)).To(BeNumerically(">=", 8))
 
-		api = NewAPI(Options{StreamConcurrency: 1})
+		api = newTestAPI(Options{StreamConcurrency: 1})
 		Expect(cap(api.admission.unary)).To(BeNumerically(">=", 8))
 		Expect(cap(api.admission.streams)).To(Equal(1))
 	})
 
-	It("limits unary RPCs independently", func() {
-		admission := &admissionInterceptor{unary: make(chan struct{}, 1), streams: make(chan struct{}, 1)}
-		entered := make(chan struct{})
-		release := make(chan struct{})
-		var enteredOnce sync.Once
-		DeferCleanup(func() {
-			select {
-			case <-release:
-			default:
-				close(release)
-			}
-		})
+	It("does not count parent deadlines as configured unary timeouts", func() {
+		for _, timeout := range []time.Duration{0, time.Hour} {
+			api := newTestAPI(Options{UnaryTimeout: timeout})
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+			request := httptest.NewRequest(http.MethodPost, statusv3alphaconnect.StatusServiceGetStatusProcedure, nil).WithContext(ctx)
+			handler := api.controlHandler(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				<-r.Context().Done()
+			}), connect.NewErrorWriter())
+			handler.ServeHTTP(httptest.NewRecorder(), request)
+			cancel()
 
-		wrapped := admission.WrapUnary(func(context.Context, connect.AnyRequest) (connect.AnyResponse, error) {
-			enteredOnce.Do(func() { close(entered) })
-			<-release
-			return nil, nil
-		})
-		firstDone := make(chan error, 1)
-		go func() {
-			_, err := wrapped(context.Background(), nil)
-			firstDone <- err
-		}()
-		Eventually(entered, 5*time.Second).Should(BeClosed())
-
-		_, err := wrapped(context.Background(), nil)
-		Expect(connect.CodeOf(err)).To(Equal(connect.CodeResourceExhausted))
-
-		close(release)
-		var firstErr error
-		Eventually(firstDone, 5*time.Second).Should(Receive(&firstErr))
-		Expect(firstErr).NotTo(HaveOccurred())
-
-		_, err = wrapped(context.Background(), nil)
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	It("limits streams independently", func() {
-		admission := &admissionInterceptor{unary: make(chan struct{}, 1), streams: make(chan struct{}, 1)}
-		entered := make(chan struct{})
-		release := make(chan struct{})
-		var enteredOnce sync.Once
-		DeferCleanup(func() {
-			select {
-			case <-release:
-			default:
-				close(release)
-			}
-		})
-
-		wrapped := admission.WrapStreamingHandler(func(context.Context, connect.StreamingHandlerConn) error {
-			enteredOnce.Do(func() { close(entered) })
-			<-release
-			return nil
-		})
-		firstDone := make(chan error, 1)
-		go func() { firstDone <- wrapped(context.Background(), nil) }()
-		Eventually(entered, 5*time.Second).Should(BeClosed())
-
-		err := wrapped(context.Background(), nil)
-		Expect(connect.CodeOf(err)).To(Equal(connect.CodeResourceExhausted))
-
-		close(release)
-		var firstErr error
-		Eventually(firstDone, 5*time.Second).Should(Receive(&firstErr))
-		Expect(firstErr).NotTo(HaveOccurred())
-
-		Expect(wrapped(context.Background(), nil)).To(Succeed())
-	})
-
-	It("sets configured unary deadlines", func() {
-		admission := &admissionInterceptor{
-			unary:        make(chan struct{}, 1),
-			streams:      make(chan struct{}, 1),
-			unaryTimeout: 10 * time.Millisecond,
+			labels := prometheus.Labels{"service": statusv3alphaconnect.StatusServiceName, "procedure": "GetStatus"}
+			Expect(testutil.ToFloat64(api.admission.metrics.unaryDeadlines.With(labels))).To(BeZero())
 		}
-		wrapped := admission.WrapUnary(func(ctx context.Context, _ connect.AnyRequest) (connect.AnyResponse, error) {
-			<-ctx.Done()
-			return nil, ctx.Err()
-		})
+	})
 
-		_, err := wrapped(context.Background(), nil)
-		Expect(connect.CodeOf(err)).To(Equal(connect.CodeDeadlineExceeded))
+	It("limits unary RPCs independently", func() {
+		admission := &admissionInterceptor{
+			unary:   make(chan struct{}, 1),
+			streams: make(chan struct{}, 1),
+			metrics: newRPCMetrics(nil),
+		}
+		unary := procedureDescriptor{service: "test", procedure: "Unary", streamType: connect.StreamTypeUnary}
+		stream := procedureDescriptor{service: "test", procedure: "Stream", streamType: connect.StreamTypeServer}
+
+		releaseUnary, err := admission.enter(unary)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = admission.enter(unary)
+		Expect(connect.CodeOf(err)).To(Equal(connect.CodeResourceExhausted))
+
+		releaseStream, err := admission.enter(stream)
+		Expect(err).NotTo(HaveOccurred())
+		releaseStream()
+		releaseUnary()
+
+		releaseUnary, err = admission.enter(unary)
+		Expect(err).NotTo(HaveOccurred())
+		releaseUnary()
+	})
+
+	It("limits and releases streams over HTTP", func() {
+		api := newTestAPI(Options{UnaryConcurrency: 1, StreamConcurrency: 1})
+		api.Update(&config.Config{})
+		srv := httptest.NewServer(api.Handler())
+		DeferCleanup(srv.Close)
+		healthClient := grpchealth.NewClient(srv.Client(), srv.URL)
+		labels := prometheus.Labels{"service": grpchealth.HealthV1ServiceName, "procedure": "Watch"}
+
+		firstCtx, cancelFirst := context.WithCancel(context.Background())
+		DeferCleanup(cancelFirst)
+		first := healthClient.Watch(firstCtx, &grpchealth.CheckRequest{})
+		var event grpchealth.WatchEvent
+		Eventually(first, 5*time.Second).Should(Receive(&event))
+		Expect(event.Err).NotTo(HaveOccurred())
+		Eventually(func() float64 {
+			return testutil.ToFloat64(api.admission.metrics.streamInFlight.With(labels))
+		}).Should(Equal(float64(1)))
+
+		statusClient := statusv3alphaconnect.NewStatusServiceClient(srv.Client(), srv.URL)
+		_, err := statusClient.GetStatus(context.Background(), connect.NewRequest(&statusv3alpha.GetStatusRequest{}))
+		Expect(err).NotTo(HaveOccurred())
+
+		second := healthClient.Watch(context.Background(), &grpchealth.CheckRequest{})
+		Eventually(second, 5*time.Second).Should(Receive(&event))
+		Expect(connect.CodeOf(event.Err)).To(Equal(connect.CodeResourceExhausted))
+		Expect(testutil.ToFloat64(api.admission.metrics.streamLimitExceeded.With(labels))).To(Equal(float64(1)))
+
+		cancelFirst()
+		Eventually(first, 5*time.Second).Should(BeClosed())
+		Eventually(func() float64 {
+			return testutil.ToFloat64(api.admission.metrics.streamInFlight.With(labels))
+		}).Should(BeZero())
+
+		thirdCtx, cancelThird := context.WithCancel(context.Background())
+		DeferCleanup(cancelThird)
+		third := healthClient.Watch(thirdCtx, &grpchealth.CheckRequest{})
+		Eventually(third, 5*time.Second).Should(Receive(&event))
+		Expect(event.Err).NotTo(HaveOccurred())
+		cancelThird()
+		Eventually(third, 5*time.Second).Should(BeClosed())
+	})
+
+	It("normalizes only returned handler errors", func() {
+		Expect(normalizeContextError(nil)).To(Succeed())
+		specific := connect.NewError(connect.CodeInvalidArgument, context.Canceled)
+		Expect(normalizeContextError(specific)).To(BeIdenticalTo(specific))
+		Expect(connect.CodeOf(normalizeContextError(context.DeadlineExceeded))).To(Equal(connect.CodeDeadlineExceeded))
+		Expect(connect.CodeOf(normalizeContextError(context.Canceled))).To(Equal(connect.CodeCanceled))
+
+		generic := errors.New("failed")
+		Expect(normalizeContextError(generic)).To(BeIdenticalTo(generic))
+	})
+
+	It("panics on missing internal request state", func() {
+		admission := &admissionInterceptor{procedures: map[string]procedureDescriptor{}}
+		Expect(func() { admission.descriptor("/missing") }).To(PanicWith("missing Connect procedure descriptor for /missing"))
+		Expect(func() { unaryRequestStateFromContext(context.Background()) }).To(PanicWith("missing Connect unary request state"))
 	})
 })

--- a/app/app.go
+++ b/app/app.go
@@ -383,16 +383,22 @@ func (a *App) setup() error {
 	}
 
 	apih, err := api.New(api.Options{
-		Alerts:          alerts,
-		Silences:        silences,
-		GroupMutedFunc:  groupMarker.Muted,
-		Peer:            clusterPeer,
-		Timeout:         opts.HTTPTimeout,
-		Concurrency:     opts.GetConcurrency,
-		Logger:          logger.With("component", "api"),
-		Registry:        reg,
-		RequestDuration: m.requestDuration,
-		GroupFunc:       groupFn,
+		Alerts:                     alerts,
+		Silences:                   silences,
+		GroupMutedFunc:             groupMarker.Muted,
+		Peer:                       clusterPeer,
+		Timeout:                    opts.HTTPTimeout,
+		Concurrency:                opts.GetConcurrency,
+		ConnectUnaryConcurrency:    opts.ConnectUnaryConcurrency,
+		ConnectStreamConcurrency:   opts.ConnectStreamConcurrency,
+		ConnectUnaryTimeout:        opts.ConnectUnaryTimeout,
+		ConnectReadMaxBytes:        opts.ConnectReadMaxBytes,
+		ConnectSendMaxBytes:        opts.ConnectSendMaxBytes,
+		ConnectMaxRequestBodyBytes: opts.ConnectMaxRequestBodyBytes,
+		Logger:                     logger.With("component", "api"),
+		Registry:                   reg,
+		RequestDuration:            m.requestDuration,
+		GroupFunc:                  groupFn,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create API: %w", err)

--- a/app/options.go
+++ b/app/options.go
@@ -64,11 +64,17 @@ type Options struct {
 	DispatchStartDelay          time.Duration
 
 	// Web server.
-	WebConfig      *web.FlagConfig
-	ExternalURL    string
-	RoutePrefix    string
-	GetConcurrency int
-	HTTPTimeout    time.Duration
+	WebConfig                  *web.FlagConfig
+	ExternalURL                string
+	RoutePrefix                string
+	GetConcurrency             int
+	HTTPTimeout                time.Duration
+	ConnectUnaryConcurrency    int
+	ConnectStreamConcurrency   int
+	ConnectUnaryTimeout        time.Duration
+	ConnectReadMaxBytes        int
+	ConnectSendMaxBytes        int
+	ConnectMaxRequestBodyBytes int64
 
 	// Cluster.
 	ClusterBindAddr        string

--- a/app/options_test.go
+++ b/app/options_test.go
@@ -55,6 +55,9 @@ func TestOptions_Validate(t *testing.T) {
 
 	base := valid()
 	require.NoError(t, base.validate())
+	require.Zero(t, base.ConnectReadMaxBytes)
+	require.Zero(t, base.ConnectSendMaxBytes)
+	require.Zero(t, base.ConnectMaxRequestBodyBytes)
 
 	for _, tc := range []struct {
 		name   string

--- a/cmd/alertmanager/main.go
+++ b/cmd/alertmanager/main.go
@@ -60,11 +60,17 @@ func run() int {
 		dispatchMaintenanceInterval = kingpin.Flag("dispatch.maintenance-interval", "Interval between maintenance of aggregation groups in the dispatcher.").Default("30s").Duration()
 		dispatchStartDelay          = kingpin.Flag("dispatch.start-delay", "Minimum amount of time to wait before dispatching alerts. This option should be synced with value of --rules.alert.resend-delay on Prometheus.").Default("0s").Duration()
 
-		webConfig      = webflag.AddFlags(kingpin.CommandLine, ":9093")
-		externalURL    = kingpin.Flag("web.external-url", "The URL under which Alertmanager is externally reachable (for example, if Alertmanager is served via a reverse proxy). Used for generating relative and absolute links back to Alertmanager itself. If the URL has a path portion, it will be used to prefix all HTTP endpoints served by Alertmanager. If omitted, relevant URL components will be derived automatically.").String()
-		routePrefix    = kingpin.Flag("web.route-prefix", "Prefix for the internal routes of web endpoints. Defaults to path of --web.external-url.").String()
-		getConcurrency = kingpin.Flag("web.get-concurrency", "Maximum number of GET requests processed concurrently. If negative or zero, the limit is GOMAXPROC or 8, whichever is larger.").Default("0").Int()
-		httpTimeout    = kingpin.Flag("web.timeout", "Timeout for HTTP requests. If negative or zero, no timeout is set.").Default("0").Duration()
+		webConfig                  = webflag.AddFlags(kingpin.CommandLine, ":9093")
+		externalURL                = kingpin.Flag("web.external-url", "The URL under which Alertmanager is externally reachable (for example, if Alertmanager is served via a reverse proxy). Used for generating relative and absolute links back to Alertmanager itself. If the URL has a path portion, it will be used to prefix all HTTP endpoints served by Alertmanager. If omitted, relevant URL components will be derived automatically.").String()
+		routePrefix                = kingpin.Flag("web.route-prefix", "Prefix for the internal routes of web endpoints. Defaults to path of --web.external-url.").String()
+		getConcurrency             = kingpin.Flag("web.get-concurrency", "Maximum number of GET requests processed concurrently. If negative or zero, the limit is GOMAXPROC or 8, whichever is larger.").Default("0").Int()
+		httpTimeout                = kingpin.Flag("web.timeout", "Timeout for HTTP requests. If negative or zero, no timeout is set.").Default("0").Duration()
+		connectUnaryConcurrency    = kingpin.Flag("api.connect.unary-concurrency", "[EXPERIMENTAL] Maximum number of Connect unary RPCs processed concurrently. If negative or zero, the limit uses --web.get-concurrency.").Default("0").Int()
+		connectStreamConcurrency   = kingpin.Flag("api.connect.stream-concurrency", "[EXPERIMENTAL] Maximum number of Connect streams processed concurrently. If negative or zero, the limit uses --web.get-concurrency.").Default("0").Int()
+		connectUnaryTimeout        = kingpin.Flag("api.connect.unary-timeout", "[EXPERIMENTAL] Timeout for Connect unary RPCs, including request reads. Zero uses --web.timeout. A negative value disables the Connect unary timeout.").Default("0").Duration()
+		connectReadMaxBytes        = kingpin.Flag("api.connect.read-max-bytes", "[EXPERIMENTAL] Maximum size of each incoming Connect protobuf message. If zero or negative, no limit is set.").Default("0").Int()
+		connectSendMaxBytes        = kingpin.Flag("api.connect.send-max-bytes", "[EXPERIMENTAL] Maximum size of each outgoing Connect protobuf message. If zero or negative, no limit is set.").Default("0").Int()
+		connectMaxRequestBodyBytes = kingpin.Flag("api.connect.max-request-body-bytes", "[EXPERIMENTAL] Maximum wire size of a Connect unary request body. If zero or negative, no limit is set.").Default("0").Int64()
 
 		memlimitEnable = kingpin.Flag("auto-gomemlimit", "Automatically set GOMEMLIMIT to match Linux container or system memory limit").
 				Default("false").Bool()
@@ -175,11 +181,17 @@ func run() int {
 		DispatchMaintenanceInterval: *dispatchMaintenanceInterval,
 		DispatchStartDelay:          *dispatchStartDelay,
 
-		WebConfig:      webConfig,
-		ExternalURL:    *externalURL,
-		RoutePrefix:    *routePrefix,
-		GetConcurrency: *getConcurrency,
-		HTTPTimeout:    *httpTimeout,
+		WebConfig:                  webConfig,
+		ExternalURL:                *externalURL,
+		RoutePrefix:                *routePrefix,
+		GetConcurrency:             *getConcurrency,
+		HTTPTimeout:                *httpTimeout,
+		ConnectUnaryConcurrency:    *connectUnaryConcurrency,
+		ConnectStreamConcurrency:   *connectStreamConcurrency,
+		ConnectUnaryTimeout:        *connectUnaryTimeout,
+		ConnectReadMaxBytes:        *connectReadMaxBytes,
+		ConnectSendMaxBytes:        *connectSendMaxBytes,
+		ConnectMaxRequestBodyBytes: *connectMaxRequestBodyBytes,
 
 		ClusterBindAddr:        *clusterBindAddr,
 		ClusterAdvertiseAddr:   *clusterAdvertiseAddr,


### PR DESCRIPTION
Extend the procedure catalog with service, procedure, and stream metadata, move RPC admission ahead of decoding, and expose configurable resource limits with bounded lifecycle metrics. Preserve successful and specifically coded handler results when request contexts expire.

Part of #5478

#### Which user-facing changes does this PR introduce?

```release-notes
[ENHANCEMENT] API: Add configurable ConnectRPC admission, message-size, request-body, and unary timeout controls.
```
