### PR TITLE
Makefile: Remove redundant version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,6 @@
 # Needs to be defined before including Makefile.common to auto-generate targets
 DOCKER_ARCHS ?= amd64 armv7 arm64 ppc64le s390x
 
-GOLANGCI_LINT_VERSION := v2.13.1
-
 include Makefile.common
 
 FRONTEND_DIR             = $(BIN_DIR)/ui/app


### PR DESCRIPTION
Superseded by #5535


```release-notes
NONE
```
