### PR TITLE
test(ui): cover createQueryFn against a live server

### DIFF
--- a/ui/mantine-ui/src/data/api.test.tsx
+++ b/ui/mantine-ui/src/data/api.test.tsx
@@ -120,7 +120,7 @@ describe('createQueryFn', () => {
 
   it('throws "Network error..." when the server is unreachable', async () => {
     // Port 1 requires root on Linux and is never open in test environments.
-    const unreachable = createQueryFn({ pathPrefix: 'http://localhost:1', path: '/test' });
+    const unreachable = createQueryFn({ pathPrefix: 'http://localhost:0', path: '/test' });
     await expect(unreachable({ signal: signal() })).rejects.toThrow(
       'Network error or unable to reach the server'
     );

--- a/ui/mantine-ui/src/data/api.test.tsx
+++ b/ui/mantine-ui/src/data/api.test.tsx
@@ -1,0 +1,208 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import { API_PATH, createQueryFn } from './api';
+
+// ---------------------------------------------------------------------------
+// Live test server
+// ---------------------------------------------------------------------------
+
+let server: Server;
+let serverPort: number;
+let currentHandler: (req: IncomingMessage, res: ServerResponse) => void = (_req, res) => {
+  res.writeHead(404);
+  res.end();
+};
+
+const serverPrefix = () => `http://localhost:${serverPort}`;
+
+beforeAll(async () => {
+  server = createServer((req, res) => currentHandler(req, res));
+  await new Promise<void>((resolve) => {
+    server.listen(0, () => {
+      serverPort = (server.address() as AddressInfo).port;
+      resolve();
+    });
+  });
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) =>
+    server.close((err) => (err ? reject(err) : resolve()))
+  );
+});
+
+function setHandler(fn: (req: IncomingMessage, res: ServerResponse) => void) {
+  currentHandler = fn;
+}
+
+function jsonResponse(res: ServerResponse, status: number, body: unknown) {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(payload);
+}
+// ---------------------------------------------------------------------------
+// createQueryFn tests
+// ---------------------------------------------------------------------------
+
+describe('createQueryFn', () => {
+  function qfn(
+    path: string,
+    params?: Record<string, string | string[]>,
+    recordResponseTime?: (t: number) => void
+  ) {
+    return createQueryFn({
+      pathPrefix: serverPrefix(),
+      path,
+      params,
+      recordResponseTime,
+    });
+  }
+
+  function signal() {
+    return new AbortController().signal;
+  }
+
+  it('returns data from a successful API envelope', async () => {
+    setHandler((_req, res) => jsonResponse(res, 200, { status: 'success', data: { id: 1 } }));
+    const result = await qfn('/test')({ signal: signal() });
+    expect(result).toEqual({ id: 1 });
+  });
+
+  it('returns raw JSON when the response is not an API envelope', async () => {
+    setHandler((_req, res) => jsonResponse(res, 200, [{ id: 1 }, { id: 2 }]));
+    const result = await qfn('/test')({ signal: signal() });
+    expect(result).toEqual([{ id: 1 }, { id: 2 }]);
+  });
+
+  it('returns raw JSON for objects that lack a status field', async () => {
+    setHandler((_req, res) => jsonResponse(res, 200, { foo: 'bar' }));
+    const result = await qfn('/test')({ signal: signal() });
+    expect(result).toEqual({ foo: 'bar' });
+  });
+
+  it('throws the error field from an API error envelope', async () => {
+    setHandler((_req, res) =>
+      jsonResponse(res, 200, { status: 'error', error: 'something went wrong' })
+    );
+    await expect(qfn('/test')({ signal: signal() })).rejects.toThrow('something went wrong');
+  });
+
+  it('throws a fallback message when the error envelope lacks the error field', async () => {
+    setHandler((_req, res) => jsonResponse(res, 200, { status: 'error' }));
+    await expect(qfn('/test')({ signal: signal() })).rejects.toThrow(
+      'missing "error" field in response JSON'
+    );
+  });
+
+  it('throws statusText for non-OK responses with a non-JSON content type', async () => {
+    setHandler((_req, res) => {
+      res.writeHead(503, 'Service Unavailable', { 'Content-Type': 'text/plain' });
+      res.end('Starting up...');
+    });
+    await expect(qfn('/test')({ signal: signal() })).rejects.toThrow('Service Unavailable');
+  });
+
+  it('parses a JSON error envelope for non-OK responses with application/json content type', async () => {
+    setHandler((_req, res) =>
+      jsonResponse(res, 422, { status: 'error', error: 'invalid request' })
+    );
+    await expect(qfn('/test')({ signal: signal() })).rejects.toThrow('invalid request');
+  });
+
+  it('throws "Invalid JSON response" for malformed JSON bodies', async () => {
+    setHandler((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end('this is not json {{{');
+    });
+    await expect(qfn('/test')({ signal: signal() })).rejects.toThrow('Invalid JSON response');
+  });
+
+  it('throws "Network error..." when the server is unreachable', async () => {
+    // Port 1 requires root on Linux and is never open in test environments.
+    const unreachable = createQueryFn({ pathPrefix: 'http://localhost:1', path: '/test' });
+    await expect(unreachable({ signal: signal() })).rejects.toThrow(
+      'Network error or unable to reach the server'
+    );
+  });
+
+  it('propagates AbortError when the signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const fn = createQueryFn({ pathPrefix: serverPrefix(), path: '/test' });
+    await expect(fn({ signal: controller.signal })).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  it('sends no query string when params is undefined', async () => {
+    let capturedUrl = '';
+    setHandler((req, res) => {
+      capturedUrl = req.url ?? '';
+      jsonResponse(res, 200, { status: 'success', data: null });
+    });
+    await qfn('/alerts')({ signal: signal() });
+    expect(capturedUrl).toBe(`/${API_PATH}/alerts`);
+  });
+
+  it('appends single-value query params to the URL', async () => {
+    let capturedUrl = '';
+    setHandler((req, res) => {
+      capturedUrl = req.url ?? '';
+      jsonResponse(res, 200, { status: 'success', data: null });
+    });
+    await qfn('/alerts', { filter: 'active', severity: 'critical' })({ signal: signal() });
+    const params = new URLSearchParams(capturedUrl.split('?')[1]);
+    expect(params.get('filter')).toBe('active');
+    expect(params.get('severity')).toBe('critical');
+  });
+
+  it('appends repeated keys for array query params', async () => {
+    let capturedUrl = '';
+    setHandler((req, res) => {
+      capturedUrl = req.url ?? '';
+      jsonResponse(res, 200, { status: 'success', data: null });
+    });
+    await qfn('/alerts', { matchers: ['severity=critical', 'env=prod'] })({ signal: signal() });
+    const params = new URLSearchParams(capturedUrl.split('?')[1]);
+    expect(params.getAll('matchers')).toEqual(['severity=critical', 'env=prod']);
+  });
+
+  it('builds the URL with API_PATH between pathPrefix and path', async () => {
+    let capturedUrl = '';
+    setHandler((req, res) => {
+      capturedUrl = req.url ?? '';
+      jsonResponse(res, 200, { status: 'success', data: null });
+    });
+    await qfn('/silences')({ signal: signal() });
+    expect(capturedUrl).toBe(`/${API_PATH}/silences`);
+  });
+
+  it('calls recordResponseTime with a non-negative elapsed time on success', async () => {
+    setHandler((_req, res) => jsonResponse(res, 200, { status: 'success', data: {} }));
+    const times: number[] = [];
+    await qfn('/test', undefined, (t) => times.push(t))({ signal: signal() });
+    expect(times).toHaveLength(1);
+    expect(times[0]).toBeGreaterThanOrEqual(0);
+  });
+
+  it('calls recordResponseTime even when the API envelope carries an error', async () => {
+    // recordResponseTime fires after JSON is parsed, before the envelope error is thrown.
+    setHandler((_req, res) => jsonResponse(res, 200, { status: 'error', error: 'oops' }));
+    const times: number[] = [];
+    await expect(
+      qfn('/test', undefined, (t) => times.push(t))({ signal: signal() })
+    ).rejects.toThrow('oops');
+    expect(times).toHaveLength(1);
+  });
+
+  it('does not call recordResponseTime when the HTTP response is non-OK with non-JSON body', async () => {
+    setHandler((_req, res) => {
+      res.writeHead(503, 'Service Unavailable', { 'Content-Type': 'text/plain' });
+      res.end('down');
+    });
+    const times: number[] = [];
+    await expect(
+      qfn('/test', undefined, (t) => times.push(t))({ signal: signal() })
+    ).rejects.toThrow();
+    expect(times).toHaveLength(0);
+  });
+});

--- a/ui/mantine-ui/src/data/api.ts
+++ b/ui/mantine-ui/src/data/api.ts
@@ -28,7 +28,7 @@ const isAPIEnvelope = <T>(value: unknown): value is APIResponse<T> => {
   );
 };
 
-const createQueryFn =
+export const createQueryFn =
   <T>({
     pathPrefix,
     path,


### PR DESCRIPTION
`createQueryFn` in `ui/mantine-ui/src/data/api.ts` builds every API request the Mantine
UI makes — URL construction, query parameter encoding, envelope unwrapping, and error
translation — and has no test coverage today.

This exports it and adds 17 tests that run against an ephemeral `node:http` server
rather than a mocked `fetch`. Per @SoloJacobs's feedback on #5128, avoiding `fetch`
mocks keeps the assertions honest about real status codes and real JSON parse failures.

No production behavior changes; the only non-test edit is the `export`.
This is the "test `api.ts` first" half of #5128. The silences datasource tests will be
rebased onto this harness separately.

#### Pull Request Checklist
Please check all the applicable boxes.

- Please list all open issue(s) discussed with maintainers related to this change
    - Fixes #<issue number>
    <!--
    If it applies.
    Automatically closes linked issue when PR is merged.
    Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
    More at https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
    -->
- [ ] I have added/updated the required documentation
- [x] I have signed-off my commits
- [x] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?
<!--
If no, just write "NONE" in the release-notes block below.
Otherwise, please describe what should be mentioned in the CHANGELOG. Use the following prefixes:
[FEATURE] [ENHANCEMENT] [PERF] [BUGFIX] [SECURITY] [CHANGE]
Refer to the existing CHANGELOG for inspiration:  https://github.com/prometheus/alertmanager/blob/main/CHANGELOG.md
A concrete example may look as follows (be sure to leave out the surrounding quotes): "[FEATURE] API: Add /api/v1/features for clients to understand which features are supported".
If you need help formulating your entries, consult the reviewer(s).
-->
```release-notes
NONE
```
