### PR TITLE
notify/webex: retry on 429 and honor Retry-After header

### DIFF
--- a/notify/webex/webex.go
+++ b/notify/webex/webex.go
@@ -105,6 +105,7 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	if err != nil {
 		return true, notify.RedactURL(err)
 	}
+	defer notify.Drain(resp)
 
 	shouldRetry, err := n.retrier.Check(resp.StatusCode, resp.Body)
 	if err != nil {

--- a/notify/webex/webex.go
+++ b/notify/webex/webex.go
@@ -19,6 +19,8 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"strconv"
+	"time"
 
 	commoncfg "github.com/prometheus/common/config"
 
@@ -105,12 +107,37 @@ func (n *Notifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error)
 	if err != nil {
 		return true, notify.RedactURL(err)
 	}
-	defer notify.Drain(resp)
 
 	shouldRetry, err := n.retrier.Check(resp.StatusCode, resp.Body)
+	// Not deferred: Check has already consumed the body, and the connection must be
+	// released before the Retry-After wait below rather than held for its duration.
+	notify.Drain(resp)
+
 	if err != nil {
+		if resp.StatusCode == http.StatusTooManyRequests {
+			if d := parseRetryAfter(resp.Header.Get("Retry-After")); d > 0 {
+				logger.Warn("Rate limited by Webex, waiting before retry", "retry_after_secs", d.Seconds())
+				select {
+				case <-time.After(d):
+				case <-ctx.Done():
+				}
+			}
+		}
 		return shouldRetry, notify.NewErrorWithReason(notify.GetFailureReasonFromStatusCode(resp.StatusCode), err)
 	}
 
 	return false, nil
+}
+
+// parseRetryAfter parses Retry-After as seconds; 0 if empty, invalid, or non-positive.
+// TODO: switch to notify.ParseRetryAfter once upstream #5389 merges a shared helper.
+func parseRetryAfter(val string) time.Duration {
+	if val == "" {
+		return 0
+	}
+	seconds, err := strconv.Atoi(val)
+	if err != nil || seconds <= 0 {
+		return 0
+	}
+	return time.Duration(seconds) * time.Second
 }

--- a/notify/webex/webex.go
+++ b/notify/webex/webex.go
@@ -54,7 +54,7 @@ func New(c *config.WebexConfig, t *template.Template, l *slog.Logger, httpOpts .
 		tmpl:    t,
 		logger:  l,
 		client:  client,
-		retrier: &notify.Retrier{},
+		retrier: &notify.Retrier{RetryCodes: []int{http.StatusTooManyRequests}},
 	}
 
 	return n, nil

--- a/notify/webex/webex_test.go
+++ b/notify/webex/webex_test.go
@@ -170,6 +170,88 @@ func TestWebexTemplating(t *testing.T) {
 	}
 }
 
+func TestWebexRetryAfterSleep(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "1")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	notifier, err := New(
+		&config.WebexConfig{
+			HTTPConfig: &commoncfg.HTTPClientConfig{},
+			APIURL:     &amcommoncfg.URL{URL: u},
+		},
+		test.CreateTmpl(t),
+		promslog.NewNopLogger(),
+	)
+	require.NoError(t, err)
+
+	ctx := notify.WithGroupKey(context.Background(), "1")
+	alert := &types.Alert{
+		Alert: model.Alert{
+			Labels:   model.LabelSet{"lbl1": "val1"},
+			StartsAt: time.Now(),
+			EndsAt:   time.Now().Add(time.Hour),
+		},
+	}
+
+	start := time.Now()
+	retry, err := notifier.Notify(ctx, alert)
+	elapsed := time.Since(start)
+
+	require.True(t, retry)
+	require.Error(t, err)
+	require.GreaterOrEqual(t, elapsed, 1*time.Second, "should have waited at least 1 second for Retry-After")
+}
+
+func TestWebexRetryAfterContextCancelled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "2")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	notifier, err := New(
+		&config.WebexConfig{
+			HTTPConfig: &commoncfg.HTTPClientConfig{},
+			APIURL:     &amcommoncfg.URL{URL: u},
+		},
+		test.CreateTmpl(t),
+		promslog.NewNopLogger(),
+	)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx = notify.WithGroupKey(ctx, "1")
+
+	// Cancel context after a short delay to interrupt the Retry-After sleep.
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	alert := &types.Alert{
+		Alert: model.Alert{
+			Labels:   model.LabelSet{"lbl1": "val1"},
+			StartsAt: time.Now(),
+			EndsAt:   time.Now().Add(time.Hour),
+		},
+	}
+
+	start := time.Now()
+	retry, err := notifier.Notify(ctx, alert)
+	elapsed := time.Since(start)
+
+	require.True(t, retry)
+	require.Error(t, err)
+	require.Less(t, elapsed, 2*time.Second, "should not have waited the full Retry-After duration")
+}
+
 func TestWebexFailureReason(t *testing.T) {
 	for _, tc := range []struct {
 		name           string

--- a/notify/webex/webex_test.go
+++ b/notify/webex/webex_test.go
@@ -49,7 +49,8 @@ func TestWebexRetry(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	for statusCode, expected := range test.RetryTests(test.DefaultRetryCodes()) {
+	retryCodes := append(test.DefaultRetryCodes(), http.StatusTooManyRequests)
+	for statusCode, expected := range test.RetryTests(retryCodes) {
 		actual, _ := notifier.retrier.Check(statusCode, nil)
 		require.Equal(t, expected, actual, "error on status %d", statusCode)
 	}


### PR DESCRIPTION
The Webex notifier is built with a bare `notify.Retrier{}`, so only 5xx is retried. A 429 is classified unrecoverable and the notification is dropped after one attempt (`notify retry canceled due to unrecoverable error after 1 attempts`).

Webex is the outlier here. `discord`, `jira`, `opsgenie`, `slack`, `incidentio` and `pagerduty`
already set `RetryCodes` for 429.

Follows the implementation for Slack in #5048 (see also #2112, #2128), and uses the shared `notify.ParseRetryAfter` helper from #5389 now that it has landed. Rebased onto current `main`.

The first commit adds the missing `defer notify.Drain(resp)`. `Retrier.Check` returns early on 2xx without reading the body, so on the success path webex never drained or closed the response at all. That is a pre-existing leak rather than something the 429 handling introduces, so it is split into its own commit and can be taken independently.

#### Pull Request Checklist

- Please list all open issue(s) discussed with maintainers related to this change
    - None
- Is this a new Receiver integration?
    - No
- Is this a bugfix?
    - [x] I have added tests that can reproduce the bug which pass with this bugfix applied
- Is this a new feature?
    - [x] I have added tests that test the new feature's functionality
- Does this change affect performance?
    - No
- Is this a breaking change?
    - No
- [ ] I have added/updated the required documentation
   - Found nothing to update
- [x] I have signed-off my commits
- [x] I will follow [best practices for contributing to this project](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-open-source)

#### Which user-facing changes does this PR introduce?

```release-notes
[BUGFIX] webex: Retry notifications on HTTP 429 and honor the Retry-After header. Previously a rate-limited notification was dropped after a single attempt.
[BUGFIX] webex: Drain and close the response body to allow connection reuse.
```
